### PR TITLE
✨ feat: 채팅 가시성 관련 웹 소켓 연결 관리

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   const isMobile = useMediaQuery("(max-width: 767px)");
   const { hasVisited, setVisited } = useVisitStore();
   const location = useLocation();
+  const userID = localStorage.getItem("userID");
   const state =
     location.state && location.state.backgroundLocation
       ? { backgroundLocation: location.state.backgroundLocation }
@@ -37,8 +38,8 @@ export default function App() {
 
   useEffect(() => {
     console.log(denamuAscii);
+    if (!userID) localStorage.setItem("userID", crypto.randomUUID());
   }, []);
-
   useEffect(() => {
     if (location.state?.backgroundLocation) {
       window.history.replaceState({}, document.title, window.location.pathname + window.location.search);

--- a/client/src/components/chat/Chat.tsx
+++ b/client/src/components/chat/Chat.tsx
@@ -10,7 +10,7 @@ import { useVisible } from "@/hooks/common/useVisible";
 import { useChatStore } from "@/store/useChatStore";
 
 export function Chat() {
-  const { userCount, connect, disconnect, getHistory } = useChatStore();
+  const { userCount, isConnected, connect, disconnect, getHistory } = useChatStore();
   const [isFull, setIsFull] = useState<boolean>(false);
   const visible = useVisible();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -52,7 +52,7 @@ export function Chat() {
     <Sidebar side="right" variant="floating">
       <SidebarContent>
         <ChatHeader />
-        <ChatSection isFull={isFull} />
+        <ChatSection isFull={isFull} isConnected={isConnected} />
         <ChatFooter />
       </SidebarContent>
     </Sidebar>

--- a/client/src/components/chat/Chat.tsx
+++ b/client/src/components/chat/Chat.tsx
@@ -1,16 +1,19 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 import ChatFooter from "@/components/chat/layout/ChatFooter";
 import ChatHeader from "@/components/chat/layout/ChatHeader";
 import ChatSection from "@/components/chat/layout/ChatSection";
 import { Sidebar, SidebarContent } from "@/components/ui/sidebar";
 
+import { useVisible } from "@/hooks/common/useVisible";
+
 import { useChatStore } from "@/store/useChatStore";
 
 export function Chat() {
   const { userCount, connect, disconnect, getHistory } = useChatStore();
   const [isFull, setIsFull] = useState<boolean>(false);
-  // Socket 연결 관리
+  const visible = useVisible();
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   useEffect(() => {
     if (userCount >= 500) {
       setIsFull(true);
@@ -21,6 +24,29 @@ export function Chat() {
       disconnect();
     };
   }, []);
+
+  useEffect(() => {
+    if (!visible) {
+      timeoutRef.current = setTimeout(
+        () => {
+          disconnect();
+        },
+        3 * 60 * 1000
+      );
+    } else {
+      connect();
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [visible]);
 
   return (
     <Sidebar side="right" variant="floating">

--- a/client/src/components/chat/ChatItem.tsx
+++ b/client/src/components/chat/ChatItem.tsx
@@ -1,4 +1,5 @@
 import Avvvatars from "avvvatars-react";
+import clsx from "clsx";
 
 import { Avatar } from "@/components/ui/avatar";
 
@@ -11,29 +12,40 @@ type ChatItemProps = {
   chatItem: ChatType;
   isSameUser: boolean;
 };
+
 const chatStyle = "p-3 bg-gray-200 text-black break-words whitespace-pre-wrap rounded-md inline-block max-w-[90%]";
 export default function ChatItem({ chatItem, isSameUser }: ChatItemProps) {
+  const isUser = localStorage.getItem("userID") === chatItem.userId;
   if (chatItem.username === "system")
     return <div className="flex justify-center">{formatDate(chatItem.timestamp)}</div>;
   return (
     <div className="flex flex-col ">
       {!isSameUser ? (
-        <span className="flex gap-1 items-center text-left">
-          <Avatar>
-            <Avvvatars value={chatItem.username} style="shape" />
-          </Avatar>
-          {/* 이름, 시간 */}
-          <span className="flex gap-2 items-center inline-block">
-            <span className="text-sm">{chatItem.username}</span>
+        <span className={clsx("flex gap-1 items-center", isUser ? "justify-end" : "justify-start")}>
+          {!isUser && (
+            <Avatar>
+              <Avvvatars value={chatItem.username} style="shape" />
+            </Avatar>
+          )}
+
+          <span className="flex gap-2 items-center">
+            <span className="text-sm">{isUser ? "나" : chatItem.username}</span>
             <span className="text-xs">{formatTime(chatItem.timestamp)}</span>
           </span>
         </span>
       ) : (
         <></>
       )}
-      <div className="w-full ml-[2rem]">
-        {!isSameUser ? <FirstChat message={chatItem.message} /> : <OtherChat message={chatItem.message} />}
-      </div>
+      {!isUser && (
+        <div className="w-full ml-[2rem]">
+          {!isSameUser ? <FirstChat message={chatItem.message} /> : <OtherChat message={chatItem.message} />}
+        </div>
+      )}
+      {isUser && (
+        <div className="w-full  flex justify-end">
+          {!isSameUser ? <FirstChat message={chatItem.message} /> : <OtherChat message={chatItem.message} />}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/chat/ChatItem.tsx
+++ b/client/src/components/chat/ChatItem.tsx
@@ -6,6 +6,7 @@ import { Avatar } from "@/components/ui/avatar";
 import { formatDate } from "@/utils/date";
 import { formatTime } from "@/utils/time";
 
+import { useChatStore } from "@/store/useChatStore";
 import { ChatType } from "@/types/chat";
 
 type ChatItemProps = {
@@ -16,8 +17,11 @@ type ChatItemProps = {
 const chatStyle = "p-3 bg-gray-200 text-black break-words whitespace-pre-wrap rounded-md inline-block max-w-[90%]";
 export default function ChatItem({ chatItem, isSameUser }: ChatItemProps) {
   const isUser = localStorage.getItem("userID") === chatItem.userId;
+  const resendMessage = useChatStore((state) => state.resendMessage);
+  const deleteMessage = useChatStore((state) => state.deleteMessage);
   if (chatItem.username === "system")
     return <div className="flex justify-center">{formatDate(chatItem.timestamp)}</div>;
+
   return (
     <div className="flex flex-col ">
       {!isSameUser ? (
@@ -30,7 +34,7 @@ export default function ChatItem({ chatItem, isSameUser }: ChatItemProps) {
 
           <span className="flex gap-2 items-center">
             <span className="text-sm">{isUser ? "나" : chatItem.username}</span>
-            <span className="text-xs">{formatTime(chatItem.timestamp)}</span>
+            <span className="text-xs">{chatItem.isFailed ? "전송실패" : formatTime(chatItem.timestamp)}</span>
           </span>
         </span>
       ) : (
@@ -46,7 +50,17 @@ export default function ChatItem({ chatItem, isSameUser }: ChatItemProps) {
         </div>
       )}
       {isUser && (
-        <div className="w-full  flex justify-end">
+        <div className="w-full flex justify-end gap-2">
+          {chatItem.isFailed && (
+            <div className="flex gap-2">
+              <button className="hover:text-black" onClick={() => resendMessage(chatItem)}>
+                재전송
+              </button>
+              <button className="hover:text-black" onClick={() => deleteMessage(chatItem.messageId as string)}>
+                삭제
+              </button>
+            </div>
+          )}
           {!isSameUser ? (
             <FirstChat message={chatItem.message} isUser={isUser} />
           ) : (

--- a/client/src/components/chat/ChatItem.tsx
+++ b/client/src/components/chat/ChatItem.tsx
@@ -38,23 +38,36 @@ export default function ChatItem({ chatItem, isSameUser }: ChatItemProps) {
       )}
       {!isUser && (
         <div className="w-full ml-[2rem]">
-          {!isSameUser ? <FirstChat message={chatItem.message} /> : <OtherChat message={chatItem.message} />}
+          {!isSameUser ? (
+            <FirstChat message={chatItem.message} isUser={isUser} />
+          ) : (
+            <OtherChat message={chatItem.message} />
+          )}
         </div>
       )}
       {isUser && (
         <div className="w-full  flex justify-end">
-          {!isSameUser ? <FirstChat message={chatItem.message} /> : <OtherChat message={chatItem.message} />}
+          {!isSameUser ? (
+            <FirstChat message={chatItem.message} isUser={isUser} />
+          ) : (
+            <OtherChat message={chatItem.message} />
+          )}
         </div>
       )}
     </div>
   );
 }
 
-function FirstChat({ message }: { message: string }) {
+function FirstChat({ message, isUser }: { message: string; isUser: boolean }) {
   return (
     <span className={`${chatStyle} relative `}>
       {message}
-      <div className="absolute top-[-5px] left-[0px] w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[8px]"></div>
+      <div
+        className={clsx(
+          "absolute top-[-5px] w-0 h-0 border-l-[8px] border-l-transparent border-r-[8px] border-r-transparent border-b-[8px]",
+          isUser ? "right-[0px]" : "left-[0px]"
+        )}
+      ></div>
     </span>
   );
 }

--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { Send } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -6,10 +8,10 @@ import { SheetFooter } from "@/components/ui/sheet";
 
 import { useKeyboardShortcut } from "@/hooks/common/useKeyboardShortcut";
 
-import { useChatValueStore, useChatStore } from "@/store/useChatStore";
+import { useChatStore } from "@/store/useChatStore";
 
 export default function ChatFooter() {
-  const { message, setMessage } = useChatValueStore();
+  const [message, setMessage] = useState<string>("");
   const { sendMessage } = useChatStore();
 
   const handleSendMessage = () => {

--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -16,7 +16,11 @@ export default function ChatFooter() {
 
   const handleSendMessage = () => {
     if (message.trim() !== "") {
-      sendMessage(message);
+      sendMessage({
+        message: message,
+        messageId: crypto.randomUUID(),
+        userId: localStorage.getItem("userID") as string,
+      });
       setMessage("");
     }
   };

--- a/client/src/components/chat/layout/ChatHistory.tsx
+++ b/client/src/components/chat/layout/ChatHistory.tsx
@@ -1,0 +1,56 @@
+import { CircleAlert } from "lucide-react";
+
+import ChatItem from "@/components/chat/ChatItem";
+import ChatSkeleton from "@/components/chat/layout/ChatSkeleton";
+
+import Empty from "@/assets/empty-panda.svg";
+
+import { useChatStore } from "@/store/useChatStore";
+
+export default function ChatHistory({ isFull, isConnected }: { isFull: boolean; isConnected: boolean }) {
+  const { chatHistory, isLoading } = useChatStore();
+
+  if (isLoading) return <ChatSkeleton number={14} />;
+  if (!isConnected) return <NotConnected />;
+  if (isFull) return <FullChatWarning />;
+  if (chatHistory.length === 0) return <EmptyChatHistory />;
+
+  return (
+    <span className="flex flex-col gap-3 px-3">
+      {chatHistory.map((item, index) => {
+        const isSameUser = index > 0 && chatHistory[index - 1]?.username === item.username;
+        return <ChatItem key={index} chatItem={item} isSameUser={isSameUser} />;
+      })}
+    </span>
+  );
+}
+
+const FullChatWarning = () => (
+  <div className="flex flex-col justify-center items-center h-[70vh] gap-3">
+    <CircleAlert color="red" size={200} />
+    <div className="flex flex-col items-center gap-1">
+      <p className="font-bold">채팅창 인원이 500명 이상입니다</p>
+      <p>잠시 기다렸다가 새로고침을 해주세요</p>
+    </div>
+  </div>
+);
+
+const EmptyChatHistory = () => (
+  <div className="flex flex-col flex-1 justify-center items-center h-[70vh] gap-3">
+    <img src={Empty} alt="비어있는 채팅" className="w-[50%] rounded-full" />
+    <div className="flex flex-col items-center gap-1">
+      <p className="font-bold">이전 채팅 기록이 없습니다</p>
+      <p>새로운 채팅을 시작해보세요!!</p>
+    </div>
+  </div>
+);
+
+const NotConnected = () => (
+  <div className="flex flex-col justify-center items-center h-[70vh] gap-3">
+    <CircleAlert color="red" size={200} />
+    <div className="flex flex-col items-center gap-1">
+      <p className="font-bold">채팅이 연결되지 않았습니다.</p>
+      <p>잠시 기다리면 연결이 됩니다.</p>
+    </div>
+  </div>
+);

--- a/client/src/components/chat/layout/ChatSection.tsx
+++ b/client/src/components/chat/layout/ChatSection.tsx
@@ -31,16 +31,29 @@ const EmptyChatHistory = () => (
   </div>
 );
 
+const NotConnected = () => (
+  <div className="flex flex-col justify-center items-center h-[70vh] gap-3">
+    <CircleAlert color="red" size={200} />
+    <div className="flex flex-col items-center gap-1">
+      <p className="font-bold">채팅이 연결되지 않았습니다.</p>
+      <p>잠시 기다리면 연결이 됩니다.</p>
+    </div>
+  </div>
+);
+
 const RenderHistory = ({
   chatHistory,
   isFull,
   isLoading,
+  isConnected,
 }: {
   chatHistory: ChatType[];
   isFull: boolean;
   isLoading: boolean;
+  isConnected: boolean;
 }) => {
   if (isLoading) return <ChatSkeleton number={14} />;
+  if (!isConnected) return <NotConnected />;
   if (isFull) return <FullChatWarning />;
   if (chatHistory.length === 0) return <EmptyChatHistory />;
   return (
@@ -55,7 +68,7 @@ const RenderHistory = ({
 
 export default function ChatSection({ isFull }: { isFull: boolean }) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { chatHistory, isLoading } = useChatStore();
+  const { chatHistory, isLoading, isConnected } = useChatStore();
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -71,7 +84,7 @@ export default function ChatSection({ isFull }: { isFull: boolean }) {
 
   return (
     <ScrollArea ref={scrollRef} className="h-full">
-      <RenderHistory chatHistory={chatHistory} isFull={isFull} isLoading={isLoading} />
+      <RenderHistory chatHistory={chatHistory} isFull={isFull} isLoading={isLoading} isConnected={isConnected} />
     </ScrollArea>
   );
 }

--- a/client/src/components/chat/layout/ChatSection.tsx
+++ b/client/src/components/chat/layout/ChatSection.tsx
@@ -1,90 +1,28 @@
 import { useEffect, useRef } from "react";
 
-import { CircleAlert } from "lucide-react";
-
-import ChatItem from "@/components/chat/ChatItem";
-import ChatSkeleton from "@/components/chat/layout/ChatSkeleton";
+import ChatHistory from "@/components/chat/layout/ChatHistory";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
-import Empty from "@/assets/empty-panda.svg";
-
 import { useChatStore } from "@/store/useChatStore";
-import { ChatType } from "@/types/chat";
 
-const FullChatWarning = () => (
-  <div className="flex flex-col justify-center items-center h-[70vh] gap-3">
-    <CircleAlert color="red" size={200} />
-    <div className="flex flex-col items-center gap-1">
-      <p className="font-bold">채팅창 인원이 500명 이상입니다</p>
-      <p>잠시 기다렸다가 새로고침을 해주세요</p>
-    </div>
-  </div>
-);
-
-const EmptyChatHistory = () => (
-  <div className="flex flex-col flex-1 justify-center items-center h-[70vh] gap-3">
-    <img src={Empty} alt="비어있는 채팅" className="w-[50%] rounded-full" />
-    <div className="flex flex-col items-center gap-1">
-      <p className="font-bold">이전 채팅 기록이 없습니다</p>
-      <p>새로운 채팅을 시작해보세요!!</p>
-    </div>
-  </div>
-);
-
-const NotConnected = () => (
-  <div className="flex flex-col justify-center items-center h-[70vh] gap-3">
-    <CircleAlert color="red" size={200} />
-    <div className="flex flex-col items-center gap-1">
-      <p className="font-bold">채팅이 연결되지 않았습니다.</p>
-      <p>잠시 기다리면 연결이 됩니다.</p>
-    </div>
-  </div>
-);
-
-const RenderHistory = ({
-  chatHistory,
-  isFull,
-  isLoading,
-  isConnected,
-}: {
-  chatHistory: ChatType[];
-  isFull: boolean;
-  isLoading: boolean;
-  isConnected: boolean;
-}) => {
-  if (isLoading) return <ChatSkeleton number={14} />;
-  if (!isConnected) return <NotConnected />;
-  if (isFull) return <FullChatWarning />;
-  if (chatHistory.length === 0) return <EmptyChatHistory />;
-  return (
-    <span className="flex flex-col gap-3 px-3">
-      {chatHistory.map((item, index) => {
-        const isSameUser = index > 0 && chatHistory[index - 1]?.username === item.username;
-        return <ChatItem key={index} chatItem={item} isSameUser={isSameUser} />;
-      })}
-    </span>
-  );
-};
-
-export default function ChatSection({ isFull }: { isFull: boolean }) {
+export default function ChatSection({ isFull, isConnected }: { isFull: boolean; isConnected: boolean }) {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { chatHistory, isLoading, isConnected } = useChatStore();
+  const chatLength = useChatStore((state) => state.chatLength);
 
   useEffect(() => {
     if (scrollRef.current) {
       const scrollContent = scrollRef.current.querySelector("[data-radix-scroll-area-viewport]");
-      if (scrollContent && chatHistory.length > 0) {
+      if (scrollContent && chatLength() > 0) {
         scrollContent.scrollTo({
           top: scrollContent.scrollHeight,
           behavior: "smooth",
         });
       }
     }
-  }, [chatHistory.length]);
-
+  }, [chatLength()]);
   return (
     <ScrollArea ref={scrollRef} className="h-full">
-      <RenderHistory chatHistory={chatHistory} isFull={isFull} isLoading={isLoading} isConnected={isConnected} />
+      <ChatHistory isFull={isFull} isConnected={isConnected} />
     </ScrollArea>
   );
 }

--- a/client/src/hooks/common/useVisible.ts
+++ b/client/src/hooks/common/useVisible.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+export const useVisible = () => {
+  const [visible, setVisible] = useState<boolean>(true);
+  useEffect(() => {
+    const handleVisible = () => {
+      const isVisible = document.visibilityState === "visible";
+      setVisible(isVisible);
+    };
+    document.addEventListener("visibilitychange", handleVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisible);
+    };
+  }, []);
+  return visible;
+};

--- a/client/src/store/useChatStore.ts
+++ b/client/src/store/useChatStore.ts
@@ -6,6 +6,7 @@ import { CHAT_SERVER_URL } from "@/constants/endpoints";
 import { ChatType, SendChatType } from "@/types/chat";
 
 let socket: Socket | null = null;
+const pendingTimeouts: Record<string, NodeJS.Timeout> = {};
 
 type State = {
   chatHistory: ChatType[];
@@ -18,12 +19,14 @@ type Action = {
   disconnect: () => void;
   getHistory: () => void;
   sendMessage: (message: SendChatType) => void;
+  resendMessage: (data: ChatType) => void;
+  deleteMessage: (messageId: string) => void;
+  chatLength: () => number;
 };
 
-export const useChatStore = create<State & Action>((set) => {
+export const useChatStore = create<State & Action>((set, get) => {
   const initializeSocket = () => {
     if (socket) return socket;
-
     socket = io(CHAT_SERVER_URL, {
       path: "/chat",
       transports: ["websocket"],
@@ -34,9 +37,20 @@ export const useChatStore = create<State & Action>((set) => {
     });
 
     socket.on("message", (data) => {
-      set((state) => ({
-        chatHistory: [...state.chatHistory, data],
-      }));
+      if (pendingTimeouts[data.messageId]) {
+        clearTimeout(pendingTimeouts[data.messageId]);
+        delete pendingTimeouts[data.messageId];
+      }
+
+      set((state) => {
+        const index = state.chatHistory.findIndex((msg) => msg.messageId === data.messageId);
+        if (index !== -1) {
+          const newHistory = [...state.chatHistory];
+          newHistory[index] = { ...data, isSend: true, isFailed: false };
+          return { chatHistory: newHistory };
+        }
+        return { chatHistory: [...state.chatHistory, { ...data, isSend: true, isFailed: false }] };
+      });
     });
 
     socket.on("updateUserCount", (data) => {
@@ -71,34 +85,95 @@ export const useChatStore = create<State & Action>((set) => {
 
     getHistory: () => {
       const s = initializeSocket();
-      if (s.connected) {
+
+      const requestHistory = () => {
         s.emit("getHistory");
+        s.off("connect", requestHistory);
+      };
+      if (s.connected) {
+        requestHistory();
       } else {
-        s.once("connect", () => {
-          s.emit("getHistory");
-        });
+        s.on("connect", requestHistory);
         s.connect();
       }
 
       s.on("chatHistory", (data) => {
-        console.log(data);
-        useChatStore.setState({
-          chatHistory: data,
-          isLoading: false,
+        useChatStore.setState((state) => {
+          const failedMessages = state.chatHistory.filter((chat) => chat.isFailed || !chat.isSend);
+          return {
+            chatHistory: [...data, ...failedMessages],
+            isLoading: false,
+          };
         });
       });
     },
 
     sendMessage: (message: SendChatType) => {
       const s = initializeSocket();
+
+      useChatStore.setState((state) => ({
+        chatHistory: [
+          ...state.chatHistory,
+          {
+            timestamp: "전송중",
+            username: "나",
+            isMidNight: false,
+            message: message.message,
+            messageId: message.messageId,
+            userId: localStorage.getItem("userID"),
+          } as ChatType,
+        ],
+      }));
+
+      pendingTimeouts[message.messageId] = setTimeout(() => {
+        useChatStore.setState((state) => ({
+          chatHistory: state.chatHistory.map((m) => (m.messageId === message.messageId ? { ...m, isFailed: true } : m)),
+        }));
+        delete pendingTimeouts[message.messageId];
+      }, 5000);
+
       if (s.connected) {
         s.emit("message", message);
       } else {
-        s.once("connect", () => {
-          s.emit("message", message);
-        });
         s.connect();
       }
     },
+
+    resendMessage: (data: ChatType) => {
+      const s = initializeSocket();
+      if (s.connected) {
+        s.emit("message", {
+          message: data.message,
+          messageId: data.messageId,
+          userId: data.userId,
+        });
+        useChatStore.setState((state) => ({
+          chatHistory: state.chatHistory.map((m) =>
+            m.messageId === data.messageId ? { ...m, isFailed: false, timestamp: "전송중", isSend: false } : m
+          ),
+        }));
+
+        pendingTimeouts[data.messageId as string] = setTimeout(() => {
+          useChatStore.setState((state) => ({
+            chatHistory: state.chatHistory.map((m) => (m.messageId === data.messageId ? { ...m, isFailed: true } : m)),
+          }));
+          delete pendingTimeouts[data.messageId as string];
+        }, 5000);
+      } else {
+        console.error("소켓이 끊겼습니다. 재전송할 수 없습니다.");
+        alert("지금은 연결이 끊겨 재전송할 수 없습니다.");
+      }
+    },
+    deleteMessage: (messageId: string) => {
+      if (pendingTimeouts[messageId]) {
+        clearTimeout(pendingTimeouts[messageId]);
+        delete pendingTimeouts[messageId];
+      }
+      useChatStore.setState((state) => ({
+        chatHistory: state.chatHistory.filter((m) => m.messageId !== messageId),
+      }));
+      alert("메시지가 삭제되었습니다");
+    },
+    chatLength: () => get().chatHistory.length,
   };
 });

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -4,4 +4,12 @@ export type ChatType = {
   timestamp: string;
   message: string;
   isMidNight?: boolean;
+  userId?: string;
+  messageId?: string;
+};
+
+export type SendChatType = {
+  message: string;
+  userId: string;
+  messageId: string;
 };

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -6,6 +6,8 @@ export type ChatType = {
   isMidNight?: boolean;
   userId?: string;
   messageId?: string;
+  isSend?: boolean;
+  isFailed?: boolean;
 };
 
 export type SendChatType = {


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #377

### 웹 가시성에 따른 웹 소켓 해제 및 재연결

-   크롬 브라우저의 discard 메모리 최적화 정책을 최대한 활용해보기 위해서 도입했습니다.
-   크롬 브라우저의 경우 웹 소켓이 연결된 탭의 경우 백그라운드에 있더라도 메모리를 계속해서 점유하도록 되어있습니다.
-   위 불필요한 메모리 점유를 막고자 웹 가시성API를 이용해 서비스가 백그라운드로 들어가게 되면 일정 시간이 지난 후 웹 소켓을 끊어버리는 식으로 수정했습니다.

### 채팅 낙관적 업데이트 및 채팅 개별 재전송

-  이전에 구현된 방식은 사용자가 채팅을 서버로 보내면 서버는 웹 소켓에 브로드캐스팅 방식을 이용해 해당 채팅을 뿌렸습니다.
-  이때 사용자가 연결이 불안정한 상태에서 채팅을 보내게 된다면 해당 브로드캐스팅을 받을 수 없게 되며 이에 따른 문제가 발생합니다.
-  위 문제를 해결하고자 채팅 낙관적 업데이트를 도입했고 서버로부터 해당 채팅에 대한 ack을 받아 업데이트 하는 식으로 수정했습니다.

### 본인 채팅 오른쪽에 나오도록 수정
-  말 그대로 본인이 보낸 채팅과 다른 유저가 보낸 채팅을 구분하기 위해 도입했습니다.

# 📋 작업 내용

- 웹 가시성에 따른 웹 소켓 해제 및 재연결
- 채팅 낙관적 업데이트
- 본인 채팅 오른쪽에 나오도록 수정

# 📷 스크린 샷(선택 사항)

![image](https://github.com/user-attachments/assets/603b103d-c0c3-4e8b-a28f-5ad840edf63f)


![image](https://github.com/user-attachments/assets/a5fb3e85-9199-4b20-8da3-82332cd335a4)

