### PR TITLE
🐛 fix: logger transport 배열 push 오류 수정

### DIFF
--- a/email-worker/src/logger.ts
+++ b/email-worker/src/logger.ts
@@ -13,32 +13,34 @@ function getLogTransport() {
   const transports = [];
 
   if (process.env.NODE_ENV === 'LOCAL' || process.env.NODE_ENV === 'PROD') {
-    transports.push([
-      new DailyRotateFile({
-        level: 'info',
-        datePattern: 'YYYY-MM-DD',
-        dirname: logDir,
-        filename: `%DATE%.email-worker.log`,
-        maxFiles: 30,
-        zippedArchive: true,
-      }),
-      new DailyRotateFile({
-        level: 'error',
-        datePattern: 'YYYY-MM-DD',
-        dirname: `${logDir}/error`,
-        filename: `%DATE%.email-worker.error.log`,
-        maxFiles: 30,
-        zippedArchive: true,
-      }),
-      new DailyRotateFile({
-        level: 'warn',
-        datePattern: 'YYYY-MM-DD',
-        dirname: `${logDir}/warn`,
-        filename: `%DATE%.email-worker.warn.log`,
-        maxFiles: 30,
-        zippedArchive: true,
-      }),
-    ]);
+    transports.push(
+      ...[
+        new DailyRotateFile({
+          level: 'info',
+          datePattern: 'YYYY-MM-DD',
+          dirname: logDir,
+          filename: `%DATE%.email-worker.log`,
+          maxFiles: 30,
+          zippedArchive: true,
+        }),
+        new DailyRotateFile({
+          level: 'error',
+          datePattern: 'YYYY-MM-DD',
+          dirname: `${logDir}/error`,
+          filename: `%DATE%.email-worker.error.log`,
+          maxFiles: 30,
+          zippedArchive: true,
+        }),
+        new DailyRotateFile({
+          level: 'warn',
+          datePattern: 'YYYY-MM-DD',
+          dirname: `${logDir}/warn`,
+          filename: `%DATE%.email-worker.warn.log`,
+          maxFiles: 30,
+          zippedArchive: true,
+        }),
+      ],
+    );
   }
 
   if (process.env.NODE_ENV === 'LOCAL' || process.env.NODE_ENV === 'DEV') {


### PR DESCRIPTION
# 📋 작업 내용

Email Worker 배포 시 컨테이너가 종료되는 문제가 발생했습니다.

원인은 logger.ts에서 winston transport 배열을 잘못된 방식으로 추가했는데요,
spread 연산자가 없어서 중첩 배열 구조가 생성되었고 winston이 이것을 객체로 인식하지 못해서 에러가 발생했습니다.

spread 연산자를 사용해서 feed-crawler와 동일한 패턴으로 통일했습니다.

<발생한 에러>
```shell
Error: Invalid transport, must be an object with a log method.
    at new LegacyTransportStream (/app/node_modules/winston-transport/legacy.js:18:11)
    at DerivedLogger.add (/app/node_modules/winston/lib/winston/logger.js:375:11)
    at /app/node_modules/winston/lib/winston/logger.js:124:44
    at Array.forEach (<anonymous>)
    at DerivedLogger.configure (/app/node_modules/winston/lib/winston/logger.js:124:18)
    at new Logger (/app/node_modules/winston/lib/winston/logger.js:42:10)
    at new DerivedLogger (/app/node_modules/winston/lib/winston/create-logger.js:44:7)
    at module.exports [as createLogger] (/app/node_modules/winston/lib/winston/create-logger.js:48:18)
    at Object.<anonymous> (/app/dist/src/logger.js:47:24)
    at Module._compile (node:internal/modules/cjs/loader:1706:14)
```
