### PR TITLE
📦 chore: CD 파이프라인 nvm 환경 변수 명시

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,11 +20,15 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.PORT }}
           script: |
+            node -v
+            export NVM_DIR=~/.nvm
+            source ~/.nvm/nvm.sh
+            node -v
             cd /root/web05-Denamu
             git pull origin main
             cd server/
-            npm install
+            npm ci
             npm build
-            pm2 start ecosystem.config.js
+            nohup npm run start_server > server.log 2>&1 &
 
 # TODO : 환경변수 추가

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "cross-env NODE_ENV=production pm2 start ecosystem.config.js",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",


### PR DESCRIPTION
# 🔨 테스크
-  비로그인 셸 버전 관리를 위한 스크립트 작성

# 📋 작업 내용
```bash
export NVM_DIR=~/.nvm
source ~/.nvm/nvm.sh
```
Github Actions에서 ssh 접속 시, 비 정상적인 node 및 npm 버전을 사용하는 것을 발견.
이에 별도의 `NVM_DIR` 환경변수를 정의 해주는 스크립트를 추가하였습니다.
