### PR TITLE
🐛 fix: rss-notifier 배포 스크립트 오탈자 및 의존성 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,13 +42,13 @@ jobs:
             cd ..
             cd rss-notifier/
 
-            echo "PORT"=${{ secrets.RSS_NOTIFIER_PORT }} > .env
-            echo "DB_HOST=${{ secrets.RSS_NOTIFIER_DB_HOST }} >> .env
-            echo "DB_NAME=${{ secrets.RSS_NOTIFIER_DB_DATABASE }} >> .env
-            echo "DB_USER=${{ secrets.RSS_NOTIFIER_DB_USER }} >> .env
-            echo "DB_PASS=${{ secrets.RSS_NOTIFIER_DB_PASSWORD }} >> .env
-            echo "DB_TABLE=${{ secrets.RSS_NOTIFIER_DB_TABLE }} >> .env
-            echo "TIME_INTERVAL=${{ vars.RSS_NOTIFIER_TIME_INTERVAL }} >> .env
+            echo "PORT=${{ secrets.RSS_NOTIFIER_PORT }}" > .env
+            echo "DB_HOST=${{ secrets.RSS_NOTIFIER_DB_HOST }}" >> .env
+            echo "DB_NAME=${{ secrets.RSS_NOTIFIER_DB_DATABASE }}" >> .env
+            echo "DB_USER=${{ secrets.RSS_NOTIFIER_DB_USER }}" >> .env
+            echo "DB_PASS=${{ secrets.RSS_NOTIFIER_DB_PASSWORD }}" >> .env
+            echo "DB_TABLE=${{ secrets.RSS_NOTIFIER_DB_TABLE }}" >> .env
+            echo "TIME_INTERVAL=${{ vars.RSS_NOTIFIER_TIME_INTERVAL }}" >> .env
 
             npm ci
             tsc

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,7 +5,7 @@ module.exports = {
     {
       name: "Denamu",
       script: "./server/dist/main.js",
-      instances: "1",
+      instances: "max",
       exec_mode: "cluster",
       watch: false,
       autorestart: true,

--- a/rss-notifier/package-lock.json
+++ b/rss-notifier/package-lock.json
@@ -17,7 +17,8 @@
       "devDependencies": {
         "@types/node": "^22.9.0",
         "@types/node-fetch": "^2.6.11",
-        "@types/winston": "^2.4.4"
+        "@types/winston": "^2.4.4",
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@colors/colors": {
@@ -742,6 +743,19 @@
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/undici-types": {

--- a/rss-notifier/package-lock.json
+++ b/rss-notifier/package-lock.json
@@ -17,7 +17,6 @@
       "devDependencies": {
         "@types/node": "^22.9.0",
         "@types/node-fetch": "^2.6.11",
-        "@types/winston": "^2.4.4",
         "typescript": "^5.6.3"
       }
     },
@@ -62,16 +61,6 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
-    },
-    "node_modules/@types/winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
-      "deprecated": "This is a stub types definition. winston provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "winston": "*"
-      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/rss-notifier/package.json
+++ b/rss-notifier/package.json
@@ -12,7 +12,6 @@
   "devDependencies": {
     "@types/node": "^22.9.0",
     "@types/node-fetch": "^2.6.11",
-    "@types/winston": "^2.4.4",
     "typescript": "^5.6.3"
   },
   "rootDir": "src",

--- a/rss-notifier/package.json
+++ b/rss-notifier/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "@types/node": "^22.9.0",
     "@types/node-fetch": "^2.6.11",
-    "@types/winston": "^2.4.4"
+    "@types/winston": "^2.4.4",
+    "typescript": "^5.6.3"
   },
   "rootDir": "src",
   "scripts": {


### PR DESCRIPTION
# 🔨 테스크

`deploy.yml` 오탈자 수정 및 의존성 추가

# 📋 작업 내용

rss-notifier에 개발 의존성으로 `typescript` 를 추가하였습니다.
기존에 개발환경에서는 typescript가 global하게 설치되어 있던 터라, 이 부분을 놓쳤네요 😓 
