### PR TITLE
✨ feat: 태그 필터링 API 구현

### DIFF
--- a/server/src/feed/api-docs/readFeedPagination.api-docs.ts
+++ b/server/src/feed/api-docs/readFeedPagination.api-docs.ts
@@ -26,6 +26,13 @@ export function ApiReadFeedPagination() {
       example: 5,
       default: 12,
     }),
+    ApiQuery({
+      name: 'tags',
+      required: false,
+      type: Array,
+      description: '태그 이름 목록',
+      example: '',
+    }),
     ApiOkResponse({
       description: 'Ok',
       schema: {

--- a/server/src/feed/dto/request/feed-pagination.dto.ts
+++ b/server/src/feed/dto/request/feed-pagination.dto.ts
@@ -21,10 +21,11 @@ export class FeedPaginationRequestDto {
 
   @IsOptional()
   @IsIn(ALLOWED_TAGS, {
+    each: true,
     message: `tag 값은 ${ALLOWED_TAGS.join(', ')} 목록에 포함 되어야 합니다.`,
   })
-  @Type(() => String)
-  tag: AllowedTag;
+  @Type(() => Array)
+  tags?: AllowedTag[];
 
   constructor(partial: Partial<FeedPaginationRequestDto>) {
     Object.assign(this, partial);

--- a/server/src/feed/dto/request/feed-pagination.dto.ts
+++ b/server/src/feed/dto/request/feed-pagination.dto.ts
@@ -1,5 +1,6 @@
-import { IsInt, IsOptional, Min } from 'class-validator';
+import { IsIn, IsInt, IsOptional, Min } from 'class-validator';
 import { Type } from 'class-transformer';
+import { ALLOWED_TAGS, AllowedTag } from '../../tagType.constants';
 
 export class FeedPaginationRequestDto {
   @IsOptional()
@@ -17,6 +18,13 @@ export class FeedPaginationRequestDto {
   })
   @Type(() => Number)
   limit?: number = 12;
+
+  @IsOptional()
+  @IsIn(ALLOWED_TAGS, {
+    message: `tag 값은 ${ALLOWED_TAGS.join(', ')} 목록에 포함 되어야 합니다.`,
+  })
+  @Type(() => String)
+  tag: AllowedTag;
 
   constructor(partial: Partial<FeedPaginationRequestDto>) {
     Object.assign(this, partial);

--- a/server/src/feed/dto/response/feed-detail.dto.ts
+++ b/server/src/feed/dto/response/feed-detail.dto.ts
@@ -11,7 +11,7 @@ export class FeedDetailResponseDto {
     private thumbnail: string,
     private viewCount: number,
     private summary: string,
-    private tag: string[],
+    private tag: string,
   ) {}
 
   static toResponseDto(feed: FeedView) {
@@ -25,7 +25,7 @@ export class FeedDetailResponseDto {
       feed.thumbnail,
       feed.viewCount,
       feed.summary,
-      feed.tag?.split(',') ?? [],
+      feed.tag,
     );
   }
 

--- a/server/src/feed/dto/response/feed-pagination.dto.ts
+++ b/server/src/feed/dto/response/feed-pagination.dto.ts
@@ -11,7 +11,7 @@ export class FeedResult {
     private thumbnail: string,
     private viewCount: number,
     private isNew: boolean,
-    private tag: string[],
+    private tag: string,
   ) {}
 
   private static toResultDto(feed: FeedPaginationResult) {
@@ -25,7 +25,7 @@ export class FeedResult {
       feed.thumbnail,
       feed.viewCount,
       feed.isNew,
-      feed.tag?.split(',') ?? [],
+      feed.tag,
     );
   }
 
@@ -62,7 +62,7 @@ export class FeedTrendResponseDto {
     private createdAt: Date,
     private thumbnail: string,
     private viewCount: number,
-    private tag: string[],
+    private tag: string,
   ) {}
 
   private static toResponseDto(feed: FeedView) {
@@ -75,7 +75,7 @@ export class FeedTrendResponseDto {
       feed.createdAt,
       feed.thumbnail,
       feed.viewCount,
-      feed.tag?.split(',') ?? [],
+      feed.tag,
     );
   }
 

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -84,18 +84,17 @@ export class Feed extends BaseEntity {
       .addSelect('rss_accept.blog_platform', 'blog_platform')
       .addSelect(
         `(
-  SELECT JSON_ARRAYAGG(t.tag)
-  FROM (
-    SELECT DISTINCT tag_map.tag AS tag
-    FROM tag_map
-    WHERE tag_map.feed_id = feed.id
-  ) t
-)`,
+          SELECT JSON_ARRAYAGG(t.tag)
+          FROM (
+            SELECT DISTINCT tag_map.tag AS tag
+            FROM tag_map
+            WHERE tag_map.feed_id = feed.id
+          ) t
+        )`,
         'tag',
       )
       .from(Feed, 'feed')
       .innerJoin(RssAccept, 'rss_accept', 'rss_accept.id = feed.blog_id')
-      .leftJoin(TagMap, 'tag_map', 'tag_map.feed_id = feed.id')
       .groupBy('feed.id'),
   name: 'feed_view',
 })

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -82,7 +82,17 @@ export class Feed extends BaseEntity {
       .addSelect('feed.summary', 'summary')
       .addSelect('rss_accept.name', 'blog_name')
       .addSelect('rss_accept.blog_platform', 'blog_platform')
-      .addSelect('GROUP_CONCAT(DISTINCT tag_map.tag)', 'tag')
+      .addSelect(
+        `(
+  SELECT JSON_ARRAYAGG(t.tag)
+  FROM (
+    SELECT DISTINCT tag_map.tag AS tag
+    FROM tag_map
+    WHERE tag_map.feed_id = feed.id
+  ) t
+)`,
+        'tag',
+      )
       .from(Feed, 'feed')
       .innerJoin(RssAccept, 'rss_accept', 'rss_accept.id = feed.blog_id')
       .leftJoin(TagMap, 'tag_map', 'tag_map.feed_id = feed.id')

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -73,21 +73,20 @@ export class Feed extends BaseEntity {
       .createQueryBuilder()
       .select()
       .addSelect('ROW_NUMBER() OVER (ORDER BY feed.created_at) AS order_id')
-      .addSelect('feed.id', 'feed_id')
-      .addSelect('title', 'feed_title')
-      .addSelect('feed.path', 'feed_path')
-      .addSelect('feed.created_at', 'feed_created_at')
-      .addSelect('feed.thumbnail', 'feed_thumbnail')
-      .addSelect('feed.view_count', 'feed_view_count')
-      .addSelect('feed.summary', 'feed_summary')
+      .addSelect('feed.id', 'id')
+      .addSelect('title', 'title')
+      .addSelect('feed.path', 'path')
+      .addSelect('feed.created_at', 'created_at')
+      .addSelect('feed.thumbnail', 'thumbnail')
+      .addSelect('feed.view_count', 'view_count')
+      .addSelect('feed.summary', 'summary')
       .addSelect('rss_accept.name', 'blog_name')
       .addSelect('rss_accept.blog_platform', 'blog_platform')
-      .addSelect('GROUP_CONCAT(DISTINCT tag_map.tag)', 'feed_tag')
+      .addSelect('GROUP_CONCAT(DISTINCT tag_map.tag)', 'tag')
       .from(Feed, 'feed')
       .innerJoin(RssAccept, 'rss_accept', 'rss_accept.id = feed.blog_id')
       .leftJoin(TagMap, 'tag_map', 'tag_map.feed_id = feed.id')
-      .groupBy('feed.id')
-      .orderBy('feed_created_at'),
+      .groupBy('feed.id'),
   name: 'feed_view',
 })
 export class FeedView {
@@ -97,32 +96,32 @@ export class FeedView {
   orderId: number;
 
   @ViewColumn({
-    name: 'feed_id',
+    name: 'id',
   })
   feedId: number;
 
   @ViewColumn({
-    name: 'feed_title',
+    name: 'title',
   })
   title: string;
 
   @ViewColumn({
-    name: 'feed_path',
+    name: 'path',
   })
   path: string;
 
   @ViewColumn({
-    name: 'feed_created_at',
+    name: 'created_at',
   })
   createdAt: Date;
 
   @ViewColumn({
-    name: 'feed_thumbnail',
+    name: 'thumbnail',
   })
   thumbnail: string;
 
   @ViewColumn({
-    name: 'feed_view_count',
+    name: 'view_count',
   })
   viewCount: number;
 
@@ -137,12 +136,12 @@ export class FeedView {
   blogPlatform: string;
 
   @ViewColumn({
-    name: 'feed_summary',
+    name: 'summary',
   })
   summary: string;
 
   @ViewColumn({
-    name: 'feed_tag',
+    name: 'tag',
   })
   tag: string;
 }

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -41,11 +41,17 @@ export class FeedService {
   ) {}
 
   async readFeedPagination(feedPaginationQueryDto: FeedPaginationRequestDto) {
-    const feedList = await this.feedViewRepository.findFeedPagination(
-      feedPaginationQueryDto.lastId,
-      feedPaginationQueryDto.limit,
-    );
+    let feedList;
+    feedPaginationQueryDto.tags
+      ? (feedList = await this.feedRepository.searchFeedListWithTags(
+          feedPaginationQueryDto,
+        ))
+      : (feedList = await this.feedViewRepository.findFeedPagination(
+          feedPaginationQueryDto,
+        ));
+
     const hasMore = this.existNextFeed(feedList, feedPaginationQueryDto.limit);
+    console.log(feedList);
 
     if (hasMore) feedList.pop();
     const lastId = this.getLastIdFromFeedList(feedList);

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -41,14 +41,9 @@ export class FeedService {
   ) {}
 
   async readFeedPagination(feedPaginationQueryDto: FeedPaginationRequestDto) {
-    let feedList;
-    feedPaginationQueryDto.tags
-      ? (feedList = await this.feedRepository.searchFeedListWithTags(
-          feedPaginationQueryDto,
-        ))
-      : (feedList = await this.feedViewRepository.findFeedPagination(
-          feedPaginationQueryDto,
-        ));
+    const feedList = await this.feedViewRepository.findFeedPagination(
+      feedPaginationQueryDto,
+    );
 
     const hasMore = this.existNextFeed(feedList, feedPaginationQueryDto.limit);
     console.log(feedList);

--- a/server/src/feed/tagType.constants.ts
+++ b/server/src/feed/tagType.constants.ts
@@ -1,0 +1,26 @@
+export const ALLOWED_TAGS = [
+  '회고',
+  'Frontend',
+  'Backend',
+  'DB',
+  'Network',
+  'OS',
+  'Algorithm',
+  'Infra',
+  'TypeScript',
+  'JavaScript',
+  'Java',
+  'React',
+  'Vue.JS',
+  'Nest.JS',
+  'Express.JS',
+  'Spring',
+  'MySQL',
+  'SQLite',
+  'PostgreSQL',
+  'MongoDB',
+  'Redis',
+  'Docker',
+] as const;
+
+export type AllowedTag = (typeof ALLOWED_TAGS)[number];


### PR DESCRIPTION
# 🔨 테스크
- #361 

# 📋 작업 내용
### FeedPagination API Spec 변경
Request Query Param에 `tags` 가 추가되었습니다.
- 복수 요청 및 빈 요청 허용
- **여러개의 태그 요청 시 해당 태그들중 하나라도 포함되면** 조회 결과에 포함 함.

### `FeedView` tag 필드 변경
기존의 `LEFT JOIN + CONCAT` 조회 방식을 `JSON_ARRAYAGG` 방식으로 변경하였습니다.
> `JSON_ARRAYAGG`는 무엇인가요?
[참고](https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_json-arrayagg) 결과 집합을 각 행이 요소로 구성되어있는 배열로 집계하는 함수입니다.

```typescript
.addSelect('GROUP_CONCAT(DISTINCT tag_map.tag)', 'feed_tag')
```
```typescript
      .addSelect(
        `(
  SELECT JSON_ARRAYAGG(t.tag)
  FROM (
    SELECT DISTINCT tag_map.tag AS tag
    FROM tag_map
    WHERE tag_map.feed_id = feed.id
  ) t
)`,
        'tag',
      )
```
> **:왜 이렇게 구현했나요?**
ViewEntity도 TypeORM에서 엔티티로 취급되긴 하지만, **내부적으로 데이터베이스 뷰의 결과를 단순한 객체로 매핑하기 때문에 원본 관계(예: Feed와 Tag의 1:N 관계)를 그대로 반영하지는 않습니다.** (필터링을 위해서는 여전히 QueryBuilder를 통한 SQL 을 사용해야 함.)
>
> 그리하여 LIKE 연산이 아닌 개별 태그 데이터들을 다루기 위한 연산을 위해서는 `FeedViewRepository`가 아닌 `FeedRepository`를 사용하거나, 현재 방법 뿐이었고 전자는 타입 매핑, 뷰 활용성 저하 등의 문제가 있다고 판단하여 후자 방법을 선택하였습니다.

### `FeedViewRepository.findFeedPagination()` 변경
tag가 존재할 시 `JSON_ARRAYAGG` 함수를 통해 가져온 배열 형태의 값들을 기반으로 합집합 조건을 추가하였습니다.

### 응답 dto 및 요청 dto 변경
변경된 사안들에 맞게 해당하는 dto들의 멤버변수를 변경하였습니다.
