### PR TITLE
✨ feat: 최신 게시글 실시간 업데이트 API 구현 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,10 @@ jobs:
             echo "DB_PASS=${{ secrets.RSS_NOTIFIER_DB_PASSWORD }}" >> .env
             echo "DB_TABLE=${{ secrets.RSS_NOTIFIER_DB_TABLE }}" >> .env
             echo "TIME_INTERVAL=${{ vars.RSS_NOTIFIER_TIME_INTERVAL }}" >> .env
+            echo "REDIS_HOST=${{secrets.REDIS_HOST }}" >> .env
+            echo "REDIS_PORT=${{secrets.REDIS_PORT}}" >> .env
+            echo "REDIS_USERNAME=${{secrets.REDIS_USERNAME}}" >> .env
+            echo "REDIS_PASSWORD=${{secrets.REDIS_PASSWORD}}" >> .env
 
             npm ci
             tsc

--- a/rss-notifier/package-lock.json
+++ b/rss-notifier/package-lock.json
@@ -8,6 +8,7 @@
         "dotenv": "^16.4.5",
         "fast-xml-parser": "^4.5.0",
         "html-escaper": "^3.0.3",
+        "ioredis": "^5.4.1",
         "js-yaml": "^4.1.0",
         "mysql2": "^3.11.3",
         "node-cron": "^3.0.3",
@@ -38,6 +39,12 @@
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
+      "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.9.0",
@@ -145,6 +152,15 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/color": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
@@ -221,6 +237,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/delayed-stream": {
@@ -436,6 +469,30 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
+    "node_modules/ioredis": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.4.1.tgz",
+      "integrity": "sha512-2YZsvl7jopIa1gaePkeMtd9rAcSjOOjPtpcLlOeusyO+XH2SK5ZcT+UCrElPP+WVIInh2TzeI4XW9ENaSLVVHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "^1.1.1",
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.4",
+        "denque": "^2.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.isarguments": "^3.1.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
@@ -472,6 +529,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
+      "license": "MIT"
     },
     "node_modules/logform": {
       "version": "2.6.1",
@@ -632,6 +701,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/rss-parser": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/rss-parser/-/rss-parser-3.13.0.tgz",
@@ -714,6 +804,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/rss-notifier/package.json
+++ b/rss-notifier/package.json
@@ -3,6 +3,7 @@
     "dotenv": "^16.4.5",
     "fast-xml-parser": "^4.5.0",
     "html-escaper": "^3.0.3",
+    "ioredis": "^5.4.1",
     "js-yaml": "^4.1.0",
     "mysql2": "^3.11.3",
     "node-cron": "^3.0.3",

--- a/rss-notifier/src/db-access.ts
+++ b/rss-notifier/src/db-access.ts
@@ -21,7 +21,7 @@ export const pool = mysql.createPool({
 
 export const createRedisClient = async () => {
   return new Redis({
-    host: process.env.ReDIS_HOST,
+    host: process.env.REDIS_HOST,
     port: parseInt(process.env.REDIS_PORT),
     username: process.env.REDIS_USERNAME,
     password: process.env.REDIS_PASSWORD,

--- a/rss-notifier/src/db-access.ts
+++ b/rss-notifier/src/db-access.ts
@@ -98,6 +98,7 @@ export const deleteRecentFeedStartId = async () => {
     if (keys.length > 0) {
       redis.del(...keys);
     }
+    redis.set("feed:trend:exist", "false");
   } catch (error) {
     logger.error(
       `Redis의 feed:recent:*를 삭제하는 도중 에러가 발생했습니다. 에러 내용: ${error}`,
@@ -128,6 +129,7 @@ export const setRecentFeedList = async (startId: number) => {
     for (const feed of resultList) {
       await redis.hset(`feed:recent:${feed.id}`, feed);
     }
+    redis.set("feed:trend:exist", "true");
   } catch (error) {
     logger.error(
       `Redis의 feed:recent:*를 저장하는 도중 에러가 발생했습니다. 에러 내용: ${error}`,

--- a/rss-notifier/src/db-access.ts
+++ b/rss-notifier/src/db-access.ts
@@ -2,6 +2,8 @@ import logger from "./logger.js";
 import { FeedObj, FeedDetail } from "./types.js";
 import * as dotenv from "dotenv";
 import * as mysql from "mysql2/promise";
+import Redis from "ioredis";
+import * as process from "node:process";
 
 dotenv.config({
   path: process.env.NODE_ENV === "production" ? "rss-notifier/.env" : ".env",
@@ -16,6 +18,15 @@ export const pool = mysql.createPool({
   database: process.env.DB_NAME,
   connectionLimit: CONNECTION_LIMIT,
 });
+
+export const careateRedisClient = async () => {
+  return new Redis({
+    host: process.env.ReDIS_HOST,
+    port: parseInt(process.env.REDIS_PORT),
+    username: process.env.REDIS_USERNAME,
+    password: process.env.REDIS_PASSWORD,
+  });
+};
 
 export const executeQuery = async (query: string, params: any[] = []) => {
   let connection;
@@ -60,6 +71,69 @@ export const insertFeeds = async (resultData: FeedDetail[]) => {
   } catch (error) {
     logger.error(`누락된 피드 데이터가 존재합니다. 에러 내용: ${error}`);
   }
+  logger.info(
+    `${successCount}개의 피드 데이터가 성공적으로 데이터베이스에 삽입되었습니다.`,
+  );
+};
 
-  logger.info(`${successCount}개의 피드 데이터가 성공적으로 삽입되었습니다.`);
+export const getRecentFeedStartId = async () => {
+  let startId;
+  try {
+    const query = `SELECT id
+                       FROM feed
+                       ORDER BY id desc
+                       LIMIT 1`;
+    const result = await executeQuery(query);
+    startId = result.length > 0 ? result[0].id + 1 : 1;
+  } catch (error) {
+    logger.error(`디비 접근에 실패했습니다. 에러 내용: ${error}`);
+  }
+  return startId;
+};
+
+export const deleteRecentFeedStartId = async () => {
+  const redis = await careateRedisClient();
+  try {
+    const keys = await redis.keys("feed:recent:*");
+    if (keys.length > 0) {
+      redis.del(...keys);
+    }
+  } catch (error) {
+    logger.error(
+      `Redis의 feed:recent:*를 삭제하는 도중 에러가 발생했습니다. 에러 내용: ${error}`,
+    );
+    if (redis) redis.disconnect();
+  } finally {
+    if (redis) redis.quit();
+  }
+  logger.info(`Redis의 feed:recent:* 값이 정상적으로 삭제되었습니다.`);
+};
+
+export const setRecentFeedList = async (startId: number) => {
+  const redis = await careateRedisClient();
+  try {
+    const query = `SELECT f.id,
+                              f.created_at    AS createdAt,
+                              f.title,
+                              f.view_count    AS viewCount,
+                              f.path,
+                              f.thumbnail,
+                              f.blog_id       AS blogId,
+                              r.blog_platform AS blogPlatform,
+                              r.name          AS author
+                       FROM feed f
+                                JOIN rss_accept r ON f.blog_id = r.id
+                       WHERE f.id >= ${startId}`;
+    const resultList = await executeQuery(query);
+    for (const feed of resultList) {
+      await redis.hset(`feed:recent:${feed.id}`, feed);
+    }
+  } catch (error) {
+    logger.error(
+      `Redis의 feed:recent:*를 저장하는 도중 에러가 발생했습니다. 에러 내용: ${error}`,
+    );
+  } finally {
+    if (redis) redis.quit();
+  }
+  logger.info(`Redis의 feed:recent:* 값이 정상적으로 저장되었습니다.`);
 };

--- a/rss-notifier/src/rss-notifier.ts
+++ b/rss-notifier/src/rss-notifier.ts
@@ -145,6 +145,5 @@ export const performTask = async () => {
 
   logger.info(`총 ${result.length}개의 새로운 피드가 있습니다.`);
   const recentFeedStartId = await insertFeeds(result);
-  console.log(recentFeedStartId);
   await setRecentFeedList(recentFeedStartId);
 };

--- a/rss-notifier/src/rss-notifier.ts
+++ b/rss-notifier/src/rss-notifier.ts
@@ -3,7 +3,6 @@ import "dotenv/config";
 import {
   selectAllRss,
   insertFeeds,
-  getRecentFeedStartId,
   deleteRecentFeedStartId,
   setRecentFeedList,
 } from "./db-access.js";
@@ -117,7 +116,7 @@ export const performTask = async () => {
   const rssObjects = await selectAllRss();
 
   if (rssObjects.length === 0) {
-    logger.info("등록된 RSS 피드가 없습니다.");
+    logger.info("등록된 RSS가 없습니다.");
     return;
   }
   const currentTime = new Date();
@@ -125,9 +124,8 @@ export const performTask = async () => {
   let idx = 0;
   const newFeeds = await Promise.all(
     rssObjects.map(async (rssObj) => {
-      idx += 1;
       logger.info(
-        `[${idx}번째 rss [${rssObj.rssUrl}] 에서 데이터 조회하는 중...`,
+        `[${++idx}번째 rss [${rssObj.rssUrl}] 에서 데이터 조회하는 중...`,
       );
       return await findNewFeeds(rssObj, currentTime.setMinutes(0, 0, 0));
     }),
@@ -146,7 +144,7 @@ export const performTask = async () => {
   }
 
   logger.info(`총 ${result.length}개의 새로운 피드가 있습니다.`);
-  const recentFeedStartId = await getRecentFeedStartId();
-  await insertFeeds(result);
+  const recentFeedStartId = await insertFeeds(result);
+  console.log(recentFeedStartId);
   await setRecentFeedList(recentFeedStartId);
 };

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -2,4 +2,6 @@ export const redisKeys = {
   FEED_ALL_IP_KEY: `feed:*:ip`,
   FEED_TREND_KEY: `feed:trend`,
   FEED_ORIGIN_TREND_KEY: 'feed:origin_trend',
+  FEED_RECENT_KEY: 'feed:recent',
+  FEED_RECENT_ALL_KEY: 'feed:recent:*',
 };

--- a/server/src/feed/feed.api-docs.ts
+++ b/server/src/feed/feed.api-docs.ts
@@ -300,24 +300,19 @@ export function ApiGetRecentFeedList() {
         },
       },
       example: {
-        connect: {
-          summary: '최신 피드 업데이트 완료',
-          value: {
-            message: '최신 피드 업데이트 완료',
-            data: [
-              {
-                id: 1,
-                author: '블로그 이름',
-                blogPlatform: 'etc',
-                title: '게시글 제목',
-                path: 'https://test1.com/1',
-                createdAt: '2024-11-24T01:00:00.000Z',
-                thumbnail: 'https://test1.com/test.png',
-                viewCount: 0,
-              },
-            ],
+        message: '최신 피드 업데이트 완료',
+        data: [
+          {
+            id: 1,
+            author: '블로그 이름',
+            blogPlatform: 'etc',
+            title: '게시글 제목',
+            path: 'https://test1.com/1',
+            createdAt: '2024-11-24T01:00:00.000Z',
+            thumbnail: 'https://test1.com/test.png',
+            viewCount: 0,
           },
-        },
+        ],
       },
     }),
   );

--- a/server/src/feed/feed.api-docs.ts
+++ b/server/src/feed/feed.api-docs.ts
@@ -266,7 +266,7 @@ export function ApiUpdateFeedViewCount() {
   );
 }
 
-export function ApiGetLatestFeedList() {
+export function ApiGetRecentFeedList() {
   return applyDecorators(
     ApiOperation({
       summary: '최신 게시글 업데이트 API',

--- a/server/src/feed/feed.api-docs.ts
+++ b/server/src/feed/feed.api-docs.ts
@@ -265,3 +265,70 @@ export function ApiUpdateFeedViewCount() {
     }),
   );
 }
+
+export function ApiGetLatestFeedList() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '최신 게시글 업데이트 API',
+    }),
+    ApiOkResponse({
+      description: 'Ok',
+      schema: {
+        properties: {
+          message: {
+            type: 'string',
+          },
+          data: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'number' },
+                author: { type: 'string' },
+                blogPlatform: { type: 'string' },
+                title: { type: 'string' },
+                path: { type: 'string' },
+                createdAt: {
+                  type: 'string',
+                  format: 'date-time',
+                },
+                thumbnail: { type: 'string' },
+                viewCount: { type: 'number' },
+              },
+            },
+          },
+        },
+      },
+      examples: {
+        connect: {
+          summary: '최신 피드 업데이트 완료',
+          value: {
+            message: '최신 피드 업데이트 완료',
+            data: [
+              {
+                id: 1,
+                author: '블로그 이름',
+                blogPlatform: 'etc',
+                title: '게시글 제목',
+                path: 'https://test1.com/1',
+                createdAt: '2024-11-24T01:00:00.000Z',
+                thumbnail: 'https://test1.com/test.png',
+                viewCount: 0,
+              },
+              {
+                id: 2,
+                author: '블로그 이름',
+                blogPlatform: 'etc',
+                title: '게시글 제목',
+                path: 'https://test2.com/1',
+                createdAt: '2024-11-24T02:00:00.000Z',
+                thumbnail: 'https://test2.com/test.png',
+                viewCount: 0,
+              },
+            ],
+          },
+        },
+      },
+    }),
+  );
+}

--- a/server/src/feed/feed.api-docs.ts
+++ b/server/src/feed/feed.api-docs.ts
@@ -269,7 +269,7 @@ export function ApiUpdateFeedViewCount() {
 export function ApiGetRecentFeedList() {
   return applyDecorators(
     ApiOperation({
-      summary: '최신 게시글 업데이트 API',
+      summary: '최신 피드 업데이트 API',
     }),
     ApiOkResponse({
       description: 'Ok',
@@ -299,7 +299,7 @@ export function ApiGetRecentFeedList() {
           },
         },
       },
-      examples: {
+      example: {
         connect: {
           summary: '최신 피드 업데이트 완료',
           value: {
@@ -313,16 +313,6 @@ export function ApiGetRecentFeedList() {
                 path: 'https://test1.com/1',
                 createdAt: '2024-11-24T01:00:00.000Z',
                 thumbnail: 'https://test1.com/test.png',
-                viewCount: 0,
-              },
-              {
-                id: 2,
-                author: '블로그 이름',
-                blogPlatform: 'etc',
-                title: '게시글 제목',
-                path: 'https://test2.com/1',
-                createdAt: '2024-11-24T02:00:00.000Z',
-                thumbnail: 'https://test2.com/test.png',
                 viewCount: 0,
               },
             ],

--- a/server/src/feed/feed.controller.ts
+++ b/server/src/feed/feed.controller.ts
@@ -22,7 +22,7 @@ import {
   ApiSearchFeed,
   ApiUpdateFeedViewCount,
   ApiGetTrendSse,
-  ApiGetLatestFeedList,
+  ApiGetRecentFeedList,
 } from './feed.api-docs';
 import { Response } from 'express';
 import { Observable } from 'rxjs';
@@ -109,7 +109,7 @@ export class FeedController {
     );
   }
 
-  @ApiGetLatestFeedList()
+  @ApiGetRecentFeedList()
   @Get('/recent')
   @HttpCode(HttpStatus.OK)
   async getRecentFeedList() {

--- a/server/src/feed/feed.controller.ts
+++ b/server/src/feed/feed.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiSearchFeed,
   ApiUpdateFeedViewCount,
   ApiGetTrendSse,
+  ApiGetLatestFeedList,
 } from './feed.api-docs';
 import { Response } from 'express';
 import { Observable } from 'rxjs';
@@ -105,6 +106,16 @@ export class FeedController {
     await this.feedService.updateFeedViewCount(feedId, ip, cookie, response);
     return ApiResponse.responseWithNoContent(
       '요청이 성공적으로 처리되었습니다.',
+    );
+  }
+
+  @ApiGetLatestFeedList()
+  @Get('/recent')
+  @HttpCode(HttpStatus.OK)
+  async getRecentFeedList() {
+    return ApiResponse.responseWithData(
+      '최신 피드 업데이트 완료',
+      await this.feedService.getRecentFeedList(),
     );
   }
 }

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -194,4 +194,22 @@ export class FeedService {
       await redis.del(...keys);
     }
   }
+
+  async getRecentFeedList() {
+    const redis = this.redisService.redisClient;
+    const recentFeedList = [];
+    if ((await redis.get(redisKeys.FEED_RECENT_KEY)) === 'true') {
+      const keys = await redis.keys(redisKeys.FEED_RECENT_ALL_KEY);
+      if (keys.length > 0) {
+        for (const key of keys) {
+          recentFeedList.push(await redis.hgetall(key));
+        }
+      }
+    }
+    return recentFeedList.sort((currentFeed, nextFeed) => {
+      const dateCurrent = new Date(currentFeed.createdAt);
+      const dateNext = new Date(nextFeed.createdAt);
+      return dateNext.getTime() - dateCurrent.getTime();
+    });
+  }
 }


### PR DESCRIPTION
# 🔨 테스크
### Issue

-   close #203

### keys 이슈
- keys 명령이 실행되는 도중에는 Redis의 모든 명령을 블로킹합니다.
- 현재는 데이터가 몇 개 없어서 keys를 사용해도 큰 문제는 없지만 O(N)의 시간 복잡도라도 1만개, 10만개 등 늘어나면 성능 이슈가 발생할 수 있습니다.
- 추후에 성능 이슈가 발생한다면 `SCAN`으로 방법을 바꿀 수 있을 것 같습니다.
- 저는 SCAN을 사용하진 않았지만 `feed:recent`라는 key를 두어 recent 피드가 존재하는지 파악할 수 있도록 해놓았습니다.
- (PR을 작성하면서 생각해보니, 객체를 직렬화해서 List 하나에만 담아두는 것이 더 좋은 방법일 것 같습니다.)

### 소소한 이슈
- 처음에는 Redis 공식 문서에 있던 Node-redis를 사용했으나 Hash 데이터를 저장할 때 알 수 없는 에러가 발생했습니다.
- 혹시나 싶어 ioredis로 변경하니 기존 코드를 거의 수정하지 않고 에러 없이 사용할 수 있었습니다.
- 정보를 좀 더 찾아보니 Node-redis는 직렬화에 있어서 엄격한 편이고 ioredis는 유연하게 처리한다고 합니다.

### 피드에 추가적인 정보가 필요했습니다
- 처음에는 블로그에서 바로 가져온 데이터를 Redis에 저장하고 프론트에 전송할 생각이었습니다.
- 다만 이렇게 하면 blogPlatform 데이터나 author 데이터를 가져올 수 없는 문제가 생겼습니다.
- 그래서 DB에 저장되어던 가장 최근 피드의 ID를 구해서 새로 업데이트된 피드 ID를 계산했습니다.
- 피드를 저장하고 가지고 있던 ID를 활용해서 `rss_accept` 테이블과 JOIN 연산을 진행했습니다.
- 결과적으로 추가적인 데이터를 가져온 뒤 Redis에 저장할 수 있었습니다.

# 📋 작업 내용

- rss-notifier에서 최신 피드가 업데이트되면 Redis에 저장하는 로직 추가
- 업데이트된 피드가 없으면 캐싱된 데이터를 Redis에서 삭제
- `api/feed/recent`로 요청을 보내면 최신 피드 목록을 Redis에서 가져와 전송

# 📷 스크린 샷
![DB에 저장된 피드 목록](https://github.com/user-attachments/assets/3b839832-c4bf-4bc1-ae86-c7e34241af96)
- 데이터가 업데이트된 경우
![레디스에 저장된 새로운 피드 확인](https://github.com/user-attachments/assets/d41dc26c-c4f3-46d6-94c1-b6ef16c7c422)
![데이터가 있는 경우](https://github.com/user-attachments/assets/43f685ad-6989-4625-8531-12220d0118df)

---
- 업데이트가 없어서 데이터가 삭제된 경우
![새로 업데이트된 피드가 없을 경우 다 삭제](https://github.com/user-attachments/assets/273f236a-d749-4887-803e-60bc61d41708)
![데이터가 없을 경우](https://github.com/user-attachments/assets/24013fe0-dabe-4cb0-be0d-89cd8383a2d1)

---
- swagger
![스웨거 example](https://github.com/user-attachments/assets/9af9f631-5a47-4e1f-b292-ad907ac51888)

![스웨거 스키마](https://github.com/user-attachments/assets/1876ce31-2406-40c8-ae97-7e1663a36d47)


