### PR TITLE
🐛 fix: 잘못된 파라미터명 수정

### DIFF
--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -9,10 +9,10 @@ export class FileService {
   constructor(private readonly fileRepository: FileRepository) {}
 
   async create(file: any, userId: number) {
-    const { originalname, mimetype, size, path } = file;
+    const { originalName, mimetype, size, path } = file;
 
     const savedFile = await this.fileRepository.save({
-      originalname,
+      originalName,
       mimetype,
       size,
       path,


### PR DESCRIPTION
# 📋 작업 내용
### 컴파일 오류 수정
`file` Entity의 멤버변수(컬럼)명을 변경하는 과정에서 Service 내에서 사용되는 파라미터 명을 수정하지 않아 컴파일 오류가 발생하였고, 이를 수정하였습니다.