### PR TITLE
🐛 fix: 쿠키 Redis String Key 일 경우 Login 보안 버그 수정

### DIFF
--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -5,12 +5,13 @@ import {
   HttpCode,
   HttpStatus,
   Post,
+  Req,
   Res,
   UseGuards,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
-import { Response } from 'express';
+import { Request, Response } from 'express';
 import { AdminService } from './admin.service';
 import { RegisterAdminDto } from './dto/register-admin.dto';
 import { ApiTags } from '@nestjs/swagger';
@@ -35,8 +36,9 @@ export class AdminController {
   async loginAdmin(
     @Body() loginAdminDto: LoginAdminDto,
     @Res({ passthrough: true }) response: Response,
+    @Req() request: Request,
   ) {
-    await this.adminService.loginAdmin(loginAdminDto, response);
+    await this.adminService.loginAdmin(loginAdminDto, response, request);
     return ApiResponse.responseWithNoContent(
       '로그인이 성공적으로 처리되었습니다.',
     );

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -36,7 +36,7 @@ export class AdminService {
     const sessionId = uuid.v4();
 
     await this.redisService.redisClient.set(
-      sessionId,
+      `login:${sessionId}`,
       admin.loginId,
       `EX`,
       this.SESSION_TTL,

--- a/server/src/common/guard/auth.guard.ts
+++ b/server/src/common/guard/auth.guard.ts
@@ -14,7 +14,7 @@ export class CookieAuthGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const sid = request.cookies['sessionId'];
-    const loginId = await this.redisService.redisClient.get(`login:${sid}`);
+    const loginId = await this.redisService.redisClient.get(`auth:${sid}`);
     if (!loginId) {
       throw new UnauthorizedException('인증되지 않은 요청입니다.');
     }

--- a/server/src/common/guard/auth.guard.ts
+++ b/server/src/common/guard/auth.guard.ts
@@ -14,7 +14,7 @@ export class CookieAuthGuard implements CanActivate {
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest<Request>();
     const sid = request.cookies['sessionId'];
-    const loginId = await this.redisService.redisClient.get(sid);
+    const loginId = await this.redisService.redisClient.get(`login:${sid}`);
     if (!loginId) {
       throw new UnauthorizedException('인증되지 않은 요청입니다.');
     }

--- a/server/test/statistic/today.e2e-spec.ts
+++ b/server/test/statistic/today.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('Today view count statistic E2E Test : GET /api/statistic/today', () =>
         email: 'test@test.com',
         rssUrl: 'https://test.com/rss',
       }),
-      redisService.redisClient.set('login:test1234', 'test'),
+      redisService.redisClient.set('auth:test1234', 'test'),
       redisService.redisClient.zadd(
         redisKeys.FEED_TREND_KEY,
         '1',

--- a/server/test/statistic/today.e2e-spec.ts
+++ b/server/test/statistic/today.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('Today view count statistic E2E Test : GET /api/statistic/today', () =>
         email: 'test@test.com',
         rssUrl: 'https://test.com/rss',
       }),
-      redisService.redisClient.set('test1234', 'test'),
+      redisService.redisClient.set('login:test1234', 'test'),
       redisService.redisClient.zadd(
         redisKeys.FEED_TREND_KEY,
         '1',


### PR DESCRIPTION
# 🔨 테스크

PR 작성자가 로그인 뚫고 작성자가 고침

### Issue

-   close #58

### 세션 기반 Login Guard 및 Login 세션 ID Key 문제

-   Login Guard 코드를 자세히 보다가 이상한 점을 발견했다.
```typescript
    const loginId = await this.redisService.redisClient.get(sid);
    if (!loginId) {
      throw new UnauthorizedException('인증되지 않은 요청입니다.');
    }
```
- 위 코드로 구현이 되어있을 경우, Redis에 string 값을 가지는 키가 있다면, 쿠키에 그 Redis string 값에 대한 키를 대입할 경우 관리자 권한이 뚫릴 것 같았다.
- 실제로 해보니 뚫렸다.
- prefix로 로그인 서비스, CookieAuthGuards에 `login:` 도메인을 추가하여 해결하였다.
- Redis에서 도메인의 중요성을 느꼈다.

### 중복 로그인의 허용

-   관리자 계정이 중복 로그인이 되어야 할지 의문을 가졌다.
- 관리자 계정은 혹여나 임시 PC에 로그인했을 때, 로그아웃을 안 하고 다른 곳에서 로그인 한다면 임시 PC에 쿠키가 남아있어 치명적으로 다가올 수 있기에 중복 로그인 기능을 막았다.
- 이때, key = login:{sid}, value = {관리자ID} 라서, 관리자 ID에 대응하는 키를 찾아야했는데, 이러면 풀스캔을 해야한다.
- 관리자 같은 경우 계정이 많지 않아서 속도상 큰 문제가 되지 않을 거라 생각했다.
- 그리고 100개씩 가져오게 하면 Redis의 부하를 줄일 수 있기에 100개씩 세션을 가져와서 검사하게 했다.

# 📋 작업 내용

- Guard Redis login Prefix 추가
- Login Redis login Prefix 추가
- 테스트 코드 임의 데이터 login Prefix 추가
- 중복 로그인 기존 세션 제거

# 📷 스크린 샷(선택 사항)
- 한 명의 유저에 대한 세션은 오로지 단 하나만 존재하도록 구현하여 중복 로그인 불가능하게 변경
![수행 결과](https://github.com/user-attachments/assets/825a7a98-4b6e-484d-87d5-43ccd8b47644)
