### PR TITLE
🐛 fix: 트랜딩 포스트가 없을 때 EmptyPost 컴포넌트가 나오지 않던 버그 수정 & 스켈레톤 UI가 나오지 않던 버그 수정

### DIFF
--- a/client/src/components/common/Card/PostCardSkeleton.tsx
+++ b/client/src/components/common/Card/PostCardSkeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 
 const PostCardSkeleton = () => {
   return (
-    <div className="h-[240px] bg-white rounded-lg p-4 space-y-3 shadow-sm">
+    <div className="h-[240px] bg-white rounded-lg p-4 space-y-3">
       <Skeleton className="w-full h-40 rounded-lg" />
       <div className="space-y-2">
         <Skeleton className="h-4 w-3/4" />
@@ -12,9 +12,9 @@ const PostCardSkeleton = () => {
   );
 };
 
-const PostGridSkeleton = ({ count = 8 }) => {
+const PostGridSkeleton = ({ count = 4 }) => {
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+    <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-6 w-full">
       {Array.from({ length: count }).map((_, index) => (
         <PostCardSkeleton key={index} />
       ))}

--- a/client/src/components/sections/AnimatedPostGrid.tsx
+++ b/client/src/components/sections/AnimatedPostGrid.tsx
@@ -11,7 +11,7 @@ interface AnimatedPostGridProps {
   posts: Post[];
 }
 
-const AnimatedPostGrid = ({ posts }: AnimatedPostGridProps) => {
+const AnimatedPostGrid = ({ posts = [] }: AnimatedPostGridProps) => {
   const { hasPosition } = usePositionTracking(posts);
   if (posts.length === 0) {
     return <EmptyPost />;

--- a/client/src/components/sections/TrendingSection.tsx
+++ b/client/src/components/sections/TrendingSection.tsx
@@ -12,6 +12,7 @@ export default function TrendingSection() {
   const { posts, isLoading } = useTrendingPosts();
   const isMobile = useMediaStore((state) => state.isMobile);
   const sectionStyle = isMobile ? undefined : { boxShadow: "0 0 15px rgba(0, 0, 0, 0.1)" };
+
   return (
     <section className="flex flex-col md:p-4 min-h-[300px]">
       <SectionHeader
@@ -22,7 +23,7 @@ export default function TrendingSection() {
       />
 
       <div className="flex flex-1 md:mt-4 md:p-6 bg-white rounded-2xl transition-all duration-300" style={sectionStyle}>
-        {isLoading || !posts.length ? <PostGridSkeleton count={4} /> : <AnimatedPostGrid posts={posts} />}
+        {isLoading ? <PostGridSkeleton count={4} /> : <AnimatedPostGrid posts={posts} />}
       </div>
     </section>
   );


### PR DESCRIPTION
# 🔨 테스크

### 트랜딩 포스트가 없을 때 스켈레톤 UI가 아니라 다른 에러 문구가 나오도록 수정했었습니다. 하지만 이 에러 문구가 나오지않고 흰 바탕만 나오는 버그가 있었고 이를 해결했습니다. 

### Loading중일때 트랜딩 포스트에 스켈레톤 UI가 나와야 했지만 나오지않고 있던 버그가 있었고 width값을 조정해주면서 해결했습니다.

# 📋 작업 내용

###   에러문구
```
   <div className="flex flex-1 md:mt-4 md:p-6 bg-white rounded-2xl transition-all duration-300" style={sectionStyle}>
        {isLoading || !posts.length ? <PostGridSkeleton count={4} /> : <AnimatedPostGrid posts={posts} />}
      </div>
```
- 기존에 스켈레톤 UI가 나오도록 하는 조건이 isLoading이 true일때와 post.length가 없을때 나오로독 했습니다.
- 여기서 문제가 post가 없을때 0이 들어오게 되고 false로 잡히게 되어 계속 스켈레톤 UI만 나오도록 구현이 되어있었습니다.

```
<div className="flex flex-1 md:mt-4 md:p-6 bg-white rounded-2xl transition-all duration-300" style={sectionStyle}>
        {isLoading ? <PostGridSkeleton count={4} /> : <AnimatedPostGrid posts={posts} />}
      </div>
```
- 처럼 length에 대한 검사는 AnimatedPostGrid로 넘겨 에러문구가 나오도록 수정했습니다.

### 스켈레톤 UI
```
const PostGridSkeleton = ({ count = 8 }) => {
  return (
    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
      {Array.from({ length: count }).map((_, index) => (
        <PostCardSkeleton key={index} />
      ))}
```
- 기존의 PostGridSkeleton은 width가 설정되어있지 않아 스켈레톤UI가 제대로 보이지 않는 버그가 있었습니다.
```
const PostGridSkeleton = ({ count = 4 }) => {
  return (
    <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-4 gap-6 w-full">
      {Array.from({ length: count }).map((_, index) => (
        <PostCardSkeleton key={index} />
      ))}
```
- 수정 이후 w값을 부모태그에 대해 100%로 주면서 위치를 제대로 잡도록 했고
- grid의 cols를 4개/2개/1개로 바꿔 비대칭적으로 스켈레톤 UI가 나오던 현상을 수정했습니다.
# 📷 스크린 샷

![image](https://github.com/user-attachments/assets/fb189e85-5695-45ce-b047-bef5b41f9873)
![image](https://github.com/user-attachments/assets/1219b459-e3c0-41dc-b461-58565c770f43)

