### PR TITLE
⚡️ perf: 피드 순위 변동이 생길 경우에만 이벤트가 발생하도록 수정

### DIFF
--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -76,7 +76,7 @@ export class FeedService {
     await this.redisService.redisClient.del(redisKeys.FEED_TREND_KEY);
   }
 
-  @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_30_SECONDS)
   async analyzeTrend() {
     const [originTrend, nowTrend] = await Promise.all([
       this.redisService.redisClient.lrange(


### PR DESCRIPTION
# 🔨 테스크
### Issue

- close #19

### 테스크 확인
- netlify, cloudeflare 등의 외부 의존성을 제거함에 따라서 QUIC 에러를 고려하지 않아도 됨
- 이에 따라서 강제 이벤트 발생을 삭제할 필요성을 확인

### 학습 키워드
- rxjs
- lodash
- eventsource
- SSE

### 참고 자료
- [테오님 블로그, Rxjs](https://velog.io/@teo/rxjs)
- [Nest.js SSE 공식문서](https://docs.nestjs.com/techniques/server-sent-events)
- [Event Source API](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)
- [김용성님 블로그, lodash 소개](https://velog.io/@kysung95/%EC%A7%A4%EB%A7%89%EA%B8%80-lodash-%EC%95%8C%EA%B3%A0-%EC%93%B0%EC%9E%90)

# 📋 작업 내용

- 피드 순위 변경이 생길 경우에만 이벤트가 발생하도록 수정

# 📷 스크린 샷(선택 사항)
- 조회수 업데이트 전
![업데이트가 안 됨을 확인](https://github.com/user-attachments/assets/a427bd6b-e442-4576-a8f8-27711bedf0e6)

- 조회수 업데이트 후
![조회수 업데이트 후 이벤트 발생 확인](https://github.com/user-attachments/assets/e5a96b80-d9ba-45f7-8bf2-83999d3a442f)

