### PR TITLE
🐛 fix: 채팅 날짜 변경 알림 로직 수정

### DIFF
--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -8,7 +8,7 @@ export const formatDate = (dateString: string | undefined | null) => {
     if (isNaN(date.getTime())) {
       return "-";
     }
-    return date.toISOString().split("T")[0];
+    return date.toLocaleDateString('en-CA');
   } catch (error) {
     console.error("Date formatting error:", error);
     return "-";

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -34,6 +34,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
   private cronTask: cron.ScheduledTask;
+  private dayInit: boolean;
 
   constructor(private readonly redisService: RedisService) {}
 
@@ -47,7 +48,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   private startMidnightCron() {
     this.cronTask = cron.schedule('0 0 * * *', () => {
-      this.emitMidnightMessage();
+      this.dayInit = true;
     });
   }
 
@@ -109,6 +110,11 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     };
 
     await this.saveMessageToRedis(broadcastPayload);
+
+    if (this.dayInit) {
+      this.dayInit = false;
+      this.emitMidnightMessage();
+    }
 
     this.server.emit('message', broadcastPayload);
   }


### PR DESCRIPTION
# 🔨 테스크
### Issue
- close #110 

# 📋 작업 내용
### 하루 전 날짜가 찍히던 문제 수정
FE에서 날짜를 찍을 때, `toISOString()` 메서드를 사용중이었습니다. 해당 시간은 **UTC시간을 기준으로 반환하므로, 서버 시간인 한국시보다 약 9시간이 늦습니다.**

날짜 부분을 가져오는 과정을 `date.toLocaleDateString('en-CA');`로 수정하여 로컬 시간과 동일한 날짜가 뜨도록 수정하였습니다.

### 해당 일에 새로운 채팅내역이 없어도 날짜가 추가되던 문제 수정
![image](https://github.com/user-attachments/assets/ece37c10-cc57-4eec-ab0f-5d3999c3392b)

위 사진과 같이 해당 일에 새로운 채팅내역이 없어도 매 자정에 날짜가 표시되는 문제가 있었습니다.
이를 수정하기 위해 메소드 내 bool 멤버변수를 선언하고, 이를 체킹하여 날짜를 표현해주도록 수정하였습니다.
