### PR TITLE
🐛 fix: nginx proxy_read_timeout 1시간으로 설정

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,7 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 3600s;
     }
 
     # WebSocket 요청 프록시


### PR DESCRIPTION
# 📋 작업 내용
#### SSE Timeout 설정
nginx는 기본값으로 SSE Connection이 60초이상 아무런 데이터가 오지 않을 시 연결을 끊어버립니다.
이 기본값을 3600초로 수정하였습니다.