### PR TITLE
✅ test: 전체 통계 API 테스트 코드 작성

### DIFF
--- a/server/test/statistic/all.e2e-spec.ts
+++ b/server/test/statistic/all.e2e-spec.ts
@@ -1,8 +1,10 @@
 import * as request from 'supertest';
 import { INestApplication } from '@nestjs/common';
-import { RedisService } from '../../src/common/redis/redis.service';
 import { RssAcceptRepository } from '../../src/rss/rss.repository';
 import { FeedRepository } from '../../src/feed/feed.repository';
+import { RssAcceptFixture } from '../fixture/rssAccept.fixture';
+import { FeedFixture } from '../fixture/feed.fixture';
+import { Feed } from '../../src/feed/feed.entity';
 
 describe('All view count statistic E2E Test : GET /api/statistic/all', () => {
   let app: INestApplication;
@@ -10,145 +12,34 @@ describe('All view count statistic E2E Test : GET /api/statistic/all', () => {
     app = global.testApp;
     const rssAcceptRepository = app.get(RssAcceptRepository);
     const feedRepository = app.get(FeedRepository);
-    const redisService = app.get(RedisService);
     const [blog] = await Promise.all([
-      rssAcceptRepository.save({
-        id: 1,
-        name: 'test',
-        userName: 'test',
-        email: 'test@test.com',
-        rssUrl: 'https://test.com/rss',
-      }),
-      redisService.redisClient.set('auth:test1234', 'test'),
+      rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
     ]);
-    await feedRepository.save([
-      {
-        id: 1,
-        createdAt: '2024-11-26 09:00:00',
-        title: 'test1',
-        path: 'test1',
-        viewCount: 5,
-        thumbnail: 'https://test.com/test.png',
-        blog: blog,
-      },
-      {
-        id: 2,
-        createdAt: '2024-11-26 09:00:00',
-        title: 'test2',
-        path: 'test2',
-        viewCount: 4,
-        thumbnail: 'https://test.com/test.png',
-        blog: blog,
-      },
-      {
-        id: 3,
-        createdAt: '2024-11-26 09:00:00',
-        title: 'test3',
-        path: 'test3',
-        viewCount: 3,
-        thumbnail: 'https://test.com/test.png',
-        blog: blog,
-      },
-      {
-        id: 4,
-        createdAt: '2024-11-26 09:00:00',
-        title: 'test4',
-        path: 'test4',
-        viewCount: 2,
-        thumbnail: 'https://test.com/test.png',
-        blog: blog,
-      },
-      {
-        id: 5,
-        createdAt: '2024-11-26 09:00:00',
-        title: 'test5',
-        path: 'test5',
-        viewCount: 1,
-        thumbnail: 'https://test.com/test.png',
-        blog: blog,
-      },
-    ]);
+    const feeds: Feed[] = [];
+    for (let i = 1; i <= 2; i++) {
+      feeds.push(FeedFixture.createFeedFixture(blog, { viewCount: i - 1 }, i));
+    }
+    await feedRepository.save(feeds);
   });
 
-  describe('limit 값을 올바르게 입력하지 않았을 경우', () => {
-    it('실수를 입력한다.', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/api/statistic/all?limit=1.1')
-        .set('Cookie', 'sessionId=test1234');
-      expect(response.status).toBe(400);
-      expect(response.body.message).toBe('정수로 입력해주세요.');
-    });
-    it('문자열을 입력한다.', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/api/statistic/all?limit=test')
-        .set('Cookie', 'sessionId=test1234');
-      expect(response.status).toBe(400);
-      expect(response.body.message).toBe('정수로 입력해주세요.');
-    });
+  it('값을 입력 하지 않는다.', async () => {
+    // when
+    const response = await request(app.getHttpServer()).get(
+      '/api/statistic/all',
+    );
 
-    it('음수를 입력한다.', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/api/statistic/all?limit=-100')
-        .set('Cookie', 'sessionId=test1234');
-      expect(response.status).toBe(400);
-      expect(response.body).toStrictEqual({
-        message: 'limit 값은 1 이상이어야 합니다.',
-      });
-    });
+    // then
+    expect(response.status).toBe(200);
+    expect(response.body.data.map((item) => item.id)).toStrictEqual([2, 1]);
   });
+  it('양수를 입력한다.', async () => {
+    // when
+    const response = await request(app.getHttpServer()).get(
+      '/api/statistic/all?limit=1',
+    );
 
-  describe('limit 값을 올바르게 입력했을 경우', () => {
-    it('값을 입력 하지 않는다.', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/api/statistic/all')
-        .set('Cookie', 'sessionId=test1234');
-      expect(response.status).toBe(200);
-      expect(response.body).toStrictEqual({
-        message: '전체 조회수 통계 조회 완료',
-        data: [
-          {
-            id: 1,
-            title: 'test1',
-            viewCount: 5,
-          },
-          {
-            id: 2,
-            title: 'test2',
-            viewCount: 4,
-          },
-          {
-            id: 3,
-            title: 'test3',
-            viewCount: 3,
-          },
-          {
-            id: 4,
-            title: 'test4',
-            viewCount: 2,
-          },
-          {
-            id: 5,
-            title: 'test5',
-            viewCount: 1,
-          },
-        ],
-      });
-    });
-    it('양수를 입력한다.', async () => {
-      const response = await request(app.getHttpServer())
-        .get('/api/statistic/all?limit=1')
-        .set('Cookie', 'sessionId=test1234');
-      expect(response.status).toBe(200);
-      expect(response.body).toStrictEqual({
-        message: '전체 조회수 통계 조회 완료',
-        data: [
-          {
-            id: 1,
-            title: 'test1',
-            viewCount: 5,
-          },
-        ],
-      });
-    });
+    // then
+    expect(response.status).toBe(200);
+    expect(response.body.data.map((item) => item.id)).toStrictEqual([2]);
   });
 });

--- a/server/test/statistic/all.e2e-spec.ts
+++ b/server/test/statistic/all.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest';
+import * as supertest from 'supertest';
 import { INestApplication } from '@nestjs/common';
 import { RssAcceptRepository } from '../../src/rss/rss.repository';
 import { FeedRepository } from '../../src/feed/feed.repository';
@@ -25,7 +25,7 @@ describe('GET /api/statistic/all E2E Test', () => {
 
   it('값을 입력 하지 않으면 10개의 데이터만 응답한다.', async () => {
     // when
-    const response = await request(app.getHttpServer()).get(
+    const response = await supertest(app.getHttpServer()).get(
       '/api/statistic/all',
     );
 
@@ -35,7 +35,7 @@ describe('GET /api/statistic/all E2E Test', () => {
   });
   it('양수를 입력하면 제한된 개수의 통계 결과를 응답한다.', async () => {
     // when
-    const response = await request(app.getHttpServer()).get(
+    const response = await supertest(app.getHttpServer()).get(
       '/api/statistic/all?limit=1',
     );
 

--- a/server/test/statistic/all.e2e-spec.ts
+++ b/server/test/statistic/all.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as supertest from 'supertest';
+import * as request from 'supertest';
 import { INestApplication } from '@nestjs/common';
 import { RssAcceptRepository } from '../../src/rss/rss.repository';
 import { FeedRepository } from '../../src/feed/feed.repository';
@@ -25,7 +25,7 @@ describe('GET /api/statistic/all E2E Test', () => {
 
   it('값을 입력 하지 않으면 10개의 데이터만 응답한다.', async () => {
     // when
-    const response = await supertest(app.getHttpServer()).get(
+    const response = await request(app.getHttpServer()).get(
       '/api/statistic/all',
     );
 
@@ -35,7 +35,7 @@ describe('GET /api/statistic/all E2E Test', () => {
   });
   it('양수를 입력하면 제한된 개수의 통계 결과를 응답한다.', async () => {
     // when
-    const response = await supertest(app.getHttpServer()).get(
+    const response = await request(app.getHttpServer()).get(
       '/api/statistic/all?limit=1',
     );
 

--- a/server/test/statistic/all.e2e-spec.ts
+++ b/server/test/statistic/all.e2e-spec.ts
@@ -13,9 +13,9 @@ describe('GET /api/statistic/all E2E Test', () => {
     app = global.testApp;
     const rssAcceptRepository = app.get(RssAcceptRepository);
     const feedRepository = app.get(FeedRepository);
-    const [blog] = await Promise.all([
-      rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
-    ]);
+    const blog = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
     const feeds: Feed[] = [];
     for (let i = 1; i <= 2; i++) {
       feeds.push(FeedFixture.createFeedFixture(blog, { viewCount: i - 1 }, i));

--- a/server/test/statistic/all.e2e-spec.ts
+++ b/server/test/statistic/all.e2e-spec.ts
@@ -6,8 +6,9 @@ import { RssAcceptFixture } from '../fixture/rssAccept.fixture';
 import { FeedFixture } from '../fixture/feed.fixture';
 import { Feed } from '../../src/feed/feed.entity';
 
-describe('All view count statistic E2E Test : GET /api/statistic/all', () => {
+describe('GET /api/statistic/all E2E Test', () => {
   let app: INestApplication;
+
   beforeAll(async () => {
     app = global.testApp;
     const rssAcceptRepository = app.get(RssAcceptRepository);
@@ -22,7 +23,7 @@ describe('All view count statistic E2E Test : GET /api/statistic/all', () => {
     await feedRepository.save(feeds);
   });
 
-  it('값을 입력 하지 않는다.', async () => {
+  it('값을 입력 하지 않으면 10개의 데이터만 응답한다.', async () => {
     // when
     const response = await request(app.getHttpServer()).get(
       '/api/statistic/all',
@@ -32,7 +33,7 @@ describe('All view count statistic E2E Test : GET /api/statistic/all', () => {
     expect(response.status).toBe(200);
     expect(response.body.data.map((item) => item.id)).toStrictEqual([2, 1]);
   });
-  it('양수를 입력한다.', async () => {
+  it('양수를 입력하면 제한된 개수의 통계 결과를 응답한다.', async () => {
     // when
     const response = await request(app.getHttpServer()).get(
       '/api/statistic/all?limit=1',

--- a/server/test/statistic/today.e2e-spec.ts
+++ b/server/test/statistic/today.e2e-spec.ts
@@ -8,7 +8,7 @@ import { RssAcceptRepository } from '../../src/rss/rss.repository';
 import { FeedFixture } from '../fixture/feed.fixture';
 import { Feed } from '../../src/feed/feed.entity';
 
-describe('Today view count statistic E2E Test : GET /api/statistic/today', () => {
+describe('GET /api/statistic/today E2E Test', () => {
   let app: INestApplication;
 
   beforeAll(async () => {
@@ -26,7 +26,7 @@ describe('Today view count statistic E2E Test : GET /api/statistic/today', () =>
     }
     await feedRepository.save(feeds);
   });
-  it('값을 입력 하지 않아 10개의 데이터만 요청한다.', async () => {
+  it('값을 입력 하지 않으면 10개의 데이터만 응답한다.', async () => {
     // when
     const response = await request(app.getHttpServer()).get(
       '/api/statistic/today',
@@ -36,7 +36,7 @@ describe('Today view count statistic E2E Test : GET /api/statistic/today', () =>
     expect(response.status).toBe(200);
     expect(response.body.data.map((item) => item.id)).toStrictEqual([1, 2]);
   });
-  it('양수를 입력하여 제한된 통계를 요청한다.', async () => {
+  it('양수를 입력하면 제한된 개수의 통계 결과를 응답한다.', async () => {
     // when
     const response = await request(app.getHttpServer()).get(
       '/api/statistic/today?limit=1',

--- a/server/test/statistic/today.e2e-spec.ts
+++ b/server/test/statistic/today.e2e-spec.ts
@@ -6,6 +6,7 @@ import { RssAcceptFixture } from '../fixture/rssAccept.fixture';
 import { FeedRepository } from '../../src/feed/feed.repository';
 import { RssAcceptRepository } from '../../src/rss/rss.repository';
 import { FeedFixture } from '../fixture/feed.fixture';
+import { Feed } from '../../src/feed/feed.entity';
 
 describe('Today view count statistic E2E Test : GET /api/statistic/today', () => {
   let app: INestApplication;
@@ -19,9 +20,11 @@ describe('Today view count statistic E2E Test : GET /api/statistic/today', () =>
       rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
       redisService.redisClient.zadd(redisKeys.FEED_TREND_KEY, 5, '1', 4, '2'),
     ]);
+    const feeds: Feed[] = [];
     for (let i = 1; i <= 2; i++) {
-      await feedRepository.save(FeedFixture.createFeedFixture(blog, {}, i));
+      feeds.push(FeedFixture.createFeedFixture(blog, {}, i));
     }
+    await feedRepository.save(feeds);
   });
   it('값을 입력 하지 않아 10개의 데이터만 요청한다.', async () => {
     // when


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #204

# 📋 작업 내용

-   InMemory DB 1회 접근 방식으로 변경
- dto 테스트 분리
- 테스트 데이터 개수, 범위 축소

# 📷 스크린 샷(선택 사항)
- 일일 통계 API의 DTO 검증과 동일한 DTO라 테스트 3개가 줄었습니다.
![image](https://github.com/user-attachments/assets/bf341ca2-1ffb-4c89-8bad-f57225147d4f)
