### PR TITLE
♻️ refactor: 조회수 증가 API의 메서드를 Post 방식으로 변경

### DIFF
--- a/server/src/feed/feed.controller.ts
+++ b/server/src/feed/feed.controller.ts
@@ -6,6 +6,7 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  Post,
   Query,
   Req,
   Res,
@@ -87,7 +88,7 @@ export class FeedController {
   }
 
   @ApiUpdateFeedViewCount()
-  @Get('/:feedId')
+  @Post('/:feedId')
   @HttpCode(HttpStatus.OK)
   @UsePipes(new ValidationPipe({ transform: true }))
   async updateFeedViewCount(


### PR DESCRIPTION
# 🔨 테스크

### Issue

-  #20

### GET메서드로 업데이트를 하는 것에 대한 수정
- GET 요청으로 조회수를 업데이트하는 것이 어색하다는 의견이 있었습니다.
- 저도 듣고 보니 업데이트에 대한 요청으로 GET이 어색하다는 생각이 들었고
POST, PATCH, PUT 3가지 메서드 중 무엇을 사용할지 고민했습니다.
- 그 중에서 POST를 사용했는데 그 이유는 클라이언트가 상태를 인지할 수 있나, 없나를 판단하는 것에서 찾을 수 있었습니다.
- 클라이언트가 현재 조회수 값을 모르고 조회수 증가 이벤트를 생성한다고 볼 수 있었고 매번 새로운 상태가 만들어집니다. 
(위 내용을 찾아보며 멱등성에 대한 개념도 새롭게 알 수 있었습니다.)

# 📋 작업 내용

-  조회수 업데이트 API의 메서드를 POST로 수정
