### PR TITLE
✨ feat: Cookie 기반 인가 Guard 작성

### DIFF
--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -14,7 +14,7 @@ import { RegisterAdminDto } from './dto/register-admin.dto';
 import { ApiTags } from '@nestjs/swagger';
 import { ApiPostLoginAdmin, ApiPostRegisterAdmin } from './admin.api-docs';
 import { ApiResponse } from '../common/response/common.response';
-import type { LoginAdminDto } from './dto/login-admin.dto';
+import { LoginAdminDto } from './dto/login-admin.dto';
 
 @ApiTags('Admin')
 @Controller('admin')

--- a/server/src/admin/admin.entity.ts
+++ b/server/src/admin/admin.entity.ts
@@ -8,7 +8,6 @@ abstract class UserInformation extends BaseEntity {
     name: 'login_id',
     length: 255,
     nullable: false,
-    unique: true,
   })
   loginId: string;
 

--- a/server/src/admin/admin.entity.ts
+++ b/server/src/admin/admin.entity.ts
@@ -8,6 +8,7 @@ abstract class UserInformation extends BaseEntity {
     name: 'login_id',
     length: 255,
     nullable: false,
+    unique: true,
   })
   loginId: string;
 

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -3,14 +3,14 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import type { Response } from 'express';
-import type { RegisterAdminDto } from './dto/register-admin.dto';
+import { Response } from 'express';
+import { RegisterAdminDto } from './dto/register-admin.dto';
 import { AdminRepository } from './admin.repository';
 import * as bcrypt from 'bcrypt';
 import { cookieConfig } from '../common/cookie/cookie.config';
 import * as uuid from 'uuid';
 import { RedisService } from '../common/redis/redis.service';
-import type { LoginAdminDto } from './dto/login-admin.dto';
+import { LoginAdminDto } from './dto/login-admin.dto';
 
 @Injectable()
 export class AdminService {

--- a/server/src/blog/blog.entity.ts
+++ b/server/src/blog/blog.entity.ts
@@ -1,7 +1,7 @@
 import { Feed } from '../feed/feed.entity';
 import { RssInformation } from '../rss/rss.entity';
 import { Entity, OneToMany } from 'typeorm';
-import type { Rss } from '../rss/rss.entity';
+import { Rss } from '../rss/rss.entity';
 
 @Entity({
   name: 'blog',

--- a/server/src/common/guard/auth.guard.ts
+++ b/server/src/common/guard/auth.guard.ts
@@ -15,14 +15,9 @@ export class CookieAuthGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const sid = request.cookies['sessionId'];
-
-    if (!sid) {
-      throw new UnauthorizedException('인증되지 않은 요청입니다.');
-    }
-
     const loginId = await this.redisService.get(sid);
     if (!loginId) {
-      throw new ForbiddenException('세션이 유효하지 않은 요청입니다.');
+      throw new UnauthorizedException('인증되지 않은 요청입니다.');
     }
 
     request['user'] = { loginId };

--- a/server/src/feed/feed.repository.ts
+++ b/server/src/feed/feed.repository.ts
@@ -1,7 +1,7 @@
 import { DataSource, Repository } from 'typeorm';
 import { Feed } from './feed.entity';
 import { Injectable } from '@nestjs/common';
-import type { QueryFeedDto } from './dto/query-feed.dto';
+import { QueryFeedDto } from './dto/query-feed.dto';
 
 @Injectable()
 export class FeedRepository extends Repository<Feed> {

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { FeedRepository } from './feed.repository';
-import type { QueryFeedDto } from './dto/query-feed.dto';
+import { QueryFeedDto } from './dto/query-feed.dto';
 import { Feed } from './feed.entity';
 
 @Injectable()

--- a/server/src/rss/rss.api-docs.ts
+++ b/server/src/rss/rss.api-docs.ts
@@ -6,6 +6,7 @@ import {
   ApiConflictResponse,
   ApiParam,
   ApiNotFoundResponse,
+  ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 
 export function ApiPostRegisterRss() {
@@ -79,6 +80,16 @@ export function ApiAcceptRss() {
         },
       },
     }),
+    ApiUnauthorizedResponse({
+      description: '유효한 사용자 세션이 존재하지 않는 경우',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: '인증되지 않은 요청입니다.',
+          error: 'Unauthorized',
+        },
+      },
+    }),
     ApiNotFoundResponse({
       description: '해당 ID의 RSS가 존재하지 않는 경우',
       schema: {
@@ -108,6 +119,16 @@ export function ApiRejectRss() {
       schema: {
         example: {
           message: '거절처리 되었습니다.',
+        },
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: '유효한 사용자 세션이 존재하지 않는 경우',
+      schema: {
+        example: {
+          statusCode: 401,
+          message: '인증되지 않은 요청입니다.',
+          error: 'Unauthorized',
         },
       },
     }),

--- a/server/src/rss/rss.api-docs.ts
+++ b/server/src/rss/rss.api-docs.ts
@@ -84,9 +84,7 @@ export function ApiAcceptRss() {
       description: '유효한 사용자 세션이 존재하지 않는 경우',
       schema: {
         example: {
-          statusCode: 401,
           message: '인증되지 않은 요청입니다.',
-          error: 'Unauthorized',
         },
       },
     }),
@@ -94,9 +92,7 @@ export function ApiAcceptRss() {
       description: '해당 ID의 RSS가 존재하지 않는 경우',
       schema: {
         example: {
-          statusCode: 404,
           message: '존재하지 않는 rss 입니다.',
-          error: 'Not Found',
         },
       },
     }),
@@ -126,9 +122,7 @@ export function ApiRejectRss() {
       description: '유효한 사용자 세션이 존재하지 않는 경우',
       schema: {
         example: {
-          statusCode: 401,
           message: '인증되지 않은 요청입니다.',
-          error: 'Unauthorized',
         },
       },
     }),
@@ -136,9 +130,7 @@ export function ApiRejectRss() {
       description: '해당 ID의 RSS가 존재하지 않는 경우',
       schema: {
         example: {
-          statusCode: 404,
           message: '존재하지 않는 rss 입니다.',
-          error: 'Not Found',
         },
       },
     }),

--- a/server/src/rss/rss.controller.ts
+++ b/server/src/rss/rss.controller.ts
@@ -9,7 +9,9 @@ import {
   Post,
   UsePipes,
   ValidationPipe,
+  UseGuards,
 } from '@nestjs/common';
+import { CookieAuthGuard } from '../common/guard/auth.guard';
 import { ApiTags } from '@nestjs/swagger';
 import { RssService } from './rss.service';
 import { RssRegisterDto } from './dto/rss-register.dto';
@@ -45,6 +47,7 @@ export class RssController {
   }
 
   @ApiAcceptRss()
+  @UseGuards(CookieAuthGuard)
   @Post('accept/:id')
   @HttpCode(201)
   async acceptRss(@Param('id', ParseIntPipe) id: number) {
@@ -53,6 +56,7 @@ export class RssController {
   }
 
   @ApiRejectRss()
+  @UseGuards(CookieAuthGuard)
   @Delete('reject/:id')
   @HttpCode(204)
   async rejectRss(@Param('id', ParseIntPipe) id: number) {

--- a/server/src/rss/rss.entity.ts
+++ b/server/src/rss/rss.entity.ts
@@ -1,5 +1,4 @@
 import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
-import { Blog } from '../blog/blog.entity';
 
 export abstract class RssInformation extends BaseEntity {
   @PrimaryGeneratedColumn()
@@ -36,6 +35,4 @@ export abstract class RssInformation extends BaseEntity {
 @Entity({
   name: 'rss',
 })
-export class Rss extends RssInformation {
-  toBlog(rss: Rss) {}
-}
+export class Rss extends RssInformation {}


### PR DESCRIPTION
# 📋 작업 내용

### 쿠키 기반 인가 처리 guard 작성
HTTP 요청에서 쿠키로 전달된 `sessionId`를 Redis를 통해 검증하여 사용자를 인증하는 `CookieAuthGuard`를 작성했습니다.
`쿠키가 없는경우` && `전달된 쿠키의 sid가 redis에 존재하지 않는경우(즉, 만료된 경우)` 에 `UnauthorizedException` 이 반환됩니다.

### 기존 import type 미사용 결정으로 인한 type import 제거
사전에 백엔드 팀에서 논의된대로, `import type`은 사용하지 않기로 하고 일괄 제거 처리 하였습니다.
> **사용하지 않는 이유**
**TypeScript에서 import type 구문은 타입 전용으로만 선언을 가져올 때 사용됩니다.** 
이를 통해 컴파일러는 가져온 선언이 런타임에 영향을 미치지 않는다는 것을 보장합니다. 하지만 이 방식에는 몇 가지 문제점이 있어, 프로젝트에서는 import type을 사용하지 않기로 결정했습니다.

1. import type의 문제점
`import type`은 오직 타입 정보를 위해 존재합니다. 따라서 TypeScript 컴파일 후 JavaScript로 변환될 때, 실제로 런타임에 필요한 객체나 모듈은 포함되지 않지만, 실제로 컴파일 단계에서 에러가 발생하지 않습니다.

2. 개발자 실수로 인한 런타임 에러의 발생 가능성
이렇게 _"개발자가 실수로 런타임 에러를 발생시킬수 있는 환경이 된다."_ 라는 것 자체가 매우 치명적으로 다가왔고, 이는 제거해야하는 부분이라고 생각했습니다.


# 📷 스크린 샷(선택 사항)
- cookie가 없는채로 요청 시
![image](https://github.com/user-attachments/assets/68735fa3-d8d5-4f15-b379-fae1bf0024cd)
