### PR TITLE
🐛 fix: 메일 내 회원 가입완료 링크 수정

### DIFF
--- a/server/src/common/email/email.service.ts
+++ b/server/src/common/email/email.service.ts
@@ -71,7 +71,7 @@ export class EmailService {
     user: User,
     uuid: string,
   ): nodemailer.SendMailOptions {
-    const redirectUrl = `${PRODUCT_DOMAIN}/api/user/cert?token=${uuid}`;
+    const redirectUrl = `${PRODUCT_DOMAIN}/user/certificate?token=${uuid}`;
 
     return {
       from: `Denamu<${this.emailUser}>`,


### PR DESCRIPTION
# 📋 작업 내용
### 기존 회원가입 플로우에 맞게 잘못된 URL 수정
메일에 포함되는 인증 URL을 수정하였습니다.