### PR TITLE
♻️ refactor: 메인 페이지 로고 사이즈 변경

### DIFF
--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -37,7 +37,7 @@ export default function Header() {
         <div className="flex h-20 items-center justify-between">
           {/* Logo */}
           <div className="flex-shrink-0">
-            <img className="h-10 w-auto cursor-pointer" src={logo} alt="Logo" onClick={() => location.reload()} />
+            <img className="h-14 w-auto cursor-pointer" src={logo} alt="Logo" onClick={() => location.reload()} />
           </div>
 
           {/* Desktop Navigation */}


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #171

### UI/UX 개선
- 로고가 작다는 피드백 반영을 위해 로고 크기 3.5rem으로 조정
- h-14 Tailwind 클래스 사용

# 📋 작업 내용

- 로고 이미지의 height를 3.5rem(h-14)로 설정
- 기존 cursor-pointer 및 onClick 이벤트 유지

# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/1bc275a6-d0d0-41d6-bd04-f82b084457f7)