### PR TITLE
♻️ refactor: feed crawler 로그 수집 개선

### DIFF
--- a/feed-crawler/package-lock.json
+++ b/feed-crawler/package-lock.json
@@ -16,7 +16,8 @@
         "node-schedule": "^2.1.1",
         "reflect-metadata": "^0.2.2",
         "tsyringe": "^4.8.0",
-        "winston": "^3.16.0"
+        "winston": "^3.16.0",
+        "winston-daily-rotate-file": "^5.0.0"
       },
       "devDependencies": {
         "@testcontainers/mysql": "^10.25.0",
@@ -3280,6 +3281,14 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "dependencies": {
+        "moment": "^2.29.1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4973,6 +4982,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -5131,6 +5148,14 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -6664,6 +6689,23 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
       }
     },
     "node_modules/winston-transport": {

--- a/feed-crawler/package.json
+++ b/feed-crawler/package.json
@@ -11,7 +11,8 @@
     "node-schedule": "^2.1.1",
     "reflect-metadata": "^0.2.2",
     "tsyringe": "^4.8.0",
-    "winston": "^3.16.0"
+    "winston": "^3.16.0",
+    "winston-daily-rotate-file": "^5.0.0"
   },
   "devDependencies": {
     "@testcontainers/mysql": "^10.25.0",

--- a/feed-crawler/src/claude.service.ts
+++ b/feed-crawler/src/claude.service.ts
@@ -25,15 +25,8 @@ export class ClaudeService {
   }
 
   async startRequestAI() {
-    try {
-      const feeds = await this.loadFeeds();
-      await Promise.all(feeds.map((feed) => this.processFeed(feed)));
-    } catch (error) {
-      logger.error(
-        `${this.nameTag} startRequestAI 실패: ${error.message}`,
-        error.stack,
-      );
-    }
+    const feeds = await this.loadFeeds();
+    await Promise.all(feeds.map((feed) => this.processFeed(feed)));
   }
 
   private async loadFeeds() {


### PR DESCRIPTION
# 📋 작업 내용

- close #408

### Feed Crawler 로그 수집 방식 변경
로그 수집이 중요한 Feed Crawler의 특성을 고려하여 Server와 동일하게 `winston-daily-rotate-file`를 적용하여 일별로 로그파일을 관리 하도록 했습니다.

### ClaudeService 코드 개선
불필요한 try - catch 구문을 제거 하였습니다.