### PR TITLE
✨ feat: 채팅 낙관적 업데이트를 지원하기 위한 채팅 페이로드 변경

### DIFF
--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -55,10 +55,15 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
   }
 
   @SubscribeMessage('message')
-  async handleMessage(client: Socket, payload: { message: string }) {
+  async handleMessage(
+    client: Socket,
+    payload: { messageId: string; userId: string; message: string },
+  ) {
     const clientName = await this.chatService.getClientNameByIp(client);
 
     const broadcastPayload: BroadcastPayload = {
+      userId: payload.userId,
+      messageId: payload.messageId,
       username: clientName,
       message: payload.message,
       timestamp: new Date(),

--- a/server/src/chat/chat.type.ts
+++ b/server/src/chat/chat.type.ts
@@ -1,4 +1,6 @@
 export type BroadcastPayload = {
+  messageId: string;
+  userId: string;
   username: string;
   message: string;
   timestamp: Date;

--- a/server/src/chat/scheduler/chat.scheduler.ts
+++ b/server/src/chat/scheduler/chat.scheduler.ts
@@ -20,6 +20,8 @@ export class ChatScheduler {
 
   private async saveDateMessage() {
     const broadcastPayload: BroadcastPayload = {
+      userId: CHAT_MIDNIGHT_CLIENT_NAME,
+      messageId: CHAT_MIDNIGHT_CLIENT_NAME,
       username: CHAT_MIDNIGHT_CLIENT_NAME,
       message: '',
       timestamp: new Date(),


### PR DESCRIPTION
# 🔨 테스크
-   close #377

# 📋 작업 내용
### 채팅 낙관적 업데이트를 위한 Payload 변경
```typescript
export type BroadcastPayload = {
  messageId: string;
  userId: string;
  username: string;
  message: string;
  timestamp: Date;
};
```
채팅 메시지에 사용되는 `BroadcastPayload` 타입이 변경되었습니다.
추가된 행은 아래와 같습니다.
- `messageId`: 각 메시지마다 별도로 가지는 고유 ID. **채팅 전송 여부 확인에 사용 됨.**
- `userId`: 채팅을 보낸 사용자를 구분하기 위한 고유 ID. **자신의 채팅을 구분하기 위해 사용됨.**

