### PR TITLE
✨ feat: 첫 방문 사용자 about페이지로 리다이렉트

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useEffect } from "react";
-import { Routes, Route, useLocation } from "react-router-dom";
+import { Routes, Route, useLocation, Navigate } from "react-router-dom";
 
 import PostDetail from "@/components/common/Card/PostDetail";
 import { Toaster } from "@/components/ui/toaster";
@@ -15,6 +15,7 @@ import { useMediaQuery } from "@/hooks/common/useMediaQuery";
 import { denamuAscii } from "@/constants/denamuAscii";
 
 import { useMediaStore } from "@/store/useMediaStore";
+import { useVisitStore } from "@/store/useVisitStore";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
@@ -27,6 +28,7 @@ const queryClient = new QueryClient();
 export default function App() {
   const setIsMobile = useMediaStore((state) => state.setIsMobile);
   const isMobile = useMediaQuery("(max-width: 767px)");
+  const { hasVisited, setVisited } = useVisitStore();
   const location = useLocation();
   const state =
     location.state && location.state.backgroundLocation
@@ -46,7 +48,10 @@ export default function App() {
   useEffect(() => {
     setIsMobile(isMobile);
   }, [isMobile]);
-
+  if (!hasVisited) {
+    setVisited();
+    return <Navigate to="/about" replace />;
+  }
   return (
     <QueryClientProvider client={queryClient}>
       <Routes location={state?.backgroundLocation || location}>

--- a/client/src/components/sections/MainContent.tsx
+++ b/client/src/components/sections/MainContent.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from "react";
+
 import LatestSection from "@/components/sections/LatestSection";
 import TrandingSection from "@/components/sections/TrendingSection";
 
@@ -5,6 +7,9 @@ import { useMediaStore } from "@/store/useMediaStore";
 
 export default function MainContent() {
   const isMobile = useMediaStore((state) => state.isMobile);
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   return (
     <div className="flex flex-col px-4 md:p-8 md:gap-8">
       <TrandingSection />

--- a/client/src/store/useVisitStore.ts
+++ b/client/src/store/useVisitStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+import { persist, createJSONStorage } from "zustand/middleware";
+
+interface VisitState {
+  hasVisited: boolean;
+  setVisited: () => void;
+}
+
+export const useVisitStore = create<VisitState>()(
+  persist(
+    (set) => ({
+      hasVisited: false,
+      setVisited: () => set({ hasVisited: true }),
+    }),
+    {
+      name: "visit-flag",
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #323 

### 첫 방문 사용자 체크 후 about페이지로 리다이렉트

-   localStore에 visit-flag를 생성하여 첫방문 체크를 했습니다.

### 메인페이지 접근 시 스크롤 최상단으로 이동

-   about페이지에서 메인페이지에 접근하기 위해서 아래로 내려가있던 스크롤이 메인페이지에서도 그대로 유지되어 메인페이지 접근 시 해당 스크롤 위치까지 내려가는 현상이 있어서 수정했습니다.

# 📋 작업 내용

-   useVisitStore를 생성하여 hasVistied 상태를 저장하고 localStore에 flag를 생성하도록 구현했습니다.
```
import { create } from "zustand";

import { persist, createJSONStorage } from "zustand/middleware";

interface VisitState {
  hasVisited: boolean;
  setVisited: () => void;
}

export const useVisitStore = create<VisitState>()(
  persist(
    (set) => ({
      hasVisited: false,
      setVisited: () => set({ hasVisited: true }),
    }),
    {
      name: "visit-flag",
      storage: createJSONStorage(() => localStorage),
    }
  )
);
```

-  메인페이지 접근 시 스크롤을 최상단으로 올리기 위해 MainContent.tsx에 useEffect를 활용하여 스크롤을 올렸습니다.

# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/c5237c14-3847-4558-9df8-3d8b60452575)

