### PR TITLE
✨ feat: 어드민 페이지 출력 시 세션 아이디를 검증하기 위한 API 추가

### DIFF
--- a/server/src/admin/admin.api-docs.ts
+++ b/server/src/admin/admin.api-docs.ts
@@ -71,3 +71,27 @@ export function ApiPostLoginAdmin() {
     }),
   );
 }
+
+export function ApiCheckAdminSessionId() {
+  return applyDecorators(
+    ApiOperation({
+      summary: `관리자 페이지 출력을 위한 sessionId 확인 API`,
+    }),
+    ApiOkResponse({
+      description: 'Ok',
+      schema: {
+        example: {
+          message: '정상적인 sessionId입니다.',
+        },
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'Unauthorized',
+      schema: {
+        example: {
+          message: '인증되지 않은 요청입니다.',
+        },
+      },
+    }),
+  );
+}

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -1,10 +1,13 @@
 import {
   Body,
   Controller,
+  Get,
   HttpCode,
   HttpStatus,
   Post,
+  Req,
   Res,
+  UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -15,11 +18,12 @@ import { ApiTags } from '@nestjs/swagger';
 import { ApiPostLoginAdmin, ApiPostRegisterAdmin } from './admin.api-docs';
 import { ApiResponse } from '../common/response/common.response';
 import { LoginAdminDto } from './dto/login-admin.dto';
+import { CookieAuthGuard } from '../common/guard/auth.guard';
 
 @ApiTags('Admin')
 @Controller('admin')
 export class AdminController {
-  constructor(private readonly loginService: AdminService) {}
+  constructor(private readonly adminService: AdminService) {}
 
   @ApiPostLoginAdmin()
   @Post('/login')
@@ -29,7 +33,7 @@ export class AdminController {
     @Body() loginAdminDto: LoginAdminDto,
     @Res({ passthrough: true }) response: Response,
   ) {
-    await this.loginService.loginAdmin(loginAdminDto, response);
+    await this.adminService.loginAdmin(loginAdminDto, response);
     return ApiResponse.responseWithNoContent(
       '로그인이 성공적으로 처리되었습니다.',
     );
@@ -39,9 +43,17 @@ export class AdminController {
   @Post('/register')
   @UsePipes(ValidationPipe)
   async registerAdmin(@Body() registerAdminDto: RegisterAdminDto) {
-    await this.loginService.registerAdmin(registerAdminDto);
+    await this.adminService.registerAdmin(registerAdminDto);
     return ApiResponse.responseWithNoContent(
       '성공적으로 관리자 계정이 생성되었습니다.',
     );
+  }
+
+  @Get('/sessionId')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(CookieAuthGuard)
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async checkAdminSessionId() {
+    return ApiResponse.responseWithNoContent('정상적인 sessionId 입니다.');
   }
 }

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -5,7 +5,6 @@ import {
   HttpCode,
   HttpStatus,
   Post,
-  Req,
   Res,
   UseGuards,
   UsePipes,
@@ -15,7 +14,11 @@ import { Response } from 'express';
 import { AdminService } from './admin.service';
 import { RegisterAdminDto } from './dto/register-admin.dto';
 import { ApiTags } from '@nestjs/swagger';
-import { ApiPostLoginAdmin, ApiPostRegisterAdmin } from './admin.api-docs';
+import {
+  ApiCheckAdminSessionId,
+  ApiPostLoginAdmin,
+  ApiPostRegisterAdmin,
+} from './admin.api-docs';
 import { ApiResponse } from '../common/response/common.response';
 import { LoginAdminDto } from './dto/login-admin.dto';
 import { CookieAuthGuard } from '../common/guard/auth.guard';
@@ -49,6 +52,7 @@ export class AdminController {
     );
   }
 
+  @ApiCheckAdminSessionId()
   @Get('/sessionId')
   @HttpCode(HttpStatus.OK)
   @UseGuards(CookieAuthGuard)


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #169

# 📋 작업 내용

- 어드민 페이지 출력 시 세션 아이디를 검증하기 위한 API를 추가했습니다.
- 명기님과 이야기를 나눈 결과, 가드가 설정되어 있어 어드민 페이지에서 아무 작업도 할 수 없지만 어드민 페이지 랜더링도 막아야 할 것 같다고 의견이 합쳐졌습니다.
- 그래서 새로고침 등 요청을 보낼 때 세션아이디를 검증할 수 있는 API를 추가했습니다.

- 그 이외에도 adminService를 loginService라고 표기한 파트가 있어 수정을 했습니다.
- API에 swagger를 적용시켜 명세를 확인할 수 있도록 작성했습니다.

# 📷 스크린 샷
- 첫 번째 스크린 샷은 정상적으로 로그인하고 sessionId가 유요한 경우입니다.
- 두 번째 부터는 틀린 sessionId로 설정했을 때 응답입니다.
![성공적으로 로그인 할 때](https://github.com/user-attachments/assets/b5193621-69d3-477f-9ed7-160c3bac4a68)

![틀린 세션 아이디를 저장하고](https://github.com/user-attachments/assets/7a6196f4-5ff3-400d-86a2-51af69c3766b)

![틀린 세션 아이디면 인증되지 않은 요청](https://github.com/user-attachments/assets/0afc6e27-e074-47fe-b6e6-aac081e96618)
