### PR TITLE
🐛 fix: redis rdb 설정 추가

### DIFF
--- a/docker-compose/redis/redis-init.sh
+++ b/docker-compose/redis/redis-init.sh
@@ -11,33 +11,32 @@ fi
 
 echo "REDIS_USER: $REDIS_USER"
 
+ACL_FILE=/data/users.acl
+
 # ACL파일이 없으면 생성
 if [ ! -f /data/users.acl ]; then
-    echo "Creating empty ACL file..."
-    touch /data/users.acl
+  cat > "$ACL_FILE" <<EOF
+user default off
+user ${REDIS_USER} on >${REDIS_PASSWORD} ~* +@all
+EOF
+  echo "ACL file created at $ACL_FILE"
+else
+  echo "ACL file is already existed"
 fi
 
-# Redis를 설정 파일과 함께 백그라운드 시작
-redis-server --daemonize yes --dir /data --aclfile /data/users.acl
+CONF_FILE=/data/redis.conf
 
-# 시작 대기
-sleep 8
+# CONF 파일이 없으면 생성
+if [ ! -f "$CONF_FILE" ]; then
+  cat > "$CONF_FILE" <<EOF
+aclfile /data/users.acl
+save 3600 1
+save 300 100
+save 60 10000
+EOF
+ echo "CONF file created at $CONF_FILE"
+else
+  echo "CONF file is already existed"
+fi
 
-# ACL 사용자 생성
-echo "Creating ACL user..."
-redis-cli ACL SETUSER "$REDIS_USER" on ">$REDIS_PASSWORD" allkeys allcommands
-
-# ACL 설정을 파일에 저장 (이제 가능!)
-redis-cli ACL SAVE
-echo "ACL saved to /data/users.acl"
-
-# 확인
-redis-cli ACL LIST
-
-# Redis 종료
-redis-cli shutdown
-sleep 2
-
-# 재시작 시에도 ACL 파일 사용
-echo "Starting Redis with ACL configuration..."
-exec redis-server --dir /data --aclfile /data/users.acl
+exec docker-entrypoint.sh redis-server /data/redis.conf


### PR DESCRIPTION
# 🔨 테스크

### Issue
- close #579

### 디버깅 과정 정리

11월 23일 저장된 rdb 파일이 있으므로 해당 날짜를 기준으로 변경점을 추적했습니다.
대상은 다음 두 가지였습니다.
1. [denamu infra 변경 PR](https://github.com/Team5-Denamu/Denamu-iac/pull/5)
2. [redis-init.sh 변경 PR](https://github.com/boostcampwm-2024/web05-Denamu/pull/494)

1번의 경우, 볼륨을 직접 건드리지 않았기 때문에 큰 문제는 없다고 판단했습니다.

2번을 확인하기 위해 local 환경에서 여러 테스트를 해본 결과,
`redis-server`로 실행하면 default 값이 적용되는데 `redis-server --dir ... --aclfile ...`와 같이 실행하면 default가 적용되지 않는 것을 확인했습니다.
[redis docker 6.2 깃헙](https://github.com/redis/docker-library-redis/blob/master/6.2/alpine/Dockerfile)에서 redis-server 실행 할 때 protected-mode 인수를 주면 모든 default가 초기화되어 사용자가 직접 설정해야 한다는 주석을 확인했습니다. (우리가 사용하는 6.0.16 alpine은 찾을 수가 없어서 6.2로 확인)

위 주석으로 우리가 redis-server 실행 시 `--dir`, `--aclfile`과 같은 인수(flag)를 넣으면서 초기화된다는 것을 확인했고, 설정 파일을 작성하는 방향으로 작업을 진행했습니다.
 
[관련 issue](https://github.com/redis/docker-library-redis/issues/4#issuecomment-50780840)  한 줄 요약 by GPT:
**Redis가 CLI 옵션을 하나라도 받으면 기본 설정을 모두 override한다고 가정하는 특성** 때문에 Docker에서 SIGTERM 시 데이터 저장이 동작하지 않는 문제를 해결하기 위한 논의이며, 결국 Docker Redis 이미지는 Redis 소스 코드를 수정해 기본 save 동작이 유지되도록 설계하게 되었습니다.

# 📋 작업 내용

- redis-init.sh에서 redis.conf, users.acl 파일을 생성하도록 스크립트 수정
- redis.conf 파일 내용
  - RDB 설정
  - ACL 파일 경로

# 📷 스크린 샷(선택 사항)

<dump 파일 생성 확인>
<img width="638" height="131" alt="image" src="https://github.com/user-attachments/assets/9f3886b7-7ab2-4f31-b9df-cfa6fd3fee25" />

