### PR TITLE
🐛 fix: 어드민 계정 생성 시 기존 어드민 계정 로그인 시에만 생성할 수 있도록 가드 적용

### DIFF
--- a/server/src/admin/admin.api-docs.ts
+++ b/server/src/admin/admin.api-docs.ts
@@ -37,6 +37,14 @@ export function ApiPostRegisterAdmin() {
         },
       },
     }),
+    ApiUnauthorizedResponse({
+      description: 'Unauthorized',
+      schema: {
+        example: {
+          message: '인증되지 않은 요청입니다.',
+        },
+      },
+    }),
   );
 }
 

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -5,6 +5,7 @@ import {
   HttpStatus,
   Post,
   Res,
+  UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -15,6 +16,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { ApiPostLoginAdmin, ApiPostRegisterAdmin } from './admin.api-docs';
 import { ApiResponse } from '../common/response/common.response';
 import { LoginAdminDto } from './dto/login-admin.dto';
+import { CookieAuthGuard } from '../common/guard/auth.guard';
 
 @ApiTags('Admin')
 @Controller('admin')
@@ -36,6 +38,7 @@ export class AdminController {
   }
 
   @ApiPostRegisterAdmin()
+  @UseGuards(CookieAuthGuard)
   @Post('/register')
   @UsePipes(ValidationPipe)
   async registerAdmin(@Body() registerAdminDto: RegisterAdminDto) {

--- a/server/src/common/guard/auth.guard.ts
+++ b/server/src/common/guard/auth.guard.ts
@@ -3,7 +3,6 @@ import {
   CanActivate,
   ExecutionContext,
   UnauthorizedException,
-  ForbiddenException,
 } from '@nestjs/common';
 import { RedisService } from '../redis/redis.service';
 import { Request } from 'express';


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #169

# 📋 작업 내용

- 기존에는 어드민 계정을 생성 후 빠르게 deprecated 시킬 계획이었으나 API를 살려놓는 방향으로 수정되었습니다.
- 그에 따라 어드민 계정 생성 API에 아무나 접근하지 못하도록 Guard를 적용시켜서 기존 어드민이 로그인했을 때만 접근할 수 있도록 수정했습니다.

# 📷 스크린 샷

![쿠키가 없을 때 회원가입2](https://github.com/user-attachments/assets/09c7ab70-a22d-46f9-8ced-d1d1b1039e21)

![로그인 후 쿠키가 생김](https://github.com/user-attachments/assets/9df507ce-4401-42d3-9f92-be1e2dd94688)

![회원가입이 성공함](https://github.com/user-attachments/assets/1d1769c3-2d61-4de9-8df0-e0994ecae31e)


![회원가입 후 디비 확인](https://github.com/user-attachments/assets/4f33f7e9-7620-4e38-9cb0-243efed57fba)
