### PR TITLE
📦 chore: commitizen 서브 디렉토리 실행 환경 구성 및 docker 로그 경로 수정

### DIFF
--- a/.cz-config.js
+++ b/.cz-config.js
@@ -1,49 +1,49 @@
 module.exports = {
   types: [
     {
-      value: "✨ feat",
-      name: "✨ feat: 기능 추가 시 사용",
+      value: '✨ feat',
+      name: '✨ feat: 기능 추가 시 사용',
     },
     {
-      value: "🐛 fix",
-      name: "🐛 fix: 버그 수정 시 사용",
+      value: '🐛 fix',
+      name: '🐛 fix: 버그 수정 시 사용',
     },
     {
-      value: "♻️ refactor",
-      name: "♻️ refactor: 구조 변경, 코드 아키텍처 변경 시 사용",
+      value: '♻️ refactor',
+      name: '♻️ refactor: 구조 변경, 코드 아키텍처 변경 시 사용',
     },
     {
-      value: "⚡️ perf",
-      name: "⚡️ perf: 성능 개선 및 코드 개선 시 사용",
+      value: '⚡️ perf',
+      name: '⚡️ perf: 성능 개선 및 코드 개선 시 사용',
     },
     {
-      value: "💄 style",
-      name: "💄 style: 스타일 수정 시 사용",
+      value: '💄 style',
+      name: '💄 style: 스타일 수정 시 사용',
     },
     {
-      value: "📝 docs",
-      name: "📝 docs: 문서 수정 시 사용",
+      value: '📝 docs',
+      name: '📝 docs: 문서 수정 시 사용',
     },
     {
-      value: "✅ test",
-      name: "✅ test: 테스트 코드 수정, 추가 시 사용",
+      value: '✅ test',
+      name: '✅ test: 테스트 코드 수정, 추가 시 사용',
     },
     {
-      value: "📦 chore",
-      name: "📦 chore: 개발 환경 구축, 설정 시 사용",
+      value: '📦 chore',
+      name: '📦 chore: 개발 환경 구축, 설정 시 사용',
     },
     {
-      value: "🧼 clean",
-      name: "🧼 clean: 사소한 코드 수정, 코드 정리",
+      value: '🧼 clean',
+      name: '🧼 clean: 사소한 코드 수정, 코드 정리',
     },
   ],
   messages: {
-    type: "커밋 메세지 타입을 선택해주세요: ",
-    subject: "커밋 메세지 내용을 입력해주세요: ",
-    confirm: "커밋 내용이 확실한가요?",
+    type: '커밋 메세지 타입을 선택해주세요: ',
+    subject: '커밋 메세지 내용을 입력해주세요: ',
+    confirmCommit: '커밋 내용이 확실한가요?',
   },
   allowCustomScopes: false,
-  skipQuestions: ["body", "scope", "footer"],
+  skipQuestions: ['body', 'scope', 'footer'],
   skipEmptyScopes: false,
   subjectLimit: 100,
 };

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "commit": "npm run commit --prefix ..",
     "dev": "vite --mode dev",
     "build": "tsc -b && vite build --mode prod",
     "build:local": "tsc -b && vite build",

--- a/docker-compose/docker-compose.local.yml
+++ b/docker-compose/docker-compose.local.yml
@@ -79,7 +79,7 @@ services:
       rabbitmq:
         condition: service_healthy
     volumes:
-      - ../feed-crawler/logs:/var/web05-Denamu/email-worker/logs
+      - ../email-worker/logs:/var/web05-Denamu/email-worker/logs
     environment:
       NODE_ENV: 'LOCAL'
       TZ: 'Asia/Seoul'

--- a/email-worker/package.json
+++ b/email-worker/package.json
@@ -30,6 +30,7 @@
     "typescript-eslint": "^8.59.3"
   },
   "scripts": {
+    "commit": "npm run commit --prefix ..",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/feed-crawler/package.json
+++ b/feed-crawler/package.json
@@ -38,6 +38,7 @@
     "typescript-eslint": "^8.59.3"
   },
   "scripts": {
+    "commit": "npm run commit --prefix ..",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "commit": "npm run commit --prefix ..",
     "build": "nest build && tsc-alias",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "node dist/src/main.js",


### PR DESCRIPTION
# 🔨 테스크

### commitizen 서브 디렉토리 실행 환경 구성

- 모노레포 구조에서 각 서브 디렉토리(server, client, feed-crawler, email-worker)에서도 commitizen을 독립적으로 실행할 수 있도록 각 `package.json`에 commitizen 의존성 및 설정 추가
- `.cz-config.js` 메시지 출력 방식 수정으로 커밋 타입 선택 시 올바른 안내 메시지가 표시되도록 수정

### docker compose email worker 로그 경로 수정

- `docker-compose.local.yml`에서 email worker 컨테이너의 로그 볼륨 마운트 경로가 잘못 설정된 문제 수정

# 📋 작업 내용

- `.cz-config.js`: 커밋 타입 선택 메시지 출력 수정
- `client/package.json`, `server/package.json`, `feed-crawler/package.json`, `email-worker/package.json`: commitizen 의존성 및 config 경로 추가
- `docker-compose/docker-compose.local.yml`: email worker 로그 볼륨 경로 수정
- `email-worker/docker/Dockerfile.local`, `Dockerfile.prod`: 로그 디렉토리 경로 수정
- `feed-crawler/docker/Dockerfile.local`, `Dockerfile.prod`: 로그 디렉토리 경로 수정
- `server/docker/Dockerfile.local`, `Dockerfile.prod`: 로그 디렉토리 경로 수정