### PR TITLE
♻️ refactor: mailService 내 강결합 제거

### DIFF
--- a/server/src/common/email/email.service.ts
+++ b/server/src/common/email/email.service.ts
@@ -31,33 +31,41 @@ export class EmailService {
     });
   }
 
-  async sendMail(rss: Rss, approveFlag: boolean, description?: string) {
+  private async sendMail(
+    mailOptions: nodemailer.SendMailOptions,
+  ): Promise<void> {
     try {
-      const { subject, content } = this.createEmail(
-        rss,
-        approveFlag,
-        description,
-      );
-      await this.transporter.sendMail({
-        from: `Denamu<${this.emailUser}>`,
-        to: `${rss.userName}<${rss.email}>`,
-        subject,
-        html: content,
-      });
-      this.logger.log(`${rss.email} 주소로 메일이 전송되었습니다`);
+      await this.transporter.sendMail(mailOptions);
+      this.logger.log(`${mailOptions.to} 이메일 전송 성공`);
     } catch (error) {
-      this.logger.error(
-        `${rss.email} 주소로 메일 전송 중 오류가 발생했습니다: ${error}`,
-      );
+      this.logger.error(`${mailOptions.to} 이메일 전송 실패: ${error}`);
     }
   }
 
-  private createEmail(rss: Rss, approveFlag: boolean, description?: string) {
-    const result = approveFlag ? `승인` : `거부`;
-    const mail = {
+  async sendRssMail(
+    rss: Rss,
+    approveFlag: boolean,
+    description?: string,
+  ): Promise<void> {
+    const mailOptions = this.createRssRegistrationMail(
+      rss,
+      approveFlag,
+      description,
+    );
+    await this.sendMail(mailOptions);
+  }
+
+  private createRssRegistrationMail(
+    rss: Rss,
+    approveFlag: boolean,
+    description?: string,
+  ): nodemailer.SendMailOptions {
+    const result = approveFlag ? '승인' : '거부';
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: `${rss.userName}<${rss.email}>`,
       subject: `[🎋 Denamu] RSS 등록이 ${result} 되었습니다.`,
-      content: createMailContent(rss, approveFlag, this.emailUser, description),
+      html: createMailContent(rss, approveFlag, this.emailUser, description),
     };
-    return mail;
   }
 }

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -107,7 +107,11 @@ export class RssService {
       ]);
       return rejectRss;
     });
-    this.emailService.sendMail(rejectRss, false, rssRejectBodyDto.description);
+    this.emailService.sendRssMail(
+      rejectRss,
+      false,
+      rssRejectBodyDto.description,
+    );
   }
 
   async readAcceptHistory() {
@@ -167,6 +171,6 @@ export class RssService {
       rssAccept,
     );
     this.feedCrawlerService.saveAiQueue(feedsWithId);
-    this.emailService.sendMail(rssAccept, true);
+    this.emailService.sendRssMail(rssAccept, true);
   }
 }


### PR DESCRIPTION
# 작업 이유
회원 가입에 이메일 인증이 필요하나, 기존 이메일 모듈 코드가 사용하기 용이한 형태가 아님에 따른 리팩토링 필요성 대두.

# 📋 작업 내용
### `EmailService` 내 강결합을 제거
기존 `EmailService` 내 `sendMail` 메소드와 `createEmail` 은 **RSS 등록 여부 응답 메일을 발송하는 로직과 강하게 결합되어 있습니다.** 

**이는 메일 발송이 필요한 다른 기능을 추가 구현하기에 적합하지 않은 형태**이기에 메일을 보내는 부분과 RSS 등록 여부 응답 메일을 생성하는 부분을 분리하였습니다.