### PR TITLE
♻️ refactor: 트렌딩 포스트 점선을 그림자로 변경, 최신 포스트 점선 제거

### DIFF
--- a/client/src/components/sections/LatestSection.tsx
+++ b/client/src/components/sections/LatestSection.tsx
@@ -40,7 +40,7 @@ export default function LatestSection() {
   return (
     <section className="flex flex-col p-4 min-h-[300px]">
       <SectionHeader icon={Rss} text="최신 포스트" description="최근에 작성된 포스트" iconColor="text-orange-500" />
-      <div className="flex-1 mt-4 p-4 border border-dashed border-gray-500 rounded-lg">
+      <div className="flex-1 mt-4 p-4 rounded-lg">
         <PostCardGrid posts={items} />
         <div ref={observerTarget} className="h-10 flex items-center justify-center mt-4">
           {isFetchingNextPage && <LoadingIndicator />}

--- a/client/src/components/sections/TrendingSection.tsx
+++ b/client/src/components/sections/TrendingSection.tsx
@@ -19,7 +19,10 @@ export default function TrendingSection() {
         description="지난 주 가장 인기있던 포스트"
         iconColor="text-red-500"
       />
-      <div className="flex-1 mt-4 p-4 border border-dashed border-gray-500 rounded-lg">
+      <div
+        className="flex-1 mt-4 p-6 bg-white rounded-2xl transition-all duration-300"
+        style={{ boxShadow: "0 0 15px rgba(0, 0, 0, 0.1)" }}
+      >
         <AnimatedPostGrid posts={posts} />
       </div>
     </section>


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #172

### UI/UX 개선
- TrendingSection의 시각적 계층 구조를 개선하기 위해 균일한 그림자 적용
- 기존의 단방향 그림자는 디자인의 깊이감을 제대로 표현하지 못 해 boxShadow 스타일을 사용, 원하는 방향으로 그림자 제어가 가능하도록 함

# 📋 작업 내용

- TrendingSection
  - boxShadow: '0 0 15px rgba(0, 0, 0, 0.1)' 적용
  - 균일한 그림자 적용
- LatestSection
  - 점선 테두리 제거
  - 기본 rounded-lg 스타일 유지

# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/a927ea1d-8433-4921-93ce-2f48b8239c97)
