### PR TITLE
🧼 clean: type을 추론할 수 없는 부분 찾아서 타입 명시

### DIFF
--- a/server/src/feed/feed.controller.ts
+++ b/server/src/feed/feed.controller.ts
@@ -17,7 +17,7 @@ import {
 import { FeedService } from './feed.service';
 import { QueryFeedDto } from './dto/query-feed.dto';
 import { SearchFeedReq } from './dto/search-feed.dto';
-import { Response } from 'express';
+import { Response, Request } from 'express';
 import { Observable } from 'rxjs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ApiReadFeedList } from './api-docs/readFeedList.api-docs';
@@ -25,6 +25,7 @@ import { ApiReadTrendFeedList } from './api-docs/readTrendFeedList.api-docs';
 import { ApiSearchFeedList } from './api-docs/searchFeedList.api-docs';
 import { ApiUpdateFeedViewCount } from './api-docs/updateFeedViewCount.api-docs';
 import { ApiReadRecentFeedList } from './api-docs/readRecentFeedList.api-docs';
+import { Feed } from './feed.entity';
 
 @ApiTags('Feed')
 @Controller('feed')
@@ -61,7 +62,7 @@ export class FeedController {
           },
         });
       });
-      this.eventService.on('ranking-update', (trendData) => {
+      this.eventService.on('ranking-update', (trendData: Feed[]) => {
         observer.next({
           data: {
             message: '새로운 트렌드 피드 수신 완료',
@@ -92,16 +93,10 @@ export class FeedController {
   @UsePipes(new ValidationPipe({ transform: true }))
   async updateFeedViewCount(
     @Param('feedId') feedId: number,
-    @Req() request,
+    @Req() request: Request,
     @Res({ passthrough: true }) response: Response,
   ) {
-    const cookie = request.headers.cookie;
-    const ip =
-      request.headers['CF-Connecting-IP'] ||
-      request.headers['x-forwarded-for'] ||
-      request.socket?.remoteAddress ||
-      'unknown';
-    await this.feedService.updateFeedViewCount(feedId, ip, cookie, response);
+    await this.feedService.updateFeedViewCount(feedId, request, response);
     return ApiResponse.responseWithNoContent(
       '요청이 성공적으로 처리되었습니다.',
     );

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -140,9 +140,10 @@ export class FeedService {
       const redis = this.redisService.redisClient;
       const [feed, hasCookie, hasIpFlag] = await Promise.all([
         this.feedRepository.findOne({ where: { id: feedId } }),
-        Boolean(cookie?.[`View_count_${feedId}`]),
+        Boolean(cookie?.includes(`View_count_${feedId}=${feedId}`)),
         redis.sismember(`feed:${feedId}:ip`, ip),
       ]);
+
       if (!feed) {
         throw new NotFoundException(`${feedId}번 피드를 찾을 수 없습니다.`);
       }


### PR DESCRIPTION
### Issue

-   #261

# 📋 작업 내용

-  타입을 명시하지 않은 부분을 찾아서 타입을 붙였습니다.
- 그 과정에서 controller에서 header로부터 정보를 추출하던 부분을 모두 service 레이어로 옮겼습니다.
- ip 같은 경우, `string | string[]` 타입을 반환하기에 타입 가드를 하나 생성하여 string일 때만 사용할 수 있도록 했습니다.

# 스크린 샷
![image](https://github.com/user-attachments/assets/aefaf881-c3b4-416d-9ebb-5dbd72b2baf8)
