### PR TITLE
🐛 fix: feed entity viewcount 기본값 설정

### DIFF
--- a/server/src/feed/feed.entity.ts
+++ b/server/src/feed/feed.entity.ts
@@ -23,8 +23,9 @@ export class Feed extends BaseEntity {
   @Column({ name: 'title', nullable: false })
   title: string;
 
-  @Column({ name: 'view_count', nullable: false })
+  @Column({ name: 'view_count', nullable: false, default: 0 })
   viewCount: number;
+
 
   @Column({
     length: 255,


### PR DESCRIPTION
# 🔨 테스크
`feed` 엔티티 속성 값 수정

# 📋 작업 내용
feed가 처음 생성될 때 조회수를 0으로 설정하는 default value가 누락되었음을 확인하여 설정 처리 하였습니다.