### PR TITLE
📦 chore: Dependabot 설정 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,226 @@
+version: 2
+
+updates:
+  # ──────────────────────────────────────────
+  # GitHub Actions
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    labels:
+      - '🤖 Dependency'
+
+  # ──────────────────────────────────────────
+  # npm — root (commitizen, lefthook, artillery)
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    labels:
+      - '🤖 Dependency'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+
+  # ──────────────────────────────────────────
+  # npm — server (NestJS)
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'npm'
+    directory: '/server'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    labels:
+      - '🤖 Dependency'
+    groups:
+      nestjs:
+        patterns:
+          - '@nestjs/*'
+      typeorm:
+        patterns:
+          - 'typeorm'
+          - '@nestjs/typeorm'
+      dev-dependencies:
+        dependency-type: 'development'
+
+  # ──────────────────────────────────────────
+  # npm — client (React + Vite)
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'npm'
+    directory: '/client'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    labels:
+      - '🤖 Dependency'
+    groups:
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - 'react-*'
+          - '@types/react*'
+          - 'eslint-plugin-react*'
+          - '@vitejs/plugin-react-swc'
+      radix-ui:
+        patterns:
+          - '@radix-ui/*'
+      tanstack:
+        patterns:
+          - '@tanstack/*'
+      dev-dependencies:
+        dependency-type: 'development'
+
+  # ──────────────────────────────────────────
+  # npm — feed-crawler
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'npm'
+    directory: '/feed-crawler'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    labels:
+      - '🤖 Dependency'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+
+  # ──────────────────────────────────────────
+  # npm — email-worker
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'npm'
+    directory: '/email-worker'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - 'version-update:semver-major'
+    labels:
+      - '🤖 Dependency'
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+
+  # ──────────────────────────────────────────
+  # Docker — server
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'docker'
+    directory: '/server/docker'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    labels:
+      - '🤖 Dependency'
+
+  # ──────────────────────────────────────────
+  # Docker — client
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'docker'
+    directory: '/client/docker'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    labels:
+      - '🤖 Dependency'
+
+  # ──────────────────────────────────────────
+  # Docker — feed-crawler
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'docker'
+    directory: '/feed-crawler/docker'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    labels:
+      - '🤖 Dependency'
+
+  # ──────────────────────────────────────────
+  # Docker — email-worker
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'docker'
+    directory: '/email-worker/docker'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    labels:
+      - '🤖 Dependency'
+
+  # ──────────────────────────────────────────
+  # Docker — nginx
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'docker'
+    directory: '/nginx'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    labels:
+      - '🤖 Dependency'
+
+  # ──────────────────────────────────────────
+  # Docker Compose — docker-compose/
+  # ──────────────────────────────────────────
+  - package-ecosystem: 'docker'
+    directory: '/docker-compose'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Asia/Seoul'
+    open-pull-requests-limit: 10
+    labels:
+      - '🤖 Dependency'


### PR DESCRIPTION
# 🔨 테스크

### Issue
- close #539 

### Dependabot 의존성 자동 업데이트 설정

-   `.github/dependabot.yml` 신규 추가
-   적용 범위: npm × 5 (root, server, client, feed-crawler, email-worker), docker × 6, github-actions × 1 (총 12개 블록)
-   스케줄: 매주 월요일 09:00 KST

### minor, patch 버전만 허용한 이유

Semver 세 단계의 의미와 npm 생태계 현실 간의 차이가 있어 아래와 같이 결정했습니다.

#### major (x.0.0)
Breaking change가 공식 선언되는 버전. API 변경, 동작 변경이 보장되므로 자동 업데이트에서 **제외**합니다.

#### minor (1.x.0)
하위 호환 신규 기능 추가가 원칙이나, npm 생태계에서는 minor 업데이트에서도 breaking change가 발생하는 경우가 있습니다. 그럼에도 CI(unit + e2e)가 안전망 역할을 하므로 **허용**합니다.

#### patch (1.0.x)
버그픽스 전용. 운영 환경에서 breaking changes를 받지 않기 위해 minor와 patch만 자동화 대상으로 제한합니다.

### Docker Dependency

Dependabot의 `docker` ecosystem은 GHCR에 올라가는 빌드 결과물이 아닌, Dockerfile의 `FROM` 베이스 이미지(예: `node:22-alpine`)를 추적합니다. Docker 이미지 태그는 semver가 아닌 태그 기반 버전이므로 major ignore 규칙을 적용하지 않고, Node.js 메이저 버전 업그레이드는 수동 검토 후 Dockerfile을 직접 수정합니다.

### PR 노이즈 감소를 위한 그룹핑

| 서비스 | 그룹 |
|---|---|
| server | `@nestjs/*`, `typeorm`, `dev-dependencies` |
| client | `react`, `@radix-ui/*`, `@tanstack/*`, `dev-dependencies` |
| 나머지 | `dev-dependencies` |

# 📋 작업 내용

-   `.github/dependabot.yml` 신규 추가
-   npm 전 블록 `version-update:semver-major` ignore 적용
-   블록당 `open-pull-requests-limit: 10` 설정