### PR TITLE
💄 style: eslint eof 오토 설정 추가

### DIFF
--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -21,5 +21,11 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
   },
 };


### PR DESCRIPTION
# 📋 작업 내용

`IntelliJ` IDE에서 이유는 모르겠지만 엔드라인 시퀀스 관련 lint 오류가 계속 떴습니다.
![image](https://github.com/user-attachments/assets/e2a660b9-c460-485b-8837-5161b5106ca7)


```javascript
    'prettier/prettier': [
      'error',
      {
        endOfLine: 'auto',
      },
    ],
```
해당 문제를 제거해주는 옵션을 lint 설정 파일에 추가하였습니다.
