### PR TITLE
✨ feat: 최근 게시글을 redis에 캐싱할 때, comments 데이터가 포함되도록 추가

### DIFF
--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -94,6 +94,7 @@ export class FeedRepository {
             title: feed.title,
             tag: Array.isArray(feed.tag) ? feed.tag : [],
             likes: 0,
+            comments: 0,
           });
         }
       });


### PR DESCRIPTION
# 🔨 테스크
### Issue

- close #427 

### recent로 최근 게시글을 가져올 때, comments 값에 대한 일관성이 보장되어야 하는가?

예를 들어서 어떤 인기 블로그 글이 올라온지 1초만에 댓글이 달리고 
지구 반대편 인터넷이 느린 곳에 사는 사람이 recent를 늦게 받으면 댓글 수와 redis에 캐싱된 값이 다를 수는 있겠더라고요.

하지만 예시와 같은 극단적인 상황이 거의 생기지 않을 것 + 댓글 수가 다르다고 치명적인 문제는 발생하지 않을 것, 두 가지의 이유로 Redis와 MySQL을 확인하며 최신 글의 comments 동기화에 대한 필요성이 없다고 느꼈습니다.
그리고 트렌드 포스트의 sse는 Redis에 feedId만 캐시하고 mysql에서 값을 가져오기 때문에 동기화 문제는 없을 것이라 생각했습니다.


# 📋 작업 내용

-   feed crawler에서 크롤링 시 comments 값을 0으로 초기화해서 Redis에 캐싱하도록 수정

# 📷 스크린 샷(선택 사항)

1. 실제 블로그 업데이트된 포스트가 없어서 더미 데이터를 직접 저장했을 때 아래와 같이 정상적인 동작을 확인했습니다.
<img width="526" height="387" alt="image" src="https://github.com/user-attachments/assets/b86d3bdf-19a8-422e-82b7-cdf335ca357a" />

2. 저번 작업에서 sse를 통해 comments 값이 반환되는 것을 첨부하지 않아서 이번 PR에 해당 동작 결과를 첨부했습니다.
<img width="1478" height="164" alt="image" src="https://github.com/user-attachments/assets/8444b3a8-5229-45b9-8a9a-7b8bb0208f97" />


