### PR TITLE
🐛 fix: RSS 관리 파이프라인 개선 및 버그 수정

### DIFF
--- a/rss-notifier/package-lock.json
+++ b/rss-notifier/package-lock.json
@@ -7,6 +7,7 @@
       "dependencies": {
         "dotenv": "^16.4.5",
         "fast-xml-parser": "^4.5.0",
+        "html-escaper": "^3.0.3",
         "js-yaml": "^4.1.0",
         "mysql2": "^3.11.3",
         "node-cron": "^3.0.3",
@@ -393,6 +394,12 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",

--- a/rss-notifier/package.json
+++ b/rss-notifier/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "fast-xml-parser": "^4.5.0",
+    "html-escaper": "^3.0.3",
     "js-yaml": "^4.1.0",
     "mysql2": "^3.11.3",
     "node-cron": "^3.0.3",

--- a/rss-notifier/src/db-access.ts
+++ b/rss-notifier/src/db-access.ts
@@ -5,11 +5,14 @@ import * as mysql from "mysql2/promise";
 
 dotenv.config({ path: "./rss-notifier/.env" });
 
+const CONNECTION_LIMIT = 50;
+
 export const pool = mysql.createPool({
   host: process.env.DB_HOST,
   user: process.env.DB_USER,
   password: process.env.DB_PASS,
   database: process.env.DB_NAME,
+  connectionLimit: CONNECTION_LIMIT,
 });
 
 export const executeQuery = async (query: string, params: any[] = []) => {
@@ -29,27 +32,38 @@ export const executeQuery = async (query: string, params: any[] = []) => {
 };
 
 export const selectAllRss = async (): Promise<FeedObj[]> => {
-  const query = `SELECT id, rss_url FROM blog`;
+  const query = `SELECT id, rss_url
+                 FROM blog`;
   return executeQuery(query);
 };
 
 export const insertFeeds = async (resultData: FeedDetail[]) => {
-  const query = `
-    INSERT INTO feed (blog_id, created_at, title, path, thumbnail)
-    VALUES ?
-  `;
+  let successCount = 0;
+  try {
+    const query = `
+        INSERT INTO feed (blog_id, created_at, title, path, thumbnail)
+        VALUES (?, ?, ?, ?, ?)
+    `;
+    for (let i = 0; i < resultData.length; i += CONNECTION_LIMIT) {
+      const resultChunk = resultData.slice(i, i + CONNECTION_LIMIT);
 
-  const values = resultData.map((feed) => [
-    feed.blog_id,
-    feed.pub_date,
-    feed.title,
-    feed.link,
-    feed.imageUrl,
-  ]);
-
-  await executeQuery(query, [values]);
+      const insertPromiseArray = resultChunk.map((feed) => {
+        return executeQuery(query, [
+          feed.blog_id,
+          feed.pub_date,
+          feed.title,
+          feed.link,
+          feed.imageUrl,
+        ]);
+      });
+      await Promise.all(insertPromiseArray);
+      successCount++;
+    }
+  } catch (error) {
+    logger.error(`누락된 피드 데이터가 존재합니다. 에러 내용: ${error}`);
+  }
 
   logger.info(
-    `${resultData.length}개의 피드 데이터가 성공적으로 삽입되었습니다.`
+    `약 ${successCount * CONNECTION_LIMIT < resultData.length ? successCount * CONNECTION_LIMIT : resultData.length}개의 피드 데이터가 성공적으로 삽입되었습니다.`,
   );
 };

--- a/rss-notifier/src/db-access.ts
+++ b/rss-notifier/src/db-access.ts
@@ -56,14 +56,15 @@ export const insertFeeds = async (resultData: FeedDetail[]) => {
           feed.imageUrl,
         ]);
       });
-      await Promise.all(insertPromiseArray);
-      successCount++;
+      await Promise.allSettled(insertPromiseArray).then((results) => {
+        results.forEach((result) => {
+          if (result.status === "fulfilled") successCount++;
+        });
+      });
     }
   } catch (error) {
     logger.error(`누락된 피드 데이터가 존재합니다. 에러 내용: ${error}`);
   }
 
-  logger.info(
-    `약 ${successCount * CONNECTION_LIMIT < resultData.length ? successCount * CONNECTION_LIMIT : resultData.length}개의 피드 데이터가 성공적으로 삽입되었습니다.`,
-  );
+  logger.info(`${successCount}개의 피드 데이터가 성공적으로 삽입되었습니다.`);
 };

--- a/rss-notifier/src/rss-notifier.ts
+++ b/rss-notifier/src/rss-notifier.ts
@@ -77,7 +77,7 @@ const findNewFeeds = async (
           blog_id: rssObj.id,
           pub_date: formattedDate,
           title: feed.title,
-          link: feed.link,
+          link: decodeURIComponent(feed.link),
           imageUrl: imageUrl,
         };
       }),

--- a/rss-notifier/src/rss-notifier.ts
+++ b/rss-notifier/src/rss-notifier.ts
@@ -116,7 +116,11 @@ export const performTask = async () => {
       return await findNewFeeds(rssObj, currentTime.setMinutes(0, 0, 0));
     }),
   );
-  const result = newFeeds.flat();
+  const result = newFeeds.flat().sort((currentFeed, nextFeed) => {
+    const dateCurrent = new Date(currentFeed.pub_date);
+    const dateNext = new Date(nextFeed.pub_date);
+    return dateCurrent.getTime() - dateNext.getTime();
+  });
 
   if (result.length === 0) {
     logger.info("새로운 피드가 없습니다.");

--- a/rss-notifier/src/rss-notifier.ts
+++ b/rss-notifier/src/rss-notifier.ts
@@ -4,6 +4,7 @@ import { pool, selectAllRss, insertFeeds } from "./db-access.js";
 import { FeedObj, FeedDetail, RawFeed } from "./types.js";
 import { XMLParser } from "fast-xml-parser";
 import { parse } from "node-html-parser";
+import { unescape } from "html-escaper";
 
 const xmlParser = new XMLParser();
 const TIME_INTERVAL = process.env.TIME_INTERVAL
@@ -42,17 +43,20 @@ const fetchRss = async (rss_url: string): Promise<RawFeed[]> => {
   }
   const xmlData = await response.text();
   const objFromXml = xmlParser.parse(xmlData);
-
-  return objFromXml.rss.channel.item.map((item) => ({
-    title: item.title,
-    link: item.link,
-    pubDate: item.pubDate,
-  }));
+  if (Array.isArray(objFromXml.rss.channel.item)) {
+    return objFromXml.rss.channel.item.map((item) => ({
+      title: customUnescape(item.title),
+      link: item.link,
+      pubDate: item.pubDate,
+    }));
+  } else {
+    return [Object.assign({}, objFromXml.rss.channel.item)];
+  }
 };
 
 const findNewFeeds = async (
   rssObj: FeedObj,
-  now: number
+  now: number,
 ): Promise<FeedDetail[]> => {
   try {
     const feeds = await fetchRss(rssObj.rss_url);
@@ -76,16 +80,21 @@ const findNewFeeds = async (
           link: feed.link,
           imageUrl: imageUrl,
         };
-      })
+      }),
     );
 
     return detailedFeeds;
   } catch (err) {
     logger.warn(
-      `[${rssObj.rss_url}] 에서 데이터 조회 중 오류 발생으로 인한 스킵 처리. 오류 내용 : ${err}`
+      `[${rssObj.rss_url}] 에서 데이터 조회 중 오류 발생으로 인한 스킵 처리. 오류 내용 : ${err}`,
     );
     return [];
   }
+};
+
+const customUnescape = (text: string): string => {
+  text = text.replace(/&middot;/g, "·");
+  return unescape(text);
 };
 
 export const performTask = async () => {
@@ -102,10 +111,10 @@ export const performTask = async () => {
     rssObjects.map(async (rssObj) => {
       idx += 1;
       logger.info(
-        `[${idx}번째 rss [${rssObj.rss_url}] 에서 데이터 조회하는 중...`
+        `[${idx}번째 rss [${rssObj.rss_url}] 에서 데이터 조회하는 중...`,
       );
       return await findNewFeeds(rssObj, currentTime.setMinutes(0, 0, 0));
-    })
+    }),
   );
   const result = newFeeds.flat();
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #152
### Velog 지원
- 먼저 Velog의 RSS와 다른 블로그의 RSS를 비교 했는데 차이점이 없었습니다.
- 고민하며 로그를 확인하니 글이 여러 개인 경우는 배열을 반환하지만 글이 한 개인 경우에는 JSON 하나만 반환하는 것을 확인했습니다.
- 블로그 서비스별로 차이가 있는 것이 아니라 1개와 여러 개의 차이점임을 발견하고 배열인지 아닌지 확인하는 로직을 추가하여 해결했습니다.

### 로그를 어떻게 기록할 것인가?
- 벌크 삽입을 사용하면 1개의 데이터만 실패해도 다른 모든 데이터가 삽입되지 않는 단점이 있었습니다.
- 이것을 보완하기 위해 단일 삽입을 병렬적으로 시도하는 방법으로 수정했습니다. 
- 이 때, Promise.all을 사용했지만 각각의 결과를 알기가 어려웠습니다.
- 찾아보니 Promise.allSettled라는 함수를 사용하면 이 부분을 처리할 수 있음을 확인했습니다.

# 📋 작업 내용

- 글이 하나인 블로그도 지원하도록 수정
- createdAt으로 정렬 후 Feed 테이블에 데이터를 삽입
- Feed 삽입 시 다른 트랜잭션으로 처리하여 하나가 실패해도 다른 Feed에 영향이 가지 않도록 수정
- 인코딩된 URL을 한글로 디코딩 후 저장

# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/252cd3b7-9aab-46d7-aa20-d74f371c932b)
- 생성순으로 정렬되어 삽입함을 확인

![image](https://github.com/user-attachments/assets/9234bcf4-f812-4e66-bac5-878dc9e1fb6b)
- `"`, `&` 등 모두 unescape된 상태로 저장됨을 확인

![image](https://github.com/user-attachments/assets/3dfb8f19-0718-4cae-88b0-634511df3f45)
- URL의 한글이 모두 디코딩되어 있는 것을 확인

