### PR TITLE
✨ feat: 게시글 상세 댓글ui추가

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -4,6 +4,7 @@ import pluginReact from "eslint-plugin-react";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
+  { ignores: ["dist", "node_modules", "coverage"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { languageOptions: { globals: globals.browser } },
   ...tseslint.configs.recommended,

--- a/client/src/api/services/comments.ts
+++ b/client/src/api/services/comments.ts
@@ -1,0 +1,21 @@
+import { BLOG } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+import { ApiData } from "@/types/api";
+import { PostCommentType } from "@/types/post";
+
+export const comments = {
+  get: async (feedId: number): Promise<PostCommentType[]> => {
+    const response = await axiosInstance.get<ApiData<PostCommentType[]>>(BLOG.COMMENT.LIST(feedId));
+    return response.data.data;
+  },
+  create: async (feedId: number, comment: string): Promise<void> => {
+    await axiosInstance.post(BLOG.COMMENT.LIST(feedId), { comment });
+  },
+  update: async (feedId: number, commentId: number, newComment: string): Promise<void> => {
+    await axiosInstance.patch(BLOG.COMMENT.ITEM(feedId, commentId), { newComment });
+  },
+  remove: async (feedId: number, commentId: number): Promise<void> => {
+    await axiosInstance.delete(BLOG.COMMENT.ITEM(feedId, commentId));
+  },
+};

--- a/client/src/components/common/Card/detail/CommentAction.tsx
+++ b/client/src/components/common/Card/detail/CommentAction.tsx
@@ -7,8 +7,12 @@ export default function CommentAction({ id, handleModify }: { id: number; handle
   };
   return (
     <div className="flex gap-2 text-sm">
-      <button onClick={() => handleModify(id)}>수정</button>
-      <button onClick={handleOpen}>삭제</button>
+      <button onClick={() => handleModify(id)} className="text-gray-400">
+        수정
+      </button>
+      <button onClick={handleOpen} className="text-gray-400">
+        삭제
+      </button>
       {isOpen && <DeleteButton id={id} handleOpen={handleOpen} />}
     </div>
   );

--- a/client/src/components/common/Card/detail/CommentAction.tsx
+++ b/client/src/components/common/Card/detail/CommentAction.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+export default function CommentAction({ id, handleModify }: { id: number; handleModify: (id: number) => void }) {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const handleOpen = () => {
+    setIsOpen(!isOpen);
+  };
+  return (
+    <div className="flex gap-2 text-sm">
+      <button onClick={() => handleModify(id)}>수정</button>
+      <button onClick={handleOpen}>삭제</button>
+      {isOpen && <DeleteButton id={id} handleOpen={handleOpen} />}
+    </div>
+  );
+}
+
+function DeleteButton({ id, handleOpen }: { id: number; handleOpen: () => void }) {
+  return (
+    <div className="w-[100%] h-[100%] absolute top-0 left-0 z-[1000] bg-white/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
+      <div className="flex flex-col fixed top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] w-full max-w-xs md:max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
+        <header className="flex flex-col space-y-2 text-center sm:text-left">
+          <span className="text-lg font-semibold">댓글 삭제</span>
+        </header>
+        <section>
+          <p className="text-sm text-muted-foreground text-center md:text-start">댓글을 정말로 삭제하시겠습니까?</p>
+        </section>
+        <footer className="flex flex-row justify-end space-x-2">
+          <button onClick={handleOpen} className="py-2 px-4 rounded-sm hover:bg-gray-100">
+            취소
+          </button>
+          <button className="bg-primary py-2 px-4 text-white rounded-sm hover:bg-primary/90">확인</button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/common/Card/detail/CommentAction.tsx
+++ b/client/src/components/common/Card/detail/CommentAction.tsx
@@ -3,16 +3,22 @@ import { useState } from "react";
 interface CommentActionProps {
   id: number;
   handleModify: (id: number) => void;
+  onDelete: (id: number) => void;
 }
 
 interface DeleteButtonProps {
   handleOpen: () => void;
+  handleDelete: () => void;
 }
 
-export default function CommentAction({ id, handleModify }: CommentActionProps) {
+export default function CommentAction({ id, handleModify, onDelete }: CommentActionProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const handleOpen = () => {
     setIsOpen(!isOpen);
+  };
+  const handleDelete = () => {
+    onDelete(id);
+    setIsOpen(false);
   };
   return (
     <div className="flex gap-2 text-sm">
@@ -22,12 +28,12 @@ export default function CommentAction({ id, handleModify }: CommentActionProps) 
       <button onClick={handleOpen} className="text-gray-400">
         삭제
       </button>
-      {isOpen && <DeleteButton handleOpen={handleOpen} />}
+      {isOpen && <DeleteButton handleOpen={handleOpen} handleDelete={handleDelete} />}
     </div>
   );
 }
 
-function DeleteButton({ handleOpen }: DeleteButtonProps) {
+function DeleteButton({ handleOpen, handleDelete }: DeleteButtonProps) {
   return (
     <div className="w-[100%] h-[100%] absolute top-0 left-0 z-[1000] bg-white/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
       <div className="flex flex-col fixed top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] w-full max-w-xs md:max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
@@ -41,7 +47,12 @@ function DeleteButton({ handleOpen }: DeleteButtonProps) {
           <button onClick={handleOpen} className="py-2 px-4 rounded-sm hover:bg-gray-100">
             취소
           </button>
-          <button className="bg-primary py-2 px-4 text-white rounded-sm hover:bg-primary/90">확인</button>
+          <button
+            onClick={handleDelete}
+            className="bg-primary py-2 px-4 text-white rounded-sm hover:bg-primary/90"
+          >
+            확인
+          </button>
         </footer>
       </div>
     </div>

--- a/client/src/components/common/Card/detail/CommentAction.tsx
+++ b/client/src/components/common/Card/detail/CommentAction.tsx
@@ -1,6 +1,15 @@
 import { useState } from "react";
 
-export default function CommentAction({ id, handleModify }: { id: number; handleModify: (id: number) => void }) {
+interface CommentActionProps {
+  id: number;
+  handleModify: (id: number) => void;
+}
+
+interface DeleteButtonProps {
+  handleOpen: () => void;
+}
+
+export default function CommentAction({ id, handleModify }: CommentActionProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const handleOpen = () => {
     setIsOpen(!isOpen);
@@ -13,12 +22,12 @@ export default function CommentAction({ id, handleModify }: { id: number; handle
       <button onClick={handleOpen} className="text-gray-400">
         삭제
       </button>
-      {isOpen && <DeleteButton id={id} handleOpen={handleOpen} />}
+      {isOpen && <DeleteButton handleOpen={handleOpen} />}
     </div>
   );
 }
 
-function DeleteButton({ id, handleOpen }: { id: number; handleOpen: () => void }) {
+function DeleteButton({ handleOpen }: DeleteButtonProps) {
   return (
     <div className="w-[100%] h-[100%] absolute top-0 left-0 z-[1000] bg-white/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
       <div className="flex flex-col fixed top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] w-full max-w-xs md:max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -98,7 +98,7 @@ export default function PostComment({ comments }: PostCommentProps) {
       {/* 더보기 버튼 */}
       {comments.length > 1 && (
         <div className="flex justify-center">
-          <button className="px-4 py-2 border border-gray-200 rounded-full text-sm text-gray-600 hover:bg-gray-50 transition-colors">
+          <button className="px-4 py-2 border border-gray-200 rounded-full text-sm text-black  hover:bg-gray-200 transition-colors">
             댓글 더보기
           </button>
         </div>

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+
+import { Heart } from "lucide-react";
+
+import CommentAction from "@/components/common/Card/detail/CommentAction";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+import { timeAgo } from "@/utils/timeago";
+
+import { PostCommentType } from "@/types/post";
+
+type PostCommentProps = {
+  comments: PostCommentType[];
+};
+export default function PostComment({ comments }: PostCommentProps) {
+  const [modifyId, setModifyId] = useState<number | null>(null);
+  const handleModify = (id: number | null) => {
+    setModifyId(id);
+  };
+  return (
+    <div className="w-full  space-y-6">
+      {/* 댓글 입력 영역 */}
+      <div className="bg-gray-50 rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+        <div className="p-4">
+          <div className="flex items-start gap-3">
+            <Avatar className="w-10 h-10">
+              <AvatarImage src="https://github.com/shadcn.png" alt="사용자 프로필" />
+              <AvatarFallback>CN</AvatarFallback>
+            </Avatar>
+            <textarea
+              placeholder="댓글을 입력하세요..."
+              className="flex-1 bg-transparent p-2 rounded-md h-20 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent resize-none"
+            ></textarea>
+          </div>
+        </div>
+        <div className="flex justify-end px-4 pb-4">
+          <button className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-full transition-colors">
+            등록
+          </button>
+        </div>
+      </div>
+
+      {/* 댓글 목록 헤더 */}
+      <div className="flex items-center border-b border-gray-200 pb-2">
+        <h3 className="font-bold text-lg">
+          댓글 <span className="text-yellow-500">{comments.length}</span>
+        </h3>
+      </div>
+
+      {/* 댓글 목록 */}
+      <ul className="space-y-4">
+        {comments
+          .sort((a, b) => Number(new Date(b.createdAt)) - Number(new Date(a.createdAt)))
+          .map((comment) => (
+            <li key={comment.id} className="border-b border-gray-100 pb-4">
+              <div className="flex items-start gap-3">
+                <Avatar className="w-8 h-8">
+                  <AvatarImage src={comment.authorImage} alt={comment.author} />
+                  <AvatarFallback>{comment.author.substring(0, 2)}</AvatarFallback>
+                </Avatar>
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <div className="flex justify-between w-full">
+                      <div className="flex gap-2 items-center">
+                        <p className="font-semibold text-sm">{comment.author}</p>
+                        <p className="text-sm text-gray-400">{timeAgo(comment.createdAt)}</p>
+                        <span className="flex text-[10px] items-center gap-1 border rounded-sm p-1 hover:bg-red-300">
+                          <Heart size={15} color="red" fill={comment.isLiked ? `red` : "#fff"} />
+                          {comment.likes}
+                        </span>
+                      </div>
+                      {modifyId !== comment.id && <CommentAction id={comment.id} handleModify={handleModify} />}
+                    </div>
+                  </div>
+                  {modifyId !== comment.id ? (
+                    <p className="mt-1 text-gray-800">{comment.content}</p>
+                  ) : (
+                    <div className="">
+                      <textarea className="w-[100%] mt-2 flex-1 bg-transparent p-2 rounded-md h-20 outline-none ring-2 ring-gray-300 border-transparent resize-none">
+                        {comment.content}
+                      </textarea>
+                      <div className="flex justify-end gap-3 text-sm">
+                        <button onClick={() => handleModify(null)} className="hover:bg-gray-200 py-2 px-4 rounded-lg">
+                          취소
+                        </button>
+                        <button className="bg-primary hover:bg-primary/80 py-2 px-4 text-white  rounded-lg">
+                          댓글 수정
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+      </ul>
+
+      {/* 더보기 버튼 */}
+      {comments.length > 1 && (
+        <div className="flex justify-center">
+          <button className="px-4 py-2 border border-gray-200 rounded-full text-sm text-gray-600 hover:bg-gray-50 transition-colors">
+            댓글 더보기
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -9,9 +9,15 @@ import { timeAgo } from "@/utils/timeago";
 
 import { PostCommentType } from "@/types/post";
 
-type PostCommentProps = {
+interface PostCommentProps {
   comments: PostCommentType[];
-};
+}
+
+interface CommentItemProps {
+  comment: PostCommentType;
+  modifyId: number | null;
+  handleModify: (id: number | null) => void;
+}
 export default function PostComment({ comments }: PostCommentProps) {
   const [modifyId, setModifyId] = useState<number | null>(null);
   const handleModify = (id: number | null) => {
@@ -49,49 +55,10 @@ export default function PostComment({ comments }: PostCommentProps) {
 
       {/* 댓글 목록 */}
       <ul className="space-y-4">
-        {comments
+        {[...comments]
           .sort((a, b) => Number(new Date(b.createdAt)) - Number(new Date(a.createdAt)))
           .map((comment) => (
-            <li key={comment.id} className="border-b border-gray-100 pb-4">
-              <div className="flex items-start gap-3">
-                <Avatar className="w-8 h-8">
-                  <AvatarImage src={comment.authorImage} alt={comment.author} />
-                  <AvatarFallback>{comment.author.substring(0, 2)}</AvatarFallback>
-                </Avatar>
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <div className="flex justify-between w-full">
-                      <div className="flex gap-2 items-center">
-                        <p className="font-semibold text-sm">{comment.author}</p>
-                        <p className="text-sm text-gray-400">{timeAgo(comment.createdAt)}</p>
-                        <span className="flex text-[10px] items-center gap-1 border rounded-sm p-1 hover:bg-red-300">
-                          <Heart size={15} color="red" fill={comment.isLiked ? `red` : "#fff"} />
-                          {comment.likes}
-                        </span>
-                      </div>
-                      {modifyId !== comment.id && <CommentAction id={comment.id} handleModify={handleModify} />}
-                    </div>
-                  </div>
-                  {modifyId !== comment.id ? (
-                    <p className="mt-1 text-gray-800">{comment.content}</p>
-                  ) : (
-                    <div className="">
-                      <textarea className="w-[100%] mt-2 flex-1 bg-transparent p-2 rounded-md h-20 outline-none ring-2 ring-gray-300 border-transparent resize-none">
-                        {comment.content}
-                      </textarea>
-                      <div className="flex justify-end gap-3 text-sm">
-                        <button onClick={() => handleModify(null)} className="hover:bg-gray-200 py-2 px-4 rounded-lg">
-                          취소
-                        </button>
-                        <button className="bg-primary hover:bg-primary/80 py-2 px-4 text-white  rounded-lg">
-                          댓글 수정
-                        </button>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </li>
+            <CommentItem key={comment.id} comment={comment} modifyId={modifyId} handleModify={handleModify} />
           ))}
       </ul>
 
@@ -106,3 +73,47 @@ export default function PostComment({ comments }: PostCommentProps) {
     </div>
   );
 }
+
+const CommentItem = ({ comment, modifyId, handleModify }: CommentItemProps) => {
+  return (
+    <li className="border-b border-gray-100 pb-4">
+      <div className="flex items-start gap-3">
+        <Avatar className="w-8 h-8">
+          <AvatarImage src={comment.authorImage} alt={comment.author} />
+          <AvatarFallback>{comment.author.substring(0, 2)}</AvatarFallback>
+        </Avatar>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <div className="flex justify-between w-full">
+              <div className="flex gap-2 items-center">
+                <p className="font-semibold text-sm">{comment.author}</p>
+                <p className="text-sm text-gray-400">{timeAgo(comment.createdAt)}</p>
+                <span className="flex text-[10px] items-center gap-1 border rounded-sm p-1 hover:bg-red-300">
+                  <Heart size={15} color="red" fill={comment.isLiked ? `red` : "#fff"} />
+                  {comment.likes}
+                </span>
+              </div>
+              {modifyId !== comment.id && <CommentAction id={comment.id} handleModify={handleModify} />}
+            </div>
+          </div>
+          {modifyId !== comment.id ? (
+            <p className="mt-1 text-gray-800">{comment.content}</p>
+          ) : (
+            <div className="">
+              <textarea
+                defaultValue={comment.content}
+                className="w-[100%] mt-2 flex-1 bg-transparent p-2 rounded-md h-20 outline-none ring-2 ring-gray-300 border-transparent resize-none"
+              ></textarea>
+              <div className="flex justify-end gap-3 text-sm">
+                <button onClick={() => handleModify(null)} className="hover:bg-gray-200 py-2 px-4 rounded-lg">
+                  취소
+                </button>
+                <button className="bg-primary hover:bg-primary/80 py-2 px-4 text-white  rounded-lg">댓글 수정</button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+};

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -1,46 +1,92 @@
 import { useState } from "react";
 
-import { Heart } from "lucide-react";
-
 import CommentAction from "@/components/common/Card/detail/CommentAction";
+import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
+import { useComments, useCreateComment, useUpdateComment, useDeleteComment } from "@/hooks/queries/useComments";
+import { useUserProfile } from "@/hooks/queries/useProfile";
+
+import { useAuthStore } from "@/store/useAuthStore";
+import { PostCommentType } from "@/types/post";
 import { timeAgo } from "@/utils/timeago";
 
-import { PostCommentType } from "@/types/post";
-
 interface PostCommentProps {
-  comments: PostCommentType[];
+  feedId: number;
 }
 
 interface CommentItemProps {
   comment: PostCommentType;
+  isOwner: boolean;
   modifyId: number | null;
   handleModify: (id: number | null) => void;
+  onUpdate: (commentId: number, newComment: string) => void;
+  onDelete: (commentId: number) => void;
 }
-export default function PostComment({ comments }: PostCommentProps) {
+
+const INITIAL_VISIBLE = 3;
+
+export default function PostComment({ feedId }: PostCommentProps) {
+  const { id: userId, userName } = useAuthStore((state) => state.userInfo);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  const { data: comments = [] } = useComments(feedId);
+  const { data: myProfile } = useUserProfile(userId ?? 0);
+  const { mutate: createComment, isPending: isCreating } = useCreateComment(feedId);
+  const { mutate: updateComment } = useUpdateComment(feedId);
+  const { mutate: deleteComment } = useDeleteComment(feedId);
+
+  const [content, setContent] = useState("");
   const [modifyId, setModifyId] = useState<number | null>(null);
-  const handleModify = (id: number | null) => {
-    setModifyId(id);
+  const [showAll, setShowAll] = useState(false);
+  const [loginOpen, setLoginOpen] = useState(false);
+
+  const handleModify = (id: number | null) => setModifyId(id);
+
+  const handleSubmit = () => {
+    if (!isAuthenticated) {
+      setLoginOpen(true);
+      return;
+    }
+    const trimmed = content.trim();
+    if (!trimmed || isCreating) return;
+    createComment(trimmed, { onSuccess: () => setContent("") });
   };
+
+  const handleUpdate = (commentId: number, newComment: string) => {
+    const trimmed = newComment.trim();
+    if (!trimmed) return;
+    updateComment({ commentId, newComment: trimmed }, { onSuccess: () => setModifyId(null) });
+  };
+
+  const sorted = [...comments].sort((a, b) => Number(new Date(b.date)) - Number(new Date(a.date)));
+  const visible = showAll ? sorted : sorted.slice(0, INITIAL_VISIBLE);
+
   return (
-    <div className="w-full  space-y-6">
+    <div className="w-full space-y-6">
       {/* 댓글 입력 영역 */}
       <div className="bg-gray-50 rounded-lg shadow-sm border border-gray-200 overflow-hidden">
         <div className="p-4">
           <div className="flex items-start gap-3">
             <Avatar className="w-10 h-10">
-              <AvatarImage src="https://github.com/shadcn.png" alt="사용자 프로필" />
-              <AvatarFallback>CN</AvatarFallback>
+              <AvatarImage src={myProfile?.profileImage ?? undefined} alt={userName ?? "사용자 프로필"} />
+              <AvatarFallback>{(myProfile?.userName ?? userName ?? "?").substring(0, 2)}</AvatarFallback>
             </Avatar>
             <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
               placeholder="댓글을 입력하세요..."
               className="flex-1 bg-transparent p-2 rounded-md h-20 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent resize-none"
             ></textarea>
           </div>
         </div>
         <div className="flex justify-end px-4 pb-4">
-          <button className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-full transition-colors">
+          <button
+            onClick={handleSubmit}
+            disabled={isCreating}
+            className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-full transition-colors disabled:opacity-60"
+          >
             등록
           </button>
         </div>
@@ -55,60 +101,85 @@ export default function PostComment({ comments }: PostCommentProps) {
 
       {/* 댓글 목록 */}
       <ul className="space-y-4">
-        {[...comments]
-          .sort((a, b) => Number(new Date(b.createdAt)) - Number(new Date(a.createdAt)))
-          .map((comment) => (
-            <CommentItem key={comment.id} comment={comment} modifyId={modifyId} handleModify={handleModify} />
-          ))}
+        {visible.map((comment) => (
+          <CommentItem
+            key={comment.id}
+            comment={comment}
+            isOwner={comment.user.id === userId}
+            modifyId={modifyId}
+            handleModify={handleModify}
+            onUpdate={handleUpdate}
+            onDelete={deleteComment}
+          />
+        ))}
       </ul>
 
       {/* 더보기 버튼 */}
-      {comments.length > 1 && (
+      {!showAll && sorted.length > INITIAL_VISIBLE && (
         <div className="flex justify-center">
-          <button className="px-4 py-2 border border-gray-200 rounded-full text-sm text-black  hover:bg-gray-200 transition-colors">
+          <button
+            onClick={() => setShowAll(true)}
+            className="px-4 py-2 border border-gray-200 rounded-full text-sm text-black hover:bg-gray-200 transition-colors"
+          >
             댓글 더보기
           </button>
         </div>
       )}
+
+      <div onClick={(e) => e.stopPropagation()}>
+        <Dialog open={loginOpen} onOpenChange={setLoginOpen}>
+          <DialogContent className="z-[1000] max-w-md border-0 bg-transparent p-0 shadow-none">
+            <DialogTitle className="sr-only">로그인</DialogTitle>
+            <AuthSignInForm hideBackButton onSuccess={() => setLoginOpen(false)} />
+          </DialogContent>
+        </Dialog>
+      </div>
     </div>
   );
 }
 
-const CommentItem = ({ comment, modifyId, handleModify }: CommentItemProps) => {
+const CommentItem = ({ comment, isOwner, modifyId, handleModify, onUpdate, onDelete }: CommentItemProps) => {
+  const [editContent, setEditContent] = useState(comment.comment);
+  const isEditing = modifyId === comment.id;
+
   return (
     <li className="border-b border-gray-100 pb-4">
       <div className="flex items-start gap-3">
         <Avatar className="w-8 h-8">
-          <AvatarImage src={comment.authorImage} alt={comment.author} />
-          <AvatarFallback>{comment.author.substring(0, 2)}</AvatarFallback>
+          <AvatarImage src={comment.user.profileImage ?? undefined} alt={comment.user.userName} />
+          <AvatarFallback>{comment.user.userName.substring(0, 2)}</AvatarFallback>
         </Avatar>
         <div className="flex-1">
           <div className="flex items-center gap-2">
             <div className="flex justify-between w-full">
               <div className="flex gap-2 items-center">
-                <p className="font-semibold text-sm">{comment.author}</p>
-                <p className="text-sm text-gray-400">{timeAgo(comment.createdAt)}</p>
-                <span className="flex text-[10px] items-center gap-1 border rounded-sm p-1 hover:bg-red-300">
-                  <Heart size={15} color="red" fill={comment.isLiked ? `red` : "#fff"} />
-                  {comment.likes}
-                </span>
+                <p className="font-semibold text-sm">{comment.user.userName}</p>
+                <p className="text-sm text-gray-400">{timeAgo(comment.date)}</p>
               </div>
-              {modifyId !== comment.id && <CommentAction id={comment.id} handleModify={handleModify} />}
+              {isOwner && !isEditing && (
+                <CommentAction id={comment.id} handleModify={handleModify} onDelete={onDelete} />
+              )}
             </div>
           </div>
-          {modifyId !== comment.id ? (
-            <p className="mt-1 text-gray-800">{comment.content}</p>
+          {!isEditing ? (
+            <p className="mt-1 text-gray-800">{comment.comment}</p>
           ) : (
             <div className="">
               <textarea
-                defaultValue={comment.content}
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
                 className="w-[100%] mt-2 flex-1 bg-transparent p-2 rounded-md h-20 outline-none ring-2 ring-gray-300 border-transparent resize-none"
               ></textarea>
               <div className="flex justify-end gap-3 text-sm">
                 <button onClick={() => handleModify(null)} className="hover:bg-gray-200 py-2 px-4 rounded-lg">
                   취소
                 </button>
-                <button className="bg-primary hover:bg-primary/80 py-2 px-4 text-white  rounded-lg">댓글 수정</button>
+                <button
+                  onClick={() => onUpdate(comment.id, editContent)}
+                  className="bg-primary hover:bg-primary/80 py-2 px-4 text-white rounded-lg"
+                >
+                  댓글 수정
+                </button>
               </div>
             </div>
           )}

--- a/client/src/components/common/Card/detail/PostContent.tsx
+++ b/client/src/components/common/Card/detail/PostContent.tsx
@@ -7,8 +7,6 @@ import ShareButton from "@/components/common/Card/detail/ShareButton";
 
 import { usePostCardActions } from "@/hooks/common/usePostCardActions";
 
-import { POST_COMMENT_DATA } from "@/constants/dummyData";
-
 import { useMediaStore } from "@/store/useMediaStore";
 import { Post } from "@/types/post";
 
@@ -58,7 +56,7 @@ export const PostContent = React.memo(({ post }: PostContentProps) => {
         <LikeButton post={post} />
         <ShareButton post={post} />
       </div>
-      <PostComment comments={POST_COMMENT_DATA} />
+      <PostComment feedId={post.id} />
     </div>
   );
 });

--- a/client/src/components/common/Card/detail/PostContent.tsx
+++ b/client/src/components/common/Card/detail/PostContent.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import Markdown from "react-markdown";
 
 import LikeButton from "@/components/common/Card/detail/LikeButton";
+import PostComment from "@/components/common/Card/detail/PostComment";
 import ShareButton from "@/components/common/Card/detail/ShareButton";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 import { usePostCardActions } from "@/hooks/common/usePostCardActions";
 
@@ -58,64 +58,7 @@ export const PostContent = React.memo(({ post }: PostContentProps) => {
         <LikeButton post={post} />
         <ShareButton post={post} />
       </div>
-      <div className="w-full  space-y-6">
-        {/* 댓글 입력 영역 */}
-        <div className="bg-gray-50 rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-          <div className="p-4">
-            <div className="flex items-start gap-3">
-              <Avatar className="w-10 h-10">
-                <AvatarImage src="https://github.com/shadcn.png" alt="사용자 프로필" />
-                <AvatarFallback>CN</AvatarFallback>
-              </Avatar>
-              <textarea
-                placeholder="댓글을 입력하세요..."
-                className="flex-1 bg-transparent p-2 rounded-md h-20 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent resize-none"
-              ></textarea>
-            </div>
-          </div>
-          <div className="flex justify-end px-4 pb-4">
-            <button className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-full transition-colors">
-              등록
-            </button>
-          </div>
-        </div>
-
-        {/* 댓글 목록 헤더 */}
-        <div className="flex items-center border-b border-gray-200 pb-2">
-          <h3 className="font-bold text-lg">
-            댓글 <span className="text-yellow-500">{POST_COMMENT_DATA.length}</span>
-          </h3>
-        </div>
-
-        {/* 댓글 목록 */}
-        <ul className="space-y-4">
-          {POST_COMMENT_DATA.map((comment) => (
-            <li key={comment.id} className="border-b border-gray-100 pb-4">
-              <div className="flex items-start gap-3">
-                <Avatar className="w-8 h-8">
-                  <AvatarImage src={comment.authorImage} alt={comment.author} />
-                  <AvatarFallback>{comment.author.substring(0, 2)}</AvatarFallback>
-                </Avatar>
-                <div className="flex-1">
-                  <div className="flex items-center gap-2">
-                    <p className="font-semibold text-sm">{comment.author}</p>
-                  </div>
-                  <p className="mt-1 text-gray-800">{comment.content}</p>
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
-
-        {/* 더보기 버튼 */}
-        {POST_COMMENT_DATA.length > 3 && (
-          <div className="flex justify-center">
-            <button className="px-4 py-2 border border-gray-200 rounded-full text-sm text-gray-600 hover:bg-gray-50 transition-colors">
-              댓글 더보기
-            </button>
-          </div>
-        )}
-      </div>
+      <PostComment comments={POST_COMMENT_DATA} />
     </div>
   );
 });

--- a/client/src/components/common/Card/detail/PostContent.tsx
+++ b/client/src/components/common/Card/detail/PostContent.tsx
@@ -3,8 +3,11 @@ import Markdown from "react-markdown";
 
 import LikeButton from "@/components/common/Card/detail/LikeButton";
 import ShareButton from "@/components/common/Card/detail/ShareButton";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 import { usePostCardActions } from "@/hooks/common/usePostCardActions";
+
+import { POST_COMMENT_DATA } from "@/constants/dummyData";
 
 import { useMediaStore } from "@/store/useMediaStore";
 import { Post } from "@/types/post";
@@ -51,9 +54,67 @@ export const PostContent = React.memo(({ post }: PostContentProps) => {
           <p className="text-gray-400">💡 인공지능이 요약한 내용입니다. 오류가 포함될 수 있으니 참고 바랍니다.</p>
         )}
       </div>
-      <div className="flex gap-3">
+      <div className="flex gap-3 border-b pb-5">
         <LikeButton post={post} />
         <ShareButton post={post} />
+      </div>
+      <div className="w-full  space-y-6">
+        {/* 댓글 입력 영역 */}
+        <div className="bg-gray-50 rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <div className="p-4">
+            <div className="flex items-start gap-3">
+              <Avatar className="w-10 h-10">
+                <AvatarImage src="https://github.com/shadcn.png" alt="사용자 프로필" />
+                <AvatarFallback>CN</AvatarFallback>
+              </Avatar>
+              <textarea
+                placeholder="댓글을 입력하세요..."
+                className="flex-1 bg-transparent p-2 rounded-md h-20 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent resize-none"
+              ></textarea>
+            </div>
+          </div>
+          <div className="flex justify-end px-4 pb-4">
+            <button className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-full transition-colors">
+              등록
+            </button>
+          </div>
+        </div>
+
+        {/* 댓글 목록 헤더 */}
+        <div className="flex items-center border-b border-gray-200 pb-2">
+          <h3 className="font-bold text-lg">
+            댓글 <span className="text-yellow-500">{POST_COMMENT_DATA.length}</span>
+          </h3>
+        </div>
+
+        {/* 댓글 목록 */}
+        <ul className="space-y-4">
+          {POST_COMMENT_DATA.map((comment) => (
+            <li key={comment.id} className="border-b border-gray-100 pb-4">
+              <div className="flex items-start gap-3">
+                <Avatar className="w-8 h-8">
+                  <AvatarImage src={comment.authorImage} alt={comment.author} />
+                  <AvatarFallback>{comment.author.substring(0, 2)}</AvatarFallback>
+                </Avatar>
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <p className="font-semibold text-sm">{comment.author}</p>
+                  </div>
+                  <p className="mt-1 text-gray-800">{comment.content}</p>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+
+        {/* 더보기 버튼 */}
+        {POST_COMMENT_DATA.length > 3 && (
+          <div className="flex justify-center">
+            <button className="px-4 py-2 border border-gray-200 rounded-full text-sm text-gray-600 hover:bg-gray-50 transition-colors">
+              댓글 더보기
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/constants/dummyData.ts
+++ b/client/src/constants/dummyData.ts
@@ -151,3 +151,17 @@ export const POST_MODAL_DATA: PostDetailType = {
     tag: ["JavaScript", "React", "Frontend"],
   },
 };
+export const POST_COMMENT_DATA = [
+  {
+    id: 1,
+    author: "나무보다 숲을",
+    content: "정말 유익한 포스트에요!!",
+    authorImage: "https://github.com/shadcn.png",
+  },
+  {
+    id: 2,
+    author: "월성참치",
+    content: "엌ㅋㅋㅋ 개추요",
+    authorImage: "https://github.com/shadcn.png",
+  },
+];

--- a/client/src/constants/dummyData.ts
+++ b/client/src/constants/dummyData.ts
@@ -1,5 +1,6 @@
 import { ChatType } from "@/types/chat";
 import { PostDetailType } from "@/types/post";
+import { PostCommentType } from "@/types/post";
 
 // export const TRENDING_POSTS: Post[] = [
 //   {
@@ -151,17 +152,23 @@ export const POST_MODAL_DATA: PostDetailType = {
     tag: ["JavaScript", "React", "Frontend"],
   },
 };
-export const POST_COMMENT_DATA = [
+export const POST_COMMENT_DATA: PostCommentType[] = [
   {
     id: 1,
     author: "나무보다 숲을",
     content: "정말 유익한 포스트에요!!",
     authorImage: "https://github.com/shadcn.png",
+    createdAt: "2025-03-23T01:00:00.000Z",
+    likes: 5,
+    isLiked: true,
   },
   {
     id: 2,
     author: "월성참치",
     content: "엌ㅋㅋㅋ 개추요",
     authorImage: "https://github.com/shadcn.png",
+    createdAt: "2025-03-24T01:00:00.000Z",
+    likes: 10,
+    isLiked: false,
   },
 ];

--- a/client/src/constants/dummyData.ts
+++ b/client/src/constants/dummyData.ts
@@ -1,6 +1,5 @@
 import { ChatType } from "@/types/chat";
 import { PostDetailType } from "@/types/post";
-import { PostCommentType } from "@/types/post";
 
 // export const TRENDING_POSTS: Post[] = [
 //   {
@@ -152,23 +151,3 @@ export const POST_MODAL_DATA: PostDetailType = {
     tag: ["JavaScript", "React", "Frontend"],
   },
 };
-export const POST_COMMENT_DATA: PostCommentType[] = [
-  {
-    id: 1,
-    author: "나무보다 숲을",
-    content: "정말 유익한 포스트에요!!",
-    authorImage: "https://github.com/shadcn.png",
-    createdAt: "2025-03-23T01:00:00.000Z",
-    likes: 5,
-    isLiked: true,
-  },
-  {
-    id: 2,
-    author: "월성참치",
-    content: "엌ㅋㅋㅋ 개추요",
-    authorImage: "https://github.com/shadcn.png",
-    createdAt: "2025-03-24T01:00:00.000Z",
-    likes: 10,
-    isLiked: false,
-  },
-];

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -27,6 +27,10 @@ export const BLOG = {
   POST: "/api/feeds",
   Trend: "/api/feeds/trend/sse",
   LIKE: (id: number) => `/api/feeds/${id}/likes`,
+  COMMENT: {
+    LIST: (feedId: number) => `/api/feeds/${feedId}/comments`,
+    ITEM: (feedId: number, commentId: number) => `/api/feeds/${feedId}/comments/${commentId}`,
+  },
   RSS: {
     REGISTRER_RSS: "/api/rss",
     CERTIFICATION: "/api/rss/certifications",

--- a/client/src/hooks/common/usePostCardActions.ts
+++ b/client/src/hooks/common/usePostCardActions.ts
@@ -1,6 +1,5 @@
 import { usePostViewIncrement } from "@/hooks/queries/usePostViewIncrement";
 
-// import { pipe } from "@/utils/pipe";
 import { Post } from "@/types/post";
 
 interface PostWithState {

--- a/client/src/hooks/queries/useComments.ts
+++ b/client/src/hooks/queries/useComments.ts
@@ -1,0 +1,36 @@
+import { comments } from "@/api/services/comments";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+const commentsKey = (feedId: number) => ["comments", feedId];
+
+export const useComments = (feedId: number) =>
+  useQuery({
+    queryKey: commentsKey(feedId),
+    queryFn: () => comments.get(feedId),
+    enabled: feedId > 0,
+  });
+
+export const useCreateComment = (feedId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (comment: string) => comments.create(feedId, comment),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: commentsKey(feedId) }),
+  });
+};
+
+export const useUpdateComment = (feedId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ commentId, newComment }: { commentId: number; newComment: string }) =>
+      comments.update(feedId, commentId, newComment),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: commentsKey(feedId) }),
+  });
+};
+
+export const useDeleteComment = (feedId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (commentId: number) => comments.remove(feedId, commentId),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: commentsKey(feedId) }),
+  });
+};

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -26,3 +26,16 @@ export type LatestPostsApiResponse = ApiData<InfiniteScrollResponse<Post>>;
 export type TrendingPostsApiResponse = ApiData<Post[]>;
 
 export type PostDetailType = ApiData<Post>;
+export interface PostDetailType {
+  message: string;
+  data: Post;
+}
+export interface PostCommentType {
+  id: number;
+  author: string;
+  content: string;
+  authorImage: string;
+  createdAt: string;
+  likes: number;
+  isLiked: boolean;
+}

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -29,10 +29,11 @@ export type PostDetailType = ApiData<Post>;
 
 export interface PostCommentType {
   id: number;
-  author: string;
-  content: string;
-  authorImage: string;
-  createdAt: string;
-  likes: number;
-  isLiked: boolean;
+  comment: string;
+  date: string;
+  user: {
+    id: number;
+    userName: string;
+    profileImage: string | null;
+  };
 }

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -26,10 +26,7 @@ export type LatestPostsApiResponse = ApiData<InfiniteScrollResponse<Post>>;
 export type TrendingPostsApiResponse = ApiData<Post[]>;
 
 export type PostDetailType = ApiData<Post>;
-export interface PostDetailType {
-  message: string;
-  data: Post;
-}
+
 export interface PostCommentType {
   id: number;
   author: string;

--- a/client/src/utils/timeago.ts
+++ b/client/src/utils/timeago.ts
@@ -1,0 +1,13 @@
+export function timeAgo(dateString: string) {
+  const now = new Date();
+  const past = new Date(dateString);
+  const diff = Number(now) - Number(past);
+
+  const diffMin = Math.floor(diff / (1000 * 60));
+  const diffHour = Math.floor(diff / (1000 * 60 * 60));
+  const diffDay = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+  if (diffMin < 60) return `${diffMin}분 전`;
+  if (diffHour < 24) return `${diffHour}시간 전`;
+  return `${diffDay}일 전`;
+}


### PR DESCRIPTION
# 🔨 테스크

-   close #347 

### 게시글 상세에 댓글 ui추가

![image](https://github.com/user-attachments/assets/dc83881e-1bcb-421e-b1f6-18b0a6a36f73)
- detail 폴더 안에 전부 몰아넣어놨습니다.
- 나중에 FSD로 변경할 때 이 컴포넌트만 따로 ui폴더로 넣으면 될거같아요

### 댓글 수정

```
{modifyId !== comment.id ? (
                    <p className="mt-1 text-gray-800">{comment.content}</p>
                  ) : (
                    <div className="">
                      <textarea className="w-[100%] mt-2 flex-1 bg-transparent p-2 rounded-md h-20 outline-none ring-2 ring-gray-300 border-transparent resize-none">
                        {comment.content}
                      </textarea>
                      <div className="flex justify-end gap-3 text-sm">
                        <button onClick={() => handleModify(null)} className="hover:bg-gray-200 py-2 px-4 rounded-lg">
                          취소
                        </button>
                        <button className="bg-primary hover:bg-primary/80 py-2 px-4 text-white  rounded-lg">
                          댓글 수정
                        </button>
                      </div>
                    </div>
                  )}
```
-   useState를 통해 수정하는 댓글을 저장하고 해당 댓글일 경우 textarea로 변경되게 했습니다.

### 댓글 삭제
```
function DeleteButton({ id, handleOpen }: { id: number; handleOpen: () => void }) {
  return (
    <div className="w-[100%] h-[100%] absolute top-0 left-0 z-[1000] bg-white/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0">
      <div className="flex flex-col fixed top-[50%] left-[50%] translate-x-[-50%] translate-y-[-50%] w-full max-w-xs md:max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
        <header className="flex flex-col space-y-2 text-center sm:text-left">
          <span className="text-lg font-semibold">댓글 삭제</span>
        </header>
        <section>
          <p className="text-sm text-muted-foreground text-center md:text-start">댓글을 정말로 삭제하시겠습니까?</p>
        </section>
        <footer className="flex flex-row justify-end space-x-2">
          <button onClick={handleOpen} className="py-2 px-4 rounded-sm hover:bg-gray-100">
            취소
          </button>
          <button className="bg-primary py-2 px-4 text-white rounded-sm hover:bg-primary/90">확인</button>
          {id}
        </footer>
      </div>
    </div>
  );
```
- 기존의 shadcn의 모달은 화면 전체에 overlay를 걸어서 클릭시 모달 자체가 꺼지는 현상이 발생해서 따로 모달 컴포넌트를 만들었습니다.
- 상세 모달 or 페이지에만 overlay가 나오도록 수정했고 overlay클릭시 모달이 꺼지는건 넣지 않았습니다.

# 📋 작업 내용

-   댓글 UI구현
-   댓글 수정/삭제 추가
-   댓글 더보기 추가

# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/62f45036-32c6-4a5e-9c0c-a4384406bc38)

