### PR TITLE
♻️ refactor: 채팅 스타일 수정, 관리자 등록 스타일 수정, 검색버튼 스타일 수정

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-switch": "^1.1.1",
         "@radix-ui/react-tabs": "^1.1.1",
         "@radix-ui/react-toast": "^1.2.2",
+        "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.3",
         "@tanstack/react-query": "^5.59.20",
         "@tanstack/react-query-devtools": "^5.59.20",
@@ -1874,6 +1875,30 @@
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.0",
         "@radix-ui/react-visually-hidden": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.0.tgz",
+      "integrity": "sha512-gwoxaKZ0oJ4vIgzsfESBuSgJNdc0rv12VhHgcqN0TEJmmZixXG/2XpsLK8kzNWYcnaoRIEEQc0bEi3dIvdUpjw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-switch": "^1.1.1",
     "@radix-ui/react-tabs": "^1.1.1",
     "@radix-ui/react-toast": "^1.2.2",
+    "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@tanstack/react-query": "^5.59.20",
     "@tanstack/react-query-devtools": "^5.59.20",

--- a/client/src/components/admin/layout/AdminMember.tsx
+++ b/client/src/components/admin/layout/AdminMember.tsx
@@ -1,12 +1,13 @@
 import { useState } from "react";
 
 import { AxiosError } from "axios";
+import { Eye, EyeOff } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
+import { Toggle } from "@/components/ui/toggle";
 
 import { useAdminRegister } from "@/hooks/queries/useAdminAuth";
 
@@ -77,7 +78,14 @@ export default function AdminMember() {
                 autoCapitalize="off"
                 spellCheck="false"
               />
-              <Switch id="airplane-mode" onCheckedChange={setViewPassword} className="absolute right-1 bottom-2" />
+              <Toggle
+                aria-label="Toggle bold"
+                variant={"outline"}
+                className="absolute right-1 bottom-0 hover:bg-transparent active:bg-transparent focus:bg-transparent"
+                onPressedChange={setViewPassword}
+              >
+                {viewPassword ? <Eye /> : <EyeOff />}
+              </Toggle>
             </div>
           </CardContent>
           <CardFooter className="flex justify-end">

--- a/client/src/components/chat/layout/ChatHeader.tsx
+++ b/client/src/components/chat/layout/ChatHeader.tsx
@@ -11,9 +11,9 @@ export default function ChatHeader() {
   const { userCount } = useChatStore();
   return (
     <SidebarHeader>
-      <div className="flex justify-between p-2.5 items-center">
+      <div className="flex justify-between px-2.5 py-5 items-center">
         <div className="flex gap-2">
-          <span>실시간 채팅</span>
+          <b>실시간 채팅</b>
           <span>
             <Users color="gray" />
           </span>

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -44,13 +44,18 @@ export default function Header() {
   return (
     <div className="border-b border-primary/20">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="h-20 items-center overflow-hidden flex justify-between">
-          <div className="flex-shrink-0 ">
+        <div className="h-20 items-center overflow-hidden flex justify-between relative z-50">
+          {/* 로고 영역 */}
+          <div className="flex-shrink-0 relative z-50">
             <img className="h-14 w-auto cursor-pointer" src={logo} alt="Logo" onClick={() => location.reload()} />
           </div>
-          <div className="absolute left-1/2 transform -translate-x-1/2 w-[30%]">
+
+          {/* 중앙 검색 버튼 */}
+          <div className="absolute left-1/2 transform -translate-x-1/2 w-full flex justify-center z-40">
             <SearchButton handleSearchModal={() => toggleModal("search")} />
           </div>
+
+          {/* 내비게이션 */}
           <div className="flex-shrink-0">
             <DesktopNavigation toggleModal={toggleModal} />
             <MobileNavigation toggleModal={toggleModal} />

--- a/client/src/components/search/SearchButton.tsx
+++ b/client/src/components/search/SearchButton.tsx
@@ -14,7 +14,8 @@ export default function SearchButton({ handleSearchModal }: { handleSearchModal:
                    justify-between 
                    items-center 
                    hover:bg-primary/5 
-                   max-w-[500px]
+                   max-w-[400px]
+                   
                    "
       onClick={handleSearchModal}
     >

--- a/client/src/components/ui/sidebar.tsx
+++ b/client/src/components/ui/sidebar.tsx
@@ -15,7 +15,7 @@ import { Slot } from "@radix-ui/react-slot";
 
 const SIDEBAR_COOKIE_NAME = "sidebar:state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
-const SIDEBAR_WIDTH = "22rem";
+const SIDEBAR_WIDTH = "22vw";
 const SIDEBAR_WIDTH_MOBILE = "18rem";
 const SIDEBAR_WIDTH_ICON = "3rem";
 const SIDEBAR_KEYBOARD_SHORTCUT = "q";

--- a/client/src/components/ui/toggle.tsx
+++ b/client/src/components/ui/toggle.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+import * as TogglePrimitive from "@radix-ui/react-toggle";
+
+const toggleVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 gap-2",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: " bg-transparent hover:bg-accent hover:text-accent-foreground",
+      },
+      size: {
+        default: "h-10 px-3 min-w-10",
+        sm: "h-9 px-2.5 min-w-9",
+        lg: "h-11 px-5 min-w-11",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+const Toggle = React.forwardRef<
+  React.ElementRef<typeof TogglePrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof TogglePrimitive.Root> & VariantProps<typeof toggleVariants>
+>(({ className, variant, size, ...props }, ref) => (
+  <TogglePrimitive.Root ref={ref} className={cn(toggleVariants({ variant, size, className }))} {...props} />
+));
+
+Toggle.displayName = TogglePrimitive.Root.displayName;
+
+export { Toggle, toggleVariants };


### PR DESCRIPTION
# 📋 작업 내용

-   Header.tsx className 수정
-   채팅 크기 조절
```
// client/src/components/ui/sidebar.tsx
const SIDEBAR_COOKIE_NAME = "sidebar:state";
const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
const SIDEBAR_WIDTH = "22vw"; // 해당 부분 크기 조절
const SIDEBAR_WIDTH_MOBILE = "18rem";
const SIDEBAR_WIDTH_ICON = "3rem";
const SIDEBAR_KEYBOARD_SHORTCUT = "q";
```
- 관리자 등록 비밀번호 보기 switch에서 toggle로 변경

# 📷 스크린 샷

- 관리자 페이지
![스크린샷 2024-11-29 014347](https://github.com/user-attachments/assets/e8304fee-39ef-44f4-b96d-67bc2f91ef84)
![스크린샷 2024-11-29 014343](https://github.com/user-attachments/assets/4f65f1e5-c70a-4454-9d3d-e902103c38e7)

- 채팅
![image](https://github.com/user-attachments/assets/bb5f1ee7-4551-4c2c-b3e7-8b3b901adda3)

- 검색버튼
![image](https://github.com/user-attachments/assets/8ff230df-0cce-4a9e-8a7d-24a378cdc8c9)
