### PR TITLE
🐛 fix: 피드 크롤러 타임 딜레이 제거

### DIFF
--- a/feed-crawler/src/common/parser/base-feed-parser.ts
+++ b/feed-crawler/src/common/parser/base-feed-parser.ts
@@ -27,10 +27,14 @@ export abstract class BaseFeedParser {
     this.parserUtil = parserUtil;
   }
 
-  async parseFeed(rssObj: RssObj, xmlData: string): Promise<FeedDetail[]> {
+  async parseFeed(
+    rssObj: RssObj,
+    xmlData: string,
+    startTime: Date,
+  ): Promise<FeedDetail[]> {
     // 각 포맷(atom1.0, rss2.0 등...)
     const rawFeeds = this.extractRawFeeds(xmlData);
-    const timeMatchedFeeds = this.filterByTime(rawFeeds);
+    const timeMatchedFeeds = this.filterByTime(rawFeeds, startTime);
     const detailedFeeds = await this.convertToFeedDetails(
       rssObj,
       timeMatchedFeeds,
@@ -42,8 +46,8 @@ export abstract class BaseFeedParser {
   abstract canParse(xmlData: string): boolean;
   protected abstract extractRawFeeds(xmlData: string): RawFeed[];
 
-  private filterByTime(rawFeeds: RawFeed[]): RawFeed[] {
-    const now = new Date().setSeconds(0, 0);
+  private filterByTime(rawFeeds: RawFeed[], startTime: Date): RawFeed[] {
+    const now = new Date(startTime).setSeconds(0, 0);
     return rawFeeds.filter((item) => {
       const pubDate = new Date(item.pubDate).setSeconds(0, 0);
       const timeDiff = (now - pubDate) / (ONE_MINUTE * TIME_INTERVAL);

--- a/feed-crawler/src/common/parser/feed-parser-manager.ts
+++ b/feed-crawler/src/common/parser/feed-parser-manager.ts
@@ -17,7 +17,7 @@ export class FeedParserManager {
     this.parsers = [rss20Parser, atom10Parser];
   }
 
-  async fetchAndParse(rssObj: RssObj): Promise<FeedDetail[]> {
+  async fetchAndParse(rssObj: RssObj, startTime: Date): Promise<FeedDetail[]> {
     try {
       const response = await fetch(rssObj.rssUrl, {
         headers: {
@@ -38,7 +38,7 @@ export class FeedParserManager {
       }
       logger.info(`${rssObj.blogName}: ${parser.constructor.name} 사용`);
 
-      return await parser.parseFeed(rssObj, xmlData);
+      return await parser.parseFeed(rssObj, xmlData, startTime);
     } catch (error) {
       logger.warn(`[${rssObj.rssUrl}] 피드 파싱 중 오류 발생: ${error}`);
       return [];

--- a/feed-crawler/src/feed-crawler.ts
+++ b/feed-crawler/src/feed-crawler.ts
@@ -17,9 +17,8 @@ export class FeedCrawler {
     private readonly feedParserManager: FeedParserManager,
   ) {}
 
-  async start() {
+  async start(startTime: Date) {
     logger.info('==========작업 시작==========');
-    const startTime = Date.now();
 
     await this.feedRepository.deleteRecentFeed();
 
@@ -29,7 +28,7 @@ export class FeedCrawler {
       return;
     }
 
-    const newFeedsByRss = await this.feedGroupByRss(rssObjects);
+    const newFeedsByRss = await this.feedGroupByRss(rssObjects, startTime);
     const newFeeds = newFeedsByRss.flat();
 
     if (!newFeeds.length) {
@@ -44,19 +43,22 @@ export class FeedCrawler {
     await this.feedRepository.setRecentFeedList(insertedData);
 
     const endTime = Date.now();
-    const executionTime = endTime - startTime;
+    const executionTime = endTime - startTime.getTime();
 
     logger.info(`실행 시간: ${executionTime / 1000}seconds`);
     logger.info('==========작업 완료==========');
   }
 
-  private feedGroupByRss(rssObjects: RssObj[]): Promise<FeedDetail[][]> {
+  private feedGroupByRss(
+    rssObjects: RssObj[],
+    startTime: Date,
+  ): Promise<FeedDetail[][]> {
     return Promise.all(
       rssObjects.map(async (rssObj: RssObj) => {
         logger.info(
           `${rssObj.blogName}(${rssObj.rssUrl}) 에서 데이터 조회하는 중...`,
         );
-        return await this.feedParserManager.fetchAndParse(rssObj);
+        return await this.feedParserManager.fetchAndParse(rssObj, startTime);
       }),
     );
   }

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -3,14 +3,11 @@ import './common/env-load';
 import logger from './common/logger';
 import { FeedCrawler } from './feed-crawler';
 import { container } from './container';
-import { RssRepository } from './repository/rss.repository';
-import { FeedRepository } from './repository/feed.repository';
 import { DEPENDENCY_SYMBOLS } from './types/dependency-symbols';
 import { DatabaseConnection } from './types/database-connection';
 import { ClaudeService } from './claude.service';
 import * as schedule from 'node-schedule';
 import { RedisConnection } from './common/redis-access';
-import { TagMapRepository } from './repository/tag-map.repository';
 
 function initializeDependencies() {
   return {
@@ -31,8 +28,9 @@ function registerSchedulers(
   dependencies: ReturnType<typeof initializeDependencies>,
 ) {
   schedule.scheduleJob('FEED CRAWLING', '0,30 * * * *', async () => {
-    logger.info(`Feed Crawling Start: ${new Date().toISOString()}`);
-    dependencies.feedCrawler.start();
+    const now = new Date();
+    logger.info(`Feed Crawling Start: ${now.toISOString()}`);
+    dependencies.feedCrawler.start(now);
   });
 
   schedule.scheduleJob(


### PR DESCRIPTION
# 📋 작업 내용

### 피드 삽입시 중복 피드 명시적 처리
#453 이슈 처리간 오류 가능성이 있는 로직을 확인 하였습니다.

- **RSS 승인시 수행되는 전체 피드 크롤링** (관리자가 승인함과 동시에 시작되므로 언제 수행될지 모름.)
- **주기적으로 수행되는 최신 피드 크롤링** (매시 정각 및 30분에 시작)

`feed` 테이블의 `path` 컬럼은 유니크 속성을 가지고있기에, 중복된 피드를 삽입할 경우 기존의 `Promise.all` 전체가 함께 실패하게 되어 멀쩡한 데이터까지 함께 누락이 발생합니다.

뿐만아니라 #453 의 경우 이러한 부분(중복된 피드의 수집 가능성)을 고려하여 작업중이지만, 미처 고려하지 못한 엣지케이스에 대한 우려로 삽입 쿼리부 자체를 안전하게 변경하였습니다.

### 피드 크롤러 타임 딜레이 제거
```typescript
function registerSchedulers(
  dependencies: ReturnType<typeof initializeDependencies>,
) {
  schedule.scheduleJob('FEED CRAWLING', '0,30 * * * *', async () => {
    const now = new Date();
    logger.info(`Feed Crawling Start: ${now.toISOString()}`);
    dependencies.feedCrawler.start(now);
  });
```
크롤링이 시작된 순간(`node-schedule`에 의해 컨텍스트가 호출 된 순간)의 시간을 스냅샷으로 찍어 내부 동작에 사용할 수 있게끔 전달하였습니다. 이를 통해 크롤러 내부 동작에서 보다 정확한 시간 (해당 내부 동작이 실행되는 시점의 시간이 아닌 크롤러 자체가 실행된 시간)을 기준으로 처리가 가능합니다.
