### PR TITLE
🐛 fix: 새롭게 등록된 도메인 cors 설정 추가

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -18,7 +18,11 @@ async function bootstrap() {
     new HttpExceptionsFilter(),
   );
   app.enableCors({
-    origin: ['http://localhost:5173', 'https://denamu.netlify.app/'],
+    origin: [
+      'http://localhost:5173',
+      'https://denamu.netlify.app/',
+      'https://denamu.shop',
+    ],
     credentials: true,
   });
   setupSwagger(app);


### PR DESCRIPTION
# 📋 작업 내용

- cors 클라이언트 도메인 추가
`https://denamu.shop` 도메인을 cors 허용처리 하였습니다.

# 📷 스크린 샷(선택 사항)
![image](https://github.com/user-attachments/assets/38ac08e7-b27f-4d68-8f1f-a790bd209289)

