### PR TITLE
📦 chore: 도메인 이전에 따른 경로 변수 변경

### DIFF
--- a/client/src/api/instance.ts
+++ b/client/src/api/instance.ts
@@ -6,7 +6,7 @@ export const api = axios.create({
 });
 
 export const axiosInstance = axios.create({
-  baseURL: "https://api.denamu.shop",
+  baseURL: "https://api.denamu.site",
   timeout: 10000,
   withCredentials: true,
 });

--- a/client/src/hooks/queries/useTrendingPosts.ts
+++ b/client/src/hooks/queries/useTrendingPosts.ts
@@ -14,7 +14,7 @@ export const useTrendingPosts = () => {
   });
 
   useEffect(() => {
-    const eventSource = new EventSource("https://api.denamu.shop/api/feed/trend/sse");
+    const eventSource = new EventSource("https://api.denamu.site/api/feed/trend/sse");
 
     eventSource.onmessage = (event) => {
       try {

--- a/client/src/store/useChatStore.ts
+++ b/client/src/store/useChatStore.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 
 import { ChatType } from "@/types/chat";
 
-const CHAT_SERVER_URL = "https://api.denamu.shop";
+const CHAT_SERVER_URL = "https://api.denamu.site";
 
 interface ChatStore {
   chatHistory: ChatType[];

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -21,7 +21,7 @@ async function bootstrap() {
     origin: [
       'http://localhost:5173',
       'https://denamu.netlify.app',
-      'https://denamu.shop',
+      'https://denamu.site',
     ],
     credentials: true,
   });


### PR DESCRIPTION
# 🔨 테스크
### Issue
-   close #199 

# 📋 작업 내용

- CloudFlare 및 Netlify에 denamu.site 설정
![image](https://github.com/user-attachments/assets/67067ffe-ba0d-424d-b0fe-ebedf226aa4f)
![image](https://github.com/user-attachments/assets/70d96cc3-3dcb-42db-a3f4-7499a9ac45dc)
![image](https://github.com/user-attachments/assets/2488a380-d225-45fe-8cce-807dc7566305)

- FE, BE 기존 도메인 변수 변경
`instance.ts` : axios에 사용되는 baseURL을 수정하였습니다.
`useTrendingPosts.ts` : sse 커넥션에 활용되는 URL을 변경하였습니다.
`useChatStore.ts` : web socket 커넥션에 사용되는 http hand-shake URL을 변경하였습니다.
`main.ts` : NestJS의 CORS 허용 URL을 변경하였습니다.
