### PR TITLE
🐛 fix: 회원탈퇴 API 메서드 수정 및 사용자 인증 강화

### DIFF
--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -33,6 +33,7 @@ export class CommentService {
     userInformation: Payload,
     commentId: number,
   ) {
+    await this.userService.getUser(userInformation.id);
     const commentObj = await this.commentRepository.findOne({
       where: {
         id: commentId,

--- a/server/src/file/controller/file.controller.ts
+++ b/server/src/file/controller/file.controller.ts
@@ -66,8 +66,11 @@ export class FileController {
   @Delete(':id')
   @ApiDeleteFile()
   @HttpCode(HttpStatus.OK)
-  async deleteFile(@Param() fileDeleteRequestDto: DeleteFileParamRequestDto) {
-    await this.fileService.deleteFile(fileDeleteRequestDto.id);
+  async deleteFile(
+    @Param() fileDeleteRequestDto: DeleteFileParamRequestDto,
+    @CurrentUser() user: Payload,
+  ) {
+    await this.fileService.deleteFile(fileDeleteRequestDto.id, user.id);
     return ApiResponse.responseWithNoContent(
       '파일이 성공적으로 삭제되었습니다.',
     );

--- a/server/src/file/module/file.module.ts
+++ b/server/src/file/module/file.module.ts
@@ -1,11 +1,13 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 
 import { FileController } from '@file/controller/file.controller';
 import { FileRepository } from '@file/repository/file.repository';
 import { FileService } from '@file/service/file.service';
 
+import { UserModule } from '@user/module/user.module';
+
 @Module({
-  imports: [],
+  imports: [forwardRef(() => UserModule)],
   controllers: [FileController],
   providers: [FileService, FileRepository],
   exports: [FileService],

--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, NotFoundException } from '@nestjs/common';
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -12,6 +12,8 @@ import { UploadFileResponseDto } from '@file/dto/response/uploadFile.dto';
 import { File } from '@file/entity/file.entity';
 import { FileRepository } from '@file/repository/file.repository';
 
+import { UserService } from '@user/service/user.service';
+
 @Injectable()
 export class FileService {
   private readonly basePath = '/app/objects';
@@ -19,6 +21,8 @@ export class FileService {
   constructor(
     private readonly fileRepository: FileRepository,
     private readonly logger: WinstonLoggerService,
+    @Inject(forwardRef(() => UserService))
+    private readonly userService: UserService,
   ) {}
 
   async handleUpload(
@@ -26,6 +30,7 @@ export class FileService {
     uploadType: FileUploadType,
     userId: number,
   ) {
+    await this.userService.getUser(userId);
     const today = this.getDateString();
     const targetDir = path.join(this.basePath, uploadType, today);
 
@@ -71,7 +76,8 @@ export class FileService {
     return file;
   }
 
-  async deleteFile(id: number): Promise<void> {
+  async deleteFile(id: number, userId: number): Promise<void> {
+    await this.userService.getUser(userId);
     const file = await this.findById(id);
 
     try {

--- a/server/src/like/module/like.module.ts
+++ b/server/src/like/module/like.module.ts
@@ -8,8 +8,10 @@ import { LikeController } from '@like/controller/like.controller';
 import { LikeRepository } from '@like/repository/like.repository';
 import { LikeService } from '@like/service/like.service';
 
+import { UserModule } from '@user/module/user.module';
+
 @Module({
-  imports: [forwardRef(() => FeedModule), JwtAuthModule],
+  imports: [forwardRef(() => FeedModule), JwtAuthModule, UserModule],
   controllers: [LikeController],
   providers: [LikeService, LikeRepository],
   exports: [LikeRepository],

--- a/server/src/like/service/like.service.ts
+++ b/server/src/like/service/like.service.ts
@@ -15,12 +15,15 @@ import { GetLikeResponseDto } from '@like/dto/response/getLike.dto';
 import { Like } from '@like/entity/like.entity';
 import { LikeRepository } from '@like/repository/like.repository';
 
+import { UserService } from '@user/service/user.service';
+
 @Injectable()
 export class LikeService {
   constructor(
     private readonly likeRepository: LikeRepository,
     private readonly feedService: FeedService,
     private readonly dataSource: DataSource,
+    private readonly userService: UserService,
   ) {}
 
   async get(
@@ -51,6 +54,7 @@ export class LikeService {
 
     try {
       const feed = await this.feedService.getFeed(feedLikeCreateDto.feedId);
+      await this.userService.getUser(userInformation.id);
       const existing = await this.likeRepository.findOneBy({
         user: { id: userInformation.id },
         feed: { id: feedLikeCreateDto.feedId },
@@ -85,6 +89,7 @@ export class LikeService {
 
     try {
       const feed = await this.feedService.getFeed(feedLikeDeleteDto.feedId);
+      await this.userService.getUser(userInformation.id);
       const existing = await this.likeRepository.findOneBy({
         user: { id: userInformation.id },
         feed: { id: feedLikeDeleteDto.feedId },

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   HttpCode,
   HttpStatus,
@@ -33,10 +34,10 @@ import { ApiResetPassword } from '@user/api-docs/resetPassword.api-docs';
 import { ApiUpdateUser } from '@user/api-docs/updateUser.api-docs';
 import { CertificateUserRequestDto } from '@user/dto/request/certificateUser.dto';
 import { CheckEmailDuplicationRequestDto } from '@user/dto/request/checkEmailDuplication.dto';
+import { ConfirmDeleteAccountParamRequestDto } from '@user/dto/request/confirmDeleteAccountParam.dto';
 import { ForgotPasswordRequestDto } from '@user/dto/request/forgotPassword.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
-import { ConfirmDeleteAccountParamRequestDto } from '@user/dto/request/confirmDeleteAccountParam.dto';
 import { ResetPasswordRequestDto } from '@user/dto/request/resetPassword.dto';
 import { ResetPasswordParamRequestDto } from '@user/dto/request/resetPasswordParam.dto';
 import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
@@ -150,9 +151,11 @@ export class UserController {
   }
 
   @ApiConfirmDeleteAccount()
-  @Patch('/deletion-requests/:token')
+  @Delete('/deletion-requests/:token')
   @HttpCode(HttpStatus.OK)
-  async confirmDeleteAccount(@Param() paramDto: ConfirmDeleteAccountParamRequestDto) {
+  async confirmDeleteAccount(
+    @Param() paramDto: ConfirmDeleteAccountParamRequestDto,
+  ) {
     await this.userService.confirmDeleteAccount(paramDto.token);
     return ApiResponse.responseWithNoContent('회원탈퇴가 완료되었습니다.');
   }
@@ -174,7 +177,10 @@ export class UserController {
     @Param() paramDto: ResetPasswordParamRequestDto,
     @Body() resetPasswordRequestDto: ResetPasswordRequestDto,
   ) {
-    await this.userService.resetPassword(paramDto.uuid, resetPasswordRequestDto.password);
+    await this.userService.resetPassword(
+      paramDto.uuid,
+      resetPasswordRequestDto.password,
+    );
     return ApiResponse.responseWithNoContent(
       '비밀번호가 성공적으로 수정되었습니다.',
     );

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -100,10 +100,10 @@ export class UserController {
   @Post('/tokens')
   @HttpCode(HttpStatus.OK)
   @UseGuards(RefreshJwtGuard)
-  refreshAccessToken(@CurrentUser() user: Payload) {
+  async refreshAccessToken(@CurrentUser() user: Payload) {
     return ApiResponse.responseWithData(
       '엑세스 토큰을 재발급했습니다.',
-      this.userService.refreshAccessToken(user),
+      await this.userService.refreshAccessToken(user),
     );
   }
 

--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 
 import { AdminModule } from '@admin/module/admin.module';
@@ -18,7 +18,7 @@ import { OAuthService } from '@user/service/oAuth.service';
 import { UserService } from '@user/service/user.service';
 
 @Module({
-  imports: [JwtAuthModule, AdminModule, FileModule, ScheduleModule.forRoot()],
+  imports: [JwtAuthModule, AdminModule, forwardRef(() => FileModule), ScheduleModule.forRoot()],
   controllers: [UserController, OAuthController],
   providers: [
     UserService,

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -1,5 +1,7 @@
 import {
   ConflictException,
+  forwardRef,
+  Inject,
   Injectable,
   NotFoundException,
   UnauthorizedException,
@@ -35,6 +37,7 @@ export class UserService {
     private readonly emailProducer: EmailProducer,
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
+    @Inject(forwardRef(() => FileService))
     private readonly fileService: FileService,
   ) {}
 
@@ -120,7 +123,8 @@ export class UserService {
     return CreateAccessTokenResponseDto.toResponseDto(accessToken);
   }
 
-  refreshAccessToken(userInformation: Payload) {
+  async refreshAccessToken(userInformation: Payload) {
+    await this.getUser(userInformation.id);
     const accessToken = this.createToken(userInformation, 'access');
     return CreateAccessTokenResponseDto.toResponseDto(accessToken);
   }

--- a/server/test/comment/e2e/delete.e2e-spec.ts
+++ b/server/test/comment/e2e/delete.e2e-spec.ts
@@ -27,7 +27,7 @@ const BASE_URL = '/api/feeds';
 describe(`DELETE ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
   let agent: TestAgent;
   let comment: Comment;
-  let user: User;
+  let user: User, user2: User;
   let rssAccept: RssAccept;
   let feed: Feed;
   let commentRepository: CommentRepository;
@@ -48,7 +48,8 @@ describe(`DELETE ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
     rssAccept = await rssAcceptRepository.save(
       RssAcceptFixture.createRssAcceptFixture(),
     );
-    [user, feed] = await Promise.all([
+    [user, user2, feed] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
       userRepository.save(await UserFixture.createUserCryptFixture()),
       feedRepository.save(FeedFixture.createFeedFixture(rssAccept)),
     ]);
@@ -90,9 +91,32 @@ describe(`DELETE ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
-  it('[401] 본인이 작성한 댓글이 아닐 경우 댓글 삭제를 실패한다.', async () => {
+  it('[404] 본인의 계정 정보가 삭제됐을 경우 댓글 삭제를 실패한다.', async () => {
     // given
     accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
+
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${feed.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedComment = await commentRepository.findOneBy({
+      id: comment.id,
+    });
+
+    // DB, Redis then
+    expect(savedComment.comment).toBe(comment.comment);
+  });
+
+  it('[401] 본인이 작성한 댓글이 아닐 경우 댓글 삭제를 실패한다.', async () => {
+    // given
+    accessToken = createAccessToken({ id: user2.id });
 
     // Http when
     const response = await agent

--- a/server/test/comment/e2e/update.e2e-spec.ts
+++ b/server/test/comment/e2e/update.e2e-spec.ts
@@ -33,7 +33,7 @@ describe(`PATCH ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
   let feedRepository: FeedRepository;
   let rssAccept: RssAccept;
   let feed: Feed;
-  let user: User;
+  let user: User, user2: User;
   let accessToken: string;
 
   beforeAll(() => {
@@ -48,7 +48,8 @@ describe(`PATCH ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
     rssAccept = await rssAcceptRepository.save(
       RssAcceptFixture.createRssAcceptFixture(),
     );
-    [user, feed] = await Promise.all([
+    [user, user2, feed] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
       userRepository.save(await UserFixture.createUserCryptFixture()),
       feedRepository.save(FeedFixture.createFeedFixture(rssAccept)),
     ]);
@@ -99,9 +100,33 @@ describe(`PATCH ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
     expect(savedComment.comment).toBe(comment.comment);
   });
 
-  it('[401] 본인이 작성한 댓글이 아닐 경우 댓글 수정을 실패한다.', async () => {
+  it('[404] 본인의 계정 정보가 삭제됐을 경우 댓글 수정을 실패한다.', async () => {
     // given
     accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
+
+    // Http when
+    const response = await agent
+      .patch(`${BASE_URL}/${feed.id}/comments/${comment.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ newComment: 'newComment' });
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedComment = await commentRepository.findOneBy({
+      id: comment.id,
+    });
+
+    // DB, Redis then
+    expect(savedComment.comment).toBe(comment.comment);
+  });
+
+  it('[401] 본인이 작성한 댓글이 아닐 경우 댓글 수정을 실패한다.', async () => {
+    // given
+    accessToken = createAccessToken({ id: user2.id });
 
     // Http when
     const response = await agent

--- a/server/test/file/e2e/delete.e2e-spec.ts
+++ b/server/test/file/e2e/delete.e2e-spec.ts
@@ -81,6 +81,29 @@ describe(`DELETE ${URL}/{fileId} E2E Test`, () => {
     expect(savedFile).not.toBeNull();
   });
 
+  it('[404] 존재하지 않는 유저가 파일 업로드를 시도할 경우 파일 업로드를 실패한다.', async () => {
+    // given
+    accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
+
+    // Http when
+    const response = await agent
+      .delete(`${URL}/${file.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedFile = await fileRepository.findOneBy({
+      user: { id: Number.MAX_SAFE_INTEGER },
+    });
+
+    // DB, Redis then
+    expect(savedFile).toBeNull();
+  });
+
   it('[200] DB에서 파일을 삭제했지만 FS 라이브러리의 삭제 문제일 경우에 서비스에서 파일 삭제를 성공한다.', async () => {
     // given
     jest

--- a/server/test/file/e2e/upload.e2e-spec.ts
+++ b/server/test/file/e2e/upload.e2e-spec.ts
@@ -87,7 +87,7 @@ describe(`POST ${URL} E2E Test`, () => {
     expect(savedFile).toBeNull();
   });
 
-  it('[400] 파일 타입이 일치하지 않을 경우 파일 업로드를 실패한다. ', async () => {
+  it('[400] 파일 타입이 일치하지 않을 경우 파일 업로드를 실패한다.', async () => {
     // given
     const requestDto = new UploadFileQueryRequestDto({
       uploadType: FileUploadType.PROFILE_IMAGE,
@@ -111,7 +111,7 @@ describe(`POST ${URL} E2E Test`, () => {
     // DB, Redis then
     expect(savedFile).toBeNull();
   });
-  it('[400] 파일 크기가 일치하지 않을 경우 파일 업로드를 실패한다. ', async () => {
+  it('[400] 파일 크기가 일치하지 않을 경우 파일 업로드를 실패한다.', async () => {
     // given
     const requestDto = new UploadFileQueryRequestDto({
       uploadType: FileUploadType.PROFILE_IMAGE,
@@ -131,6 +131,34 @@ describe(`POST ${URL} E2E Test`, () => {
 
     // DB, Redis when
     const savedFile = await fileRepository.findOneBy({ user: { id: user.id } });
+
+    // DB, Redis then
+    expect(savedFile).toBeNull();
+  });
+
+  it('[404] 존재하지 않는 유저가 파일 업로드를 시도할 경우 파일 업로드를 실패한다.', async () => {
+    // given
+    const requestDto = new UploadFileQueryRequestDto({
+      uploadType: FileUploadType.PROFILE_IMAGE,
+    });
+    accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query(requestDto)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .attach('file', Buffer.alloc(1024, 0), 'test.png');
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedFile = await fileRepository.findOneBy({
+      user: { id: Number.MAX_SAFE_INTEGER },
+    });
 
     // DB, Redis then
     expect(savedFile).toBeNull();

--- a/server/test/like/e2e/create.e2e-spec.ts
+++ b/server/test/like/e2e/create.e2e-spec.ts
@@ -81,6 +81,39 @@ describe(`POST ${BASE_URL}/:feedId/likes E2E Test`, () => {
     const { data } = response.body;
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
     expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedLike = await likeRepository.findOneBy({
+      feed: { id: feed.id },
+      user: { id: user.id },
+    });
+
+    // DB, Redis then
+    expect(savedLike).toBeNull();
+  });
+
+  it('[404] 유저 정보가 존재하지 않을 경우 좋아요 등록을 실패한다.', async () => {
+    // given
+    accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${Number.MAX_SAFE_INTEGER}/likes`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedLike = await likeRepository.findOneBy({
+      feed: { id: feed.id },
+      user: { id: Number.MAX_SAFE_INTEGER },
+    });
+
+    // DB, Redis then
+    expect(savedLike).toBeNull();
   });
 
   it('[409] 이미 좋아요를 한 게시글일 경우 좋아요 등록을 실패한다.', async () => {

--- a/server/test/like/e2e/delete.e2e-spec.ts
+++ b/server/test/like/e2e/delete.e2e-spec.ts
@@ -86,6 +86,21 @@ describe(`DELETE ${BASE_URL}/:feedId/likes E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
+  it('[404] 존재하지 않는 유저가 좋아요 삭제를 시도할 경우 좋아요 삭제를 실패한다.', async () => {
+    // given
+    accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
+
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${feed.id}/likes`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
   it('[200] 로그인이 되어 있고 좋아요를 한 경우 좋아요 삭제를 성공한다.', async () => {
     // given
     await likeRepository.save({

--- a/server/test/user/e2e/delete-account/confirm.e2e-spec.ts
+++ b/server/test/user/e2e/delete-account/confirm.e2e-spec.ts
@@ -37,7 +37,7 @@ import { testApp } from '@test/config/e2e/env/jest.setup';
 
 const makeURL = (token: string) => `/api/users/deletion-requests/${token}`;
 
-describe(`PATCH /api/users/deletion-requests/:token E2E Test`, () => {
+describe(`DELETE /api/users/deletion-requests/:token E2E Test`, () => {
   let agent: TestAgent;
   let redisService: RedisService;
   let userRepository: UserRepository;
@@ -87,7 +87,7 @@ describe(`PATCH /api/users/deletion-requests/:token E2E Test`, () => {
     const nonExistentCode = uuid.v4();
 
     // Http when
-    const response = await agent.patch(makeURL(nonExistentCode));
+    const response = await agent.delete(makeURL(nonExistentCode));
 
     // Http then
     const { data } = response.body;
@@ -120,7 +120,7 @@ describe(`PATCH /api/users/deletion-requests/:token E2E Test`, () => {
     );
 
     // Http when
-    const response = await agent.patch(makeURL(userDeleteCode));
+    const response = await agent.delete(makeURL(userDeleteCode));
 
     // Http then
     const { data } = response.body;

--- a/server/test/user/e2e/refresh-token.e2e-spec.ts
+++ b/server/test/user/e2e/refresh-token.e2e-spec.ts
@@ -40,6 +40,21 @@ describe(`POST ${URL} E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
+  it('[404] 유저 정보가 존재하지 않을 경우 Access Token 발급을 실패한다.', async () => {
+    // given
+    refreshToken = createRefreshToken({ id: Number.MAX_SAFE_INTEGER });
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `refresh_token=${refreshToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
   it('[200] Refresh Token이 있을 경우 Access Token 발급을 성공한다.', async () => {
     // Http when
     const response = await agent


### PR DESCRIPTION
# 🔨 테스크

### Issue
- #121 

### 회원탈퇴 API 메서드 수정

- `PATCH /user/deletion-requests/:token` → `DELETE /user/deletion-requests/:token` 변경
- 리소스를 삭제하는 의미이므로 RESTful 원칙에 맞게 DELETE 메서드 적용

### 탈퇴 사용자 차단 인증 추가

- JWT 만료 전에 탈퇴한 사용자가 API를 호출할 수 있는 문제 방지
- `refreshAccessToken`, `handleUpload`, `deleteFile`, 좋아요 생성/삭제, 댓글 삭제 시 `getUser()` 호출로 사용자 존재 여부 확인
- FileModule ↔ UserModule 순환 의존성 `forwardRef`로 해결

# 📋 작업 내용

- `DELETE /user/deletion-requests/:token` — HTTP 메서드 PATCH → DELETE 변경
- `UserService.refreshAccessToken()` — 토큰 재발급 전 사용자 존재 확인 추가 (async 변경)
- `FileService.handleUpload()` / `deleteFile()` — 파일 작업 전 사용자 존재 확인 추가
- `LikeService.create()` / `delete()` — 좋아요 작업 전 사용자 존재 확인 추가
- `CommentService.deleteComment()` — 댓글 삭제 전 사용자 존재 확인 추가
- `UserModule` / `FileModule` — 순환 참조 `forwardRef` 적용
- E2E 테스트 — 회원탈퇴 확인 API PATCH → DELETE 반영