### PR TITLE
✨ feat: OAuth 로그인 API 연동 및 백엔드 보완

### DIFF
--- a/client/src/components/auth/AuthSocialLoginButtons.tsx
+++ b/client/src/components/auth/AuthSocialLoginButtons.tsx
@@ -7,10 +7,16 @@ import { Button } from "@/components/ui/button.tsx";
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 
 import { TOAST_MESSAGES } from "@/constants/messages.ts";
+import { BASE_URL, OAUTH } from "@/constants/endpoints.ts";
 
 export const AuthSocialLoginButtons = () => {
   const { toast } = useCustomToast();
-  const handleSocialLogin = () => {
+
+  const handleSocialLogin = (provider: "google" | "github") => {
+    window.location.href = `${BASE_URL}${OAUTH.LOGIN}?type=${provider}`;
+  };
+
+  const handleNotPrepared = () => {
     toast(TOAST_MESSAGES.SERVICE_NOT_PREPARED);
   };
 
@@ -26,19 +32,19 @@ export const AuthSocialLoginButtons = () => {
       </div>
 
       <div className="grid gap-2">
-        <Button variant="outline" className="w-full" onClick={handleSocialLogin}>
+        <Button variant="outline" className="w-full" onClick={() => handleSocialLogin("github")}>
           <GitHub />
           <span className="text-muted-foreground">Github로 계속하기</span>
         </Button>
-        <Button variant="outline" className="w-full" onClick={handleSocialLogin}>
+        <Button variant="outline" className="w-full" onClick={() => handleSocialLogin("google")}>
           <Google />
           <span className="text-muted-foreground">Google로 계속하기</span>
         </Button>
-        <Button variant="outline" className="w-full" onClick={handleSocialLogin}>
+        <Button variant="outline" className="w-full" onClick={handleNotPrepared}>
           <Naver className="text-[#03C75A]" />
           <span className="text-muted-foreground">네이버로 계속하기</span>
         </Button>
-        <Button variant="outline" className="w-full" onClick={handleSocialLogin}>
+        <Button variant="outline" className="w-full" onClick={handleNotPrepared}>
           <Kakao className="text-[#FEE500]" />
           <span className="text-muted-foreground">카카오로 계속하기</span>
         </Button>

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -40,3 +40,7 @@ export const USER = {
   LOGIN: "/api/user/login",
   CERTIFICATE: "/api/user/certificate",
 };
+
+export const OAUTH = {
+  LOGIN: "/api/oauth",
+};

--- a/client/src/pages/OAuthSuccessPage.tsx
+++ b/client/src/pages/OAuthSuccessPage.tsx
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { useAuthStore } from "@/store/useAuthStore.ts";
+
+export const OAuthSuccessPage = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { setUserFromToken } = useAuthStore();
+
+  useEffect(() => {
+    const searchParams = new URLSearchParams(location.search);
+    const accessToken = searchParams.get("token");
+
+    if (accessToken) {
+      setUserFromToken(accessToken);
+      navigate("/", { replace: true });
+    } else {
+      navigate("/signin", { replace: true });
+    }
+  }, [location, navigate, setUserFromToken]);
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <p className="text-lg">로그인 처리 중입니다...</p>
+    </div>
+  );
+};

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -13,6 +13,7 @@ const Profile = lazy(() => import("@/pages/Profile"));
 const SignIn = lazy(() => import("@/pages/SignIn"));
 const SignUp = lazy(() => import("@/pages/SignUp"));
 const UserCertificate = lazy(() => import("@/pages/UserCertificate"));
+const OAuthSuccessPage = lazy(() => import("@/pages/OAuthSuccessPage"));
 
 interface RouterProps {
   location: Location;
@@ -60,6 +61,14 @@ export const AppRouter = ({ location, state }: RouterProps) => {
           element={
             <Suspense fallback={<Loading />}>
               <SignUp />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/oauth-success"
+          element={
+            <Suspense fallback={<Loading />}>
+              <OAuthSuccessPage />
             </Suspense>
           }
         />

--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -25,14 +25,10 @@ import { UserScheduler } from '../scheduler/user.scheduler';
     UserScheduler,
     {
       provide: 'OAUTH_PROVIDERS',
-      useFactory: (
-        google: GoogleOAuthProvider,
-        github: GithubOAuthProvider,
-      ) => ({
+      useFactory: (google: GoogleOAuthProvider) => ({
         google,
-        github,
       }),
-      inject: [GoogleOAuthProvider],
+      inject: [GoogleOAuthProvider, GithubOAuthProvider],
     },
   ],
   exports: [UserRepository, UserService],

--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -25,8 +25,12 @@ import { UserScheduler } from '../scheduler/user.scheduler';
     UserScheduler,
     {
       provide: 'OAUTH_PROVIDERS',
-      useFactory: (google: GoogleOAuthProvider) => ({
+      useFactory: (
+        google: GoogleOAuthProvider,
+        github: GithubOAuthProvider,
+      ) => ({
         google,
+        github,
       }),
       inject: [GoogleOAuthProvider, GithubOAuthProvider],
     },


### PR DESCRIPTION
# 🔨 테스크

 ### Issue
- close #407 

### OAuth 엔드포인트 상수화
  - OAuth 로그인 URL이 하드코딩되어 있어 환경에 따른 관리가 어려움
  - endpoints.ts에 통합하여 일관된 API 엔드포인트 관리 필요

  # 📋 작업 내용

  - `endpoints.ts`에 `OAUTH` 객체 추가하여 OAuth 관련 엔드포인트 상수화
  - `AuthSocialLoginButtons.tsx`에서 하드코딩된 `https://denamu.site/api/oauth` URL을 `BASE_URL + OAUTH.LOGIN` 형태로 변경
  - 환경에 따른 동적 URL 처리가 가능하도록 개선