### PR TITLE
🐛 fix: ghcr image 이름 대문자 제거

### DIFF
--- a/.github/workflows/deploy_feed-crawler.yml
+++ b/.github/workflows/deploy_feed-crawler.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/feed-crawler
+  IMAGE_NAME: ghcr.io/boostcampwm-2024/web05-denamu/feed-crawler
   IMAGE_TAG: sha-${{ github.sha }}
   SERVICE: feed-crawler
   ENV_DIR: /var/prod_config/feed-crawler

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/${{ github.repository }}/server
+  IMAGE_NAME: ghcr.io/boostcampwm-2024/web05-denamu/server
   IMAGE_TAG: sha-${{ github.sha }}
   SERVICE: app
   ENV_DIR: /var/prod_config/server

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -6,7 +6,7 @@ include:
 services:
   # WAS 서비스
   app:
-    image: ghcr.io/boostcampwm-2024/web05-Denamu/server:latest
+    image: ghcr.io/boostcampwm-2024/web05-denamu/server:latest
     ports:
       - "8080:8080"
     env_file:
@@ -27,7 +27,7 @@ services:
 
   # Feed Crawler 서비스
   feed-crawler:
-    image: ghcr.io/boostcampwm-2024/web05-Denamu/feed-crawler:latest
+    image: ghcr.io/boostcampwm-2024/web05-denamu/feed-crawler:latest
     env_file:
       - /var/prod_config/feed-crawler/.env.prod
     networks:


### PR DESCRIPTION
# 📋 작업 내용
`ghcr` 이미지명에 대문자가 포함되어 actions 실행에 실패하였습니다.
```
[build-and-push](https://github.com/boostcampwm-2024/web05-Denamu/actions/runs/18586639792/job/52991952383#step:5:197)
buildx failed with: ERROR: failed to build: invalid tag "ghcr.io/boostcampwm-2024/web05-Denamu/feed-crawler:sha-71e4ea569bb88768d04b953c799be88ee11e1a01": repository name must be lowercase
```
이에 따라 이미지명에 대문자를 제거하였습니다.