### PR TITLE
📦 chore: Docker 프로덕션 이미지 의존성 설치 방식 변경

### DIFF
--- a/email-worker/docker/Dockerfile.local
+++ b/email-worker/docker/Dockerfile.local
@@ -14,9 +14,11 @@ FROM node:22-alpine
 
 WORKDIR /var/web05-Denamu/email-worker
 
+COPY --from=builder /var/web05-Denamu/email-worker/package*.json .
+
+RUN npm ci --omit=dev
+
 COPY --from=builder /var/web05-Denamu/email-worker/dist ./dist
-COPY --from=builder /var/web05-Denamu/email-worker/package.json .
-COPY --from=builder /var/web05-Denamu/email-worker/node_modules ./node_modules
 COPY --from=builder /var/web05-Denamu/email-worker/env ./env
 
 CMD ["npm","run","start"]

--- a/email-worker/docker/Dockerfile.local
+++ b/email-worker/docker/Dockerfile.local
@@ -10,14 +10,14 @@ COPY . .
 
 RUN npm run build
 
+RUN npm prune --omit=dev
+
 FROM node:22-alpine
 
 WORKDIR /var/web05-Denamu/email-worker
 
-COPY --from=builder /var/web05-Denamu/email-worker/package*.json .
-
-RUN npm ci --omit=dev
-
+COPY --from=builder /var/web05-Denamu/email-worker/package.json .
+COPY --from=builder /var/web05-Denamu/email-worker/node_modules ./node_modules
 COPY --from=builder /var/web05-Denamu/email-worker/dist ./dist
 COPY --from=builder /var/web05-Denamu/email-worker/env ./env
 

--- a/email-worker/docker/Dockerfile.prod
+++ b/email-worker/docker/Dockerfile.prod
@@ -14,10 +14,10 @@ FROM node:22-alpine
 
 WORKDIR /app
 
-COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package.json .
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package*.json .
 
-RUN touch /var/log/email-worker.log
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/dist ./dist
 
 CMD ["npm", "start"]

--- a/email-worker/docker/Dockerfile.prod
+++ b/email-worker/docker/Dockerfile.prod
@@ -10,14 +10,14 @@ COPY . .
 
 RUN npm run build
 
+RUN npm prune --omit=dev
+
 FROM node:22-alpine
 
 WORKDIR /app
 
-COPY --from=builder /app/package*.json .
-
-RUN npm ci --omit=dev
-
+COPY --from=builder /app/package.json .
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 
 CMD ["npm", "start"]

--- a/feed-crawler/docker/Dockerfile.local
+++ b/feed-crawler/docker/Dockerfile.local
@@ -10,14 +10,14 @@ COPY . .
 
 RUN npm run build
 
+RUN npm prune --omit=dev
+
 FROM node:22-alpine
 
 WORKDIR /var/web05-Denamu/feed-crawler
 
-COPY --from=builder /var/web05-Denamu/feed-crawler/package*.json .
-
-RUN npm ci --omit=dev
-
+COPY --from=builder /var/web05-Denamu/feed-crawler/package.json .
+COPY --from=builder /var/web05-Denamu/feed-crawler/node_modules ./node_modules
 COPY --from=builder /var/web05-Denamu/feed-crawler/dist ./dist
 COPY --from=builder /var/web05-Denamu/feed-crawler/env ./env
 

--- a/feed-crawler/docker/Dockerfile.local
+++ b/feed-crawler/docker/Dockerfile.local
@@ -14,9 +14,11 @@ FROM node:22-alpine
 
 WORKDIR /var/web05-Denamu/feed-crawler
 
+COPY --from=builder /var/web05-Denamu/feed-crawler/package*.json .
+
+RUN npm ci --omit=dev
+
 COPY --from=builder /var/web05-Denamu/feed-crawler/dist ./dist
-COPY --from=builder /var/web05-Denamu/feed-crawler/package.json .
-COPY --from=builder /var/web05-Denamu/feed-crawler/node_modules ./node_modules
 COPY --from=builder /var/web05-Denamu/feed-crawler/env ./env
 
 CMD ["npm","run","start"]

--- a/feed-crawler/docker/Dockerfile.prod
+++ b/feed-crawler/docker/Dockerfile.prod
@@ -14,8 +14,10 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+COPY --from=builder /app/package*.json .
+
+RUN npm ci --omit=dev
+
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package.json .
-COPY --from=builder /app/node_modules ./node_modules
 
 CMD ["npm", "start"]

--- a/feed-crawler/docker/Dockerfile.prod
+++ b/feed-crawler/docker/Dockerfile.prod
@@ -10,14 +10,14 @@ COPY . .
 
 RUN npm run build
 
+RUN npm prune --omit=dev
+
 FROM node:22-alpine
 
 WORKDIR /app
 
-COPY --from=builder /app/package*.json .
-
-RUN npm ci --omit=dev
-
+COPY --from=builder /app/package.json .
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 
 CMD ["npm", "start"]

--- a/server/docker/Dockerfile.local
+++ b/server/docker/Dockerfile.local
@@ -16,9 +16,11 @@ FROM node:22-alpine
 
 WORKDIR /var/web05-Denamu/server
 
+COPY --from=builder /var/web05-Denamu/server/package*.json .
+
+RUN npm ci --omit=dev
+
 COPY --from=builder /var/web05-Denamu/server/dist ./dist
-COPY --from=builder /var/web05-Denamu/server/package.json .
-COPY --from=builder /var/web05-Denamu/server/node_modules ./node_modules
 COPY --from=builder /var/web05-Denamu/server/env ./env
 
 CMD ["npm","start"]

--- a/server/docker/Dockerfile.local
+++ b/server/docker/Dockerfile.local
@@ -11,15 +11,15 @@ COPY . .
 
 RUN npm run build
 
+RUN npm prune --omit=dev
+
 # 실행 빌드
 FROM node:22-alpine
 
 WORKDIR /var/web05-Denamu/server
 
-COPY --from=builder /var/web05-Denamu/server/package*.json .
-
-RUN npm ci --omit=dev
-
+COPY --from=builder /var/web05-Denamu/server/package.json .
+COPY --from=builder /var/web05-Denamu/server/node_modules ./node_modules
 COPY --from=builder /var/web05-Denamu/server/dist ./dist
 COPY --from=builder /var/web05-Denamu/server/env ./env
 

--- a/server/docker/Dockerfile.prod
+++ b/server/docker/Dockerfile.prod
@@ -14,8 +14,10 @@ FROM node:22-alpine
 
 WORKDIR /app
 
+COPY --from=builder /app/package*.json .
+
+RUN npm ci --omit=dev
+
 COPY --from=builder /app/dist ./dist
-COPY --from=builder /app/package.json .
-COPY --from=builder /app/node_modules ./node_modules
 
 CMD ["npm", "start"]

--- a/server/docker/Dockerfile.prod
+++ b/server/docker/Dockerfile.prod
@@ -10,14 +10,14 @@ COPY . .
 
 RUN npm run build
 
+RUN npm prune --omit=dev
+
 FROM node:22-alpine
 
 WORKDIR /app
 
-COPY --from=builder /app/package*.json .
-
-RUN npm ci --omit=dev
-
+COPY --from=builder /app/package.json .
+COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist ./dist
 
 CMD ["npm", "start"]


### PR DESCRIPTION
# 🔨 태스크

### Docker 이미지 devDependencies 제거

# 📋 작업 내용

## Dockerfile 변경 (`email-worker`, `feed-crawler`, `server` — prod + local 총 6개)

**Before (develop 기준):**
```dockerfile
# 빌더 스테이지
RUN npm run build

# 런타임 스테이지
COPY --from=builder /app/dist ./dist
COPY --from=builder /app/package.json .
COPY --from=builder /app/node_modules ./node_modules  # devDependencies 포함된 채로 복사
```

**After:**
```dockerfile
# 빌더 스테이지
RUN npm run build
RUN npm prune --omit=dev  # 빌더에서 devDependencies 제거

# 런타임 스테이지
COPY --from=builder /app/package.json .
COPY --from=builder /app/node_modules ./node_modules  # pruned node_modules 복사
COPY --from=builder /app/dist ./dist
```

**변경 사항:**
- 빌더 스테이지: `npm prune --omit=dev` 추가 → devDependencies를 빌더에서 제거 후 런타임 스테이지로 복사
- COPY 순서 조정: `dist`를 `node_modules` 이후로 이동 (레이어 캐시 최적화)
- `email-worker` Dockerfile.prod: 불필요한 `RUN touch /var/log/email-worker.log` 제거

# 📷 스크린 샷(선택 사항)

### Docker 이미지 크기 변화
| 서비스          |   Before |    After |        차이 |     감소율 |
| ------------ | -------: | -------: | --------: | ------: |
| email-worker | 455.73MB | 250.21MB | -205.52MB | -45.10% |
| feed-crawler | 458.56MB | 277.15MB | -181.41MB | -39.56% |
| app (server) | 679.77MB | 456.77MB | -223.00MB | -32.81% |