### PR TITLE
✨ feat: logout API 구현

### DIFF
--- a/server/src/admin/admin.api-docs.ts
+++ b/server/src/admin/admin.api-docs.ts
@@ -106,3 +106,30 @@ export function ApiCheckAdminSessionId() {
     }),
   );
 }
+
+export function ApiLogout() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '관리자 로그아웃 API',
+    }),
+    ApiOkResponse({
+      description: 'Ok',
+      schema: {
+        properties: {
+          message: {
+            type: 'string',
+          },
+        },
+      },
+      example: {
+        message: '로그아웃이 성공적으로 처리되었습니다.',
+      },
+    }),
+    ApiUnauthorizedResponse({
+      description: 'Unauthorized',
+      example: {
+        message: '인증되지 않은 요청입니다.',
+      },
+    }),
+  );
+}

--- a/server/src/admin/admin.controller.ts
+++ b/server/src/admin/admin.controller.ts
@@ -17,6 +17,7 @@ import { RegisterAdminDto } from './dto/register-admin.dto';
 import { ApiTags } from '@nestjs/swagger';
 import {
   ApiCheckAdminSessionId,
+  ApiLogout,
   ApiPostLoginAdmin,
   ApiPostRegisterAdmin,
 } from './admin.api-docs';
@@ -41,6 +42,20 @@ export class AdminController {
     await this.adminService.loginAdmin(loginAdminDto, response, request);
     return ApiResponse.responseWithNoContent(
       '로그인이 성공적으로 처리되었습니다.',
+    );
+  }
+
+  @ApiLogout()
+  @UseGuards(CookieAuthGuard)
+  @Post('/logout')
+  async logoutAdmin(
+    @Req() request: Request,
+    @Res({ passthrough: true })
+    response: Response,
+  ) {
+    await this.adminService.logoutAdmin(request, response);
+    return ApiResponse.responseWithNoContent(
+      '로그아웃이 성공적으로 처리되었습니다.',
     );
   }
 

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -88,10 +88,8 @@ export class AdminService {
 
   async logoutAdmin(request: Request, response: Response) {
     const sid = request.cookies['sessionId'];
-    await this.redisService.redisClient.del(`auth:${sid}`);
-    response.cookie('sessionId', '', {
-      maxAge: 0,
-    });
+    this.redisService.redisClient.del(`auth:${sid}`);
+    response.clearCookie('sessionId');
   }
 
   async registerAdmin(registerAdminDto: RegisterAdminDto) {

--- a/server/src/admin/admin.service.ts
+++ b/server/src/admin/admin.service.ts
@@ -86,6 +86,14 @@ export class AdminService {
     response.cookie('sessionId', sessionId, cookieConfig[process.env.NODE_ENV]);
   }
 
+  async logoutAdmin(request: Request, response: Response) {
+    const sid = request.cookies['sessionId'];
+    await this.redisService.redisClient.del(`auth:${sid}`);
+    response.cookie('sessionId', '', {
+      maxAge: 0,
+    });
+  }
+
   async registerAdmin(registerAdminDto: RegisterAdminDto) {
     let { loginId, password } = registerAdminDto;
 


### PR DESCRIPTION
# 🔨 테스크

> [!IMPORTANT]
> @asn6878님께서 테스트 코드를 많이 개편중이셔서 본 PR에 테스트 코드는 작성하지 않았습니다.

### Issue

-   close #222

### 쿠키 제거

-   httpOnly로 설정된 세션 쿠키라 백엔드에서 지워줘야해서 maxAge 0으로 응답하여 바로 만료되게 구현했다.

# 📋 작업 내용

-   로그아웃 swagger 구현
- 로그아웃 Notion API 명세서 작성
- 로그아웃 API 구현

# 📷 스크린 샷(선택 사항)
- swagger
![image](https://github.com/user-attachments/assets/1369b274-d62a-4e1e-992f-942da5dfa3ea)

- postman
![image](https://github.com/user-attachments/assets/4b5361e8-123a-4d6e-90f2-263a55bcf890)
- postman (쿠키 지워짐)
![image](https://github.com/user-attachments/assets/a1a5e332-8cba-4a1c-a42b-88ac0df9a514)

- redis
![image](https://github.com/user-attachments/assets/fd1ada5b-29e0-4eb2-bd5a-6605922b4c7e)
