### PR TITLE
✨ feat: [BE] 파일 삭제 시 소유자 확인 추가

### DIFF
--- a/server/src/file/controller/file.controller.ts
+++ b/server/src/file/controller/file.controller.ts
@@ -62,12 +62,14 @@ export class FileController {
     );
   }
 
-  // TODO: 권한검사 추가
   @Delete(':id')
   @ApiDeleteFile()
   @HttpCode(HttpStatus.OK)
-  async deleteFile(@Param() fileDeleteRequestDto: DeleteFileParamRequestDto) {
-    await this.fileService.deleteFile(fileDeleteRequestDto.id);
+  async deleteFile(
+    @Param() fileDeleteRequestDto: DeleteFileParamRequestDto,
+    @CurrentUser() user: Payload,
+  ) {
+    await this.fileService.deleteFile(fileDeleteRequestDto.id, user.id);
     return ApiResponse.responseWithNoContent(
       '파일이 성공적으로 삭제되었습니다.',
     );

--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 
 import * as fs from 'fs/promises';
 import * as path from 'path';
@@ -64,15 +68,22 @@ export class FileService {
   }
 
   async findById(id: number): Promise<File> {
-    const file = await this.fileRepository.findOne({ where: { id } });
+    const file = await this.fileRepository.findOne({
+      where: { id },
+      relations: ['user'],
+    });
     if (!file) {
       throw new NotFoundException('파일을 찾을 수 없습니다.');
     }
     return file;
   }
 
-  async deleteFile(id: number): Promise<void> {
+  async deleteFile(id: number, userId: number): Promise<void> {
     const file = await this.findById(id);
+
+    if (file.user.id !== userId) {
+      throw new UnauthorizedException('파일 삭제 권한이 없습니다.');
+    }
 
     try {
       await access(file.path);

--- a/server/test/file/e2e/delete.e2e-spec.ts
+++ b/server/test/file/e2e/delete.e2e-spec.ts
@@ -57,6 +57,32 @@ describe(`DELETE ${URL}/{fileId} E2E Test`, () => {
     expect(savedFile).not.toBeNull();
   });
 
+  it('[401] 파일 소유자가 아닌 다른 사용자가 삭제 요청할 경우 파일 삭제를 실패한다.', async () => {
+    // given
+    const otherUser = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const otherAccessToken = createAccessToken(otherUser);
+
+    // Http when
+    const response = await agent
+      .delete(`${URL}/${file.id}`)
+      .set('Authorization', `Bearer ${otherAccessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedFile = await fileRepository.findOneBy({
+      id: file.id,
+    });
+
+    // DB, Redis then
+    expect(savedFile).not.toBeNull();
+  });
+
   it('[404] 파일이 서비스에 존재하지 않을 경우 파일 삭제를 실패한다.', async () => {
     // given
     jest.spyOn(fs, 'access').mockResolvedValue(undefined);


### PR DESCRIPTION
# 🔨 테스크

### Issue
- #121 

### 파일 소유자 확인 로직 추가

- 파일 삭제 API에 권한 검사가 없어 다른 사용자가 임의로 파일을 삭제할 수 있는 보안 취약점이 존재했습니다.
- `@CurrentUser()` 데코레이터로 현재 로그인한 사용자를 주입받아 파일 소유자와 비교하도록 수정했습니다.

### 테스트 케이스 추가

- 파일 소유자가 아닌 다른 사용자가 삭제 요청 시 401 응답 및 파일이 DB에 그대로 남는지 E2E 검증

# 📋 작업 내용

- `FileController.deleteFile`: `@CurrentUser()` 주입 추가, `user.id` 서비스로 전달
- `FileService.findById`: `relations: ['user']` 추가하여 소유자 정보 로드
- `FileService.deleteFile`: `userId` 파라미터 추가, 소유자 불일치 시 `UnauthorizedException` throw
- `delete.e2e-spec.ts`: 비소유자 삭제 요청 401 테스트 케이스 추가