### PR TITLE
♻️ refactor: 카드 크기 일관성을 위한 Ellipsis 처리 및 고정 높이 설정

### DIFF
--- a/client/src/components/common/Card/PostCard.tsx
+++ b/client/src/components/common/Card/PostCard.tsx
@@ -19,7 +19,7 @@ export const PostCard = ({ post, className }: PostCardProps) => {
     <Card
       onClick={handlePostClick}
       className={cn(
-        "group shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 border-none rounded-xl cursor-pointer",
+        "h-[240px] group shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 border-none rounded-xl cursor-pointer",
         className
       )}
     >

--- a/client/src/components/common/Card/PostCardContent.tsx
+++ b/client/src/components/common/Card/PostCardContent.tsx
@@ -24,8 +24,10 @@ export const PostCardContent = ({ post }: PostCardContentProps) => {
         </Avatar>
       </div>
       <div className="px-4 pb-4">
-        <p className="font-bold text-xs text-gray-400 pb-1">{post.author}</p>
-        <p className="font-bold text-sm group-hover:text-primary transition-colors">{post.title}</p>
+        <p className="font-bold text-xs text-gray-400 pb-1 line-clamp-1">{post.author}</p>
+        <p className="h-[40px] font-bold text-sm group-hover:text-primary transition-colors line-clamp-2">
+          {post.title}
+        </p>
         <p className="text-[10px] text-gray-400 pt-2">{formatDate(post.createdAt)}</p>
       </div>
     </CardContent>

--- a/client/src/components/common/Card/PostCardImage.tsx
+++ b/client/src/components/common/Card/PostCardImage.tsx
@@ -9,7 +9,7 @@ interface PostCardImageProps {
 
 export const PostCardImage = ({ thumbnail, alt }: PostCardImageProps) => {
   return (
-    <div className="aspect-[16/9] relative bg-muted flex items-center justify-center overflow-hidden rounded-t-xl">
+    <div className="h-[120px] relative bg-muted flex items-center justify-center overflow-hidden rounded-t-xl">
       {thumbnail ? (
         <LazyImage
           src={thumbnail}


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #179 

### 문제 상황
- 트렌딩 포스트와 최신 포스트 섹션에서 PostCard 크기가 서로 다르게 표시됨
- 제목 길이에 따라 카드 크기가 변하는 문제 발생
- CSS Grid와 Motion의 레이아웃 처리 방식 차이로 인한 불일치

### 해결 방안
- PostCard 컴포넌트에 고정 높이를 적용해 크기 통일
- 이미지와 컨텐츠 영역의 크기를 제한해 일관된 레이아웃 유지

자세한 내용은 아래 노션 문서 참고
https://balsam-barometer-716.notion.site/Ellipsis-PostCard-UX-148e624056ec80109642e520b3082ed4?pvs=4

# 📋 작업 내용
- PostCard 컴포넌트
   - 전체 높이를 240px로 고정
   - flex-col 레이아웃 유지

- PostCardImage 컴포넌트
   - 이미지 영역 높이를 120px로 고정
   - aspect-ratio 제거 및 overflow 처리

- PostCardContent 컴포넌트
   - 제목 영역 40px 고정 높이 설정
   - 제목 두 줄, 작성자 이름 한 줄로 제한
   - 텍스트 크기 조정

# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/a82668c7-f721-43a4-a876-82bd8aad520d)