### PR TITLE
♻️ refactor: 테스트 환경 내부 완전 분리

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -16,7 +16,7 @@ lerna-debug.log*
 .DS_Store
 
 # Tests
-/coverage
+/test/coverage
 /.nyc_output
 
 # IDEs and editors

--- a/server/ecosystem.config.js
+++ b/server/ecosystem.config.js
@@ -2,7 +2,7 @@ module.exports = {
   apps: [
     {
       name: 'Denamu',
-      script: './dist/main.js',
+      script: './dist/src/main.js',
       instances: 'max',
       exec_mode: 'cluster',
     },

--- a/server/package.json
+++ b/server/package.json
@@ -12,14 +12,13 @@
     "start:dev": "cross-env NODE_ENV=development nest start --watch",
     "start:debug": "cross-env NODE_ENV=development nest start --debug --watch",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "test:unit": "cross-env NODE_ENV=test jest --config jest-unit.json",
-    "test:unit:cov": "cross-env NODE_ENV=test jest --config jest-unit.json --coverage",
-    "test:e2e": "cross-env NODE_ENV=test jest --config jest-e2e.json",
-    "test:e2e:cov": "cross-env NODE_ENV=test jest --config jest-e2e.json --coverage",
-    "test": "cross-env NODE_ENV=test jest",
-    "test:watch": "cross-env NODE_ENV=test jest --watch",
-    "test:cov": "cross-env NODE_ENV=test jest --coverage",
-    "test:debug": "cross-env NODE_ENV=test node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
+    "test:unit": "cross-env NODE_ENV=test jest --config test/jest-unit.json",
+    "test:unit:cov": "cross-env NODE_ENV=test jest --config test/jest-unit.json --coverage",
+    "test:e2e": "cross-env NODE_ENV=test jest --config test/jest-e2e.json",
+    "test:e2e:cov": "cross-env NODE_ENV=test jest --config test/jest-e2e.json --coverage",
+    "test": "cross-env NODE_ENV=test jest --config test/jest-integration.json",
+    "test:watch": "cross-env NODE_ENV=test jest --config test/jest-integration.json --watch",
+    "test:cov": "cross-env NODE_ENV=test jest --config test/jest-integration.json --coverage"
   },
   "dependencies": {
     "@nestjs/common": "^10.0.0",
@@ -61,22 +60,5 @@
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.1.3"
-  },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "test",
-    "testRegex": ".*\\.(e2e-spec|spec)\\.ts$",
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
   }
 }

--- a/server/test/jest-e2e.json
+++ b/server/test/jest-e2e.json
@@ -1,11 +1,10 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": "..",
   "testEnvironment": "node",
-  "testPathIgnorePatterns": [".e2e-spec.ts$"],
-  "testRegex": ".spec.ts$",
+  "rootDir": "..",
+  "testRegex": "test/.*\\.e2e-spec\\.ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "coverageDirectory": "coverage"
+  "coverageDirectory": "test/coverage"
 }

--- a/server/test/jest-integration.json
+++ b/server/test/jest-integration.json
@@ -1,0 +1,10 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "testEnvironment": "node",
+  "rootDir": "..",
+  "testRegex": "test/.*\\.(e2e-spec|spec).ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "coverageDirectory": "test/coverage"
+}

--- a/server/test/jest-unit.json
+++ b/server/test/jest-unit.json
@@ -1,10 +1,10 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": "..",
   "testEnvironment": "node",
-  "testRegex": ".e2e-spec.ts$",
+  "rootDir": "..",
+  "testRegex": "test/.*\\.(spec).ts$",
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   },
-  "coverageDirectory": "coverage"
+  "coverageDirectory": "test/coverage"
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,7 +9,7 @@
     "target": "ES2021",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "..",
+    "rootDir": ".",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #27

### 확실하지 못 한 PR을 계속 올리는 문제

-   분명 테스트 다 했다고 생각했는데, 막상 돌리니 안 돌아가는 문제가 꽤나 많았다.
- 어제 긴급 PR로 인해 어디까지 작업을 했는지 도중에 길을 잃고 커밋을 해버려서 확실한 테스트를 하지 못 하고 PR을 올렸다.
- 그래서 나만의 테스트 목록을 만들어서 이 작업들을 다 테스트 하고 커밋하고 PR을 올렸다.
---
모든 스크립트 돌려보기 ✅
- build ✅
- start ✅
- start:dev ✅
- start:debug ✅

일반 코드 import 경로 확인 ✅

테스트 코드 import ✅
- unit ✅
- e2e ✅
- integration test ✅

테스트 환경 커버리지 돌려보기 ✅
- test ✅
- e2e ✅
- unit ✅

절대 경로로 불러와지던 문제 해결 ✅
  
---
모든 스크립트가 실행됨을 확인했다.

### 테스트 코드에서 절대 경로로 불러와지던 문제

-   tsconfig에서 baseUrl 옵션 때문에 계속해서 절대 경로로 불어와졌다. 하지만, test 디렉토리가 src안에 있는게 아닌 server 안에 있었기에 절대 경로로 server 디렉토리를 baseurl로 잡을 경우 test 코드 내에서 import시 상대 경로가 아닌 `src/경로` 로 시작되는 곳에서 모듈을 불러오는 문제가 있었다. 이럴 경우 test 코드 기준으로 모듈이 올바르게 import 되지 않았다.
- tsconfig에서 baseUrl을 rootDir로 변경하여 디렉토리 기준으로 상대 경로로 가져올 수 있게 바꿨다. 모든 코드가 정상적으로 동작함을 확인했다.
일반 소스 코드에서도 import 시 경로 확인, 테스트 코드에서도 import 시 경로 확인을 하여 테스트가 정상적으로 동작함을 확인했다.

# 📋 작업 내용

-   테스트 환경을 server 디렉토리 내에서 완전 분리하였습니다.
- 기존에 nestjs에서 만들어준 jest 설정 또한 test 디렉토리에 넣어 test 설정 파일들을 한 번에 모았고, test 디렉토리 안에 있는 테스트 파일들만 동작하도록 변경하였습니다.
- 내부에서 아예 test 독립 공간을 만들어뒀다고 생각하시면 됩니다.

# 📷 스크린 샷(선택 사항)
- unit 테스트 임시 커버리지 결과
![유닛 테스트](https://github.com/user-attachments/assets/abbe4519-3917-474f-adae-a0cb86a30bfc)
-  e2e 테스트 임시 커버리지 결과
![E2E 테스트](https://github.com/user-attachments/assets/22020b3b-929d-44d4-bb3f-29b9647c7d47)
- 통합 테스트 임시 커버리지 결과
![통합 테스트](https://github.com/user-attachments/assets/a33dbe9d-c9c1-4c76-a863-436dc7880ac9)