### PR TITLE
♻️ refactor: 메인 페이지 Header 버튼 primary로 변경

### DIFF
--- a/client/src/components/RssRegistration/FormInput.tsx
+++ b/client/src/components/RssRegistration/FormInput.tsx
@@ -13,7 +13,7 @@ interface FormInputProps {
 export default function FormInput({ id, label, value, placeholder, type = "text", onChange }: FormInputProps) {
   return (
     <div className="flex items-center gap-4">
-      <Label htmlFor={id} className="text-sm font-medium">
+      <Label htmlFor={id} className="text-sm font-medium text-foreground">
         {label}
       </Label>
       <Input
@@ -22,7 +22,7 @@ export default function FormInput({ id, label, value, placeholder, type = "text"
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
         autoComplete="off"
-        className="flex-grow w-auto "
+        className="flex-grow w-auto border-input focus:border-primary focus-visible:ring-primary placeholder:text-muted-foreground placeholder:text-sm"
         type={type}
       />
     </div>

--- a/client/src/components/RssRegistration/RssRegistrationModal.tsx
+++ b/client/src/components/RssRegistration/RssRegistrationModal.tsx
@@ -33,6 +33,7 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
     handleInputChange,
     isFormValid,
   } = useRegisterModalStore();
+
   const onSuccess = () => {
     alert("RSS 등록이 성공적으로 완료되었습니다.");
     resetInputs();
@@ -59,8 +60,8 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
     <Dialog open={rssOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
-          <DialogTitle>RSS 등록</DialogTitle>
-          <DialogDescription className="flex flex-col">
+          <DialogTitle className="text-foreground font-bold">RSS 등록</DialogTitle>
+          <DialogDescription className="flex flex-col text-muted-foreground">
             <span>RSS 주소 검토 후 운영진이 서비스에 추가합니다.</span>
             <span>검토 및 등록에는 영업일 기준 3-5일이 소요될 수 있습니다.</span>
           </DialogDescription>
@@ -100,7 +101,7 @@ export default function RssRegistrationModal({ onClose, rssOpen }: { onClose: ()
             type="submit"
             onClick={handleRegister}
             disabled={!isFormValid()}
-            className="bg-black hover:bg-gray-800 text-white"
+            className="bg-primary hover:bg-primary/90 text-white"
           >
             등록
           </Button>

--- a/client/src/components/chat/ChatButton.tsx
+++ b/client/src/components/chat/ChatButton.tsx
@@ -4,7 +4,7 @@ import { NavigationMenuLink, navigationMenuTriggerStyle } from "@/components/ui/
 
 export default function ChatButton() {
   return (
-    <NavigationMenuLink className={navigationMenuTriggerStyle()} href="#">
+    <NavigationMenuLink className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`} href="#">
       <div className="flex items-center gap-2">
         <MessageCircleMore size={16} />
         <span>채팅</span>

--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -30,7 +30,7 @@ export default function ChatFooter() {
         value={message}
         onChange={(e) => setMessage(e.target.value)}
       />
-      <Button className="bg-black hover:bg-gray-800 text-white" onClick={handleSendMessage}>
+      <Button className="bg-primary hover:bg-primary/90 text-white" onClick={handleSendMessage}>
         <Send />
       </Button>
     </SheetFooter>

--- a/client/src/components/chat/layout/ChatHeader.tsx
+++ b/client/src/components/chat/layout/ChatHeader.tsx
@@ -13,7 +13,7 @@ export default function ChatHeader({ userCount }: { userCount: number }) {
           <span>
             <Users color="gray" />
           </span>
-          <Badge variant="secondary">{userCount}명 참여중</Badge>
+          <Badge color="bg-secondary/70">{userCount}명 참여중</Badge>
         </div>
       </SheetTitle>
       <Separator />

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -32,23 +32,16 @@ export default function Header() {
   useKeyboardShortcut("k", () => toggleModal("search"), true);
 
   return (
-    <div className="border-b">
+    <div className="border-b border-primary/20">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-20 items-center justify-between">
-          {/* Logo */}
           <div className="flex-shrink-0">
             <img className="h-14 w-auto cursor-pointer" src={logo} alt="Logo" onClick={() => location.reload()} />
           </div>
-
-          {/* Desktop Navigation */}
           <DesktopNavigation toggleModal={toggleModal} />
-
-          {/* Mobile Navigation */}
           <MobileNavigation toggleModal={toggleModal} />
         </div>
       </div>
-
-      {/* Modals */}
       <AnimatePresence>
         {modals.rss && <RssRegistrationModal onClose={() => toggleModal("rss")} rssOpen={modals.rss} />}
         {modals.search && <SearchModal onClose={() => toggleModal("search")} />}
@@ -67,26 +60,24 @@ function DesktopNavigation({ toggleModal }: { toggleModal: (modalType: "search" 
               <Chat />
             </div>
           </NavigationMenuItem>
-
-          {/* Search Button */}
           <NavigationMenuItem>
             <div className="flex h-full items-center">
               <SearchButton handleSearchModal={() => toggleModal("search")} />
             </div>
           </NavigationMenuItem>
-
-          {/* Login Menu */}
           <NavigationMenuItem>
-            <NavigationMenuLink className={navigationMenuTriggerStyle()} onClick={() => toggleModal("login")} href="#">
+            <NavigationMenuLink
+              className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`}
+              onClick={() => toggleModal("login")}
+              href="#"
+            >
               로그인
             </NavigationMenuLink>
           </NavigationMenuItem>
-
-          {/* Blog Registration Menu */}
           <NavigationMenuItem>
-            <NavigationMenuLink className={navigationMenuTriggerStyle()} onClick={() => toggleModal("rss")} href="#">
+            <Button variant="default" onClick={() => toggleModal("rss")} className="bg-primary hover:bg-primary/90">
               블로그 등록
-            </NavigationMenuLink>
+            </Button>
           </NavigationMenuItem>
         </NavigationMenuList>
       </NavigationMenu>
@@ -99,13 +90,13 @@ function MobileNavigation({ toggleModal }: { toggleModal: (modalType: "search" |
     <div className="md:hidden">
       <Sheet>
         <SheetTrigger asChild>
-          <Button variant="outline" size="icon">
+          <Button variant="outline" size="icon" className="hover:border-primary hover:text-primary">
             <Menu className="h-4 w-4" />
           </Button>
         </SheetTrigger>
         <SheetContent>
           <SheetHeader>
-            <SheetTitle>메뉴</SheetTitle>
+            <SheetTitle className="text-primary">메뉴</SheetTitle>
           </SheetHeader>
           <SideBar
             handleRssModal={() => toggleModal("rss")}

--- a/client/src/components/search/SearchButton.tsx
+++ b/client/src/components/search/SearchButton.tsx
@@ -4,7 +4,11 @@ import { NavigationMenuLink, navigationMenuTriggerStyle } from "@/components/ui/
 
 export default function SearchButton({ handleSearchModal }: { handleSearchModal: () => void }) {
   return (
-    <NavigationMenuLink className={navigationMenuTriggerStyle()} onClick={handleSearchModal} href="#">
+    <NavigationMenuLink
+      className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`}
+      onClick={handleSearchModal}
+      href="#"
+    >
       <div className="flex items-center gap-2">
         <Search size={16} />
         <span>검색</span>

--- a/client/src/components/sections/TrendingSection.tsx
+++ b/client/src/components/sections/TrendingSection.tsx
@@ -16,7 +16,7 @@ export default function TrendingSection() {
       <SectionHeader
         icon={TrendingUp}
         text="트렌딩 포스트"
-        description="지난 주 가장 인기있던 포스트"
+        description="오늘 가장 인기있는 포스트"
         iconColor="text-red-500"
       />
       <div

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,8 +21,8 @@ html {
     --popover-foreground: 0 0% 3.9%;
     --primary: 145 63% 42%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 96.1%;
-    --secondary-foreground: 0 0% 9%;
+    --secondary: 145 58% 35%;
+    --secondary-foreground: 0 0% 98%;
     --muted: 0 0% 96.1%;
     --muted-foreground: 0 0% 45.1%;
     --accent: 0 0% 96.1%;
@@ -49,7 +49,7 @@ html {
     --popover-foreground: 0 0% 98%;
     --primary: 145 63% 42%;
     --primary-foreground: 0 0% 98%;
-    --secondary: 0 0% 14.9%;
+    --secondary: 145 58% 35%;
     --secondary-foreground: 0 0% 98%;
     --muted: 0 0% 14.9%;
     --muted-foreground: 0 0% 63.9%;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -19,7 +19,7 @@ html {
     --card-foreground: 0 0% 3.9%;
     --popover: 0 0% 100%;
     --popover-foreground: 0 0% 3.9%;
-    --primary: 0 0% 9%;
+    --primary: 145 63% 42%;
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 96.1%;
     --secondary-foreground: 0 0% 9%;
@@ -31,7 +31,7 @@ html {
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 89.8%;
     --input: 0 0% 89.8%;
-    --ring: 0 0% 3.9%;
+    --ring: 145 63% 42%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -39,6 +39,7 @@ html {
     --chart-5: 27 87% 67%;
     --radius: 0.5rem;
   }
+
   .dark {
     --background: 0 0% 3.9%;
     --foreground: 0 0% 98%;
@@ -46,8 +47,8 @@ html {
     --card-foreground: 0 0% 98%;
     --popover: 0 0% 3.9%;
     --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
-    --primary-foreground: 0 0% 9%;
+    --primary: 145 63% 42%;
+    --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;
     --muted: 0 0% 14.9%;
@@ -58,7 +59,7 @@ html {
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 14.9%;
     --input: 0 0% 14.9%;
-    --ring: 0 0% 83.1%;
+    --ring: 145 63% 42%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #173 

### 컴포넌트별 Primary 색상 적용
- Header, 버튼 등 주요 UI 요소들에 primary 색상(#27ae60) 적용
- NavigationMenu 관련 컴포넌트(ChatButton, SearchButton)에는 hover 시 primary 색상이 적용되도록 구현
- 모바일 메뉴의 경우에도 동일한 색상 시스템 적용하여 일관성 유지

### Primary 색상 충돌 해결
- shadcn/ui의 기본 테마에서 link hover시 primary 색상을 사용하는 문제 발견
- 일반 링크와 NavigationMenu 링크를 구분해 스타일 적용
- 클래스 명시를 통해 의도한 컴포넌트에만 primary 색상이 적용되도록 수정

# 📋 작업 내용

1. global.css 수정
   - primary 색상을 HSL 값(145 63% 42%)으로 설정

2. Header 컴포넌트 수정
   - border 색상을 primary/20으로 변경
   - 로그인, 블로그 등록 버튼에 primary 색상 적용
   - 모바일 메뉴 관련 요소들에 primary 색상 적용

3. NavigationMenu 컴포넌트 수정
   - ChatButton, SearchButton에 hover 시 텍스트 색상 및 배경색 변경 로직 추가

# 📷 스크린 샷

https://github.com/user-attachments/assets/88af5b45-c880-4591-aba5-cd91f627afd4


