### PR TITLE
✨ feat: cookie의 samesite 옵션을 lax로 수정

### DIFF
--- a/server/src/common/cookie/cookie.config.ts
+++ b/server/src/common/cookie/cookie.config.ts
@@ -2,13 +2,13 @@ export const cookieConfig = {
   PROD: {
     httpOnly: true,
     secure: true,
-    sameSite: 'none',
+    sameSite: 'lax',
     path: '/',
   },
   LOCAL: {
     httpOnly: true,
     secure: true,
-    sameSite: 'none',
+    sameSite: 'lax',
     path: '/',
   },
   DEV: {


### PR DESCRIPTION
## 관련 issue
#533

# 📋 작업 내용
- JWT Refresh 토큰 쿠키 관리 방법 변경을 위해 samesite 옵션을 lax로 수정


초기에는 netlify를 통해서 프론트를 배포했기 때문에 same site 옵션을 none으로 설정하고 개발했습니다.
이후 nginx를 통해 정적 파일 서빙하도록 수정되었고, JWT Refresh 토큰 관련 보안을 생각하여 same site 옵션을 lax로 수정했습니다.
Local 환경에서 테스트했을 때, lax나 strict 모두 문제가 없었지만 배포 환경에서 예상치 못한 문제가 발생할 수도 있다고 생각하여 일단 lax로 설정했습니다. 
추후 OAuth 등에서 문제가 없을 때, strict로 승격하면 좋을 것 같습니다.

# 📷 스크린 샷
<img width="1840" height="383" alt="image" src="https://github.com/user-attachments/assets/d9bb3901-332e-4d3b-b0dd-255f1a259cb1" />
<img width="364" height="293" alt="image" src="https://github.com/user-attachments/assets/cf670411-277c-46de-90cb-f289621cef7b" />

