### PR TITLE
🐛 fix: server 디렉토리 추적 구문 제거

### DIFF
--- a/.github/workflows/server_test.yml
+++ b/.github/workflows/server_test.yml
@@ -1,9 +1,7 @@
-name: Test
+name: BE Test
 
 on:
   pull_request:
-    paths:
-      - 'server/**'
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
# 📋 작업 내용

- 브랜치 보호룰과 맞지 않는 스크립트 수정
브랜치 보호룰은 "테스트 스크립트가 반드시 성공해야 함" 인데, 기존 테스트 스크립트의 트리거 기준이 "/server 디렉토리 하위에 변경 사항이 있을 것." 이라서, /server 디렉토리 하위에 변경사항이 없는 경우 병합이 되지 않는 문제가 발생하였습니다.

그리하여 테스트 Actions 스크립트를 /server 디렉토리 뿐만 아니라 모든 디렉토리에서 돌아가도록 하였습니다.
추후 본스크립트에 FE테스트도 추가하거나, BE 테스트 내용을 추가할 것 같습니다.
