### PR TITLE
✨ feat: 댓글 조회 API 구현

### DIFF
--- a/server/src/comment/api-docs/getComment.api-docs.ts
+++ b/server/src/comment/api-docs/getComment.api-docs.ts
@@ -1,0 +1,71 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiOperation,
+} from '@nestjs/swagger';
+
+export function ApiGetComment() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '댓글 조회 API',
+    }),
+    ApiOkResponse({
+      description: 'Ok',
+      schema: {
+        properties: {
+          message: {
+            type: 'string',
+          },
+          data: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                id: { type: 'number' },
+                comment: { type: 'string' },
+                date: { type: 'string', format: 'date-time' },
+                user: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'number' },
+                    userName: { type: 'string' },
+                    profileImage: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      example: {
+        message: '댓글 조회를 성공했습니다.',
+        data: [
+          {
+            id: 1,
+            comment: 'example',
+            date: '2025-01-01T00:00:00.000Z',
+            user: {
+              id: 1,
+              userName: 'example',
+              profileImage: 'https://example.com',
+            },
+          },
+        ],
+      },
+    }),
+    ApiBadRequestResponse({
+      description: 'Bad Request',
+      example: {
+        message: '오류 메세지',
+      },
+    }),
+    ApiNotFoundResponse({
+      description: 'Not Found',
+      example: {
+        message: '게시글을 찾을 수 없습니다.',
+      },
+    }),
+  );
+}

--- a/server/src/comment/controller/comment.controller.ts
+++ b/server/src/comment/controller/comment.controller.ts
@@ -30,7 +30,7 @@ export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
   @ApiGetComment()
-  @Get('/feed/:feedId')
+  @Get('/:feedId')
   @HttpCode(HttpStatus.OK)
   async getComment(@Param() getCommentRequestDto: GetCommentRequestDto) {
     return ApiResponse.responseWithData(

--- a/server/src/comment/controller/comment.controller.ts
+++ b/server/src/comment/controller/comment.controller.ts
@@ -2,8 +2,10 @@ import {
   Body,
   Controller,
   Delete,
+  Get,
   HttpCode,
   HttpStatus,
+  Param,
   Patch,
   Post,
   Req,
@@ -19,15 +21,27 @@ import { ApiResponse } from '../../common/response/common.response';
 import { CreateCommentRequestDto } from '../dto/request/create-comment.dto';
 import { DeleteCommentRequestDto } from '../dto/request/delete-comment.dto';
 import { UpdateCommentRequestDto } from '../dto/request/update-comment.dto';
+import { GetCommentRequestDto } from '../dto/request/get-comment.dto';
+import { ApiGetComment } from '../api-docs/getComment.api-docs';
 
 @ApiTags('Comment')
 @Controller('comment')
-@UseGuards(JwtGuard)
 export class CommentController {
   constructor(private readonly commentService: CommentService) {}
 
+  @ApiGetComment()
+  @Get('/feed/:feedId')
+  @HttpCode(HttpStatus.OK)
+  async getComment(@Param() getCommentRequestDto: GetCommentRequestDto) {
+    return ApiResponse.responseWithData(
+      '댓글 조회를 성공했습니다.',
+      await this.commentService.get(getCommentRequestDto),
+    );
+  }
+
   @ApiCreateComment()
   @Post()
+  @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.CREATED)
   async createComment(@Req() req, @Body() commentDto: CreateCommentRequestDto) {
     await this.commentService.create(req.user, commentDto);
@@ -36,6 +50,7 @@ export class CommentController {
 
   @ApiDeleteComment()
   @Delete()
+  @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.OK)
   async deleteComment(@Req() req, @Body() commentDto: DeleteCommentRequestDto) {
     await this.commentService.delete(req.user, commentDto);
@@ -44,6 +59,7 @@ export class CommentController {
 
   @ApiUpdateComment()
   @Patch()
+  @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.OK)
   async updateComment(@Req() req, @Body() commentDto: UpdateCommentRequestDto) {
     await this.commentService.update(req.user, commentDto);

--- a/server/src/comment/dto/request/get-comment.dto.ts
+++ b/server/src/comment/dto/request/get-comment.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt } from 'class-validator';
+
+export class GetCommentRequestDto {
+  @ApiProperty({
+    example: '게시글 ID',
+    description: '게시글 ID를 입력해주세요',
+  })
+  @IsInt({
+    message: '숫자로 입력해주세요.',
+  })
+  @Type(() => Number)
+  feedId: number;
+}

--- a/server/src/comment/dto/request/get-comment.dto.ts
+++ b/server/src/comment/dto/request/get-comment.dto.ts
@@ -12,4 +12,8 @@ export class GetCommentRequestDto {
   })
   @Type(() => Number)
   feedId: number;
+
+  constructor(partial: Partial<GetCommentRequestDto>) {
+    Object.assign(this, partial);
+  }
 }

--- a/server/src/comment/repository/comment.repository.ts
+++ b/server/src/comment/repository/comment.repository.ts
@@ -9,21 +9,11 @@ export class CommentRepository extends Repository<Comment> {
   }
 
   async getCommentInformation(feedId: number) {
-    const results = await this.createQueryBuilder('comment')
-      .innerJoin('comment.user', 'user') // ✅ 관계명은 'user'로
+    return await this.createQueryBuilder('comment')
+      .innerJoin('comment.user', 'user')
       .where('comment.feed_id = :feedId', { feedId })
       .select(['comment', 'comment.date', 'user'])
       .orderBy('comment.date', 'ASC')
       .getMany();
-    return results.map((row) => ({
-      id: row.id,
-      comment: row.comment,
-      date: row.date,
-      user: {
-        id: row.user.id,
-        userName: row.user.userName,
-        profileImage: row.user.profileImage,
-      },
-    }));
   }
 }

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -10,6 +10,7 @@ import { UserRepository } from '../../user/repository/user.repository';
 import { Payload } from '../../common/guard/jwt.guard';
 import { DeleteCommentRequestDto } from '../dto/request/delete-comment.dto';
 import { UpdateCommentRequestDto } from '../dto/request/update-comment.dto';
+import { GetCommentRequestDto } from '../dto/request/get-comment.dto';
 
 @Injectable()
 export class CommentService {
@@ -34,6 +35,30 @@ export class CommentService {
     if (userInformation.id !== commentObj.user.id) {
       throw new UnauthorizedException('본인이 작성한 댓글이 아닙니다.');
     }
+  }
+
+  async get(commentDto: GetCommentRequestDto) {
+    const feed = await this.feedRepository.findOneBy({
+      id: commentDto.feedId,
+    });
+
+    if (!feed) {
+      throw new NotFoundException('게시글을 찾을 수 없습니다.');
+    }
+
+    const comments = await this.commentRepository.getCommentInformation(
+      commentDto.feedId,
+    );
+    return comments.map((row) => ({
+      id: row.id,
+      comment: row.comment,
+      date: row.date,
+      user: {
+        id: row.user.id,
+        userName: row.user.userName,
+        profileImage: row.user.profileImage,
+      },
+    }));
   }
 
   async create(userInformation: Payload, commentDto: CreateCommentRequestDto) {

--- a/server/test/comment/dto/comment-get.dto.spec.ts
+++ b/server/test/comment/dto/comment-get.dto.spec.ts
@@ -1,0 +1,31 @@
+import { validate } from 'class-validator';
+import { GetCommentRequestDto } from '../../../src/comment/dto/request/get-comment.dto';
+
+describe('GetCommentRequestDto Test', () => {
+  it('게시글 아이디가 비어있다면 유효성 검사에 실패한다.', async () => {
+    // given
+    const getCommentDto = new GetCommentRequestDto({
+      feedId: null,
+    });
+
+    // when
+    const errors = await validate(getCommentDto);
+
+    // then
+    expect(errors).not.toHaveLength(0);
+    expect(errors[0].constraints).toHaveProperty('isInt');
+  });
+  it('게시글 아이디가 정수가 아닐 경우 유효성 검사에 실패한다.', async () => {
+    // given
+    const getCommentDto = new GetCommentRequestDto({
+      feedId: 'test' as any,
+    });
+
+    // when
+    const errors = await validate(getCommentDto);
+
+    // then
+    expect(errors).not.toHaveLength(0);
+    expect(errors[0].constraints).toHaveProperty('isInt');
+  });
+});

--- a/server/test/comment/e2e/get.e2e-spec.ts
+++ b/server/test/comment/e2e/get.e2e-spec.ts
@@ -12,7 +12,7 @@ import { UserRepository } from '../../../src/user/repository/user.repository';
 import { UserFixture } from '../../fixture/user.fixture';
 import { GetCommentRequestDto } from '../../../src/comment/dto/request/get-comment.dto';
 
-describe('GET /api/comment/feed/:feedId E2E Test', () => {
+describe('GET /api/comment/:feedId E2E Test', () => {
   let app: INestApplication;
   let userService: UserService;
   let rssAcceptInformation: RssAccept;
@@ -46,7 +46,7 @@ describe('GET /api/comment/feed/:feedId E2E Test', () => {
 
     // when
     const response = await agent
-      .get(`/api/comment/feed/${comment.feedId}`)
+      .get(`/api/comment/${comment.feedId}`)
       .send(comment);
 
     // then
@@ -62,7 +62,7 @@ describe('GET /api/comment/feed/:feedId E2E Test', () => {
 
     // when
     const response = await agent
-      .get(`/api/comment/feed/${comment.feedId}`)
+      .get(`/api/comment/${comment.feedId}`)
       .send(comment);
 
     // then

--- a/server/test/comment/e2e/get.e2e-spec.ts
+++ b/server/test/comment/e2e/get.e2e-spec.ts
@@ -1,0 +1,71 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { RssAccept } from '../../../src/rss/entity/rss.entity';
+import { Feed } from '../../../src/feed/entity/feed.entity';
+import { RssAcceptRepository } from '../../../src/rss/repository/rss.repository';
+import { FeedRepository } from '../../../src/feed/repository/feed.repository';
+import { RssAcceptFixture } from '../../fixture/rssAccept.fixture';
+import { FeedFixture } from '../../fixture/feed.fixture';
+import { UserService } from '../../../src/user/service/user.service';
+import { User } from '../../../src/user/entity/user.entity';
+import { UserRepository } from '../../../src/user/repository/user.repository';
+import { UserFixture } from '../../fixture/user.fixture';
+import { GetCommentRequestDto } from '../../../src/comment/dto/request/get-comment.dto';
+
+describe('GET /api/comment/feed/:feedId E2E Test', () => {
+  let app: INestApplication;
+  let userService: UserService;
+  let rssAcceptInformation: RssAccept;
+  let userInformation: User;
+  let feed: Feed;
+
+  beforeAll(async () => {
+    app = global.testApp;
+    userService = app.get(UserService);
+    const userRepository = app.get(UserRepository);
+    const rssAcceptRepository = app.get(RssAcceptRepository);
+    const feedRepository = app.get(FeedRepository);
+
+    userInformation = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    rssAcceptInformation = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    feed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAcceptInformation),
+    );
+  });
+
+  it('게시글이 존재하지 않을 경우 조회 오류가 발생한다.', async () => {
+    // given
+    const comment = new GetCommentRequestDto({
+      feedId: 100,
+    });
+    const agent = request.agent(app.getHttpServer());
+
+    // when
+    const response = await agent
+      .get(`/api/comment/feed/${comment.feedId}`)
+      .send(comment);
+
+    // then
+    expect(response.status).toBe(404);
+  });
+
+  it('게시글이 존재할 경우 올바르게 댓글을 제공한다.', async () => {
+    // given
+    const comment = new GetCommentRequestDto({
+      feedId: 1,
+    });
+    const agent = request.agent(app.getHttpServer());
+
+    // when
+    const response = await agent
+      .get(`/api/comment/feed/${comment.feedId}`)
+      .send(comment);
+
+    // then
+    expect(response.status).toBe(200);
+  });
+});

--- a/server/test/like/e2e/likeCreate.e2e-spec.ts
+++ b/server/test/like/e2e/likeCreate.e2e-spec.ts
@@ -11,7 +11,6 @@ import { User } from '../../../src/user/entity/user.entity';
 import { Feed } from '../../../src/feed/entity/feed.entity';
 import { FeedLikeRequestDto } from '../../../src/like/dto/request/like.dto';
 import * as request from 'supertest';
-import { LikeRepository } from '../../../src/like/repository/like.repository';
 
 describe('POST /api/like E2E Test', () => {
   let app: INestApplication;


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #379

### 댓글 정보를 `/feed/detail/` 로 제공을 할까? 새로운 `/comment` 조회 API로 만들까

-   feed detail API에 댓글 정보를 제공할지, comment 조회 API를 만들지 고민을 헀다.
- 댓글 도메인을 만들어뒀기에 RestAPI 원칙에 따라 댓글을 조회할 수 있도록 하는 것이 맞다고 생각했다.

# 📋 작업 내용

-   comment 조회 API 구현
- comment 조회 테스트 구현

# 📷 스크린 샷(선택 사항)

![image](https://github.com/user-attachments/assets/c3fb9853-f1bb-45b7-b65d-d6b7a1dcd636)

