### PR TITLE
♻️ refactor: DockerFile ci 시 의존성 파일만 복사 후 캐시 제거 구문 추가

### DIFF
--- a/feed-crawler/docker/Dockerfile.local
+++ b/feed-crawler/docker/Dockerfile.local
@@ -2,9 +2,11 @@ FROM node:22-alpine AS builder
 
 WORKDIR /var/web05-Denamu/feed-crawler
 
-COPY .. .
+COPY package.json package-lock.json ./
+RUN npm cache clean --force \
+  && npm ci
 
-RUN npm ci
+COPY .. .
 
 RUN npm run build
 

--- a/server/docker/Dockerfile.local
+++ b/server/docker/Dockerfile.local
@@ -3,9 +3,11 @@ FROM node:22-alpine AS builder
 
 WORKDIR /var/web05-Denamu/server
 
-COPY .. .
+COPY package.json package-lock.json ./
+RUN npm cache clean --force \
+  && npm ci
 
-RUN npm ci
+COPY .. .
 
 RUN npm run build
 


### PR DESCRIPTION
# 📋 작업 내용
### Dockerfile 구문 변경
npm 캐시문제로 프로덕션 환경에서 빌드가 되지 않아 캐시를 제거하고 ci (의존성 설치)를 수행하는 구문을 추가하였습니다.
