### PR TITLE
📦 chore: Let's Encrypt SSL/TLS 인증서 발급 및 Nginx 설정 추가

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -1,23 +1,37 @@
+# HTTP로 들어오는 요청을 HTTPS로 Redirect
 server {
-	listen 80 default_server;
-	server_name _;
+    listen 80;
+    server_name denamu.site www.denamu.site;
+
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS로 들어온 요청에 대한 처리 진행
+server {
+    listen 443 ssl;
+    server_name denamu.site www.denamu.site;
+
+    ssl_certificate /etc/letsencrypt/live/denamu.site/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/denamu.site/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 
     # 정적 파일 서빙 - FE 빌드 파일
     location / {
         root /var/web05-Denamu/client/dist;
-        index index.html;  # 기본 파일 설정
-        try_files $uri /index.html;  # SPA 지원
+        index index.html;
+        try_files $uri /index.html;
     }
 
     # 정적 파일 서빙
-	location /files {
-		alias /var/web05-Denamu/static/;
-		try_files $uri $uri/ =404; # 파일이 없으면 404 반환
-	}
+    location /files {
+        alias /var/web05-Denamu/static/;
+        try_files $uri $uri/ =404;
+    }
 
     # API 요청을 NestJS로 프록시
     location /api {
-        proxy_pass http://127.0.0.1:8080;  # NestJS 서버
+        proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -25,7 +39,7 @@ server {
         proxy_cache_bypass $http_upgrade;
     }
 
-	# WebSocket 요청 프록시
+    # WebSocket 요청 프록시
     location /chat {
         proxy_pass http://127.0.0.1:8080;
         proxy_http_version 1.1;

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
   app.enableCors({
     origin: [
       'http://localhost:5173',
-      'https://denamu.netlify.app',
+      'https://www.denamu.site',
       'https://denamu.site',
     ],
     credentials: true,


### PR DESCRIPTION
# 🔨 테스크
### Issue
- close #299 

# 📋 작업 내용
> 본 PR 이후부터는 더 이상 CloudFlare를 사용하지 않습니다.

### CloudFlare 제거 및 DNS 서비스(가비아) 포워딩 설정 변경
기존에 동작중이던 CloudFlare 서비스를 삭제하였습니다.
또한, 가비아의 DNS 포워딩 설정을 아래와 같이 처리하였습니다.
![image](https://github.com/user-attachments/assets/cd3dc321-b294-48da-a946-f4c8a34c30d2)

### Let's Encrypt를 통한 SSL 인증서 발급
서버 인스턴스 내에 `certbot`, `python3-certbot-nginx` 를 설치하였습니다.
```bash
$ sudo apt-get install certbot
$ apt-get install python3-certbot-nginx
```

### Nginx 설정
HTTP 요청을 HTTPS로 리다이렉션 처리하였으며, 인증서 발급을 위한 키페어 경로를 선언해주었습니다. (SSL 인증서 발급 명령어 치면 알아서 추가됩니다.)

### SSL 인증서 재발급을 위한 crontab 설정
Let's Encrypt에서 발행해주는 DV(Domain Validation)은 90일을 주기로 만료됩니다. (인증서 보안 강화를 위해)
**이에 따라 만료되기 이전에 자동으로 인증서를 재발급 받는 과정이 필요합니다.**

서버 인스턴스에 crontab을 설정하였습니다. 서버에 접속 후 `sudo crontab -l` 입력시
`0 18 1 * * sudo certbot renew --pre-hook "sudo systemctl stop nginx" --post-hook "sudo systemctl restart nginx"` 이 추가되었음을 보실 수 있습니다.

해당 명령은 매월 1일 새벽 3시에 sudo certbot renew 명령어를 통해 인증서 재발급을 수행하며, 명령어를 실행 전과 후로 nginx를 멈추었다가 재실행 합니다. (갱신 시 nginx 서비스를 중단해야 하기에 잠시 서버의 연결이 끊길 수 있습니다. 시뮬레이팅 해본 결과 약 3~4초 정도 연결이 끊깁니다.)

### `www` Alias 경로 CORS 허용
![image](https://github.com/user-attachments/assets/6696e1fb-7981-497a-8050-1d2b0e3ec470)

현재 `www.denamu.site` 경로로 요청이 들어올 경우 요청 자체는 `denamu.site`로 리다이렉션되지만, Origin이 달라 CORS 오류가 발생하고 있습니다.
CloudFlare를 사용할때는 프록시 처리되기에 설정해줄 필요가 없었으나, 이제는 추가할 필요가 있어 추가 해 주었습니다.