### PR TITLE
📦 chore: Netlify 종속성 제거를 위한 NGINX 설정 변경 및 FE CD 스크립트 작성

### DIFF
--- a/.github/workflows/deploy_client.yml
+++ b/.github/workflows/deploy_client.yml
@@ -1,0 +1,32 @@
+name: Client Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "client/**"
+  workflow_dispatch: # 수동 실행을 허용하는 이벤트
+
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    steps:
+      # public 서버로 ssh 접속
+      - name: ssh connection
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          port: ${{ secrets.PORT }}
+          script: |
+            export NVM_DIR=~/.nvm
+            source ~/.nvm/nvm.sh
+
+            cd /var/web05-Denamu
+            git pull origin main
+            cd client/
+
+            npm ci
+            npm run build

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -1,4 +1,4 @@
-name: Deployment
+name: Server Deployment
 
 on:
   push:

--- a/client/src/api/instance.ts
+++ b/client/src/api/instance.ts
@@ -6,7 +6,7 @@ export const api = axios.create({
 });
 
 export const axiosInstance = axios.create({
-  baseURL: "https://api.denamu.site",
+  baseURL: "https://denamu.site",
   timeout: 10000,
   withCredentials: true,
 });

--- a/client/src/components/about/HeroSection.tsx
+++ b/client/src/components/about/HeroSection.tsx
@@ -17,7 +17,7 @@ export const HeroSection = () => {
         <div className="text-center max-w-4xl">
           <div className="flex items-center justify-center space-x-2 mb-6">
             <img
-              src="https://api.denamu.site/files/Denamu_Logo_ENG.svg"
+              src="https://denamu.site/files/Denamu_Logo_ENG.svg"
               alt="Denamu English Logo"
               className="w-32 md:w-52"
             />
@@ -36,7 +36,7 @@ export const HeroSection = () => {
 
       <div className="flex-grow flex items-start justify-center p-4 md:p-8">
         <img
-          src="https://api.denamu.site/files/about-first.png"
+          src="https://denamu.site/files/about-first.png"
           alt="Service Preview"
           className="max-w-[90%] md:max-w-[80%] h-auto object-contain"
         />

--- a/client/src/components/common/Card/PostCardContent.tsx
+++ b/client/src/components/common/Card/PostCardContent.tsx
@@ -11,7 +11,7 @@ interface PostCardContentProps {
 
 export const PostCardContent = ({ post }: PostCardContentProps) => {
   const authorInitial = post.author?.charAt(0)?.toUpperCase() || "?";
-  const data = `https://api.denamu.site/files/${post.blogPlatform}-icon.svg`;
+  const data = `https://denamu.site/files/${post.blogPlatform}-icon.svg`;
   return (
     <CardContent className="p-0">
       <div className="relative -mt-6 ml-4 mb-3">

--- a/client/src/hooks/queries/useTrendingPosts.ts
+++ b/client/src/hooks/queries/useTrendingPosts.ts
@@ -13,7 +13,7 @@ export const useTrendingPosts = () => {
   });
 
   useEffect(() => {
-    const eventSource = new EventSource("https://api.denamu.site/api/feed/trend/sse");
+    const eventSource = new EventSource("https://denamu.site/api/feed/trend/sse");
 
     eventSource.onmessage = (event) => {
       try {

--- a/client/src/store/useChatStore.ts
+++ b/client/src/store/useChatStore.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 
 import { ChatType } from "@/types/chat";
 
-const CHAT_SERVER_URL = "https://api.denamu.site";
+const CHAT_SERVER_URL = "https://denamu.site";
 
 interface ChatStore {
   chatHistory: ChatType[];

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,39 @@
+server {
+	listen 80 default_server;
+	server_name _;
+
+    # 정적 파일 서빙 - FE 빌드 파일
+    location / {
+        root /var/web05-Denamu/client/dist;
+        index index.html;  # 기본 파일 설정
+        try_files $uri /index.html;  # SPA 지원
+    }
+
+    # 정적 파일 서빙
+	location /files {
+		alias /var/web05-Denamu/static/;
+		try_files $uri $uri/ =404; # 파일이 없으면 404 반환
+	}
+
+    # API 요청을 NestJS로 프록시
+    location /api {
+        proxy_pass http://127.0.0.1:8080;  # NestJS 서버
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+	# WebSocket 요청 프록시
+    location /chat {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 3600s;
+        proxy_send_timeout 3600s;
+    }
+}

--- a/server/src/common/email/mail_content.ts
+++ b/server/src/common/email/mail_content.ts
@@ -10,7 +10,7 @@ export function createMailContent(
   <div style="font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', sans-serif; margin: 0; padding: 1px; background-color: #f4f4f4;">
     <div style="max-width: 600px; margin: 20px auto; background-color: #ffffff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
       <div style="text-align: center; padding: 20px 0; border-bottom: 2px solid #f0f0f0;">
-        <img src="https://api.denamu.site/files/Denamu_Logo_KOR.png" alt="Denamu Logo" width="244" height="120">
+        <img src="https://denamu.site/files/Denamu_Logo_KOR.png" alt="Denamu Logo" width="244" height="120">
       </div>
       <div style="padding: 20px 0;">
         ${


### PR DESCRIPTION
# 📋 작업 내용

### `nginx.conf` 설정파일 이동
프로젝트 내에서 nginx 설정을 하고, 직관적으로 관리할 수 있도록 루트 디렉토리 내에 nginx 설정 파일을 만들었습니다.
그 후, `/etc/nginx` 경로 내에서 루트 디렉토리의 conf 파일을 include 처리 해 주었습니다.
```
# /etc/nginx/nginx.conf
http {
        ...
	include /var/web05-Denamu/nginx.conf;
}
```

### index.html 및 vite 정적 빌드 파일을 NGINX에서 반환하도록 변경
기존에 Netlify에서 반환하던 정적파일을 NGINX에서 반환할 수 있도록 라우팅 처리 해두었습니다.
```
    # 정적 파일 서빙 - FE 빌드 파일
    location / {
        root /var/web05-Denamu/client/dist;
        index index.html;  # 기본 파일 설정
        try_files $uri /index.html;  # SPA 지원
    }

    # 정적 파일 서빙
	location /files {
		alias /var/web05-Denamu/static/;
		try_files $uri $uri/ =404; # 파일이 없으면 404 반환
	}
...
```
`/` 루트 경로로 들어오는 요청들은 client/dist 내 파일들(index.html, css 및 다양한 js 파일들)을 반환합니다. 
현재 https://www.api.denamu.site/ 경로로 접속해보시면, public-was 인스턴스에서 FE 정적파일들을 반환해주는 상태임을 확인하실 수 있으며, React Route 역시 정상적으로 동작하는 것을 보실 수 있습니다.

### Client 파일들에서 API 요청시 사용되는 baseURL 변경
> [!IMPORTANT]
> @jungmyunggi @junyeokk baseURL 변경 내용 확인하시기 바랍니다.

![image](https://github.com/user-attachments/assets/2b911a04-0b92-43ad-b998-d8d9b0ae04ce)
public-was 인스턴스 서버로 가는 요청은 기존에 `A 레코드`를 활용해 `api` prefix를 통해 구분해 프록시를 진행중이었습니다.
> - BE & 정적 파일 요청 경로 : `api.denamu.site` -> `public-was 인스턴스 Public IP`
> - FE 요청 경로 : `denamu.site` -> : `denamu.netlify.app`

**본 PR이 병합되면**, FE 요청을 public-was에 위임하였으므로 netlify 로 매핑하는 경로를 제거할 예정입니다.
> - 통합 요청 경로 : `denamu.site` -> `public-was 인스턴스 Public IP`
> - ~~FE 요청 경로 : `denamu.site` -> : `denamu.netlify.app`~~

### Client측 CD Actions 스크립트 작성
Client 측 코드에 업데이트가 있을 시, `npm run` 커맨드를 통해 배포를 수행하는 Github Actions 스크립트를 작성했습니다.

### 추후 변경 방안
현 상황에서 CloudFlare를 제거하기 위해, SSL인증서, `denamu.site` DNS 라우팅 변경 (현재는 CloudFlare로 설정되어 있지만, 이제는 가비아 네임서버에서 다이렉트로 Public IP로 가도록 변경해야 합니다.) 등의 추가적인 처리가 필요합니다.

현재 정적파일 서빙 방식은 결국 서버에 부하를 주는 방식이기에, 조금 더 개선할 여지가 있다고 생각합니다. (Object Storage 혹은 S3 사용하기.) 허나 일단은 이렇게 개선을 하자고 이야기가 나왔던 것으로 기억해 진행해보았습니다. 이견 있으시면 편하게 말씀해주세요 😄