### PR TITLE
♻️ refactor: 순위 변경 시 나타나는 파란색 border 삭제 및 usePositionTracking 분리

### DIFF
--- a/client/src/components/sections/AnimatedPostGrid.tsx
+++ b/client/src/components/sections/AnimatedPostGrid.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from "react";
-
 import { AnimatePresence, motion } from "framer-motion";
 
 import { PostCard } from "@/components/common/Card/PostCard";
+
+import { usePositionTracking } from "@/hooks/common/usePositionTracking.ts";
 
 import { Post } from "@/types/post";
 
@@ -11,31 +11,17 @@ interface AnimatedPostGridProps {
 }
 
 const AnimatedPostGrid = ({ posts }: AnimatedPostGridProps) => {
-  const [positions, setPositions] = useState(new Map());
-  const [prevPosts, setPrevPosts] = useState(posts);
-
-  useEffect(() => {
-    const newPositions = new Map();
-    prevPosts.forEach((post, index) => {
-      newPositions.set(post.id, index);
-    });
-    setPositions(newPositions);
-    setPrevPosts(posts);
-  }, [posts]);
+  const { hasPosition } = usePositionTracking(posts);
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 relative">
       <AnimatePresence initial={false}>
-        {posts.map((post, index) => {
-          const prevPosition = positions.get(post.id) ?? index;
-          const position = index;
-          const moveUp = prevPosition > position;
-
+        {posts.map((post) => {
           return (
             <motion.div
               key={post.id}
               layout
-              initial={{ opacity: positions.has(post.id) ? 1 : 0, scale: positions.has(post.id) ? 1 : 0.8 }}
+              initial={{ opacity: hasPosition(post.id) ? 1 : 0, scale: hasPosition(post.id) ? 1 : 0.8 }}
               animate={{
                 opacity: 1,
                 scale: 1,
@@ -47,21 +33,15 @@ const AnimatedPostGrid = ({ posts }: AnimatedPostGridProps) => {
                 stiffness: 350,
                 damping: 25,
               }}
-              className={`${moveUp ? "z-10" : "z-0"}`}
             >
               <motion.div
                 initial={false}
                 animate={{
-                  backgroundColor: moveUp ? "rgba(255, 255, 255, 0.1)" : "transparent",
+                  backgroundColor: "transparent",
                 }}
                 transition={{ duration: 0.2 }}
               >
-                <PostCard
-                  post={post}
-                  className={`transition-shadow duration-300 ${
-                    moveUp ? "shadow-lg ring-2 ring-blue-500 ring-opacity-50" : ""
-                  }`}
-                />
+                <PostCard post={post} className="transition-shadow duration-300" />
               </motion.div>
             </motion.div>
           );

--- a/client/src/hooks/common/usePositionTracking.ts
+++ b/client/src/hooks/common/usePositionTracking.ts
@@ -1,21 +1,19 @@
 import { useEffect, useState } from "react";
 
-interface Identifiable {
-  id: string | number;
-}
+import { Post } from "@/types/post.ts";
 
-export const usePositionTracking = <T extends Identifiable>(items: T[]) => {
+export const usePositionTracking = (posts: Post[]) => {
   const [positions, setPositions] = useState(new Map());
-  const [prevPosts, setPrevPosts] = useState(items);
+  const [prevPosts, setPrevPosts] = useState(posts);
 
   useEffect(() => {
     const newPositions = new Map();
-    prevPosts.forEach((item, index) => {
-      newPositions.set(item.id, index);
+    prevPosts.forEach((post, index) => {
+      newPositions.set(post.id, index);
     });
     setPositions(newPositions);
-    setPrevPosts(items);
-  }, [items]);
+    setPrevPosts(posts);
+  }, [posts]);
 
   return {
     hasPosition: (id: string | number) => positions.has(id),

--- a/client/src/hooks/common/usePositionTracking.ts
+++ b/client/src/hooks/common/usePositionTracking.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+interface Identifiable {
+  id: string | number;
+}
+
+export const usePositionTracking = <T extends Identifiable>(items: T[]) => {
+  const [positions, setPositions] = useState(new Map());
+  const [prevPosts, setPrevPosts] = useState(items);
+
+  useEffect(() => {
+    const newPositions = new Map();
+    prevPosts.forEach((item, index) => {
+      newPositions.set(item.id, index);
+    });
+    setPositions(newPositions);
+    setPrevPosts(items);
+  }, [items]);
+
+  return {
+    hasPosition: (id: string | number) => positions.has(id),
+  };
+};


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #180

### 코드 구조 개선
- AnimatedPostGrid 컴포넌트의 복잡한 포지션 트래킹 로직을 별도의 커스텀 훅으로 분리
- 기존에 순위 변경 시 나타나는 파란색 border 스타일 제거

# 📋 작업 내용
   - usePositionTracking 훅 생성

