### PR TITLE
🐛 fix: 조회수 증가 로직 개선

### DIFF
--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -142,9 +142,11 @@ export class FeedService {
     request: Request,
     response: Response,
   ) {
+    const feedId = viewUpdateParamDto.feedId;
+    await this.getFeed(feedId);
+
     const cookie = request.headers.cookie;
     const ip = this.getIp(request);
-    const feedId = viewUpdateParamDto.feedId;
 
     if (!ip || !this.isString(ip)) {
       return;


### PR DESCRIPTION
# 📋 작업 내용
### 비회원 조회수 증가 로직 개선
초기 설계와 다르게 잘못 구현되어 있던 조회수 증가 로직을 개선하였습니다.
현재 로직은 다음과 같습니다.

> 1. 쿠키가 있다면 바로 스킵
> 2. 쿠키가 없고 redis에 동일한 ip의 조회 내역이 존재한다면 스킵 (쿠키 재발급)
> 3. 쿠키도 없고 redis에도 조회내역이 존재하지 않는다면 정상 증가 후 쿠키 발급