### PR TITLE
♻️ refactor: 조회수 증가 API GET에서 POST로 변경 

### DIFF
--- a/client/src/api/services/view.ts
+++ b/client/src/api/services/view.ts
@@ -6,7 +6,7 @@ interface ViewResponse {
 
 export const view = {
   increment: async (feedId: number): Promise<ViewResponse> => {
-    const response = await axiosInstance.get(`/api/feed/${feedId}`);
+    const response = await axiosInstance.post(`/api/feed/${feedId}`);
     return response.data;
   },
 };

--- a/client/src/hooks/common/usePostCardActions.ts
+++ b/client/src/hooks/common/usePostCardActions.ts
@@ -10,7 +10,7 @@ interface PostWithState {
 }
 
 export const usePostCardActions = (post: Post) => {
-  const { refetch } = usePostViewIncrement(post.id);
+  const { mutate } = usePostViewIncrement(post.id);
 
   const openPost = ({ post }: Pick<PostWithState, "post">): PostWithState => {
     const link = document.createElement("a");
@@ -23,8 +23,10 @@ export const usePostCardActions = (post: Post) => {
 
   const incrementView = ({ post, isWindowOpened }: PostWithState): PostWithState => {
     if (isWindowOpened) {
-      refetch().catch((error) => {
-        console.error("조회수 증가 실패: ", error);
+      mutate(undefined, {
+        onError: (error) => {
+          console.error("조회수 증가 실패", error);
+        },
       });
     }
     return { post, isWindowOpened };

--- a/client/src/hooks/queries/usePostViewIncrement.ts
+++ b/client/src/hooks/queries/usePostViewIncrement.ts
@@ -1,11 +1,8 @@
 import { view } from "@/api/services/view";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 
 export const usePostViewIncrement = (feedId: number) => {
-  return useQuery({
-    queryKey: ["post-view", feedId],
-    queryFn: () => view.increment(feedId),
-    enabled: false,
-    retry: false,
+  return useMutation({
+    mutationFn: () => view.increment(feedId),
   });
 };


### PR DESCRIPTION


# 🔨 테스크

### Issue

-   close #209 

### API 메서드 변경 배경
- 기존 조회수 증가 API가 GET 메서드를 사용하고 있었으나, 리소스를 수정하는 작업이므로 POST가 더 RESTful함
- GET 요청은 캐싱되거나 브라우저에서 자동으로 재시도될 수 있어 조회수 증가와 같은 수정 작업에는 적합하지 않음

### React Query 패턴 개선
- GET -> POST 변경에 맞춰 useQuery에서 useMutation으로 변경
- 기존 useQuery는 enabled: false와 같은 불필요한 옵션들이 있었으나, useMutation으로 변경하며 코드가 더 간결해짐
- 사용자 인터랙션(게시글 클릭)에 의한 데이터 수정이므로 useMutation이 더 적절한 패턴임

# 📋 작업 내용

- view.increment API 호출 메서드를 GET에서 POST로 변경
- usePostViewIncrement 훅을 useQuery에서 useMutation으로 변경
 - enabled, retry 등 불필요한 옵션 제거
- usePostCardActions 내 refetch를 mutate로 변경
- useQuery와 useMutation의 차이점에 대한 문서 추가
  - https://balsam-barometer-716.notion.site/React-Query-5-useQuery-useMutation-14ae624056ec80c289d1c43ac09d9638?pvs=4

# 📷 스크린 샷

<img width="867" alt="image" src="https://github.com/user-attachments/assets/e35b280d-abf1-4492-8763-645c4306b633">
