### PR TITLE
📦 chore: docker-compose production 환경 인프라 추가시 자동 배포 구현

### DIFF
--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -1,0 +1,27 @@
+name: Infra Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docker-compose/docker-compose.prod*.yml
+  workflow_dispatch:
+
+jobs:
+  deployment:
+    runs-on: ubuntu-latest
+    steps:
+      # public 서버로 ssh 접속
+      - name: ssh connection
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.CLOUD_PUBLIC_INSTANCE_HOST }}
+          username: ${{ secrets.CLOUD_PUBLIC_INSTANCE_USERNAME }}
+          key: ${{ secrets.CLOUD_PUBLIC_INSTANCE_SSH_KEY }}
+          port: ${{ secrets.CLOUD_PUBLIC_INSTANCE_PORT }}
+          script: |
+            cd /var/web05-Denamu
+            git pull origin main
+            docker-compose -f docker-compose/docker-compose.prod.yml down
+            docker-compose -f docker-compose/docker-compose.prod.yml up --build

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -24,4 +24,4 @@ jobs:
             cd /var/web05-Denamu
             git pull origin main
             docker-compose -f docker-compose/docker-compose.prod.yml down
-            docker-compose -f docker-compose/docker-compose.prod.yml up --build
+            docker-compose -f docker-compose/docker-compose.prod.yml up


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #328

### 프로덕션 인프라 적용 안 됨 문제

-   기존에는 APP(NestJS)와 Feed Crawler, FE 코드가 변경되었을 경우 CI/CD가 적용되도록 하였지만, 운영 환경에서의 docker-compose.prod.infra.yml의 인프라가 추가되었을 경우 CI/CD가 안 돼서 수동으로 인프라들을 위한 도커 실행을 진행했어야 했다.
- 이 방식에 번거로움을 느껴서 조금 더 간편하게 수행하고자 Github CI/CD를 구현했다.

### --build 필요성

-  Dockerfile을 통한 빌드를 하는 경우는 이미 APP 배포와 Feed Crawler 배포에서 수행하기 때문에 --build 옵션을 제거했다.

# 📋 작업 내용

-   docker-compose 운영 환경 인프라 자동 배포 기능 추가