### PR TITLE
✨ feat: 사용자 활동정보 업데이트 스케줄러 작성

### DIFF
--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 import { UserRepository } from '../repository/user.repository';
 import { UserService } from '../service/user.service';
 import { UserController } from '../controller/user.controller';
@@ -9,9 +10,10 @@ import { JwtAuthModule } from '../../common/auth/jwt.module';
 import { AdminModule } from '../../admin/module/admin.module';
 import { GoogleOAuthProvider } from '../provider/google.provider';
 import { GithubOAuthProvider } from '../provider/github.provider';
+import { UserScheduler } from '../scheduler/user.scheduler';
 
 @Module({
-  imports: [JwtAuthModule, AdminModule],
+  imports: [JwtAuthModule, AdminModule, ScheduleModule.forRoot()],
   controllers: [UserController, OAuthController],
   providers: [
     UserService,
@@ -20,6 +22,7 @@ import { GithubOAuthProvider } from '../provider/github.provider';
     ProviderRepository,
     GoogleOAuthProvider,
     GithubOAuthProvider,
+    UserScheduler,
     {
       provide: 'OAUTH_PROVIDERS',
       useFactory: (

--- a/server/src/user/scheduler/user.scheduler.ts
+++ b/server/src/user/scheduler/user.scheduler.ts
@@ -1,0 +1,58 @@
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { UserRepository } from '../repository/user.repository';
+import { Not } from 'typeorm';
+import { WinstonLoggerService } from '../../common/logger/logger.service';
+
+@Injectable()
+export class UserScheduler {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async resetExpiredStreaks() {
+    const yesterday = new Date();
+    yesterday.setDate(yesterday.getDate() - 1);
+    yesterday.setHours(0, 0, 0, 0);
+
+    try {
+      const expiredUsers = await this.userRepository.find({
+        where: {
+          currentStreak: Not(0),
+          lastActiveDate: Not(null),
+        },
+      });
+
+      const usersToUpdate = expiredUsers.filter((user) => {
+        if (!user.lastActiveDate) return false;
+
+        const lastActive = new Date(user.lastActiveDate);
+        lastActive.setHours(0, 0, 0, 0);
+
+        return lastActive < yesterday;
+      });
+
+      if (usersToUpdate.length > 0) {
+        await this.userRepository
+          .createQueryBuilder()
+          .update()
+          .set({ currentStreak: 0 })
+          .whereInIds(usersToUpdate.map((user) => user.id))
+          .execute();
+
+        this.logger.log(
+          `[UserScheduler]: ${usersToUpdate.length} 명의 streak 정보 업데이트 완료.`,
+        );
+      } else {
+        this.logger.log('[UserScheduler]: streak 업데이트 된 사용자 없음.');
+      }
+    } catch (error) {
+      this.logger.error(
+        `[UserScheduler]: streak 업데이트 스케줄러 동작중 오류 발생: ${error.message}`,
+        error.stack,
+      );
+    }
+  }
+}


### PR DESCRIPTION
# 🔨 테스크
### Issue
-  #396 

# 📋 작업 내용
### 사용자 활동 데이터 업데이트 스케줄러 작성
![image](https://github.com/user-attachments/assets/144a2cda-3fd5-404c-88f2-754f9455269a)

`resetExpiredStreaks` 메서드는 매 시 자정에 `lastActivate` 컬럼을 기반으로 streak을 유지할지, 0으로 초기화 할지 결정합니다. 스케줄러의 로직 흐름은 아래와 같습니다.

> 1. `currentStreak`이 0이 아니고, `lastActivate`가 0이 아닌 모든 사용자를 조회.
> 2. `lastActivate`가 어제보다 이전인 사용자들을 필터링.
> 3. 해당 사용자들의 streak 수치를 0으로 초기화.