### PR TITLE
🐛 fix: Collation이 다르게 적용되던 부분 수정

### DIFF
--- a/server/src/migration/MigrateTagsToManyToMany1620000000000.ts
+++ b/server/src/migration/MigrateTagsToManyToMany1620000000000.ts
@@ -7,10 +7,13 @@ export class MigrateTagsToManyToMany1620000000000
     // 1. 새 테이블 생성
     await queryRunner.query(`
       CREATE TABLE tag (
-        id INT AUTO_INCREMENT PRIMARY KEY,
-        name VARCHAR(50) NOT NULL UNIQUE
-      ) ENGINE=InnoDB;
+       id INT AUTO_INCREMENT PRIMARY KEY,
+       name VARCHAR(50) NOT NULL UNIQUE
+      ) ENGINE=InnoDB
+    DEFAULT CHARSET = utf8mb4
+    COLLATE = utf8mb4_0900_ai_ci;
     `);
+
     await queryRunner.query(`
       CREATE TABLE feed_tags (
         feed_id INT NOT NULL,
@@ -49,19 +52,19 @@ export class MigrateTagsToManyToMany1620000000000
 
   public async down(queryRunner: QueryRunner): Promise<void> {
     // 1. 현재 tag_map (feed_tags) 테이블 임시 이름으로 변경
-    await queryRunner.query(`
-      RENAME TABLE tag_map TO feed_tags_temp;
-    `);
+    await queryRunner.query(`RENAME TABLE tag_map TO feed_tags_temp;`);
 
     // 2. 원래 구조의 tag_map 테이블 복원
     await queryRunner.query(`
       CREATE TABLE tag_map (
-        feed_id INT NOT NULL,
-        tag VARCHAR(50) NOT NULL,
-        INDEX IDX_tag_map_feed (feed_id),
-        INDEX IDX_tag_map_tag (tag),
-        CONSTRAINT FK_tag_map_feed FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE
-      ) ENGINE=InnoDB;
+       feed_id INT NOT NULL,
+       tag VARCHAR(50) NOT NULL,
+       INDEX IDX_tag_map_feed (feed_id),
+       INDEX IDX_tag_map_tag (tag),
+       CONSTRAINT FK_tag_map_feed FOREIGN KEY (feed_id) REFERENCES feed(id) ON DELETE CASCADE
+      ) ENGINE=InnoDB
+      DEFAULT CHARSET = utf8mb4
+      COLLATE = utf8mb4_0900_ai_ci;
     `);
 
     // 3. 데이터 재이관: 문자열 태그 복원
@@ -69,7 +72,7 @@ export class MigrateTagsToManyToMany1620000000000
       INSERT INTO tag_map (feed_id, tag)
       SELECT ft.feed_id, t.name
       FROM feed_tags_temp ft
-      JOIN tag t ON t.id = ft.tag_id;
+             JOIN tag t ON t.id = ft.tag_id;
     `);
 
     // 4. 임시 테이블과 tag 테이블 삭제


### PR DESCRIPTION
# 📋 작업 내용
### Collation 문제 해결
![image](https://github.com/user-attachments/assets/546cd1b9-bb42-48c3-b3a1-ff792fd486f3)
현재 저희 서버(TypeORM)레벨 에서 사용되는 Collation와, DB에 설정되어있는 기본 Collation이 다릅니다.
이에 따라 Migration이 실행되며 생성된 `tag` 테이블과, 기존에 존재하던 `tag_map` 테이블의 비교 연산이 수행되지 못해 Migration이 제대로 실행되지 못하였고, 이를 임의로 재실행 하자 쿼리가 끝까지 실행되지 못한채로 완료 로그가 출력되는 현상을 확인했습니다.


- TypeORM `synchronize` 에 의해 생성된 테이블의 Collation (`utf8mb4_0900_ai_ci`)
![서버 기본 Collation](https://github.com/user-attachments/assets/ea6a9252-c94a-4109-ab6c-d026edeb4f19)

- RDBMS 기본 설정 값 Collation (`utf8mb4_unicode_ci`)
![RDBMS 기본 Collation](https://github.com/user-attachments/assets/be0c004c-03f1-418b-b498-e524c8a78a32)

이에 따라 Migration시 생성되는 테이블들의 Collation을 별도로 기존 값인 `utf8mb4_0900_ai_ci` 맞추도록 별도로 명시해주는 구문을 추가하였습니다.

> [!TIP]
_테스트 환경에서는 왜 됐었음?_
확인 결과 제가 사용하는 로컬 DB는 기본값이 TypeORM의 기본값과 일치하였고, 이에 따라 로컬 테스트시에는 아무런 문제가 발생하지 않은 것으로 보입니다.
![image](https://github.com/user-attachments/assets/c8a7e073-5aeb-4592-9f38-7dda5e5f4ba2)