### PR TITLE
🐛 fix: velog rssurl 등록 시 '@'가 없으면 etc로 분류되는 버그 수정

### DIFF
--- a/server/src/rss/rss.service.ts
+++ b/server/src/rss/rss.service.ts
@@ -114,10 +114,10 @@ export class RssService {
     type Platform = 'medium' | 'tistory' | 'velog' | 'github' | 'etc';
 
     const platformRegexp: { [key in Platform]: RegExp } = {
-      medium: /^https:\/\/medium\.com\/feed\/@[\w\-]+$/,
-      tistory: /^https:\/\/[a-zA-Z0-9\-]+\.tistory\.com\/rss$/,
-      velog: /^https:\/\/v2\.velog\.io\/rss\/@[\w\-]+$/,
-      github: /^https:\/\/[\w\-]+\.github\.io\/feed\.xml$/,
+      medium: /^https:\/\/medium\.com/,
+      tistory: /^https:\/\/[a-zA-Z0-9\-]+\.tistory\.com/,
+      velog: /^https:\/\/v2\.velog\.io/,
+      github: /^https:\/\/[\w\-]+\.github\.io/,
       etc: /.*/,
     };
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #205

# 📋 작업 내용

-  rss url 형태를 사용하는 것이 문제였습니다.
  - velog는 `@ID`형태가 아니어도 RSS를 불러올 수 있어서 버그가 발생했습니다.
- 어차피 관리자가 RSS의 유효성을 검사한다고 생각하여 velog, medium 등 블로그 플랫폼만 구별할 수 있도록 수정했습니다.

# 📷 스크린 샷
- 예시 스크린 샷
![image](https://github.com/user-attachments/assets/7724ce33-9606-470e-bf0c-aee33daddebf)

- rss_accept 테이블에 들어가는 값 확인
![image](https://github.com/user-attachments/assets/1f147bcf-8ff1-444e-ba31-6ca827f87c4b)
