### PR TITLE
♻️ refactor: ci/cd fork 뜬 레포에서 ghcr 사용할 수 있도록 변경

### DIFF
--- a/.github/workflows/deploy_email-worker.yml
+++ b/.github/workflows/deploy_email-worker.yml
@@ -2,8 +2,8 @@ name: Email-Worker Deployment
 
 on:
   push:
-    branches: [ main ]
-    paths: [ "email-worker/**" ]
+    branches: [main]
+    paths: ['email-worker/**']
   workflow_dispatch:
 
 permissions:
@@ -11,8 +11,8 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/boostcampwm-2024/web05-denamu/email-worker
-  IMAGE_TAG: sha-${{ github.sha }}
+  EMAIL_WORKER_IMAGE: ${{vars.GHCR}}/email-worker
+  EMAIL_WORKER_TAG: sha-${{ github.sha }}
   SERVICE: email-worker
   ENV_DIR: /var/prod_config/email-worker
   ENV_FILE: /var/prod_config/email-worker/.env.prod
@@ -46,13 +46,13 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.EMAIL_WORKER_IMAGE }}:${{ env.EMAIL_WORKER_TAG }}
+            ${{ env.EMAIL_WORKER_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
   deploy:
-    runs-on: [ self-hosted, prod ]
+    runs-on: [self-hosted, prod]
     needs: build-and-push # Build 및 Push가 끝나면 시작
     steps:
       - name: 코드 체크아웃
@@ -97,8 +97,7 @@ jobs:
 
       - name: Docker 이미지 Pull
         run: |
-          docker pull "${IMAGE_NAME}:${IMAGE_TAG}" || true
-          docker pull "${IMAGE_NAME}:latest" || true
+          docker pull "${EMAIL_WORKER_IMAGE}:latest" || true
           docker compose -f "$COMPOSE_FILE" pull "$SERVICE"
 
       - name: Graceful Shutdown & 서비스 재시작

--- a/.github/workflows/deploy_feed-crawler.yml
+++ b/.github/workflows/deploy_feed-crawler.yml
@@ -3,7 +3,7 @@ name: Feed-Crawler Deployment
 on:
   push:
     branches: [main]
-    paths: ["feed-crawler/**"]
+    paths: ['feed-crawler/**']
   workflow_dispatch:
 
 permissions:
@@ -11,8 +11,8 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/boostcampwm-2024/web05-denamu/feed-crawler
-  IMAGE_TAG: sha-${{ github.sha }}
+  FEED_CRAWLER_IMAGE: ${{vars.GHCR}}/feed-crawler
+  FEED_CRAWLER_TAG: sha-${{ github.sha }}
   SERVICE: feed-crawler
   ENV_DIR: /var/prod_config/feed-crawler
   ENV_FILE: /var/prod_config/feed-crawler/.env.prod
@@ -45,8 +45,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.FEED_CRAWLER_IMAGE }}:${{ env.FEED_CRAWLER_TAG }}
+            ${{ env.FEED_CRAWLER_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -106,8 +106,7 @@ jobs:
 
       - name: Docker 이미지 Pull & 서비스 재시작
         run: |
-          docker pull "${IMAGE_NAME}:${IMAGE_TAG}" || true
-          docker pull "${IMAGE_NAME}:latest" || true
+          docker pull "${FEED_CRAWLER_IMAGE}:latest" || true
           docker compose -f "$COMPOSE_FILE" pull "$SERVICE"
           docker compose -f "$COMPOSE_FILE" up -d --no-deps --force-recreate "$SERVICE"
           docker image prune -f || true

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -3,7 +3,7 @@ name: BE Deployment
 on:
   push:
     branches: [main]
-    paths: ["server/**"]
+    paths: ['server/**']
   workflow_dispatch:
 
 permissions:
@@ -11,8 +11,8 @@ permissions:
   packages: write
 
 env:
-  IMAGE_NAME: ghcr.io/boostcampwm-2024/web05-denamu/server
-  IMAGE_TAG: sha-${{ github.sha }}
+  APP_IMAGE: ${{vars.GHCR}}/server
+  APP_TAG: sha-${{ github.sha }}
   SERVICE: app
   ENV_DIR: /var/prod_config/server
   ENV_FILE: /var/prod_config/server/.env.prod
@@ -45,8 +45,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.APP_IMAGE }}:${{ env.APP_TAG }}
+            ${{ env.APP_IMAGE }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -115,8 +115,7 @@ jobs:
 
       - name: Docker 이미지 Pull & 서비스 재시작
         run: |
-          docker pull "${IMAGE_NAME}:${IMAGE_TAG}" || true
-          docker pull "${IMAGE_NAME}:latest" || true
+          docker pull "${APP_IMAGE}:latest" || true
           docker compose -f "$COMPOSE_FILE" pull "$SERVICE"
           docker compose -f "$COMPOSE_FILE" up -d --no-deps --force-recreate "$SERVICE"
           docker image prune -f || true

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -6,9 +6,9 @@ include:
 services:
   # WAS 서비스
   app:
-    image: ghcr.io/boostcampwm-2024/web05-denamu/server:latest
+    image: ${APP_IMAGE}:${APP_TAG}
     ports:
-      - "8080:8080"
+      - '8080:8080'
     env_file:
       - /var/prod_config/server/.env.prod
     networks:
@@ -24,12 +24,12 @@ services:
       - /var/prod_data/server/logs:/app/logs
       - /var/prod_data/objects:/app/objects
     environment:
-      NODE_ENV: "PROD"
-      TZ: "Asia/Seoul"
+      NODE_ENV: 'PROD'
+      TZ: 'Asia/Seoul'
 
   # Feed Crawler 서비스
   feed-crawler:
-    image: ghcr.io/boostcampwm-2024/web05-denamu/feed-crawler:latest
+    image: ${FEED_CRAWLER_IMAGE}:${FEED_CRAWLER_TAG}
     env_file:
       - /var/prod_config/feed-crawler/.env.prod
     networks:
@@ -44,13 +44,12 @@ services:
     volumes:
       - /var/prod_data/feed-crawler/logs:/app/logs
     environment:
-      NODE_ENV: "PROD"
-      TZ: "Asia/Seoul"
-
+      NODE_ENV: 'PROD'
+      TZ: 'Asia/Seoul'
 
   # Email Worker 서비스
   email-worker:
-    image: ghcr.io/boostcampwm-2024/web05-denamu/email-worker:latest
+    image: ${EMAIL_WORKER_IMAGE}:${EMAIL_WORKER_TAG}
     env_file:
       - /var/prod_config/email-worker/.env.prod
     networks:
@@ -65,6 +64,6 @@ services:
     volumes:
       - /var/prod_data/email-worker/logs:/app/logs
     environment:
-      NODE_ENV: "PROD"
-      TZ: "Asia/Seoul"
+      NODE_ENV: 'PROD'
+      TZ: 'Asia/Seoul'
     stop_grace_period: 30s


### PR DESCRIPTION
# 🔨 테스크

### CI/CD에서 vars로 변수를 받게 한 이유

-   ci/cd를 메인 레포지토리에서 메인 브랜치에 매번 테스트를 하는건 올바르지 않다고 생각하여 fork를 하여 개인 레포지토리로 옮겼다.
- Oracle Virtual Box를 이용하여 운영 환경과 동일한 환경을 갖추게 하였다.
- 개인 레포지토리에서 Deploy를 해보려고 했지만, Github CI-CD에서 GHCR이 boostcampwm으로 되어 있어 이미지가 업로드 불가능했다.
- 앞으로 CI/CD를 개인 레포지토리에서 테스트 하기 위해서는 필요한 작업이라 생각되어 작업을 하게 됐다.

# 📋 작업 내용

-  서버, 피드 크롤러, 이메일 워커, 컴포즈에서 도커 이미지 레포지토리 변수 값에 따라 동적으로 ghcr 이용할 수 있도록 변경
