### PR TITLE
🐛 fix: redis Service 수정

### DIFF
--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -35,7 +35,7 @@ export class AdminService {
 
     const sessionId = uuid.v4();
 
-    await this.redisService.set(
+    await this.redisService.redisClient.set(
       sessionId,
       admin.loginId,
       `EX`,

--- a/server/src/common/guard/auth.guard.ts
+++ b/server/src/common/guard/auth.guard.ts
@@ -15,7 +15,7 @@ export class CookieAuthGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const sid = request.cookies['sessionId'];
-    const loginId = await this.redisService.get(sid);
+    const loginId = await this.redisService.redisClient.get(sid);
     if (!loginId) {
       throw new UnauthorizedException('인증되지 않은 요청입니다.');
     }

--- a/server/src/common/redis/redis.module.ts
+++ b/server/src/common/redis/redis.module.ts
@@ -13,18 +13,15 @@ import Redis_Mock from 'ioredis-mock';
       inject: [ConfigService],
       useFactory: async (configService: ConfigService) => {
         const envType = process.env.NODE_ENV;
-        let redis: Redis;
         if (envType === 'test') {
-          redis = new Redis_Mock();
-        } else {
-          redis = new Redis({
-            host: configService.get<string>('REDIS_HOST'),
-            port: configService.get<number>('REDIS_PORT'),
-            username: configService.get<string>('REDIS_USERNAME'),
-            password: configService.get<string>('REDIS_PASSWORD'),
-          });
+          return new Redis_Mock();
         }
-        return redis;
+        return new Redis({
+          host: configService.get<string>('REDIS_HOST'),
+          port: configService.get<number>('REDIS_PORT'),
+          username: configService.get<string>('REDIS_USERNAME'),
+          password: configService.get<string>('REDIS_PASSWORD'),
+        });
       },
     },
     RedisService,

--- a/server/src/common/redis/redis.service.ts
+++ b/server/src/common/redis/redis.service.ts
@@ -2,8 +2,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import Redis from 'ioredis';
 
 @Injectable()
-export class RedisService extends Redis {
-  constructor(@Inject('REDIS_CLIENT') private readonly redisClient: Redis) {
-    super(redisClient.options);
-  }
+export class RedisService {
+  constructor(@Inject('REDIS_CLIENT') public readonly redisClient: Redis) {}
 }

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -30,7 +30,11 @@ export class FeedService {
   }
 
   async getTrendList() {
-    const trendFeedIdList = await this.redisService.zrange('feed:trend', 0, 3);
+    const trendFeedIdList = await this.redisService.redisClient.zrange(
+      'feed:trend',
+      0,
+      3,
+    );
     const trendFeeds = await Promise.all(
       trendFeedIdList.map(async (feedId) => {
         const feed = await this.feedRepository.findTrendFeed(parseInt(feedId));

--- a/server/test/feed/trend.e2e-spec.ts
+++ b/server/test/feed/trend.e2e-spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppModule } from '../../src/app.module';
-import { LoggingInterceptor } from '../../src/common/logger/logger.interceptor';
 import { WinstonLoggerService } from '../../src/common/logger/logger.service';
 import { InternalExceptionsFilter } from '../../src/common/filters/internal-exceptions.filter';
 import { HttpExceptionsFilter } from '../../src/common/filters/http-exception.filter';
@@ -22,7 +21,6 @@ describe('Trend API', () => {
     app = moduleFixture.createNestApplication();
     const logger = app.get(WinstonLoggerService);
     app.setGlobalPrefix('api');
-    app.useGlobalInterceptors(new LoggingInterceptor(logger));
     app.useGlobalFilters(
       new InternalExceptionsFilter(logger),
       new HttpExceptionsFilter(),

--- a/server/test/feed/trend.e2e-spec.ts
+++ b/server/test/feed/trend.e2e-spec.ts
@@ -8,11 +8,12 @@ import { RedisService } from '../../src/common/redis/redis.service';
 import { DataSource } from 'typeorm';
 import { Feed } from '../../src/feed/feed.entity';
 import { Blog } from '../../src/blog/blog.entity';
+import { INestApplication } from '@nestjs/common';
 
 describe('Trend API', () => {
-  let app;
+  let app: INestApplication;
   let moduleFixture: TestingModule;
-  let redisService;
+  let redisService: RedisService;
   beforeAll(async () => {
     moduleFixture = await Test.createTestingModule({
       imports: [AppModule],
@@ -31,7 +32,7 @@ describe('Trend API', () => {
     const orm = app.get(DataSource);
     const feedRepository = orm.getRepository(Feed);
     const blogRepository = orm.getRepository(Blog);
-    await blogRepository.save([
+    const blogs = await blogRepository.save([
       {
         id: 1,
         name: 'test',
@@ -57,32 +58,35 @@ describe('Trend API', () => {
     await feedRepository.save([
       {
         id: 1,
+        createdAt: '2022-09-05T09:00:00.000Z',
         title:
           '자바스크립트의 구조와 실행 방식 (Ignition, TurboFan, EventLoop)',
+        viewCount: 0,
         path: 'https://asn6878.tistory.com/9',
-        createdAt: '2022-09-05T09:00:00.000Z',
         thumbnail:
           'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F2wH52%2FbtsJIskiFgS%2FQlF4XqMVZsM8y51w67dxj1%2Fimg.png',
-        blog: 1,
+        blog: blogs[0],
       },
       {
         id: 2,
+        createdAt: '2024-08-14T14:07:49.000Z',
         title:
           '[네이버 커넥트재단 부스트캠프 웹・모바일 9기] 날 것 그대로 작성하는 챌린지 수료 후기 - Web',
         path: 'https://velog.io/@seok3765/%EB%84%A4%EC%9D%B4%EB%B2%84-%EC%BB%A4%EB%84%A5%ED%8A%B8%EC%9E%AC%EB%8B%A8-%EB%B6%80%EC%8A%A4%ED%8A%B8%EC%BA%A0%ED%94%84-%EC%9B%B9%E3%83%BB%EB%AA%A8%EB%B0%94%EC%9D%BC-9%EA%B8%B0-%EB%82%A0-%EA%B2%83-%EA%B7%B8%EB%8C%80%EB%A1%9C-%EC%9E%91%EC%84%B1%ED%95%98%EB%8A%94-%EC%B1%8C%EB%A6%B0%EC%A7%80-%EC%88%98%EB%A3%8C-%ED%9B%84%EA%B8%B0-Web',
-        createdAt: '2024-08-14T14:07:49.000Z',
         thumbnail:
           'https://velog.velcdn.com/images/seok3765/post/2f863481-b594-46f8-9a28-7799afb58aa4/image.jpg',
-        blog: 2,
+        viewCount: 0,
+        blog: blogs[1],
       },
       {
         id: 3,
+        createdAt: '2022-09-05T09:00:00.000Z',
+        viewCount: 0,
         title: '제목',
         path: 'https://asn6878.tistory.com/10',
-        createdAt: '2022-09-05T09:00:00.000Z',
         thumbnail:
           'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F2wH52%2FbtsJIskiFgS%2FQlF4XqMVZsM8y51w67dxj1%2Fimg.png',
-        blog: 3,
+        blog: blogs[2],
       },
       {
         id: 4,
@@ -91,7 +95,8 @@ describe('Trend API', () => {
         createdAt: '2022-09-05T10:00:00.000Z',
         thumbnail:
           'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F2wH52%2FbtsJIskiFgS%2FQlF4XqMVZsM8y51w67dxj1%2Fimg.png',
-        blog: 3,
+        viewCount: 0,
+        blog: blogs[2],
       },
       {
         id: 5,
@@ -100,14 +105,15 @@ describe('Trend API', () => {
         createdAt: '2022-09-05T10:00:00.000Z',
         thumbnail:
           'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2F2wH52%2FbtsJIskiFgS%2FQlF4XqMVZsM8y51w67dxj1%2Fimg.png',
-        blog: 2,
+        viewCount: 0,
+        blog: blogs[2],
       },
     ]);
+    redisService = app.get(RedisService);
   });
 
   beforeEach(async () => {
-    redisService = app.get(RedisService);
-    await redisService.flushall();
+    await redisService.redisClient.flushall();
   });
 
   afterAll(async () => {
@@ -127,7 +133,7 @@ describe('Trend API', () => {
     });
 
     it('피드 1개만 조회됐을 때', async () => {
-      await redisService.zadd('feed:trend', 10, '1');
+      await redisService.redisClient.zadd('feed:trend', 10, '1');
       const response = await request(app.getHttpServer()).get(
         '/api/feed/trend',
       );
@@ -152,8 +158,8 @@ describe('Trend API', () => {
 
     it('피드 2개만 조회됐을 때', async () => {
       await Promise.all([
-        redisService.zadd('feed:trend', 10, '1'),
-        redisService.zadd('feed:trend', 20, '2'),
+        redisService.redisClient.zadd('feed:trend', 10, '1'),
+        redisService.redisClient.zadd('feed:trend', 20, '2'),
       ]);
       const response = await request(app.getHttpServer()).get(
         '/api/feed/trend',
@@ -189,9 +195,9 @@ describe('Trend API', () => {
     });
     it('피드 3개만 조회됐을 때', async () => {
       await Promise.all([
-        redisService.zadd('feed:trend', 10, '1'),
-        redisService.zadd('feed:trend', 20, '2'),
-        redisService.zadd('feed:trend', 30, '3'),
+        redisService.redisClient.zadd('feed:trend', 10, '1'),
+        redisService.redisClient.zadd('feed:trend', 20, '2'),
+        redisService.redisClient.zadd('feed:trend', 30, '3'),
       ]);
       const response = await request(app.getHttpServer()).get(
         '/api/feed/trend',
@@ -237,10 +243,10 @@ describe('Trend API', () => {
     });
     it('피드 4개만 조회됐을 때', async () => {
       await Promise.all([
-        redisService.zadd('feed:trend', 10, '1'),
-        redisService.zadd('feed:trend', 20, '2'),
-        redisService.zadd('feed:trend', 30, '3'),
-        redisService.zadd('feed:trend', 40, '4'),
+        redisService.redisClient.zadd('feed:trend', 10, '1'),
+        redisService.redisClient.zadd('feed:trend', 20, '2'),
+        redisService.redisClient.zadd('feed:trend', 30, '3'),
+        redisService.redisClient.zadd('feed:trend', 40, '4'),
       ]);
       const response = await request(app.getHttpServer()).get(
         '/api/feed/trend',
@@ -296,11 +302,11 @@ describe('Trend API', () => {
     });
     it('피드 5개 이상 조회됐을 때', async () => {
       await Promise.all([
-        redisService.zadd('feed:trend', 10, '1'),
-        redisService.zadd('feed:trend', 20, '2'),
-        redisService.zadd('feed:trend', 30, '3'),
-        redisService.zadd('feed:trend', 40, '4'),
-        redisService.zadd('feed:trend', 50, '5'),
+        redisService.redisClient.zadd('feed:trend', 10, '1'),
+        redisService.redisClient.zadd('feed:trend', 20, '2'),
+        redisService.redisClient.zadd('feed:trend', 30, '3'),
+        redisService.redisClient.zadd('feed:trend', 40, '4'),
+        redisService.redisClient.zadd('feed:trend', 50, '5'),
       ]);
       const response = await request(app.getHttpServer()).get(
         '/api/feed/trend',
@@ -353,12 +359,6 @@ describe('Trend API', () => {
           },
         ],
       });
-    });
-  });
-
-  describe('게시글이 올바르게 존재하지 않을 때', () => {
-    it('조회 테이블에만 데이터가 있고 RDBMS에 데이터가 없을 때', async () => {
-      await Promise.all([redisService.zadd('feed:trend', 10, '6')]);
     });
   });
 });

--- a/server/test/rss/rss.e2e-spec.ts
+++ b/server/test/rss/rss.e2e-spec.ts
@@ -8,7 +8,6 @@ import { Rss } from '../../src/rss/rss.entity';
 import { Blog } from '../../src/blog/blog.entity';
 import { HttpExceptionsFilter } from './../../src/common/filters/http-exception.filter';
 import { InternalExceptionsFilter } from '../../src/common/filters/internal-exceptions.filter';
-import { LoggingInterceptor } from '../../src/common/logger/logger.interceptor';
 import { WinstonLoggerService } from '../../src/common/logger/logger.service';
 
 describe('Rss Register E2E Test : POST /api/rss', () => {
@@ -25,7 +24,6 @@ describe('Rss Register E2E Test : POST /api/rss', () => {
     app = moduleFixture.createNestApplication();
     const logger = app.get(WinstonLoggerService);
     app.setGlobalPrefix('api');
-    app.useGlobalInterceptors(new LoggingInterceptor(logger));
     app.useGlobalFilters(
       new InternalExceptionsFilter(logger),
       new HttpExceptionsFilter(),


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #56

### Redis 클래스를 상속을 못 할때, 함수 맵핑 문제

-   사유: ioredis-mock의 객체를 서비스에서 주입 받았을 때, 서비스가 ioredis 라이브러리의 Redis 클래스를 상속받는 상황이면 super를 썼을 때, 실제 Redis 접속 요청을 하게 되어 무한 로딩이 되는 것을 발견했다.
- ioredis-mock 객체가 주입이 되었을 경우, 서비스에 접근하면 ioredis의 함수들을 다 사용할 수 있어야 하는데, 상속이 안 되기에 불가능하다.
- 주입받은 객체에 그 함수들이 다 있으니, public으로 접근하게 했다.
- 캡슐화의 원칙을 깨게 된다. 그렇다고 맵핑을 하기에는 라이브러리 함수가 뭐가 있는지 모르고, 함수들 맵핑하는 게 상당히 번거롭다. 사용할 때마다 추가해야 하는 번거로움이 있었다.

# 📋 작업 내용

-   테스트 Interceptor 제거
-   Redis 서비스화 -> Redis Class 상속에서 객체에 직접 접근 방식으로 변경

# 📷 스크린 샷(선택 사항)

동작 화면 첨부
