### PR TITLE
✨ feat: 프로메테우스 + 그라파나 모니터링 시스템 구축

### DIFF
--- a/docker-compose/docker-compose.prod.infra.yml
+++ b/docker-compose/docker-compose.prod.infra.yml
@@ -55,9 +55,53 @@ services:
       timeout: 5s
       retries: 3
 
+  # Prometheus
+  prometheus:
+    image: "prom/prometheus"
+    ports:
+      - "9090:9090"
+    networks:
+      - Denamu
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - denamu-prometheus:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+
+  # Grafana:
+  grafana:
+    image: "grafana/grafana"
+    ports:
+      - "3000:3000"
+    networks:
+      - Denamu
+    volumes:
+      - denamu-grafana:/var/lib/grafana
+    depends_on:
+      - prometheus
+
+  # Node Exporter
+  node_exporter:
+    image: prom/node-exporter
+    ports:
+      - "9100:9100"
+    networks:
+      - Denamu
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.rootfs=/rootfs"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+
 volumes:
   denamu-mysql:
   denamu-redis:
+  denamu-prometheus:
+  denamu-grafana:
 
 networks:
   Denamu:

--- a/docker-compose/prometheus.yml
+++ b/docker-compose/prometheus.yml
@@ -1,0 +1,13 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "node_exporter"
+    static_configs:
+      - targets: ["node_exporter:9100"]
+
+  - job_name: "nestJS Server"
+    metrics_path: "/api/metrics"
+    static_configs:
+      - targets: ["app:8080"]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -23,6 +23,7 @@
         "@nestjs/swagger": "^8.0.1",
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.4.8",
+        "@willsoto/nestjs-prometheus": "^6.0.2",
         "@woowa-babble/random-nickname": "^1.0.2",
         "axios": "^1.8.4",
         "bcrypt": "^5.1.1",
@@ -2374,6 +2375,16 @@
         "npm": ">=5.0.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3630,6 +3641,16 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "node_modules/@willsoto/nestjs-prometheus": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@willsoto/nestjs-prometheus/-/nestjs-prometheus-6.0.2.tgz",
+      "integrity": "sha512-ePyLZYdIrOOdlOWovzzMisIgviXqhPVzFpSMKNNhn6xajhRHeBsjAzSdpxZTc6pnjR9hw1lNAHyKnKl7lAPaVg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "prom-client": "^15.0.0"
+      }
+    },
     "node_modules/@woowa-babble/random-nickname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@woowa-babble/random-nickname/-/random-nickname-1.0.2.tgz",
@@ -4354,6 +4375,13 @@
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
+    },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -11494,6 +11522,20 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
@@ -13330,6 +13372,16 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bintrees": "1.0.2"
+      }
     },
     "node_modules/terser": {
       "version": "5.36.0",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -42,6 +42,7 @@
         "nodemailer": "^6.9.16",
         "passport-jwt": "^4.0.1",
         "pm2": "^5.4.2",
+        "prom-client": "^15.1.3",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "sanitize-html": "^2.14.0",
@@ -2380,7 +2381,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4380,8 +4380,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
       "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bl": {
       "version": "4.1.0",
@@ -11527,7 +11526,6 @@
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
       "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
@@ -13378,7 +13376,6 @@
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
       "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bintrees": "1.0.2"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -58,6 +58,7 @@
     "nodemailer": "^6.9.16",
     "passport-jwt": "^4.0.1",
     "pm2": "^5.4.2",
+    "prom-client": "^15.1.3",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.14.0",

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
     "@nestjs/swagger": "^8.0.1",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.4.8",
+    "@willsoto/nestjs-prometheus": "^6.0.2",
     "@woowa-babble/random-nickname": "^1.0.2",
     "axios": "^1.8.4",
     "bcrypt": "^5.1.1",

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -14,6 +14,9 @@ import { UserModule } from './user/module/user.module';
 import { ActivityModule } from './activity/module/activity.module';
 import { EmailModule } from './common/email/email.module';
 import { CommentModule } from './comment/module/comment.module';
+import { MetricsModule } from './common/metrics/metrics.module';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { MetricsInterceptor } from './common/metrics/metrics.interceptor';
 
 @Module({
   imports: [
@@ -44,8 +47,14 @@ import { CommentModule } from './comment/module/comment.module';
     StatisticModule,
     EmailModule,
     CommentModule,
+    MetricsModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: MetricsInterceptor,
+    },
+  ],
 })
 export class AppModule {}

--- a/server/src/common/logger/logger.interceptor.ts
+++ b/server/src/common/logger/logger.interceptor.ts
@@ -16,11 +16,12 @@ export class LoggingInterceptor implements NestInterceptor {
     const request = context.switchToHttp().getRequest();
     const url = request.url;
 
-    if (
-      !url.includes('register') &&
-      !url.includes('login') &&
-      !url.includes('signup')
-    ) {
+    const excludedKeywords = ['register', 'login', 'signup', 'metrics'];
+    const shouldLog = !excludedKeywords.some((keyword) =>
+      url.includes(keyword),
+    );
+
+    if (shouldLog) {
       this.logger.log(
         JSON.stringify({
           host: this.getIp(request),

--- a/server/src/common/metrics/metrics.interceptor.ts
+++ b/server/src/common/metrics/metrics.interceptor.ts
@@ -30,6 +30,10 @@ export class MetricsInterceptor implements NestInterceptor {
     const route = req.route?.path || req.url;
     const start = Date.now();
 
+    if (route.includes('metrics')) {
+      return next.handle();
+    }
+
     return next.handle().pipe(
       finalize(() => {
         const duration = (Date.now() - start) / 1000;

--- a/server/src/common/metrics/metrics.interceptor.ts
+++ b/server/src/common/metrics/metrics.interceptor.ts
@@ -1,0 +1,51 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { InjectMetric } from '@willsoto/nestjs-prometheus';
+import { Counter, Histogram } from 'prom-client';
+import { catchError, finalize, Observable, tap } from 'rxjs';
+
+@Injectable()
+export class MetricsInterceptor implements NestInterceptor {
+  constructor(
+    @InjectMetric('http_requests_total')
+    private readonly httpRequestsTotalCounter: Counter,
+    @InjectMetric('http_requests_success')
+    private readonly httpRequestsSuccessCounter: Counter,
+    @InjectMetric('http_requests_fail')
+    private readonly httpRequestsFailCounter: Counter,
+    @InjectMetric('http_request_duration_seconds')
+    private readonly httpRequestDurationHistogram: Histogram,
+  ) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Observable<any> {
+    const req = context.switchToHttp().getRequest();
+    const method = req.method;
+    const route = req.route?.path || req.url;
+    const start = Date.now();
+
+    return next.handle().pipe(
+      finalize(() => {
+        const duration = (Date.now() - start) / 1000;
+
+        if (context.switchToHttp().getResponse().statusCode >= 500) {
+          this.httpRequestsFailCounter.inc({ method, route });
+        } else {
+          this.httpRequestsSuccessCounter.inc({ method, route });
+          this.httpRequestDurationHistogram.observe(
+            { method, route },
+            duration,
+          );
+        }
+
+        this.httpRequestsTotalCounter.inc({ method, route });
+      }),
+    );
+  }
+}

--- a/server/src/common/metrics/metrics.interceptor.ts
+++ b/server/src/common/metrics/metrics.interceptor.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { InjectMetric } from '@willsoto/nestjs-prometheus';
 import { Counter, Histogram } from 'prom-client';
-import { catchError, finalize, Observable, tap } from 'rxjs';
+import { finalize, Observable } from 'rxjs';
 
 @Injectable()
 export class MetricsInterceptor implements NestInterceptor {

--- a/server/src/common/metrics/metrics.module.ts
+++ b/server/src/common/metrics/metrics.module.ts
@@ -1,12 +1,49 @@
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import {
   makeCounterProvider,
   makeGaugeProvider,
   makeHistogramProvider,
-  makeSummaryProvider,
   PrometheusModule,
 } from '@willsoto/nestjs-prometheus';
 
+const httpRequestsTotalProvider = makeCounterProvider({
+  name: 'http_requests_total',
+  help: 'API 요청 전체 수',
+  labelNames: ['method', 'route'],
+});
+
+const httpRequestsFailProvider = makeCounterProvider({
+  name: 'http_requests_fail',
+  help: 'API 요청 실패 수',
+  labelNames: ['method', 'route'],
+});
+
+const httpRequestsSuccessProvider = makeCounterProvider({
+  name: 'http_requests_success',
+  help: 'API 요청 성공 수',
+  labelNames: ['method', 'route'],
+});
+
+const anonymousChatMessageCountProvider = makeCounterProvider({
+  name: 'anonymous_chat_message_count',
+  help: '익명 채팅 수',
+  labelNames: ['room'],
+});
+
+const anonymousChatUserCountProvider = makeGaugeProvider({
+  name: 'anonymous_chat_user_count',
+  help: '익명 채팅방 현재 접속 인원 수',
+  labelNames: ['room'],
+});
+
+const httpRequestDurationSecondsProvider = makeHistogramProvider({
+  name: 'http_request_duration_seconds',
+  help: 'API 요청 성공 응답 시간',
+  buckets: [0.1, 0.3, 1.5, 5, 10],
+  labelNames: ['method', 'route'],
+});
+
+@Global()
 @Module({
   imports: [
     PrometheusModule.register({
@@ -17,31 +54,20 @@ import {
     }),
   ],
   providers: [
-    makeCounterProvider({
-      name: 'http_requests_total',
-      help: 'API 요청 전체 수',
-    }),
-    makeCounterProvider({
-      name: 'http_requests_fail',
-      help: 'API 요청 실패 수',
-    }),
-    makeCounterProvider({
-      name: 'http_requests_success',
-      help: 'API 요청 성공 수',
-    }),
-    makeCounterProvider({
-      name: 'anonymous_chat_message_count',
-      help: '익명 채팅 수',
-    }),
-    makeGaugeProvider({
-      name: 'anonymous_chat_user_count',
-      help: '익명 채팅방 현재 접속 인원 수',
-    }),
-    makeHistogramProvider({
-      name: 'http_request_duration_seconds',
-      help: 'API 요청 성공 응답 시간',
-      buckets: [0.1, 0.3, 1.5, 5, 10],
-    }),
+    httpRequestsTotalProvider,
+    httpRequestsFailProvider,
+    httpRequestsSuccessProvider,
+    anonymousChatMessageCountProvider,
+    anonymousChatUserCountProvider,
+    httpRequestDurationSecondsProvider,
+  ],
+  exports: [
+    httpRequestsTotalProvider,
+    httpRequestsFailProvider,
+    httpRequestsSuccessProvider,
+    anonymousChatMessageCountProvider,
+    anonymousChatUserCountProvider,
+    httpRequestDurationSecondsProvider,
   ],
 })
 export class MetricsModule {}

--- a/server/src/common/metrics/metrics.module.ts
+++ b/server/src/common/metrics/metrics.module.ts
@@ -1,0 +1,47 @@
+import { Module } from '@nestjs/common';
+import {
+  makeCounterProvider,
+  makeGaugeProvider,
+  makeHistogramProvider,
+  makeSummaryProvider,
+  PrometheusModule,
+} from '@willsoto/nestjs-prometheus';
+
+@Module({
+  imports: [
+    PrometheusModule.register({
+      path: '/metrics',
+      defaultMetrics: {
+        enabled: true,
+      },
+    }),
+  ],
+  providers: [
+    makeCounterProvider({
+      name: 'http_requests_total',
+      help: 'API 요청 전체 수',
+    }),
+    makeCounterProvider({
+      name: 'http_requests_fail',
+      help: 'API 요청 실패 수',
+    }),
+    makeCounterProvider({
+      name: 'http_requests_success',
+      help: 'API 요청 성공 수',
+    }),
+    makeCounterProvider({
+      name: 'anonymous_chat_message_count',
+      help: '익명 채팅 수',
+    }),
+    makeGaugeProvider({
+      name: 'anonymous_chat_user_count',
+      help: '익명 채팅방 현재 접속 인원 수',
+    }),
+    makeHistogramProvider({
+      name: 'http_request_duration_seconds',
+      help: 'API 요청 성공 응답 시간',
+      buckets: [0.1, 0.3, 1.5, 5, 10],
+    }),
+  ],
+})
+export class MetricsModule {}


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #390

### 프로메테우스란?
- 프로메테우스는 메트릭을 수집하는 애플리케이션이다.

- 서버에 단순히 프로메테우스를 설치만한다 해서 메트릭을 수집할 수 없다.

- 밑에서 나오는 Node_Exporter나 애플리케이션단에서 메트릭을 추출해서 프로메테우스에서 저장하는 방식이다. 하나의 메트릭 데이터베이스라 생각하면 된다. 그렇기에 데이터는 외부에서 측정해야 한다.

- 프로메테우스를 공부하기 전에는 프로메테우스 자체가 데이터 수집 툴인줄 알았는데 아니었다.

### Node_Exporter는 무엇일까?

-   프로메테우스를 사용하여 메트릭을 수집하는 방식을 학습하는 도중 Node_Exporter라는 것이 무엇인지 궁금했다.

- Node_Exporter는 애플리케이션단에서 얻기에는 적합하지 않은 시스템 하드웨어 메트릭(CPU, 메모리, 디스크) 정보를 수집하는 용도이다.

- 작업에서는 Node_Exporter를 통해 시스템 하드웨어 메트릭과 NestJS에서는 @willsoto/nestjs-prometheus 라이브러리를 사용하여 애플리케이션 메트릭을 수집하도록 했다.
 
### Grafana란?

- 위에서 메트릭 데이터베이스인 프로메테우스에 저장된 메트릭을 보기 좋게 시각화 하는 툴이다.

### 어떤 메트릭을 수집해야 할까?
개인적으로 필요하다고 생각되는 것들을 애플리케이션 층에서 메트릭을 수집하도록 했다.

1. API마다 요청 전체 횟수
2. API마다 요청 실패 횟수 (응답 코드 500 이상)
3. API마다 요청 성공 횟수
4. 채팅 전체 개수
5. 현재 채팅 접속 인원 수
6. API마다 요청 성공 응답 시간

# 📋 작업 내용

-   docker compose 프로메테우스, 그라파나, Node_Exporter 추가
- 프로메테우스 설정 파일 추가
- NestJS 애플리케이션 메트릭 수집하도록 구현

# 📷 스크린 샷(선택 사항)
1. NestJS Metric API
![image](https://github.com/user-attachments/assets/bc5ea56c-6b49-44f7-8d2b-4ae6952f4a5b)

2. 프로메테우스 메트릭 수집 확인
![image](https://github.com/user-attachments/assets/11c6613f-ae00-4135-bebb-0a8086b1e243)

3. 그라파나 동작 확인
![image](https://github.com/user-attachments/assets/4cdfbe01-4ec5-44be-9355-ff172850c321)

4. Node Exporter 동작 확인
![image](https://github.com/user-attachments/assets/c1bd37ae-92a7-4328-ba3d-c1718558402e)

5. 프로메테우스 + Node Exporter + NestJS 메트릭 수집 확인
![image](https://github.com/user-attachments/assets/48e0055e-7a90-4042-a5e0-d6ac3fda9a6a)

# 애프터 테스크
1. Grafana 계정 변경
2. Grafana 대쉬보드 설정
