### PR TITLE
🐛 fix: feedview 마이그레이션 파일 작성 - comment_count 추가

### DIFF
--- a/server/src/common/database/migration/1754028000000-UpdateFeedViewWithCommentCount.ts
+++ b/server/src/common/database/migration/1754028000000-UpdateFeedViewWithCommentCount.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UpdateFeedViewWithCommentCount1754028000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE OR REPLACE VIEW feed_view AS
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY f.created_at) AS order_id,
+        f.id AS id,
+        f.title AS title,
+        f.path AS path,
+        f.created_at AS created_at,
+        f.thumbnail AS thumbnail,
+        f.view_count AS view_count,
+        f.summary AS summary,
+        f.like_count AS like_count,
+        f.comment_count AS comment_count,
+        r.name AS blog_name,
+        r.blog_platform AS blog_platform,
+        (
+          SELECT JSON_ARRAYAGG(t.name)
+          FROM tag_map tm
+          INNER JOIN tag t ON t.id = tm.tag_id
+          WHERE tm.feed_id = f.id
+        ) AS tag
+      FROM feed f
+      INNER JOIN rss_accept r ON r.id = f.blog_id
+      GROUP BY f.id;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE OR REPLACE VIEW feed_view AS
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY f.created_at) AS order_id,
+        f.id AS id,
+        f.title AS title,
+        f.path AS path,
+        f.created_at AS created_at,
+        f.thumbnail AS thumbnail,
+        f.view_count AS view_count,
+        f.summary AS summary,
+        f.like_count AS like_count,
+        r.name AS blog_name,
+        r.blog_platform AS blog_platform,
+        (
+          SELECT JSON_ARRAYAGG(t.name)
+          FROM tag_map tm
+          INNER JOIN tag t ON t.id = tm.tag_id
+          WHERE tm.feed_id = f.id
+        ) AS tag
+      FROM feed f
+      INNER JOIN rss_accept r ON r.id = f.blog_id
+      GROUP BY f.id;`,
+    );
+  }
+}


### PR DESCRIPTION
# 📋 작업 내용

아래와 같은 에러가 발생했음을 확인하고 마이그레이션 파일을 생성했습니다.
```
2025-08-12 14:09:42 error: QueryFailedError: Unknown column 'FeedView.comment_count' in 'field list'
```
dev 환경에서는 sync 옵션이 true라 FeedView 엔티티를 수정함으로 DB가 수정되었는데,
배포 환경에는 해당 옵션이 false임을 고려하지 못했습니다.