### PR TITLE
♻️ refactor: dto 테스트 suite 명칭 클래스 이름으로 변경

### DIFF
--- a/server/test/activity/dto/activity-param.dto.spec.ts
+++ b/server/test/activity/dto/activity-param.dto.spec.ts
@@ -1,7 +1,7 @@
 import { ReadActivityParamRequestDto } from '../../../src/activity/dto/request/readActivity.dto';
 import { validate } from 'class-validator';
 
-describe('ReadActivityParamRequestDto Test', () => {
+describe(`${ReadActivityParamRequestDto.name} Test`, () => {
   let dto: ReadActivityParamRequestDto;
 
   beforeEach(() => {

--- a/server/test/activity/dto/activity-query.dto.spec.ts
+++ b/server/test/activity/dto/activity-query.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ReadActivityQueryRequestDto } from '../../../src/activity/dto/request/readActivity.dto';
 
-describe('ReadActivityQueryRequestDto Test', () => {
+describe(`${ReadActivityQueryRequestDto.name} Test`, () => {
   let dto: ReadActivityQueryRequestDto;
 
   beforeEach(() => {

--- a/server/test/admin/dto/login.dto.spec.ts
+++ b/server/test/admin/dto/login.dto.spec.ts
@@ -2,7 +2,7 @@ import { LoginAdminRequestDto } from '../../../src/admin/dto/request/loginAdmin.
 import { validate } from 'class-validator';
 import { AdminFixture } from '../../fixture/admin.fixture';
 
-describe('LoginAdminRequestDto Test', () => {
+describe(`${LoginAdminRequestDto.name} Test`, () => {
   let dto: LoginAdminRequestDto;
 
   beforeEach(() => {

--- a/server/test/admin/dto/register.dto.spec.ts
+++ b/server/test/admin/dto/register.dto.spec.ts
@@ -2,7 +2,7 @@ import { AdminFixture } from '../../fixture/admin.fixture';
 import { RegisterAdminRequestDto } from '../../../src/admin/dto/request/registerAdmin.dto';
 import { validate } from 'class-validator';
 
-describe('RegisterAdminRequestDto Test', () => {
+describe(`${RegisterAdminRequestDto.name} Test`, () => {
   let dto: RegisterAdminRequestDto;
 
   beforeEach(() => {

--- a/server/test/comment/dto/create.dto.spec.ts
+++ b/server/test/comment/dto/create.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { CreateCommentRequestDto } from '../../../src/comment/dto/request/createComment.dto';
 
-describe('CreateCommentRequestDto Test', () => {
+describe(`${CreateCommentRequestDto.name} Test`, () => {
   let dto: CreateCommentRequestDto;
 
   beforeEach(() => {

--- a/server/test/comment/dto/delete.dto.spec.ts
+++ b/server/test/comment/dto/delete.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { DeleteCommentRequestDto } from '../../../src/comment/dto/request/deleteComment.dto';
 
-describe('DeleteCommentRequestDto Test', () => {
+describe(`${DeleteCommentRequestDto.name} Test`, () => {
   let dto: DeleteCommentRequestDto;
 
   beforeEach(() => {

--- a/server/test/comment/dto/get.dto.spec.ts
+++ b/server/test/comment/dto/get.dto.spec.ts
@@ -1,7 +1,7 @@
 import { GetCommentRequestDto } from '../../../src/comment/dto/request/getComment.dto';
 import { validate } from 'class-validator';
 
-describe('GetCommentRequestDto Test', () => {
+describe(`${GetCommentRequestDto.name} Test`, () => {
   let dto: GetCommentRequestDto;
 
   beforeEach(() => {

--- a/server/test/comment/dto/update.dto.spec.ts
+++ b/server/test/comment/dto/update.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { UpdateCommentRequestDto } from '../../../src/comment/dto/request/updateComment.dto';
 
-describe('UpdateCommentRequestDto Test', () => {
+describe(`${UpdateCommentRequestDto.name} Test`, () => {
   let dto: UpdateCommentRequestDto;
 
   beforeEach(() => {

--- a/server/test/feed/dto/manage.dto.spec.ts
+++ b/server/test/feed/dto/manage.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ManageFeedRequestDto } from '../../../src/feed/dto/request/manageFeed.dto';
 
-describe('ManageFeedRequestDto Test', () => {
+describe(`${ManageFeedRequestDto.name} Test`, () => {
   let dto: ManageFeedRequestDto;
 
   beforeEach(() => {

--- a/server/test/feed/dto/pagination.dto.spec.ts
+++ b/server/test/feed/dto/pagination.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ReadFeedPaginationRequestDto } from '../../../src/feed/dto/request/readFeedPagination.dto';
 
-describe('ReadFeedPaginationRequestDto Test', () => {
+describe(`${ReadFeedPaginationRequestDto.name} Test`, () => {
   let dto: ReadFeedPaginationRequestDto;
 
   beforeEach(() => {

--- a/server/test/feed/dto/search.dto.spec.ts
+++ b/server/test/feed/dto/search.dto.spec.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../src/feed/dto/request/searchFeed.dto';
 import { validate } from 'class-validator';
 
-describe('SearchFeedRequestDto Test', () => {
+describe(`${SearchFeedRequestDto.name} Test`, () => {
   let dto: SearchFeedRequestDto;
 
   beforeEach(() => {

--- a/server/test/file/dto/delete.dto.spec.ts
+++ b/server/test/file/dto/delete.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { DeleteFileRequestDto } from '../../../src/file/dto/request/deleteFile.dto';
 
-describe('DeleteFileRequestDto Test', () => {
+describe(`${DeleteFileRequestDto.name} Test`, () => {
   let dto: DeleteFileRequestDto;
 
   beforeEach(() => {

--- a/server/test/like/dto/manage.dto.spec.ts
+++ b/server/test/like/dto/manage.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ManageLikeRequestDto } from '../../../src/like/dto/request/manageLike.dto';
 
-describe('ManageLikeRequestDto Test', () => {
+describe(`${ManageLikeRequestDto.name} Test`, () => {
   let dto: ManageLikeRequestDto;
 
   beforeEach(() => {

--- a/server/test/rss/dto/delete-certificate.dto.spec.ts
+++ b/server/test/rss/dto/delete-certificate.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { DeleteCertificateRssRequestDto } from '../../../src/rss/dto/request/deleteCertificateRss.dto';
 
-describe('DeleteCertificateRssRequestDto Test', () => {
+describe(`${DeleteCertificateRssRequestDto.name} Test`, () => {
   let dto: DeleteCertificateRssRequestDto;
 
   beforeEach(() => {

--- a/server/test/rss/dto/delete.dto.spec.ts
+++ b/server/test/rss/dto/delete.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { DeleteRssRequestDto } from '../../../src/rss/dto/request/deleteRss.dto';
 
-describe('DeleteRssRequestDto Test', () => {
+describe(`${DeleteRssRequestDto.name} Test`, () => {
   let dto: DeleteRssRequestDto;
 
   beforeEach(() => {

--- a/server/test/rss/dto/manage.dto.spec.ts
+++ b/server/test/rss/dto/manage.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ManageRssRequestDto } from '../../../src/rss/dto/request/manageRss.dto';
 
-describe('ManageRssRequestDto Test', () => {
+describe(`${ManageRssRequestDto.name} Test`, () => {
   let dto: ManageRssRequestDto;
 
   beforeEach(() => {

--- a/server/test/rss/dto/register.dto.spec.ts
+++ b/server/test/rss/dto/register.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { RegisterRssRequestDto } from '../../../src/rss/dto/request/registerRss.dto';
 
-describe('RegisterRssRequestDto Test', () => {
+describe(`${RegisterRssRequestDto.name} Test`, () => {
   let dto: RegisterRssRequestDto;
 
   beforeEach(() => {

--- a/server/test/rss/dto/reject.dto.spec.ts
+++ b/server/test/rss/dto/reject.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { RejectRssRequestDto } from '../../../src/rss/dto/request/rejectRss';
 
-describe('RejectRssRequestDto Test', () => {
+describe(`${RejectRssRequestDto.name} Test`, () => {
   let dto: RejectRssRequestDto;
 
   beforeEach(() => {

--- a/server/test/statistic/dto/read.dto.spec.ts
+++ b/server/test/statistic/dto/read.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ReadStatisticRequestDto } from '../../../src/statistic/dto/request/readStatistic.dto';
 
-describe('ReadStatisticRequestDto Test', () => {
+describe(`${ReadStatisticRequestDto.name} Test`, () => {
   let dto: ReadStatisticRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/check-email-duplication.dto.spec.ts
+++ b/server/test/user/dto/check-email-duplication.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { CheckEmailDuplicationRequestDto } from '../../../src/user/dto/request/checkEmailDuplication.dto';
 
-describe('CheckEmailDuplicationRequestDto Test', () => {
+describe(`${CheckEmailDuplicationRequestDto.name} Test`, () => {
   let dto: CheckEmailDuplicationRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/confirmDeleteAccount.dto.spec.ts
+++ b/server/test/user/dto/confirmDeleteAccount.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ConfirmDeleteAccountDto } from '../../../src/user/dto/request/confirmDeleteAccount.dto';
 
-describe('ConfirmDeleteAccountDto Test', () => {
+describe(`${ConfirmDeleteAccountDto.name} Test`, () => {
   let dto: ConfirmDeleteAccountDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/forgotPassword.dto.spec.ts
+++ b/server/test/user/dto/forgotPassword.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ForgotPasswordRequestDto } from '../../../src/user/dto/request/forgotPassword.dto';
 
-describe('ForgotPasswordRequestDto Test', () => {
+describe(`${ForgotPasswordRequestDto.name} Test`, () => {
   let dto: ForgotPasswordRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/login.dto.spec.ts
+++ b/server/test/user/dto/login.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { LoginUserRequestDto } from '../../../src/user/dto/request/loginUser.dto';
 
-describe('LoginUserRequestDto Test', () => {
+describe(`${LoginUserRequestDto.name} Test`, () => {
   let dto: LoginUserRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/oAuth-type.dto.spec.ts
+++ b/server/test/user/dto/oAuth-type.dto.spec.ts
@@ -2,7 +2,7 @@ import { validate } from 'class-validator';
 import { OAuthTypeRequestDto } from '../../../src/user/dto/request/oAuthType.dto';
 import { OAuthType } from '../../../src/user/constant/oauth.constant';
 
-describe('OAuthTypeRequest Test', () => {
+describe(`${OAuthTypeRequestDto.name} Test`, () => {
   let dto: OAuthTypeRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/register-certificate.dto.spec.ts
+++ b/server/test/user/dto/register-certificate.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { CertificateUserRequestDto } from '../../../src/user/dto/request/certificateUser.dto';
 
-describe('CertificateUserRequestDto Test', () => {
+describe(`${CertificateUserRequestDto.name} Test`, () => {
   let dto: CertificateUserRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/register.dto.spec.ts
+++ b/server/test/user/dto/register.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { RegisterUserRequestDto } from '../../../src/user/dto/request/registerUser.dto';
 
-describe('RegisterUserRequestDto Test', () => {
+describe(`${RegisterUserRequestDto.name} Test`, () => {
   let dto: RegisterUserRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/resetPassword.dto.spec.ts
+++ b/server/test/user/dto/resetPassword.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { ResetPasswordRequestDto } from '../../../src/user/dto/request/resetPassword.dto';
 
-describe('ResetPasswordRequestDto Test', () => {
+describe(`${ResetPasswordRequestDto.name} Test`, () => {
   let dto: ResetPasswordRequestDto;
 
   beforeEach(() => {

--- a/server/test/user/dto/update.dto.spec.ts
+++ b/server/test/user/dto/update.dto.spec.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator';
 import { UpdateUserRequestDto } from '../../../src/user/dto/request/updateUser.dto';
 
-describe('UpdateUserRequestDto Test', () => {
+describe(`${UpdateUserRequestDto.name} Test`, () => {
   let dto: UpdateUserRequestDto;
 
   beforeEach(() => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #496 

# 📋 작업 내용

-   DTO 테스트의 Test suite 문구가 문자열 하드코딩이라 클래스 이름을 이용하도록 변경
