### PR TITLE
✨ feat: PostCard 로드될 때 Skeleton UI 적용

### DIFF
--- a/client/src/components/common/Card/PostCardSkeleton.tsx
+++ b/client/src/components/common/Card/PostCardSkeleton.tsx
@@ -1,0 +1,25 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+const PostCardSkeleton = () => {
+  return (
+    <div className="h-[240px] bg-white rounded-lg p-4 space-y-3 shadow-sm">
+      <Skeleton className="w-full h-40 rounded-lg" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+      </div>
+    </div>
+  );
+};
+
+const PostGridSkeleton = ({ count = 8 }) => {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+      {Array.from({ length: count }).map((_, index) => (
+        <PostCardSkeleton key={index} />
+      ))}
+    </div>
+  );
+};
+
+export { PostCardSkeleton, PostGridSkeleton };

--- a/client/src/components/sections/LatestSection.tsx
+++ b/client/src/components/sections/LatestSection.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef } from "react";
 import { Rss } from "lucide-react";
 
 import { PostCardGrid } from "@/components/common/Card/PostCardGrid";
-import { LoadingIndicator } from "@/components/common/LoadingIndicator";
+import { PostGridSkeleton } from "@/components/common/Card/PostCardSkeleton.tsx";
 import { SectionHeader } from "@/components/common/SectionHeader";
 
 import { useInfiniteScrollQuery } from "@/hooks/queries/useInfiniteScrollQuery";
@@ -25,7 +25,7 @@ export default function LatestSection() {
           fetchNextPage();
         }
       },
-      { threshold: 0.1 }
+      { threshold: 0.3, rootMargin: "100px" }
     );
 
     if (observerTarget.current) {
@@ -35,16 +35,23 @@ export default function LatestSection() {
     return () => observer.disconnect();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-  if (isLoading) return <LoadingIndicator />;
-
   return (
     <section className="flex flex-col p-4 min-h-[300px]">
       <SectionHeader icon={Rss} text="최신 포스트" description="최근에 작성된 포스트" iconColor="text-orange-500" />
       <div className="flex-1 mt-4 p-4 rounded-lg">
-        <PostCardGrid posts={items} />
-        <div ref={observerTarget} className="h-10 flex items-center justify-center mt-4">
-          {isFetchingNextPage && <LoadingIndicator />}
-        </div>
+        {isLoading ? (
+          <PostGridSkeleton count={8} />
+        ) : (
+          <>
+            <PostCardGrid posts={items} />
+            {isFetchingNextPage && (
+              <div className="mt-8">
+                <PostGridSkeleton count={4} />
+              </div>
+            )}
+            <div ref={observerTarget} className="h-10" />
+          </>
+        )}
       </div>
     </section>
   );

--- a/client/src/components/sections/TrendingSection.tsx
+++ b/client/src/components/sections/TrendingSection.tsx
@@ -1,6 +1,6 @@
 import { TrendingUp } from "lucide-react";
 
-import { LoadingIndicator } from "@/components/common/LoadingIndicator";
+import { PostGridSkeleton } from "@/components/common/Card/PostCardSkeleton.tsx";
 import { SectionHeader } from "@/components/common/SectionHeader";
 import AnimatedPostGrid from "@/components/sections/AnimatedPostGrid";
 
@@ -8,8 +8,6 @@ import { useTrendingPosts } from "@/hooks/queries/useTrendingPosts";
 
 export default function TrendingSection() {
   const { posts, isLoading } = useTrendingPosts();
-
-  if (isLoading) return <LoadingIndicator />;
 
   return (
     <section className="flex flex-col p-4 min-h-[300px]">
@@ -23,7 +21,7 @@ export default function TrendingSection() {
         className="flex-1 mt-4 p-6 bg-white rounded-2xl transition-all duration-300"
         style={{ boxShadow: "0 0 15px rgba(0, 0, 0, 0.1)" }}
       >
-        <AnimatedPostGrid posts={posts} />
+        {isLoading || !posts.length ? <PostGridSkeleton count={4} /> : <AnimatedPostGrid posts={posts} />}
       </div>
     </section>
   );


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #270

### Skeleton UI 도입 배경
- 데이터 로딩 중에 빈 화면이 보이는 것은 사용자 경험을 저하시킬 수 있음
- LoadingIndicator만으로는 실제 로드될 컨텐츠의 구조를 미리 파악하기 어려움
- 데이터 로딩 시 PostCard 이외의 컴포넌트에서 움직임 발생

### 구현 시 고려사항
- shadcn/ui의 Skeleton 컴포넌트 활용으로 디자인 시스템 일관성 유지
- 무한 스크롤의 부드러운 경험을 위한 Intersection Observer 최적화
  - threshold: 0.3, rootMargin: "100px"로 설정해 비교적 빨리 로딩할 수 있도록 함
- 데이터 로딩 상태에 따른 레이아웃 유지를 위한 최소 높이 설정

# 📋 작업 내용

- PostCardSkeleton 컴포넌트 구현
  - shadcn/ui Skeleton 컴포넌트 활용
  - 실제 PostCard와 동일한 레이아웃 구성
  - 반응형 그리드 레이아웃 적용

- 최신 포스트 섹션(LatestSection) Skeleton UI 적용
  - 초기 로딩 및 무한 스크롤 시 Skeleton UI 구현
  - Intersection Observer 설정 최적화
  - 추가 로딩 시 Skeleton UI 자연스러운 전환

- 트렌딩 포스트 섹션(TrendingSection) Skeleton UI 적용
  - 초기 로딩 상태 Skeleton UI 구현
  - 데이터 로딩 상태 처리 로직 개선

# 📷 스크린 샷

### skeleton ui
https://github.com/user-attachments/assets/3f6326b5-5322-498e-98cd-a7cf4cc02213

### skeleton ui + 실제 데이터
https://github.com/user-attachments/assets/bf7f06d3-8a11-4ffd-8505-14bdf049a7f4

### skeleton 무한 스크롤 다음 페이지 로딩 넣기 전
https://github.com/user-attachments/assets/f1fe8ec3-7837-407a-93c0-13d26f7bd675

### skeleton 무한 스크롤 다음 페이지 로딩 넣은 후
https://github.com/user-attachments/assets/88e043e6-31f3-4248-a5a8-abdc157bd96c

