### PR TITLE
⚡️ perf: 서버 안정성 향상을 위한 채팅 서버 최대 사용자 제한 추가

### DIFF
--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -29,7 +29,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(private readonly redisService: RedisService) {}
 
   async handleConnection(client: Socket) {
-    const userCount = this.server.sockets.sockets.size;
+    const userCount = this.server.engine.clientsCount;
     if (userCount > MAX_CLIENTS) {
       client.emit('maximum_exceeded', {
         message: '채팅 서버의 한계에 도달했습니다. 잠시후 재시도 해주세요.',
@@ -57,7 +57,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   handleDisconnect() {
     this.server.emit('updateUserCount', {
-      userCount: this.server.sockets.sockets.size,
+      userCount: this.server.engine.clientsCount,
     });
   }
 


### PR DESCRIPTION
# 🔨 테스크
### Issue
-   close #195 

# 📋 작업 내용

- 웹소켓 채팅서버 최대 커넥션 수 제한
[4주차 스프린트 리뷰회의](https://balsam-barometer-716.notion.site/Week-4-09a81378938f43399603575ec409f506?pvs=4)에서 발의된 안건을 반영하기 위해 웹소켓 서버에서 `handleConnection` 을 수행할 때 서버의 커넥션 수를 확인하고, 500명 이상이면 아래와 같은 이벤트를 connection을 요청한 클라이언트에게 반환합니다.

`error`, `message: '채팅 서버의 한계에 도달했습니다. 잠시후 재시도 해주세요.'`