### PR TITLE
📦 chore: vite 개발용 포트 cors 허용

### DIFF
--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -22,6 +22,7 @@ async function bootstrap() {
   app.enableCors({
     origin: [
       'http://localhost:5173',
+      'http://localhost:4173',
       'https://www.denamu.site',
       'https://denamu.site',
     ],


### PR DESCRIPTION
# 📋 작업 내용
### vite 정적 웹서버 포트 허용
FE팀의 요청으로 `http://localhost:4173` 포트를 허용처리 하였습니다.