### PR TITLE
🐛 fix: Nginx Forwarded-IP 전달 설정 및 채팅 날짜 알림 로직 수정

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,11 @@ server {
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 3600s;
+
+        proxy_set_header Host $host; # Host 헤더로 host 변수값 전달
+        proxy_set_header X-Real-IP $remote_addr;  # X-Real-IP 헤더로 실제 IP 전달
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For 헤더로 실제 IP 전달
+        proxy_set_header X-Forwarded-Proto $scheme; # 클라이언트의 프로토콜 전달
     }
 
     # WebSocket 요청 프록시
@@ -50,5 +55,10 @@ server {
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
+
+        proxy_set_header Host $host; # Host 헤더로 host 변수값 전달
+        proxy_set_header X-Real-IP $remote_addr;  # X-Real-IP 헤더로 실제 IP 전달
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For 헤더로 실제 IP 전달
+        proxy_set_header X-Forwarded-Proto $scheme; # 클라이언트의 프로토콜 전달
     }
 }

--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,6 @@ server {
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 3600s;
 
-        proxy_set_header Host $host; # Host 헤더로 host 변수값 전달
         proxy_set_header X-Real-IP $remote_addr;  # X-Real-IP 헤더로 실제 IP 전달
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For 헤더로 실제 IP 전달
         proxy_set_header X-Forwarded-Proto $scheme; # 클라이언트의 프로토콜 전달
@@ -56,7 +55,6 @@ server {
         proxy_read_timeout 3600s;
         proxy_send_timeout 3600s;
 
-        proxy_set_header Host $host; # Host 헤더로 host 변수값 전달
         proxy_set_header X-Real-IP $remote_addr;  # X-Real-IP 헤더로 실제 IP 전달
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For 헤더로 실제 IP 전달
         proxy_set_header X-Forwarded-Proto $scheme; # 클라이언트의 프로토콜 전달

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -103,7 +103,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     if (this.dayInit) {
       this.dayInit = false;
-      this.emitMidnightMessage();
+      await this.emitMidnightMessage();
     }
 
     this.server.emit('message', broadcastPayload);

--- a/server/src/common/logger/logger.interceptor.ts
+++ b/server/src/common/logger/logger.interceptor.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { finalize } from 'rxjs';
 import { WinstonLoggerService } from './logger.service';
+import { Request } from 'express';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -18,11 +19,7 @@ export class LoggingInterceptor implements NestInterceptor {
     if (!url.includes('register') && !url.includes('login')) {
       this.logger.log(
         JSON.stringify({
-          host:
-            request.headers['x-forwarded-for'] ||
-            request.headers['CF-Connecting-IP'] ||
-            request.socket?.remoteAddress ||
-            'unknown',
+          host: this.getIp(request),
           method: request.method,
           url: request.url,
           body: request.body,
@@ -38,5 +35,16 @@ export class LoggingInterceptor implements NestInterceptor {
         }
       }),
     );
+  }
+
+  private getIp(request: Request) {
+    const forwardedFor = request.headers['x-forwarded-for'];
+
+    if (typeof forwardedFor === 'string') {
+      const forwardedIps = forwardedFor.split(',');
+      return forwardedIps[0].trim();
+    }
+
+    return request.socket.remoteAddress;
   }
 }

--- a/server/src/feed/feed.service.ts
+++ b/server/src/feed/feed.service.ts
@@ -132,11 +132,7 @@ export class FeedService {
     response: Response,
   ) {
     const cookie = request.headers.cookie;
-    const ip =
-      request.headers['CF-Connecting-IP'] ||
-      request.headers['x-forwarded-for'] ||
-      request.socket?.remoteAddress ||
-      'unknown';
+    const ip = this.getIp(request);
     if (ip && this.isString(ip)) {
       const redis = this.redisService.redisClient;
       const [feed, hasCookie, hasIpFlag] = await Promise.all([
@@ -218,5 +214,16 @@ export class FeedService {
       const dateNext = new Date(nextFeed.createdAt);
       return dateNext.getTime() - dateCurrent.getTime();
     });
+  }
+
+  private getIp(request: Request) {
+    const forwardedFor = request.headers['x-forwarded-for'];
+
+    if (typeof forwardedFor === 'string') {
+      const forwardedIps = forwardedFor.split(',');
+      return forwardedIps[0].trim();
+    }
+
+    return request.socket.remoteAddress;
   }
 }


### PR DESCRIPTION
# 🔨 테스크
-   close #300 

# 📋 작업 내용
### Nginx 설정 파일에 IP 관련 헤더 전달 설정 추가
```
    location /api {
       ...
        proxy_set_header Host $host; # Host 헤더로 host 변수값 전달
        proxy_set_header X-Real-IP $remote_addr;  # X-Real-IP 헤더로 실제 IP 전달
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;  # X-Forwarded-For 헤더로 실제 IP 전달
        proxy_set_header X-Forwarded-Proto $scheme; # 클라이언트의 프로토콜 전달
    }
...
```
https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/X-Forwarded-For
- **`X-Real-IP` 헤더** : 클라이언트의 실제 IP 주소를 **단일 값으로 전달** 하는 헤더. 프록시 서버가 실제 IP를 백엔드 서버에 전달하는 용도로 주로 사용됨. (의미상으로는 _바로 직전의 IP 주소_ 가 맞는거 같긴한데, 이건 표준은 아닌 것 같아서 일단 이렇게 설정해두었습니다. 😅)

- **`X-Forwarded-For` 헤더** : 클라이언트의 IP 주소뿐만 아니라 **요청이 거쳐온 모든 프록시 서버의 IP 주소를 목록 형식으로 전달**하는 헤더. 
> 예시 
클라이언트 : `1.2.3.4`, 리버스 프록시 서버 : `127.0.0.1` 일때, `X-Forwarded-For` 헤더 값은 `1.2.3.4, 127.0.0.1`이 됨.

- **`X-Forwarded-Proto` 헤더** : 클라이언트의 프로토콜을 전달하는 헤더.

### 서버 내 IP 획득 로직 수정
`CF-Connecting-IP`는 CloudFlare에서 사용하는 헤더로, 이제 사용되지 않기에 제거하였습니다.
또한, `request.socket?.remoteAddress` 역시 Nginx에서 소켓 연결시에도 `X-Forwarded-For` 헤더를 설정해두도록 하였으므로 필요없어 제거 하였습니다.

### 채팅 오류 개선을 위한 await 키워드 추가
기존에 날짜 알림보다 채팅이 먼저 emit 되는 문제가 있어, 해당 메시지가 해당일 최초 메시지인지 확인 후 날짜 알림을 발행하는 부분에 await을 추가하여 순서를 보장할 수 있도록 처리하였습니다.