### PR TITLE
🐛 fix: 채팅 자정 Cron 동작을 위한 ScheduleModule 임포트

### DIFF
--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -33,7 +33,7 @@ type BroadcastPayload = {
 export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()
   server: Server;
-  private dayInit: boolean;
+  private dayInit: boolean = false;
 
   constructor(private readonly redisService: RedisService) {}
 

--- a/server/src/chat/chat.module.ts
+++ b/server/src/chat/chat.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ChatGateway } from './chat.gateway';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
-  imports: [],
+  imports: [ScheduleModule.forRoot()],
   providers: [ChatGateway],
 })
 export class ChatModule {}


### PR DESCRIPTION
# 🔨 테스크


### Issue
-   close #280 

# 📋 작업 내용
### 자정 알림 크론이 동작하지 않는 문제
기존의 `node-cron`에서 `@nestjs/schedule` 으로 변경하며 실행이 되지 않았습니다.
이에 따라 모듈 설정에 임포트를 추가하였습니다.