### PR TITLE
🐛 fix: 블로그 썸네일 상대 경로 문제 해결

### DIFF
--- a/rss-notifier/src/rss-notifier.ts
+++ b/rss-notifier/src/rss-notifier.ts
@@ -25,10 +25,25 @@ const getImageUrl = async (link: string): Promise<string> => {
   const htmlData = await response.text();
   const root = parse(htmlData);
   const metaImage = root.querySelector('meta[property="og:image"]');
-  const imageUrl = metaImage?.getAttribute("content") ?? "";
-  if (imageUrl.length === 0) logger.warn(`${link}에서 사진 추출 실패`);
-
+  let imageUrl = metaImage?.getAttribute("content") ?? "";
+  if (!imageUrl.length) {
+    logger.warn(`${link}에서 사진 추출 실패`);
+    return imageUrl;
+  }
+  if (!isUrlPath(imageUrl)) {
+    imageUrl = getHttpOriginPath(link) + imageUrl;
+  }
   return imageUrl;
+};
+
+const isUrlPath = (imageUrl: string) => {
+  const reg = /^(http|https):\/\//;
+  return reg.test(imageUrl);
+};
+
+const getHttpOriginPath = (imageUrl: string) => {
+  const url = new URL(imageUrl);
+  return url.origin;
 };
 
 const fetchRss = async (rssUrl: string): Promise<RawFeed[]> => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #23

### 상대 경로 처리
- 썸네일 경로가 상대 경로일 경우, 그대로 저장하는 문제가 있었다.
- 이 문제 같은 경우 우리 서비스로 가져오면 우리 도메인의 경로로 썸네일을 요청하기에 썸네일 소스가 존재하지 않았다.
- 원본 블로그 경로에 요청을 보내야했는데, 블로그 게시글의 썸네일 경로를 저장할 때, 블로그 경로와 디렉토리 경로를 합쳐 한 번에 저장하면 된다고 생각했다.
- 원본 블로그 도메인에 디렉토리 경로를 합쳐 요청을 하면 이미지가 불러와짐을 확인하여 이대로 구현을 진행했다.

# 📋 작업 내용

-   블로그 게시글 HTML에 og:image 태그의 썸네일 이미지가 상대 경로일 경우 게시글의 썸네일을 데나무 서비스에서 로드할 수 없는 문제 발생

# 📷 스크린 샷(선택 사항)
- 마지막 행이 썸네일 경로 행이다.
- 몇몇 블로그에서 썸네일 경로가 상대 경로로 `/assets/img/logo.png` 로 저장되는 문제가 있었다.
- 앞에 도메인을 붙여서 저장함으로써 이미지를 불러올 수 있도록 문제를 해결했다.
![image](https://github.com/user-attachments/assets/7c52f905-dac1-4adb-b3c0-6789863c7b8b)
