### PR TITLE
🧼 clean: fetch -> axios 변경

### DIFF
--- a/email-worker/test/config/e2e/common/rabbitmq-test.helper.ts
+++ b/email-worker/test/config/e2e/common/rabbitmq-test.helper.ts
@@ -1,4 +1,5 @@
 import { Channel } from 'amqplib';
+import axios from 'axios';
 import { StartedTestContainer } from 'testcontainers';
 
 import { EmailPayload } from '@email/types';
@@ -47,30 +48,33 @@ export async function getMessagesFromQueue(
 
   const url = `http://${host}:${managementPort}/api/queues/%2f/${encodeURIComponent(queueName)}/get`;
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization:
-        'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64'),
-    },
-    body: JSON.stringify({
+  const response = await axios.post<RabbitMQRawMessage[]>(
+    url,
+    {
       count,
       ackmode: 'ack_requeue_true', // 메시지를 다시 큐에 넣음 (소비하지 않음)
       encoding: 'auto',
-    }),
-  });
+    },
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization:
+          'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64'),
+      },
+      validateStatus: () => true,
+    },
+  );
 
-  if (!response.ok) {
-    if (response.status === 404) {
-      return []; // 큐가 존재하지 않으면 빈 배열 반환
-    }
+  if (response.status === 404) {
+    return [];
+  }
+  if (response.status < 200 || response.status >= 300) {
     throw new Error(
       `Failed to get messages from queue: ${response.statusText}`,
     );
   }
 
-  const messages = (await response.json()) as RabbitMQRawMessage[];
+  const messages = response.data;
 
   return messages.map((msg) => ({
     content: JSON.parse(msg.payload) as EmailPayload,
@@ -178,7 +182,7 @@ export async function clearMailpit(): Promise<void> {
 
   const webPort = mailpitContainer.getMappedPort(8025);
   const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
-  await fetch(`${baseUrl}/api/v1/messages`, { method: 'DELETE' });
+  await axios.delete(`${baseUrl}/api/v1/messages`);
 }
 
 /**
@@ -191,7 +195,9 @@ export async function getMailpitMessages(): Promise<any[]> {
 
   const webPort = mailpitContainer.getMappedPort(8025);
   const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
-  const response = await fetch(`${baseUrl}/api/v1/messages`);
-  const data = (await response.json()) as { messages?: unknown[] };
+  const response = await axios.get<{ messages?: unknown[] }>(
+    `${baseUrl}/api/v1/messages`,
+  );
+  const data = response.data;
   return data.messages ?? [];
 }

--- a/email-worker/test/e2e/email-consumer.e2e-spec.ts
+++ b/email-worker/test/e2e/email-consumer.e2e-spec.ts
@@ -1,5 +1,7 @@
 import 'reflect-metadata';
 
+import axios from 'axios';
+
 import { setupTestContainer } from '@test/config/e2e/common/testContext.setup';
 import { StartedTestContainer } from 'testcontainers';
 
@@ -69,12 +71,10 @@ describe(`Email Normal Scenario E2E Test`, () => {
     const webPort = mailpitContainer.getMappedPort(8025);
     const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
 
-    const response = await fetch(`${baseUrl}/api/v1/messages`);
-    const data = (await response.json()) as MailpitResponse;
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
 
-    await fetch(`${baseUrl}/api/v1/messages`, {
-      method: 'DELETE',
-    });
+    await axios.delete(`${baseUrl}/api/v1/messages`);
 
     expect(data.messages).toHaveLength(1);
     expect(data.messages[0].To[0].Address).toBe('test@test.com');
@@ -109,12 +109,10 @@ describe(`Email Normal Scenario E2E Test`, () => {
     const webPort = mailpitContainer.getMappedPort(8025);
     const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
 
-    const response = await fetch(`${baseUrl}/api/v1/messages`);
-    const data = (await response.json()) as MailpitResponse;
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
 
-    await fetch(`${baseUrl}/api/v1/messages`, {
-      method: 'DELETE',
-    });
+    await axios.delete(`${baseUrl}/api/v1/messages`);
 
     expect(data.messages).toHaveLength(1);
     expect(data.messages[0].To[0].Address).toBe('test@test.com');
@@ -152,12 +150,10 @@ describe(`Email Normal Scenario E2E Test`, () => {
     const webPort = mailpitContainer.getMappedPort(8025);
     const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
 
-    const response = await fetch(`${baseUrl}/api/v1/messages`);
-    const data = (await response.json()) as MailpitResponse;
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
 
-    await fetch(`${baseUrl}/api/v1/messages`, {
-      method: 'DELETE',
-    });
+    await axios.delete(`${baseUrl}/api/v1/messages`);
 
     expect(data.messages).toHaveLength(1);
     expect(data.messages[0].To[0].Address).toBe('test@test.com');
@@ -196,12 +192,10 @@ describe(`Email Normal Scenario E2E Test`, () => {
     const webPort = mailpitContainer.getMappedPort(8025);
     const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
 
-    const response = await fetch(`${baseUrl}/api/v1/messages`);
-    const data = (await response.json()) as MailpitResponse;
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
 
-    await fetch(`${baseUrl}/api/v1/messages`, {
-      method: 'DELETE',
-    });
+    await axios.delete(`${baseUrl}/api/v1/messages`);
 
     expect(data.messages).toHaveLength(1);
     expect(data.messages[0].To[0].Address).toBe('test@test.com');
@@ -234,12 +228,10 @@ describe(`Email Normal Scenario E2E Test`, () => {
     const webPort = mailpitContainer.getMappedPort(8025);
     const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
 
-    const response = await fetch(`${baseUrl}/api/v1/messages`);
-    const data = (await response.json()) as MailpitResponse;
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
 
-    await fetch(`${baseUrl}/api/v1/messages`, {
-      method: 'DELETE',
-    });
+    await axios.delete(`${baseUrl}/api/v1/messages`);
 
     expect(data.messages).toHaveLength(1);
     expect(data.messages[0].To[0].Address).toBe('test@test.com');
@@ -272,12 +264,10 @@ describe(`Email Normal Scenario E2E Test`, () => {
     const webPort = mailpitContainer.getMappedPort(8025);
     const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
 
-    const response = await fetch(`${baseUrl}/api/v1/messages`);
-    const data = (await response.json()) as MailpitResponse;
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
 
-    await fetch(`${baseUrl}/api/v1/messages`, {
-      method: 'DELETE',
-    });
+    await axios.delete(`${baseUrl}/api/v1/messages`);
 
     expect(data.messages).toHaveLength(1);
     expect(data.messages[0].To[0].Address).toBe('test@test.com');

--- a/feed-crawler/src/common/parser/feed-parser-manager.ts
+++ b/feed-crawler/src/common/parser/feed-parser-manager.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { inject, injectable } from 'tsyringe';
 
 import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
@@ -26,18 +27,15 @@ export class FeedParserManager {
   async fetchAndParse(rssObj: RssObj, startTime: Date): Promise<FeedDetail[]> {
     this.metrics.total.inc({ type: 'scheduled' });
     try {
-      const response = await fetch(rssObj.rssUrl, {
+      const response = await axios.get<string>(rssObj.rssUrl, {
         headers: {
           Accept:
             'application/rss+xml, application/xml, text/xml, application/atom+xml',
         },
+        responseType: 'text',
       });
 
-      if (!response.ok) {
-        throw new Error(`${rssObj.rssUrl}에서 피드 데이터 가져오기 실패`);
-      }
-
-      const xmlData = await response.text();
+      const xmlData = response.data;
 
       const parser = this.findSuitableParser(xmlData);
       if (!parser) {
@@ -62,18 +60,15 @@ export class FeedParserManager {
   async fetchAndParseAll(rssObj: RssObj): Promise<FeedDetail[]> {
     this.metrics.total.inc({ type: 'full' });
     try {
-      const response = await fetch(rssObj.rssUrl, {
+      const response = await axios.get<string>(rssObj.rssUrl, {
         headers: {
           Accept:
             'application/rss+xml, application/xml, text/xml, application/atom+xml',
         },
+        responseType: 'text',
       });
 
-      if (!response.ok) {
-        throw new Error(`${rssObj.rssUrl}에서 피드 데이터 가져오기 실패`);
-      }
-
-      const xmlData = await response.text();
+      const xmlData = response.data;
 
       const parser = this.findSuitableParser(xmlData);
       if (!parser) {

--- a/feed-crawler/src/common/parser/utils/parser-util.ts
+++ b/feed-crawler/src/common/parser/utils/parser-util.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { injectable } from 'tsyringe';
 
 import { unescape } from 'html-escaper';
@@ -8,16 +9,18 @@ import logger from '@common/logger';
 @injectable()
 export class ParserUtil {
   async getThumbnailUrl(feedUrl: string) {
-    const response = await fetch(feedUrl, {
+    const response = await axios.get<string>(feedUrl, {
       headers: {
         Accept: 'text/html',
       },
+      responseType: 'text',
+      validateStatus: () => true,
     });
-    if (!response.ok) {
+    if (response.status < 200 || response.status >= 300) {
       throw new Error(`${feedUrl}에 GET 요청 실패`);
     }
 
-    const htmlData = await response.text();
+    const htmlData = response.data;
     const htmlRootElement = parse(htmlData);
     const metaImage = htmlRootElement.querySelector(
       'meta[property="og:image"]',

--- a/feed-crawler/test/unit/feed-parser-manager.spec.ts
+++ b/feed-crawler/test/unit/feed-parser-manager.spec.ts
@@ -1,5 +1,7 @@
 import 'reflect-metadata';
 
+import axios, { HttpStatusCode } from 'axios';
+
 import { FeedMetrics } from '@common/metrics/feed-metrics';
 import { Notifier } from '@common/notification/notifier.interface';
 import { FeedParserManager } from '@common/parser/feed-parser-manager';
@@ -7,14 +9,11 @@ import { Atom10Parser } from '@common/parser/formats/atom10-parser';
 import { Rss20Parser } from '@common/parser/formats/rss20-parser';
 import { FeedDetail, RssObj } from '@common/types';
 
-// fetch 모킹
-global.fetch = jest.fn();
-
 describe('FeedParserManager', () => {
   let feedParserManager: FeedParserManager;
   let mockRss20Parser: jest.Mocked<Rss20Parser>;
   let mockAtom10Parser: jest.Mocked<Atom10Parser>;
-  let mockFetch: jest.MockedFunction<typeof fetch>;
+  let mockAxiosGet: jest.SpyInstance;
   let mockNotifier: jest.Mocked<Notifier>;
   let mockFeedMetrics: jest.Mocked<FeedMetrics>;
   let rss20CanParseMock: jest.Mock;
@@ -46,7 +45,7 @@ describe('FeedParserManager', () => {
   ];
 
   beforeEach(() => {
-    mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+    mockAxiosGet = jest.spyOn(axios, 'get');
 
     rss20CanParseMock = jest.fn();
     rss20ParseFeedMock = jest.fn();
@@ -97,10 +96,10 @@ describe('FeedParserManager', () => {
     it('RSS 2.0 피드를 성공적으로 파싱해야 한다', async () => {
       // Given
       const rssXmlData = '<?xml version="1.0"?><rss version="2.0">...</rss>';
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(rssXmlData),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: rssXmlData,
+        status: HttpStatusCode.Ok,
+      });
       rss20CanParseMock.mockReturnValue(true);
       atom10CanParseMock.mockReturnValue(false);
       rss20ParseFeedMock.mockResolvedValue(mockFeedDetails);
@@ -112,11 +111,12 @@ describe('FeedParserManager', () => {
       );
 
       // Then
-      expect(mockFetch).toHaveBeenCalledWith(mockRssObj.rssUrl, {
+      expect(mockAxiosGet).toHaveBeenCalledWith(mockRssObj.rssUrl, {
         headers: {
           Accept:
             'application/rss+xml, application/xml, text/xml, application/atom+xml',
         },
+        responseType: 'text',
       });
       expect(rss20CanParseMock).toHaveBeenCalledWith(rssXmlData);
       expect(rss20ParseFeedMock).toHaveBeenCalledWith(
@@ -131,10 +131,10 @@ describe('FeedParserManager', () => {
       // Given
       const atomXmlData =
         '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom">...</feed>';
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(atomXmlData),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: atomXmlData,
+        status: HttpStatusCode.Ok,
+      });
       rss20CanParseMock.mockReturnValue(false);
       atom10CanParseMock.mockReturnValue(true);
       atom10ParseFeedMock.mockResolvedValue(mockFeedDetails);
@@ -157,10 +157,9 @@ describe('FeedParserManager', () => {
 
     it('HTTP 요청이 실패할 때 빈 배열을 반환해야 한다', async () => {
       // Given
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      } as any);
+      mockAxiosGet.mockRejectedValueOnce(
+        new Error('Request failed with status code 404'),
+      );
 
       // When
       const result = await feedParserManager.fetchAndParse(
@@ -175,10 +174,10 @@ describe('FeedParserManager', () => {
     it('지원하지 않는 피드 형식일 때 빈 배열을 반환해야 한다', async () => {
       // Given
       const invalidXmlData = '<?xml version="1.0"?><invalid>...</invalid>';
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(invalidXmlData),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: invalidXmlData,
+        status: HttpStatusCode.Ok,
+      });
       rss20CanParseMock.mockReturnValue(false);
       atom10CanParseMock.mockReturnValue(false);
 
@@ -195,10 +194,10 @@ describe('FeedParserManager', () => {
     it('파서에서 에러가 발생할 때 빈 배열을 반환해야 한다', async () => {
       // Given
       const rssXmlData = '<?xml version="1.0"?><rss version="2.0">...</rss>';
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(rssXmlData),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: rssXmlData,
+        status: HttpStatusCode.Ok,
+      });
       rss20CanParseMock.mockReturnValue(true);
       rss20ParseFeedMock.mockRejectedValueOnce(new Error('Parser error'));
 
@@ -217,10 +216,10 @@ describe('FeedParserManager', () => {
     const startTime = new Date('2024-01-01T12:00:00Z');
     it('빈 응답을 처리해야 한다', async () => {
       // Given
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(''),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: '',
+        status: HttpStatusCode.Ok,
+      });
       rss20CanParseMock.mockReturnValue(false);
       atom10CanParseMock.mockReturnValue(false);
 
@@ -240,10 +239,10 @@ describe('FeedParserManager', () => {
         '<?xml version="1.0"?><rss version="2.0">' +
         'x'.repeat(10000) +
         '</rss>';
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(largeXmlData),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: largeXmlData,
+        status: HttpStatusCode.Ok,
+      });
       rss20CanParseMock.mockReturnValue(true);
       rss20ParseFeedMock.mockResolvedValue(mockFeedDetails);
 

--- a/feed-crawler/test/unit/parser-util.spec.ts
+++ b/feed-crawler/test/unit/parser-util.spec.ts
@@ -1,17 +1,16 @@
 import 'reflect-metadata';
 
-import { ParserUtil } from '@common/parser/utils/parser-util';
+import axios, { HttpStatusCode } from 'axios';
 
-// fetch 모킹
-global.fetch = jest.fn();
+import { ParserUtil } from '@common/parser/utils/parser-util';
 
 describe('ParserUtil', () => {
   let parserUtil: ParserUtil;
-  let mockFetch: jest.MockedFunction<typeof fetch>;
+  let mockAxiosGet: jest.SpyInstance;
 
   beforeEach(() => {
     parserUtil = new ParserUtil();
-    mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+    mockAxiosGet = jest.spyOn(axios, 'get');
   });
 
   afterEach(() => {
@@ -31,17 +30,19 @@ describe('ParserUtil', () => {
           </head>
         </html>
       `;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(htmlContent),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: htmlContent,
+        status: HttpStatusCode.Ok,
+      });
 
       // When
       const result = await parserUtil.getThumbnailUrl(feedUrl);
 
       // Then
-      expect(mockFetch).toHaveBeenCalledWith(feedUrl, {
+      expect(mockAxiosGet).toHaveBeenCalledWith(feedUrl, {
         headers: { Accept: 'text/html' },
+        responseType: 'text',
+        validateStatus: expect.any(Function),
       });
       expect(result).toBe(absoluteThumbnailUrl);
     });
@@ -57,10 +58,10 @@ describe('ParserUtil', () => {
           </head>
         </html>
       `;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(htmlContent),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: htmlContent,
+        status: HttpStatusCode.Ok,
+      });
 
       // When
       const result = await parserUtil.getThumbnailUrl(feedUrl);
@@ -78,10 +79,10 @@ describe('ParserUtil', () => {
           </head>
         </html>
       `;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(htmlContent),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: htmlContent,
+        status: HttpStatusCode.Ok,
+      });
 
       // When
       const result = await parserUtil.getThumbnailUrl(feedUrl);
@@ -99,10 +100,10 @@ describe('ParserUtil', () => {
           </head>
         </html>
       `;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(htmlContent),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: htmlContent,
+        status: HttpStatusCode.Ok,
+      });
 
       // When
       const result = await parserUtil.getThumbnailUrl(feedUrl);
@@ -113,10 +114,10 @@ describe('ParserUtil', () => {
 
     it('HTTP 요청이 실패할 때 에러를 던져야 한다', async () => {
       // Given
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: null,
+        status: HttpStatusCode.NotFound,
+      });
 
       // When & Then
       await expect(parserUtil.getThumbnailUrl(feedUrl)).rejects.toThrow(
@@ -127,7 +128,7 @@ describe('ParserUtil', () => {
     it('fetch 자체가 실패할 때 에러를 던져야 한다', async () => {
       // Given
       const networkError = new Error('Network error');
-      mockFetch.mockRejectedValueOnce(networkError);
+      mockAxiosGet.mockRejectedValueOnce(networkError);
 
       // When & Then
       await expect(parserUtil.getThumbnailUrl(feedUrl)).rejects.toThrow(
@@ -156,10 +157,10 @@ describe('ParserUtil', () => {
           </body>
         </html>
       `;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(complexHtmlContent),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: complexHtmlContent,
+        status: HttpStatusCode.Ok,
+      });
 
       // When
       const result = await parserUtil.getThumbnailUrl(feedUrl);
@@ -180,10 +181,10 @@ describe('ParserUtil', () => {
           </head>
         </html>
       `;
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        text: () => Promise.resolve(htmlContent),
-      } as any);
+      mockAxiosGet.mockResolvedValueOnce({
+        data: htmlContent,
+        status: HttpStatusCode.Ok,
+      });
 
       // When
       const result = await parserUtil.getThumbnailUrl(subdomainUrl);

--- a/feed-crawler/test/unit/parser.spec.ts
+++ b/feed-crawler/test/unit/parser.spec.ts
@@ -7,6 +7,7 @@ import {
   MOCK_RSS_OBJ,
   RSS_20_SAMPLE,
 } from '@test/config/constant/parser-fixtures';
+import axios, { HttpStatusCode } from 'axios';
 
 import { FeedMetrics } from '@common/metrics/feed-metrics';
 import { Notifier } from '@common/notification/notifier.interface';
@@ -21,6 +22,7 @@ describe('Parser 모듈 테스트', () => {
   let atom10Parser: Atom10Parser;
   let feedParserManager: FeedParserManager;
   let notifier: Notifier;
+  let mockAxiosGet: jest.SpyInstance;
 
   const mockFeedMetrics = {
     total: { inc: jest.fn() },
@@ -42,24 +44,23 @@ describe('Parser 모듈 테스트', () => {
       mockFeedMetrics,
     );
 
-    // URL 기반 조건부 fetch 모킹 (순서 의존성 제거)
-    global.fetch = jest.fn().mockImplementation((url: string) => {
-      // RSS/Atom 피드 URL
-      if (url.includes('/rss') || url.includes('denamu.site')) {
+    // URL 기반 조건부 axios 모킹 (순서 의존성 제거)
+    mockAxiosGet = jest
+      .spyOn(axios, 'get')
+      .mockImplementation((url: string) => {
+        // RSS/Atom 피드 URL
+        if (url.includes('/rss') || url.includes('denamu.site')) {
+          return Promise.resolve({
+            data: RSS_20_SAMPLE,
+            status: HttpStatusCode.Ok,
+          });
+        }
+        // HTML 페이지 (og:image 추출용)
         return Promise.resolve({
-          ok: true,
-          text: () => Promise.resolve(RSS_20_SAMPLE),
+          data: '<html><head><meta property="og:image" content="https://example.com/image.jpg"></head></html>',
+          status: HttpStatusCode.Ok,
         });
-      }
-      // HTML 페이지 (og:image 추출용)
-      return Promise.resolve({
-        ok: true,
-        text: () =>
-          Promise.resolve(
-            '<html><head><meta property="og:image" content="https://example.com/image.jpg"></head></html>',
-          ),
       });
-    });
   });
 
   afterEach(() => {
@@ -88,19 +89,16 @@ describe('Parser 모듈 테스트', () => {
       describe('RSS 2.0 피드', () => {
         beforeEach(() => {
           // URL 기반 조건부 모킹으로 순서 의존성 제거
-          (global.fetch as jest.Mock).mockImplementation((url: string) => {
+          mockAxiosGet.mockImplementation((url: string) => {
             if (url.includes('/rss') || url.includes('denamu.dev')) {
               return Promise.resolve({
-                ok: true,
-                text: () => Promise.resolve(RSS_20_SAMPLE),
+                data: RSS_20_SAMPLE,
+                status: HttpStatusCode.Ok,
               });
             }
             return Promise.resolve({
-              ok: true,
-              text: () =>
-                Promise.resolve(
-                  '<html><head><meta property="og:image" content="https://example.com/image.jpg"></head></html>',
-                ),
+              data: '<html><head><meta property="og:image" content="https://example.com/image.jpg"></head></html>',
+              status: HttpStatusCode.Ok,
             });
           });
         });
@@ -130,19 +128,16 @@ describe('Parser 모듈 테스트', () => {
       describe('Atom 1.0 피드', () => {
         beforeEach(() => {
           // URL 기반 조건부 모킹으로 순서 의존성 제거
-          (global.fetch as jest.Mock).mockImplementation((url: string) => {
+          mockAxiosGet.mockImplementation((url: string) => {
             if (url.includes('/rss') || url.includes('denamu.dev')) {
               return Promise.resolve({
-                ok: true,
-                text: () => Promise.resolve(ATOM_10_SAMPLE),
+                data: ATOM_10_SAMPLE,
+                status: HttpStatusCode.Ok,
               });
             }
             return Promise.resolve({
-              ok: true,
-              text: () =>
-                Promise.resolve(
-                  '<html><head><meta property="og:image" content="https://example.com/image.jpg"></head></html>',
-                ),
+              data: '<html><head><meta property="og:image" content="https://example.com/image.jpg"></head></html>',
+              status: HttpStatusCode.Ok,
             });
           });
         });

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -1,5 +1,6 @@
 import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
 
+import axios from 'axios';
 import { Request, Response } from 'express';
 
 import { cookieConfig } from '@common/cookie/cookie.config';
@@ -253,7 +254,7 @@ export class FeedService {
 
   async deleteCheckFeed(feedDeleteCheckDto: ManageFeedRequestDto) {
     const feed = await this.getFeed(feedDeleteCheckDto.feedId);
-    const response = await fetch(feed.path);
+    const response = await axios.get(feed.path, { validateStatus: () => true });
 
     if (response.status === Number(HttpStatus.NOT_FOUND)) {
       await this.feedRepository.delete({ id: feedDeleteCheckDto.feedId });

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -5,6 +5,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 
+import axios from 'axios';
 import * as uuid from 'uuid';
 import { DataSource } from 'typeorm';
 
@@ -84,13 +85,13 @@ export class RssService {
       throw new NotFoundException('신청 목록에서 사라진 등록 요청입니다.');
     }
 
-    const preFetchResponse = await fetch(rss.rssUrl, {
-      headers: {
-        Accept: 'application/rss+xml, application/xml, text/xml',
-      },
-    });
-
-    if (!preFetchResponse.ok) {
+    try {
+      await axios.get(rss.rssUrl, {
+        headers: {
+          Accept: 'application/rss+xml, application/xml, text/xml',
+        },
+      });
+    } catch {
       throw new BadRequestException(`${rss.rssUrl}이 올바른 RSS가 아닙니다.`);
     }
 

--- a/server/test/feed/e2e/delete-check.e2e-spec.ts
+++ b/server/test/feed/e2e/delete-check.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
 
+import axios from 'axios';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
@@ -35,6 +36,10 @@ describe(`HEAD ${URL}/{feedId} E2E Test`, () => {
     feed = await feedRepository.save(FeedFixture.createFeedFixture(rssAccept));
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('[404] 존재하지 않는 게시글 ID에 요청을 보낼 경우 404를 응답한다.', async () => {
     // Http when
     const response = await agent.head(`${URL}/${Number.MAX_SAFE_INTEGER}`);
@@ -55,9 +60,7 @@ describe(`HEAD ${URL}/{feedId} E2E Test`, () => {
 
   it('[404] 원본 게시글이 존재하지 않을 경우 서비스에서 게시글 정보를 삭제하여 조회를 실패한다.', async () => {
     // given
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ ok: false, status: HttpStatus.NOT_FOUND });
+    jest.spyOn(axios, 'get').mockResolvedValue({ data: null, status: HttpStatus.NOT_FOUND });
 
     // Http when
     const response = await agent.head(`${URL}/${feed.id}`);
@@ -78,9 +81,7 @@ describe(`HEAD ${URL}/{feedId} E2E Test`, () => {
 
   it('[200] 원본 게시글이 존재할 경우 조회를 성공한다.', async () => {
     // given
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ ok: true, status: HttpStatus.OK });
+    jest.spyOn(axios, 'get').mockResolvedValue({ data: null, status: HttpStatus.OK });
 
     // Http when
     const response = await agent.head(`${URL}/${feed.id}`);

--- a/server/test/rss/e2e/accept.e2e-spec.ts
+++ b/server/test/rss/e2e/accept.e2e-spec.ts
@@ -1,5 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
 
+import axios from 'axios';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
@@ -38,6 +39,10 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
       rssRepository.save(RssFixture.createRssFixture()),
       redisService.set(redisKeyMake(sessionKey), 'test1234'),
     ]);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('[401] 관리자 로그인 쿠키가 없을 경우 RSS 승인을 실패한다.', async () => {
@@ -118,10 +123,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
   it('[400] 잘못된 RSS URL을 승인할 경우 RSS 승인을 실패한다.', async () => {
     // given
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      status: HttpStatus.BAD_REQUEST,
-    });
+    jest.spyOn(axios, 'get').mockRejectedValue(new Error('Request failed'));
 
     // Http when
     const response = await agent
@@ -150,10 +152,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
   it('[201] 관리자 로그인이 되어 있을 경우 RSS 승인을 성공한다.', async () => {
     // given
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true,
-      status: HttpStatus.OK,
-    });
+    jest.spyOn(axios, 'get').mockResolvedValue({ data: '', status: HttpStatus.OK });
 
     // Http when
     const response = await agent


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #651
- #652
- #121 

### fetch → axios 전환

- 프로젝트 전반에 걸쳐 Native `fetch` API를 `axios`로 통일하였습니다.
- `axios`는 이미 프로젝트에 설치된 의존성으로, HTTP 요청 방식을 일관되게 유지하기 위해 마이그레이션하였습니다.

### 주요 변경 사항

- `fetch(url).then(r => r.text())` 패턴을 `axios.get(url, { responseType: 'text' }).then(r => r.data)`로 교체
- `response.ok` 체크를 `axios`의 기본 예외 처리(4xx/5xx → throw) 또는 `validateStatus` 옵션으로 대체
- 관련 테스트 코드(`email-worker`, `feed-crawler`, `server`) mock 방식을 `axios` 기반으로 수정

# 📋 작업 내용

- `server/src/feed/service/feed.service.ts`: `fetch` → `axios.get` (validateStatus로 404 감지)
- `server/src/rss/service/rss.service.ts`: `fetch` → `axios.get` (예외 catch로 RSS URL 유효성 검증)
- `feed-crawler/src/common/parser/feed-parser-manager.ts`: `fetch` → `axios.get` (responseType: 'text')
- `feed-crawler/src/common/parser/utils/parser-util.ts`: `fetch` → `axios.get` (validateStatus + responseType: 'text')
- 테스트 파일 11개: axios mock 방식에 맞게 수정

# 📷 스크린 샷(선택 사항)

해당 없음