### PR TITLE
🐛 fix: 멀티 아키텍처 지원 구문 추가

### DIFF
--- a/.github/workflows/deploy_feed-crawler.yml
+++ b/.github/workflows/deploy_feed-crawler.yml
@@ -24,7 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - name: QEMU 멀티 아키텍쳐 에뮬레이터
+        uses: docker/setup-qemu-action@v3
+
+      - name: Buildx 멀티 아키텍쳐 빌더
+        uses: docker/setup-buildx-action@v3
 
       - name: GHCR 로그인
         uses: docker/login-action@v3
@@ -39,6 +43,7 @@ jobs:
           context: ./feed-crawler
           file: ./feed-crawler/docker/Dockerfile.prod
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
             ${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -24,7 +24,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-buildx-action@v3
+      - name: QEMU 멀티 아키텍쳐 에뮬레이터
+        uses: docker/setup-qemu-action@v3
+
+      - name: Buildx 멀티 아키텍쳐 빌더
+        uses: docker/setup-buildx-action@v3
 
       - name: GHCR 로그인
         uses: docker/login-action@v3
@@ -39,6 +43,7 @@ jobs:
           context: ./server
           file: ./server/docker/Dockerfile.prod
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
             ${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
# 📋 작업 내용
### 멀티 아키텍처 지원 구문 추가
```
sha-3cd74d7f9f8de619dc8adfdef50689b06d2a6852: Pulling from boostcampwm-
2024/web05-***/feed-crawler no matching manifest for linux/arm64/v8 in the 
manifest list entries latest: Pulling from boostcampwm-2024/web05-***/feed-crawler 
no matching manifest for linux/arm64/v8 in the manifest list entries feed-crawler 
Pulling no matching manifest for linux/arm64/v8 in the manifest list entries
```
위 오류는 GHCR에 업로드된 이미지에 arm64 _(저희 prod서버의 아키텍처 입니다.)_ 매니페스트가 존재하지 않아 pull에 실패하여 발생하였습니다.

**즉, 빌드 단계 환경(GitHub hosted runner)이 arm64가 아니라면, 빌드 되는 이미지는 빌드 환경의 아키텍처로 진행되어 발생하는 문제임을 파악하였습니다.**

이를 해결하기 위해 `QEMU`, `Buildx`를 사용하여 멀티 아키텍처 이미지를 빌드하여 푸시하도록 수정하였습니다. [공식 문서](https://github.com/docker/build-push-action?utm_source=chatgpt.com)를 참고해보면 이해가 빠를것 같습니다 :) 
각 도구들의 역할은 다음과 같습니다.

**`QEMU`: 빌드 호스트와 다른 아키텍처(예: arm64)를 에뮬레이션해 RUN 단계가 타겟 아키로 실행되게 해줌.**
**`Buildx`: Docker의 확장 빌더로 멀티아키(매니페스트 리스트) 이미지 빌드·푸시를 지원.**

> 다만, 위 방법은 두개의 아키텍처를 모두 미리 빌드를 하는 방식이기에, 빌드 시간이 약 2배 소요 됩니다.