### PR TITLE
✨ feat: Github OAuth 회원가입 API 구현

### DIFF
--- a/server/src/user/api-docs/oAuth.api-docs.ts
+++ b/server/src/user/api-docs/oAuth.api-docs.ts
@@ -5,14 +5,14 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 
-export function ApiGoogleOAuth() {
+export function ApiOAuth() {
   return applyDecorators(
     ApiOperation({
-      summary: 'Google OAuth 로그인 리디렉션 API',
+      summary: 'OAuth 로그인 리디렉션 API',
     }),
     ApiResponse({
       status: 302,
-      description: 'Google OAuth 로그인 페이지 리디렉션',
+      description: 'Provider별 OAuth 로그인 페이지 리디렉션',
     }),
     ApiBadRequestResponse({
       description: 'Bad Request',

--- a/server/src/user/constant/oauth.constant.ts
+++ b/server/src/user/constant/oauth.constant.ts
@@ -5,9 +5,9 @@ export const OAUTH_URL_PATH = {
     USER_INFO_URL: `https://www.googleapis.com/oauth2/v1/userinfo`,
   },
   GITHUB: {
-    AUTH_URL: '',
-    TOKEN_URL: '',
-    USER_INFO_URL: '',
+    AUTH_URL: 'https://github.com/login/oauth/authorize',
+    TOKEN_URL: 'https://github.com/login/oauth/access_token',
+    USER_INFO_URL: 'https://api.github.com/user',
   },
   REDIRECT_PATH: {
     CALLBACK: `api/oauth/callback`,
@@ -23,10 +23,11 @@ export const OAUTH_CONSTANT = {
 };
 
 export type OAuthTokenResponse = {
-  id_token: string;
   access_token: string;
   refresh_token?: string;
   expires_in?: number;
+  scope?: string;
+  id_token?: string;
 };
 
 export type UserInfo = {

--- a/server/src/user/constant/oauth.constant.ts
+++ b/server/src/user/constant/oauth.constant.ts
@@ -4,6 +4,11 @@ export const OAUTH_URL_PATH = {
     TOKEN_URL: `https://oauth2.googleapis.com/token`,
     USER_INFO_URL: `https://www.googleapis.com/oauth2/v1/userinfo`,
   },
+  GITHUB: {
+    AUTH_URL: '',
+    TOKEN_URL: '',
+    USER_INFO_URL: '',
+  },
   REDIRECT_PATH: {
     CALLBACK: `api/oauth/callback`,
   },
@@ -13,6 +18,7 @@ export const OAUTH_URL_PATH = {
 export const OAUTH_CONSTANT = {
   PROVIDER_TYPE: {
     GOOGLE: `google`,
+    GITHUB: 'github',
   },
 };
 
@@ -38,3 +44,8 @@ export type ProviderData = {
 export type StateData = {
   provider: string;
 };
+
+export enum OAuthType {
+  Google = 'google',
+  Github = 'github',
+}

--- a/server/src/user/controller/oauth.controller.ts
+++ b/server/src/user/controller/oauth.controller.ts
@@ -1,22 +1,24 @@
-import { Controller, Get, Req, Res } from '@nestjs/common';
+import { Controller, Get, Query, Req, Res } from '@nestjs/common';
 import { OAuthService } from '../service/oauth.service';
 import { ApiTags } from '@nestjs/swagger';
 import { Response, Request } from 'express';
-import { ApiGoogleOAuth } from '../api-docs/googleOAuth.api-docs';
+import { ApiOAuth } from '../api-docs/oAuth.api-docs';
 import { ApiOAuthCallback } from '../api-docs/oauthCallback.api-docs';
 import { OAUTH_CONSTANT } from '../constant/oauth.constant';
+import { OAuthTypeDto } from '../dto/request/oauth-type.dto';
 
 @ApiTags('OAuth')
 @Controller('oauth')
 export class OAuthController {
   constructor(private readonly oauthService: OAuthService) {}
 
-  @Get('google')
-  @ApiGoogleOAuth()
-  async signupGoogle(@Res() res: Response) {
-    return res.redirect(
-      this.oauthService.getAuthUrl(OAUTH_CONSTANT.PROVIDER_TYPE.GOOGLE),
-    );
+  @Get()
+  @ApiOAuth()
+  async signupGoogle(
+    @Query('provider') provider: OAuthTypeDto,
+    @Res() res: Response,
+  ) {
+    return res.redirect(this.oauthService.getAuthUrl(provider.type));
   }
 
   @Get('callback')

--- a/server/src/user/controller/oauth.controller.ts
+++ b/server/src/user/controller/oauth.controller.ts
@@ -13,10 +13,7 @@ export class OAuthController {
 
   @Get()
   @ApiOAuth()
-  async signupGoogle(
-    @Query('provider') provider: OAuthTypeDto,
-    @Res() res: Response,
-  ) {
+  async getProvider(@Query() provider: OAuthTypeDto, @Res() res: Response) {
     return res.redirect(this.oauthService.getAuthUrl(provider.type));
   }
 

--- a/server/src/user/controller/oauth.controller.ts
+++ b/server/src/user/controller/oauth.controller.ts
@@ -4,7 +4,6 @@ import { ApiTags } from '@nestjs/swagger';
 import { Response, Request } from 'express';
 import { ApiOAuth } from '../api-docs/oAuth.api-docs';
 import { ApiOAuthCallback } from '../api-docs/oauthCallback.api-docs';
-import { OAUTH_CONSTANT } from '../constant/oauth.constant';
 import { OAuthTypeDto } from '../dto/request/oauth-type.dto';
 
 @ApiTags('OAuth')

--- a/server/src/user/dto/request/oauth-type.dto.ts
+++ b/server/src/user/dto/request/oauth-type.dto.ts
@@ -1,7 +1,11 @@
 import { OAuthType } from '../../constant/oauth.constant';
 import { IsEnum } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class OAuthTypeDto {
+  @ApiProperty({
+    description: '제공자 타입',
+  })
   @IsEnum(OAuthType, {
     message: '지원하지 않는 인증 제공자입니다.',
   })

--- a/server/src/user/dto/request/oauth-type.dto.ts
+++ b/server/src/user/dto/request/oauth-type.dto.ts
@@ -1,0 +1,9 @@
+import { OAuthType } from '../../constant/oauth.constant';
+import { IsEnum } from 'class-validator';
+
+export class OAuthTypeDto {
+  @IsEnum(OAuthType, {
+    message: '지원하지 않는 인증 제공자입니다.',
+  })
+  type: OAuthType;
+}

--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -8,6 +8,7 @@ import { ProviderRepository } from '../repository/provider.repository';
 import { JwtAuthModule } from '../../common/auth/jwt.module';
 import { AdminModule } from '../../admin/module/admin.module';
 import { GoogleOAuthProvider } from '../provider/google.provider';
+import { GithubOAuthProvider } from '../provider/github.provider';
 
 @Module({
   imports: [JwtAuthModule, AdminModule],
@@ -18,10 +19,15 @@ import { GoogleOAuthProvider } from '../provider/google.provider';
     UserRepository,
     ProviderRepository,
     GoogleOAuthProvider,
+    GithubOAuthProvider,
     {
       provide: 'OAUTH_PROVIDERS',
-      useFactory: (google: GoogleOAuthProvider) => ({
+      useFactory: (
+        google: GoogleOAuthProvider,
+        github: GithubOAuthProvider,
+      ) => ({
         google,
+        github,
       }),
       inject: [GoogleOAuthProvider],
     },

--- a/server/src/user/provider/github.provider.ts
+++ b/server/src/user/provider/github.provider.ts
@@ -1,0 +1,92 @@
+import { BadGatewayException, Injectable } from '@nestjs/common';
+import { OAuthProvider } from './oauth-provider.interface';
+import {
+  OAUTH_CONSTANT,
+  OAUTH_URL_PATH,
+  OAuthTokenResponse,
+  UserInfo,
+} from '../constant/oauth.constant';
+import * as querystring from 'node:querystring';
+import axios from 'axios';
+import { WinstonLoggerService } from '../../common/logger/logger.service';
+
+@Injectable()
+export class GithubOAuthProvider implements OAuthProvider {
+  constructor(private readonly logger: WinstonLoggerService) {}
+
+  getAuthUrl() {
+    const stateData = {
+      provider: OAUTH_CONSTANT.PROVIDER_TYPE.GITHUB,
+    };
+
+    const state = Buffer.from(JSON.stringify(stateData)).toString('base64');
+
+    const options = {
+      redirect_uri: `${OAUTH_URL_PATH.BASE_URL}/${OAUTH_URL_PATH.REDIRECT_PATH.CALLBACK}`,
+      client_id: process.env.GITHUB_CLIENT_ID,
+      scope: ['user:email', 'read:user'].join(','),
+      state: state,
+    };
+
+    return `${OAUTH_URL_PATH.GITHUB.AUTH_URL}?${querystring.stringify(options)}`;
+  }
+
+  // state의 검증 + code를 사용한 UserResource에 대한 AccessToken 반환
+  async getTokens(code: string): Promise<OAuthTokenResponse> {
+    const tokenUrl = OAUTH_URL_PATH.GITHUB.TOKEN_URL;
+
+    const queries = {
+      code,
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET
+    };
+
+    try {
+      const response = await axios.post(
+        tokenUrl,
+        querystring.stringify(queries),
+        {
+          headers: {
+            Accept: 'application/json',
+          },
+        },
+      );
+
+      const {
+        access_token: access_token,
+        refresh_token: refresh_token,
+        expires_in: expires_in,
+        scope: scope,
+      } = response.data as OAuthTokenResponse;
+
+      return {
+        access_token,
+        refresh_token,
+        expires_in,
+        scope,
+      };
+    } catch (error) {
+      this.logger.error(`Oauth 로그인 중 에러 발생, ${error}`);
+      throw new BadGatewayException(
+        '현재 외부 서비스와의 연결에 실패했습니다.',
+      );
+    }
+  }
+
+  getUserInfo(tokenResponse: OAuthTokenResponse): Promise<UserInfo> {
+    const { access_token: accessToken } = tokenResponse;
+
+    try {
+      const response = await axios.get(
+          `${OAUTH_URL_PATH.GITHUB.USER_INFO_URL}`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`
+            },
+          },
+      );
+
+      return response.data;
+    }
+  }
+}

--- a/server/src/user/provider/github.provider.ts
+++ b/server/src/user/provider/github.provider.ts
@@ -38,7 +38,7 @@ export class GithubOAuthProvider implements OAuthProvider {
     const queries = {
       code,
       client_id: process.env.GITHUB_CLIENT_ID,
-      client_secret: process.env.GITHUB_CLIENT_SECRET
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
     };
 
     try {
@@ -73,20 +73,30 @@ export class GithubOAuthProvider implements OAuthProvider {
     }
   }
 
-  getUserInfo(tokenResponse: OAuthTokenResponse): Promise<UserInfo> {
+  async getUserInfo(tokenResponse: OAuthTokenResponse): Promise<UserInfo> {
     const { access_token: accessToken } = tokenResponse;
 
     try {
       const response = await axios.get(
-          `${OAUTH_URL_PATH.GITHUB.USER_INFO_URL}`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`
-            },
+        `${OAUTH_URL_PATH.GITHUB.USER_INFO_URL}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
           },
+        },
       );
 
-      return response.data;
+      const { id, email, name, avatar_url } = response.data as any;
+      return {
+        id,
+        email,
+        name,
+        picture: avatar_url,
+      } as UserInfo;
+    } catch (error) {
+      throw new BadGatewayException(
+        '현재 외부 서비스와의 연결에 실패했습니다.',
+      );
     }
   }
 }

--- a/server/src/user/provider/google.provider.ts
+++ b/server/src/user/provider/google.provider.ts
@@ -5,6 +5,7 @@ import {
   OAUTH_CONSTANT,
   OAUTH_URL_PATH,
   OAuthTokenResponse,
+  UserInfo,
 } from '../constant/oauth.constant';
 import axios from 'axios';
 
@@ -84,7 +85,14 @@ export class GoogleOAuthProvider implements OAuthProvider {
           },
         },
       );
-      return response.data;
+
+      const { id, email, name, picture } = response.data;
+      return {
+        id,
+        email,
+        name,
+        picture,
+      } as UserInfo;
     } catch (error) {
       throw new BadGatewayException(
         '현재 외부 서비스와의 연결에 실패했습니다.',

--- a/server/src/user/provider/google.provider.ts
+++ b/server/src/user/provider/google.provider.ts
@@ -1,7 +1,11 @@
 import { OAuthProvider } from './oauth-provider.interface';
 import * as querystring from 'node:querystring';
 import { BadGatewayException, Injectable } from '@nestjs/common';
-import { OAUTH_CONSTANT, OAUTH_URL_PATH } from '../constant/oauth.constant';
+import {
+  OAUTH_CONSTANT,
+  OAUTH_URL_PATH,
+  OAuthTokenResponse,
+} from '../constant/oauth.constant';
 import axios from 'axios';
 
 @Injectable()
@@ -49,14 +53,28 @@ export class GoogleOAuthProvider implements OAuthProvider {
         },
       );
 
-      return response.data;
+      const {
+        id_token: id_token,
+        access_token: access_token,
+        refresh_token: refresh_token,
+        expires_in: expires_in,
+      } = response.data as OAuthTokenResponse;
+
+      return {
+        id_token,
+        access_token,
+        refresh_token,
+        expires_in,
+      };
     } catch (error) {
       throw new BadGatewayException(
         '현재 외부 서비스와의 연결에 실패했습니다.',
       );
     }
   }
-  async getUserInfo(idToken: string, accessToken: string) {
+  async getUserInfo(tokenResponse: OAuthTokenResponse) {
+    const { id_token: idToken, access_token: accessToken } = tokenResponse;
+
     try {
       const response = await axios.get(
         `${OAUTH_URL_PATH.GOOGLE.USER_INFO_URL}?alt=json&access_token=${accessToken}`,

--- a/server/src/user/provider/oauth-provider.interface.ts
+++ b/server/src/user/provider/oauth-provider.interface.ts
@@ -3,5 +3,5 @@ import { OAuthTokenResponse, UserInfo } from '../constant/oauth.constant';
 export interface OAuthProvider {
   getAuthUrl(): string;
   getTokens(code: string): Promise<OAuthTokenResponse>;
-  getUserInfo(idToken: string, accessToken: string): Promise<UserInfo>;
+  getUserInfo(tokenResponse: OAuthTokenResponse): Promise<UserInfo>;
 }

--- a/server/src/user/service/oauth.service.ts
+++ b/server/src/user/service/oauth.service.ts
@@ -39,19 +39,12 @@ export class OAuthService {
     const tokenData = await this.providers[providerType].getTokens(
       code as string,
     );
-    const {
-      id_token: idToken,
-      access_token: accessToken,
-      refresh_token: refreshToken,
-    } = tokenData;
-    const userInfo = await this.providers[providerType].getUserInfo(
-      idToken,
-      accessToken,
-    );
+
+    const userInfo = await this.providers[providerType].getUserInfo(tokenData);
 
     await this.saveOAuthUser(userInfo, {
       providerType,
-      refreshToken: refreshToken,
+      refreshToken: tokenData.refresh_token,
     });
 
     return `${OAUTH_URL_PATH.BASE_URL}`;

--- a/server/src/user/service/oauth.service.ts
+++ b/server/src/user/service/oauth.service.ts
@@ -7,6 +7,7 @@ import { User } from '../entity/user.entity';
 import { Provider } from '../entity/provider.entity';
 import {
   OAUTH_URL_PATH,
+  OAuthType,
   ProviderData,
   StateData,
   UserInfo,
@@ -23,7 +24,7 @@ export class OAuthService {
     private readonly providers: Record<string, OAuthProvider>,
   ) {}
 
-  getAuthUrl(providerType: string) {
+  getAuthUrl(providerType: OAuthType) {
     const oauth = this.providers[providerType];
     if (!oauth)
       throw new BadRequestException('지원하지 않는 인증 제공자입니다.');


### PR DESCRIPTION
# 🔨 테스크
### Issue
- #333 

# 📋 작업 내용
### 각 프로바이더 별 메서드 반환 타입 변경
각 프로바이더별로 OAuth flow에서 사용되는 데이터들과 반환받는 프로필 데이터가 다름에 따라, 사전에 타입(`OAuthTokenResponse`, `ProviderData`, `UserInfo`)을 지정해두고 해당 타입을 반환하는 형태로 코드를 변경하였습니다.

### Github Provider 작성
기존에 설계된 OAuthService의 플로우 스펙을 만족하는 `GithubOAuthProvider`를 작성하였습니다.
기존 Google OAuth와 대부분이 동일합니다. (주고받는 데이터, 데이터 빌딩 과정 등은 다릅니다.)

> **로그인 처리, Migraiton 작성은 다음 PR에서 일괄 처리하겠습니다 :)**
 
# 📷 스크린 샷(선택 사항)
![image](https://github.com/user-attachments/assets/612fafb2-e4a9-443b-95bb-bb138b69395f)
