### PR TITLE
✨ feat: RSS 블로그 이름/URL 중복 검증 및 DB Unique 제약 추가

### DIFF
--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -15,7 +15,9 @@ CREATE TABLE `rss` (
   `user_name` varchar(50) NOT NULL,
   `email` varchar(255) NOT NULL,
   `rss_url` varchar(255) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UQ_21beac47feacb87e57c59d6958f` (`name`),
+  UNIQUE KEY `UQ_af1d102908727aa95ef09e16065` (`rss_url`)
 );
 
 -- denamu.rss_accept definition
@@ -28,6 +30,8 @@ CREATE TABLE `rss_accept` (
   `rss_url` varchar(255) NOT NULL,
   `blog_platform` varchar(255) NOT NULL DEFAULT 'etc',
   PRIMARY KEY (`id`),
+  UNIQUE KEY `UQ_59f4be4de3817b3f975acff0766` (`name`),
+  UNIQUE KEY `UQ_b3a5d4196368864d938dae4e9ff` (`rss_url`),
   FULLTEXT KEY (`name`)
 );
 
@@ -153,18 +157,6 @@ CREATE TABLE `provider` (
   PRIMARY KEY (`id`),
   KEY `FK_d3d18186b602240b93c9f1621ea` (`user_id`),
   CONSTRAINT `FK_d3d18186b602240b93c9f1621ea` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-);
-
--- denamu.rss_remove definition
-
-CREATE TABLE `rss_remove` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `request_date` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `reason` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  `blog_id` int NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `REL_69e45fd3ff04dac43a89e1951e` (`blog_id`),
-  CONSTRAINT `FK_69e45fd3ff04dac43a89e1951e4` FOREIGN KEY (`blog_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.admin insert data
@@ -391,8 +383,3 @@ INSERT INTO activity (activity_date, view_count, user_id) VALUES
 INSERT INTO likes(feed_id, user_id, like_date) VALUES
 	(94,1,'2025-06-13 17:47:05.575811'),
 	(95,1,'2025-06-13 17:47:07.575811');
-
--- denamu.rss_remove insert data
-
-INSERT INTO rss_remove(request_date, reason, blog_id) VALUES
-	('2025-07-01 11:48:00.575811', 'example reason', 1);

--- a/feed-crawler/test/config/e2e/global/jest.global-setup.ts
+++ b/feed-crawler/test/config/e2e/global/jest.global-setup.ts
@@ -13,7 +13,9 @@ export default async function globalSetup() {
   await createMysqlContainer();
   await createDatabaseTable();
   const elapsedMs = Number(process.hrtime.bigint() - startTime) / 1_000_000;
-  console.log(`Global setup completed. Elapsed time: ${elapsedMs.toFixed(2)} ms`);
+  console.log(
+    `Global setup completed. Elapsed time: ${elapsedMs.toFixed(2)} ms`,
+  );
 }
 
 const createMysqlContainer = async () => {
@@ -43,6 +45,8 @@ const createDatabaseTable = async () => {
       rss_url varchar(255) NOT NULL,
       blog_platform varchar(255) NOT NULL DEFAULT 'etc',
       PRIMARY KEY (id),
+      UNIQUE KEY UK_rss_accept_name (name),
+      UNIQUE KEY UK_rss_accept_rss_url (rss_url),
       FULLTEXT KEY IDX_59f4be4de3817b3f975acff076 (name)
     ) ;
     `,

--- a/server/src/common/database/migration/1780396210573-AddRssNameUrlUnique.ts
+++ b/server/src/common/database/migration/1780396210573-AddRssNameUrlUnique.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRssNameUrlUnique1780396210573 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `rss` ADD UNIQUE `UQ_21beac47feacb87e57c59d6958f` (`name`);',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss` ADD UNIQUE `UQ_af1d102908727aa95ef09e16065` (`rss_url`);',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` ADD UNIQUE `UQ_59f4be4de3817b3f975acff0766` (`name`);',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` ADD UNIQUE `UQ_b3a5d4196368864d938dae4e9ff` (`rss_url`);',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP INDEX `UQ_b3a5d4196368864d938dae4e9ff`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP INDEX `UQ_59f4be4de3817b3f975acff0766`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss` DROP INDEX `UQ_af1d102908727aa95ef09e16065`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss` DROP INDEX `UQ_21beac47feacb87e57c59d6958f`;',
+    );
+  }
+}

--- a/server/src/common/database/migration/1780482000000-RenameRssAcceptNameFulltext.ts
+++ b/server/src/common/database/migration/1780482000000-RenameRssAcceptNameFulltext.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RenameRssAcceptNameFulltext1780482000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP INDEX `name`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` ADD FULLTEXT INDEX `FT_rss_accept_name` (`name`) WITH PARSER ngram;',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP INDEX `FT_rss_accept_name`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` ADD FULLTEXT INDEX `name` (`name`);',
+    );
+  }
+}

--- a/server/src/rss/entity/rss.entity.ts
+++ b/server/src/rss/entity/rss.entity.ts
@@ -5,7 +5,6 @@ import {
   Index,
   OneToMany,
   PrimaryGeneratedColumn,
-  Unique,
 } from 'typeorm';
 
 import { Feed } from '@feed/entity/feed.entity';
@@ -44,9 +43,13 @@ export class RssInformation extends BaseEntity {
 @Entity({
   name: 'rss',
 })
-@Unique(['name'])
-@Unique(['rssUrl'])
-export class Rss extends RssInformation {}
+export class Rss extends RssInformation {
+  @Column({ name: 'name', nullable: false, unique: true })
+  name: string;
+
+  @Column({ name: 'rss_url', length: 255, nullable: false, unique: true })
+  rssUrl: string;
+}
 
 @Entity({
   name: 'rss_reject',
@@ -62,15 +65,16 @@ export class RssReject extends RssInformation {
 @Entity({
   name: 'rss_accept',
 })
-@Unique(['name'])
-@Unique(['rssUrl'])
 export class RssAccept extends RssInformation {
   @OneToMany(() => Feed, (feed) => feed.blog)
   feeds: Feed[];
 
-  @Index({ fulltext: true, parser: 'ngram' })
-  @Column({ name: 'name', nullable: false })
+  @Index('FT_rss_accept_name', { fulltext: true, parser: 'ngram' })
+  @Column({ name: 'name', nullable: false, unique: true })
   name: string;
+
+  @Column({ name: 'rss_url', length: 255, nullable: false, unique: true })
+  rssUrl: string;
 
   @Column({ name: 'blog_platform', default: 'etc', nullable: false })
   blogPlatform: string;

--- a/server/src/rss/entity/rss.entity.ts
+++ b/server/src/rss/entity/rss.entity.ts
@@ -5,6 +5,7 @@ import {
   Index,
   OneToMany,
   PrimaryGeneratedColumn,
+  Unique,
 } from 'typeorm';
 
 import { Feed } from '@feed/entity/feed.entity';
@@ -43,6 +44,8 @@ export class RssInformation extends BaseEntity {
 @Entity({
   name: 'rss',
 })
+@Unique(['name'])
+@Unique(['rssUrl'])
 export class Rss extends RssInformation {}
 
 @Entity({
@@ -59,6 +62,8 @@ export class RssReject extends RssInformation {
 @Entity({
   name: 'rss_accept',
 })
+@Unique(['name'])
+@Unique(['rssUrl'])
 export class RssAccept extends RssInformation {
   @OneToMany(() => Feed, (feed) => feed.blog)
   feeds: Feed[];

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -45,25 +45,21 @@ export class RssService {
   ) {}
 
   async createRss(rssRegisterBodyDto: RegisterRssRequestDto) {
-    const [alreadyURLRss, alreadyURLBlog] = await Promise.all([
+    const { blog, rssUrl } = rssRegisterBodyDto;
+    const [duplicateRss, duplicateBlog] = await Promise.all([
       this.rssRepository.findOne({
-        where: {
-          rssUrl: rssRegisterBodyDto.rssUrl,
-        },
+        where: [{ rssUrl }, { name: blog }],
       }),
       this.rssAcceptRepository.findOne({
-        where: {
-          rssUrl: rssRegisterBodyDto.rssUrl,
-        },
+        where: [{ rssUrl }, { name: blog }],
       }),
     ]);
 
-    if (alreadyURLRss || alreadyURLBlog) {
-      throw new ConflictException(
-        alreadyURLRss
-          ? '이미 신청된 RSS URL입니다.'
-          : '이미 등록된 RSS URL입니다.',
-      );
+    if (duplicateRss || duplicateBlog) {
+      const status = duplicateRss ? '신청' : '등록';
+      const duplicate = duplicateRss ?? duplicateBlog;
+      const field = duplicate.rssUrl === rssUrl ? 'RSS URL' : '블로그 이름';
+      throw new ConflictException(`이미 ${status}된 ${field}입니다.`);
     }
 
     await this.rssRepository.insert(rssRegisterBodyDto.toEntity());

--- a/server/test/config/common/fixture/rss-accept.fixture.ts
+++ b/server/test/config/common/fixture/rss-accept.fixture.ts
@@ -5,7 +5,7 @@ import { RssAccept } from '@rss/entity/rss.entity';
 export class RssAcceptFixture {
   static createGeneralRssAccept() {
     return {
-      name: 'test name',
+      name: `test name ${uuid.v4()}`,
       userName: 'test user name',
       email: `test${uuid.v4()}@test.com`,
       rssUrl: `https://example${uuid.v4()}.com/rss`,

--- a/server/test/config/common/fixture/rss.fixture.ts
+++ b/server/test/config/common/fixture/rss.fixture.ts
@@ -5,7 +5,7 @@ import { Rss } from '@rss/entity/rss.entity';
 export class RssFixture {
   static createGeneralRss(): Partial<Rss> {
     return {
-      name: 'test',
+      name: `test${uuid.v4()}`,
       userName: 'test',
       email: `test${uuid.v4()}@test.com`,
       rssUrl: `https://test${uuid.v4()}.com/rss`,


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 관련 이슈 없음 (RSS 중복 신청/등록 방어)

### RSS 신청 중복 검증 강화

- 기존에는 `rss_url` 중복만 검사했으나, 동일한 블로그 이름(`name`)으로도 중복 신청/등록이 가능한 허점이 있었습니다.
- `createRss`에서 `rss`, `rss_accept` 양쪽 테이블에 대해 `rssUrl` **또는** `name` 일치 여부를 조회하도록 확장했습니다.
- 충돌 시 어떤 필드(RSS URL / 블로그 이름)가, 어떤 상태(신청 / 등록)에서 중복인지 메시지로 구분해 반환합니다.

### DB Unique 제약 추가 (데이터 무결성)

- 애플리케이션 레벨 검증만으로는 동시 요청(race condition) 시 중복 INSERT를 막을 수 없습니다.
- `rss`, `rss_accept` 테이블의 `name`, `rss_url` 컬럼에 DB Unique 제약을 추가해 최종 방어선을 확보했습니다.
- TypeORM `@Unique` 데코레이터, 마이그레이션, `init.sql`을 함께 반영했습니다.

### rss_remove 테이블 제거

- 현재 사용되지 않는 `rss_remove` 테이블 정의 및 더미 데이터를 `init.sql`에서 제거했습니다.

# 📋 작업 내용

- `rss.service.ts`: 중복 검증 조건을 `rssUrl` + `name` 으로 확장, 충돌 메시지 구분
- `rss.entity.ts`: `Rss`, `RssAccept` 엔티티에 `@Unique(['name'])`, `@Unique(['rssUrl'])` 추가
- `1780396210573-AddRssNameUrlUnique.ts`: Unique 제약 추가/롤백 마이그레이션 작성
- `docker-compose/db/init.sql`: Unique Key 반영 및 `rss_remove` 테이블 제거
- 관련 fixture 데이터 정리

# 📷 스크린 샷(선택 사항)

해당 없음