### PR TITLE
✨ feat: 그라파나 A 레코드 수정

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,6 +37,37 @@ server {
     }
 }
 
+# Portainer 서브도메인 - HTTP to HTTPS Redirect
+server {
+    listen 80;
+    server_name portainer.denamu.dev;
+
+    return 301 https://$host$request_uri;
+}
+
+# Portainer 서브도메인 - HTTPS 프록시
+server {
+    listen 443 ssl;
+    server_name portainer.denamu.dev;
+
+    ssl_certificate /etc/letsencrypt/live/denamu.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/denamu.dev/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:9000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+}
+
 # HTTPS로 들어온 요청에 대한 처리 진행
 server {
     listen 443 ssl;


### PR DESCRIPTION
# 📋 작업 내용
### 그라파나 대시보드 A 레코드 등록
도메인 변경 후 `https` 자동 승격으로 대시보드에 접근 되지 않아 A 레코드를 추가하여 Nginx가 직접 https를 기반으로 처리하도록 수정 하였습니다.

본 PR 병합, Nginx 재시작 및 Certbot에 `grafana.denamu.dev` 추가 인증 후
`https://grafana.denamu.dev`로 그라파나 대시보드에 접근 가능합니다.