### PR TITLE
✨ feat: 트렌딩 포스트 순위 변경 시 위치가 바뀌는 애니메이션 구현

### DIFF
--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SheetFooter } from "@/components/ui/sheet";
 
-import { useKeyboardShortcut } from "@/hooks/useKeyboardShortcut";
+import { useKeyboardShortcut } from "@/hooks/common/useKeyboardShortcut";
 
 import { useChatValueStroe } from "@/store/useChatStore";
 import { useChatStore } from "@/store/useChatStore";

--- a/client/src/components/sections/AnimatedPostGrid.tsx
+++ b/client/src/components/sections/AnimatedPostGrid.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from "react";
+
+import { AnimatePresence, motion } from "framer-motion";
+
+import { PostCard } from "@/components/common/Card/PostCard";
+
+import { Post } from "@/types/post";
+
+interface AnimatedPostGridProps {
+  posts: Post[];
+}
+
+const AnimatedPostGrid = ({ posts }: AnimatedPostGridProps) => {
+  const [positions, setPositions] = useState(new Map());
+  const [prevPosts, setPrevPosts] = useState(posts);
+
+  useEffect(() => {
+    const newPositions = new Map();
+    prevPosts.forEach((post, index) => {
+      newPositions.set(post.id, index);
+    });
+    setPositions(newPositions);
+    setPrevPosts(posts);
+  }, [posts]);
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 relative">
+      <AnimatePresence initial={false}>
+        {posts.map((post, index) => {
+          const prevPosition = positions.get(post.id) ?? index;
+          const position = index;
+          const moveUp = prevPosition > position;
+
+          return (
+            <motion.div
+              key={post.id}
+              layout
+              initial={{ opacity: positions.has(post.id) ? 1 : 0, scale: positions.has(post.id) ? 1 : 0.8 }}
+              animate={{
+                opacity: 1,
+                scale: 1,
+                transition: { duration: 0.3 },
+              }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{
+                type: "spring",
+                stiffness: 350,
+                damping: 25,
+              }}
+              className={`${moveUp ? "z-10" : "z-0"}`}
+            >
+              <motion.div
+                initial={false}
+                animate={{
+                  backgroundColor: moveUp ? "rgba(255, 255, 255, 0.1)" : "transparent",
+                }}
+                transition={{ duration: 0.2 }}
+              >
+                <PostCard
+                  post={post}
+                  className={`transition-shadow duration-300 ${
+                    moveUp ? "shadow-lg ring-2 ring-blue-500 ring-opacity-50" : ""
+                  }`}
+                />
+              </motion.div>
+            </motion.div>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default AnimatedPostGrid;

--- a/client/src/components/sections/TrendingSection.tsx
+++ b/client/src/components/sections/TrendingSection.tsx
@@ -1,8 +1,8 @@
 import { TrendingUp } from "lucide-react";
 
-import { PostCardGrid } from "@/components/common/Card/PostCardGrid";
 import { LoadingIndicator } from "@/components/common/LoadingIndicator";
 import { SectionHeader } from "@/components/common/SectionHeader";
+import AnimatedPostGrid from "@/components/sections/AnimatedPostGrid";
 
 import { useTrendingPosts } from "@/hooks/queries/useTrendingPosts";
 
@@ -20,7 +20,7 @@ export default function TrendingSection() {
         iconColor="text-red-500"
       />
       <div className="flex-1 mt-4 p-4 border border-dashed border-gray-500 rounded-lg">
-        <PostCardGrid posts={posts} />
+        <AnimatedPostGrid posts={posts} />
       </div>
     </section>
   );


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #123 


# 📋 작업 내용

- 트렌딩 포스트 애니메이션 기능 추가
   - PostCardGrid를 AnimatedPostGrid로 교체
   - framer-motion으로 순위 변경 시 애니메이션 구현
   - 순위 상승 시 시각적 피드백 추가 (파란색 테두리, 그림자 효과)

- 애니메이션 구현 사항
   - useEffect와 useState를 사용해 이전 포지션 추적
   - AnimatePresence로 부드러운 진입/퇴장 처리
   - spring 애니메이션으로 자연스러운 움직임 구현
   - 순위 상승 시 z-index 조정으로 자연스럽게 겹쳐지도록 표현

# 📷 스크린 샷
### 순위 내에서 변경될 때
https://github.com/user-attachments/assets/2219e0b9-34e7-43ba-a693-7fd57d70bb0b


### 순위 내로 진입할 때
https://github.com/user-attachments/assets/98e22c56-28a0-4d77-8de2-8d3b91ae692f

