### PR TITLE
📦 chore: 도커 이미지 태그 추가

### DIFF
--- a/docker-compose/docker-compose.dev.yml
+++ b/docker-compose/docker-compose.dev.yml
@@ -53,6 +53,7 @@ services:
     build:
       context: ../server
       dockerfile: docker/Dockerfile.dev
+    image: denamu-dev-app:latest
     ports:
       - "8080:8080"
     networks:
@@ -78,6 +79,7 @@ services:
     build:
       context: ../feed-crawler
       dockerfile: docker/Dockerfile.dev
+    image: denamu-dev-feed-crawler:latest
     networks:
       - Denamu
     depends_on:

--- a/docker-compose/docker-compose.local.yml
+++ b/docker-compose/docker-compose.local.yml
@@ -26,6 +26,7 @@ services:
     build:
       context: ../server
       dockerfile: docker/Dockerfile.local
+    image: denamu-local-portfolio-app:latest
     ports:
       - "8080:8080"
     networks:
@@ -46,6 +47,7 @@ services:
     build:
       context: ../feed-crawler
       dockerfile: docker/Dockerfile.local
+    image: denamu-local-portfolio-feed-crawler:latest
     networks:
       - Denamu
     depends_on:

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -9,6 +9,7 @@ services:
     build:
       context: ../server
       dockerfile: docker/Dockerfile.local
+    image: denamu-production-app:latest
     ports:
       - "8080:8080"
     networks:
@@ -29,6 +30,7 @@ services:
     build:
       context: ../feed-crawler
       dockerfile: docker/Dockerfile.local
+    image: denamu-production-feed-crawler:latest
     networks:
       - Denamu
     depends_on:


### PR DESCRIPTION
# 🔨 테스크

### Docker Production 배포 안 되는 문제

-   이미지 빌드 수행시 기존 이미지가 <none> 으로 변경되는 오류 발견
- 새로운 이미지가 빌드 되었음에도 새로운 이미지는 `denamu-production-app` 이름으로 이미지가 만들어졌으나 기존 이미지 때문에 새로운 컨테이너가 `<none>` 이미지 기반으로 생성되어 새로운 코드가 적용 안 되는 문제 발견

### 태그의 문제?

-  이미지 빌드시 이미지 버전의 문제일 수도 있기에 태그를 할당

# 📋 작업 내용

-   Docker Compose 이미지 태그 설정
