### PR TITLE
🧼 clean: 네이밍 컨벤션 수정

### DIFF
--- a/server/src/rss/rss.controller.ts
+++ b/server/src/rss/rss.controller.ts
@@ -34,18 +34,18 @@ export class RssController {
   @ApiPostRegisterRss()
   @Post()
   @UsePipes(ValidationPipe)
-  async postRegisterRss(@Body() rssRegisterDto: RssRegisterDto) {
-    await this.rssService.registerRss(rssRegisterDto);
+  async createRss(@Body() rssRegisterDto: RssRegisterDto) {
+    await this.rssService.createRss(rssRegisterDto);
     return ApiResponse.responseWithNoContent('신청이 완료되었습니다.');
   }
 
   @ApiGetRss()
   @Get()
   @HttpCode(200)
-  async getRss() {
+  async readAllRss() {
     return ApiResponse.responseWithData(
       'Rss 조회 완료',
-      await this.rssService.getAllRss(),
+      await this.rssService.readAllRss(),
     );
   }
 
@@ -77,8 +77,8 @@ export class RssController {
   @ApiAcceptHistory()
   @UseGuards(CookieAuthGuard)
   @Get('history/accept')
-  async getHistoryAcceptRss() {
-    const rssAcceptHistory = await this.rssService.acceptRssHistory();
+  async readAcceptHistory() {
+    const rssAcceptHistory = await this.rssService.readAcceptHistory();
     return ApiResponse.responseWithData(
       '승인 기록 조회가 완료되었습니다.',
       rssAcceptHistory,
@@ -88,8 +88,8 @@ export class RssController {
   @ApiRejectHistory()
   @UseGuards(CookieAuthGuard)
   @Get('history/reject')
-  async getHistoryRejectRss() {
-    const rssRejectHistory = await this.rssService.rejectRssHistory();
+  async readRejectHistory() {
+    const rssRejectHistory = await this.rssService.readRejectHistory();
     return ApiResponse.responseWithData(
       'RSS 거절 기록을 조회하였습니다.',
       rssRejectHistory,

--- a/server/src/rss/rss.service.ts
+++ b/server/src/rss/rss.service.ts
@@ -23,7 +23,7 @@ export class RssService {
     private readonly dataSource: DataSource,
   ) {}
 
-  async registerRss(rssRegisterDto: RssRegisterDto) {
+  async createRss(rssRegisterDto: RssRegisterDto) {
     const [alreadyURLRss, alreadyURLBlog] = await Promise.all([
       this.rssRepository.findOne({
         where: {
@@ -48,7 +48,7 @@ export class RssService {
     await this.rssRepository.insertNewRss(rssRegisterDto);
   }
 
-  async getAllRss() {
+  async readAllRss() {
     return await this.rssRepository.find();
   }
 
@@ -94,7 +94,7 @@ export class RssService {
     this.emailService.sendMail(result, false, description);
   }
 
-  async acceptRssHistory() {
+  async readAcceptHistory() {
     return await this.rssAcceptRepository.find({
       order: {
         id: 'DESC',
@@ -102,7 +102,7 @@ export class RssService {
     });
   }
 
-  async rejectRssHistory() {
+  async readRejectHistory() {
     return await this.rssRejectRepository.find({
       order: {
         id: 'DESC',


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #260

### 컨벤션
- Swagger 네이밍에 맞춰서 컨트롤러, 서비스 메소드 명 변경
- Controller, Serivce 함수명 컨벤션 정해서 통일하기
    - 동작 Prefix + 도메인 이름
    - 동사가 앞에
        - 조회 : read
        - 쓰기 : create
        - 수정 : update
        - 제거 : delete
        - 그 외 : 직접 작성
    - Controller, Service 명은 동일하게 맞추기

# 📋 작업 내용

-   동작 Prefix + 도메인 이름으로 변경

# 📷 스크린 샷(선택 사항)

![image](https://github.com/user-attachments/assets/19252072-36fb-4ab9-873c-9de5f53a9832)
