### PR TITLE
🐛 fix: 255자 이상의 인코딩된 path를 대비한 entity 변경 및 정책 변경에 따른 필드명 변경

### DIFF
--- a/server/src/blog/blog.entity.ts
+++ b/server/src/blog/blog.entity.ts
@@ -11,8 +11,8 @@ export class Blog extends RssInformation {
   feeds: Feed[];
 
   @Index({ fulltext: true, parser: 'ngram' })
-  @Column({ name: 'user_name', nullable: false })
-  userName: string;
+  @Column({ name: 'name', nullable: false })
+  name: string;
 
   static fromRss(rss: Rss) {
     const blog = new Blog();

--- a/server/src/feed/dto/feed-response.dto.ts
+++ b/server/src/feed/dto/feed-response.dto.ts
@@ -1,42 +1,20 @@
 import { Feed } from '../feed.entity';
 
 export class FeedResponseDto {
-  id: number;
-
-  author: string;
-
-  title: string;
-
-  path: string;
-
-  createAt: Date;
-
-  thumbnail: string;
-
-  viewCount: number;
-
   private constructor(
-    id: number,
-    author: string,
-    title: string,
-    path: string,
-    ceratedAt: Date,
-    thumbnail: string,
-    viewCount: number,
-  ) {
-    this.id = id;
-    this.author = author;
-    this.title = title;
-    this.path = path;
-    this.createAt = ceratedAt;
-    this.thumbnail = thumbnail;
-    this.viewCount = viewCount;
-  }
+    private id: number,
+    private author: string,
+    private title: string,
+    private path: string,
+    private ceratedAt: Date,
+    private thumbnail: string,
+    private viewCount: number,
+  ) {}
 
   private static mapFeedToFeedResponseDto(feed: Feed) {
     return new FeedResponseDto(
       feed.id,
-      feed.blog.userName,
+      feed.blog.name,
       feed.title,
       feed.path,
       feed.createdAt,

--- a/server/src/feed/dto/search-feed.dto.ts
+++ b/server/src/feed/dto/search-feed.dto.ts
@@ -4,7 +4,7 @@ import { Type } from 'class-transformer';
 
 export enum SearchType {
   TITLE = 'title',
-  USERNAME = 'userName',
+  BLOGNAME = 'blogName',
   ALL = 'all',
 }
 
@@ -18,7 +18,7 @@ export class SearchFeedReq {
     message: '검색 타입을 입력해주세요.',
   })
   @IsEnum(SearchType, {
-    message: '검색 타입은 title, userName, all 중 하나여야 합니다.',
+    message: '검색 타입은 title, blogName, all 중 하나여야 합니다.',
   })
   type: SearchType;
   @IsInt({
@@ -36,7 +36,7 @@ export class SearchFeedReq {
 export class SearchFeedResult {
   constructor(
     private id: number,
-    private userName: string,
+    private blogName: string,
     private title: string,
     private path: string,
     private createdAt: Date,
@@ -46,7 +46,7 @@ export class SearchFeedResult {
     return feeds.map((item) => {
       return new SearchFeedResult(
         item.id,
-        item.blog.userName,
+        item.blog.name,
         item.title,
         item.path,
         item.createdAt,

--- a/server/src/feed/feed.entity.ts
+++ b/server/src/feed/feed.entity.ts
@@ -29,7 +29,7 @@ export class Feed extends BaseEntity {
   viewCount: number;
 
   @Column({
-    length: 255,
+    length: 512,
     nullable: false,
     unique: true,
   })

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -83,8 +83,6 @@ export class FeedService {
   }
 
   async search(searchFeedReq: SearchFeedReq) {
-    console.log(typeof searchFeedReq.page);
-
     const { find, page, limit, type } = searchFeedReq;
     const offset = (page - 1) * limit;
 

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -117,7 +117,7 @@ export class FeedService {
         break;
       case 'all':
         qb.where('MATCH (feed.title) AGAINST (:find)', { find }).orWhere(
-          'MATCH (blog.userName) AGAINST (:find)',
+          'MATCH (blog.name) AGAINST (:find)',
           { find },
         );
         break;


### PR DESCRIPTION
# 📋 작업 내용
**연동간 발생하는 버그들의 핫픽스 처리 PR 입니다.**

- `blog` entity의 path길이 512로 변경
- `userName` 필드가 아닌 `blogName`으로 검색 정책 변경
- 피드 무한스크롤 API 또한 `author` 필드에 들어가는 값이 `userName`에서 `blogName`으로 변경
- `feed.service.ts`의 불필요한 console.log 제거