### PR TITLE
♻️ refactor: trending posts API를 SSE로 단일화

### DIFF
--- a/client/src/api/services/posts.ts
+++ b/client/src/api/services/posts.ts
@@ -1,11 +1,7 @@
 import { axiosInstance } from "@/api/instance";
-import { InfiniteScrollResponse, LatestPostsApiResponse, TrendingPostsApiResponse, Post } from "@/types/post";
+import { InfiniteScrollResponse, LatestPostsApiResponse, Post } from "@/types/post";
 
 export const posts = {
-  trending: async (): Promise<TrendingPostsApiResponse> => {
-    const response = await axiosInstance.get<TrendingPostsApiResponse>("/api/feed/trend");
-    return response.data;
-  },
   latest: async (params: { limit: number; lastId: number }): Promise<InfiniteScrollResponse<Post>> => {
     const response = await axiosInstance.get<LatestPostsApiResponse>("/api/feed", {
       params: {

--- a/client/src/hooks/queries/useTrendingPosts.ts
+++ b/client/src/hooks/queries/useTrendingPosts.ts
@@ -1,15 +1,14 @@
 import { useEffect } from "react";
 
-import { posts } from "@/api/services/posts";
 import { TrendingPostsApiResponse } from "@/types/post";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useTrendingPosts = () => {
   const queryClient = useQueryClient();
 
-  const query = useQuery<TrendingPostsApiResponse, Error>({
+  const query = useQuery<TrendingPostsApiResponse>({
     queryKey: ["trending-posts"],
-    queryFn: posts.trending,
+    queryFn: () => Promise.resolve({ message: "", data: [] }),
     refetchOnWindowFocus: false,
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #211

### API 단일화 배경
- 트렌딩 포스트 데이터를 REST API(/api/feed/trend)와 SSE(/api/feed/trend/sse) 두 가지 방식으로 받아오고 있었음
- 초기 데이터 로딩 시 REST API를 호출하고, 실시간 업데이트를 SSE로 받는 구조였음
- 불필요한 중복 호출을 제거하고 로직을 단순화하기 위해 SSE로 통합

### 구현 시 고려사항
- SSE 연결 즉시 서버가 초기 데이터를 보내주는 방식으로 변경
- useQuery의 초기값 처리 방식 (빈 배열로 시작)

# 📋 작업 내용
- `/api/feed/trend` REST API 엔드포인트와 관련 메서드 제거
 ```ts
 // posts.ts에서 trending 메서드 제거
 export const posts = {
   latest: async (params: { limit: number; lastId: number }) => {
     // ... 기존 코드 유지
   },
 };

- useTrendingPosts 훅 리팩토링
```ts
export const useTrendingPosts = () => {
  const query = useQuery<TrendingPostsApiResponse>({
    queryKey: ["trending-posts"],
    queryFn: () => Promise.resolve({ message: "", data: [] }),
    refetchOnWindowFocus: false,
  });

  useEffect(() => {
    const eventSource = new EventSource("https://api.denamu.site/api/feed/trend/sse");
  }, [queryClient]);

  return { ...query, posts: query.data?.data || [] };
};
```