### PR TITLE
✅ test: 서버 서비스 계층 단위 테스트 작성

### DIFF
--- a/server/test/activity/unit/activity.service.unit.spec.ts
+++ b/server/test/activity/unit/activity.service.unit.spec.ts
@@ -1,0 +1,126 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ActivityRepository } from '@activity/repository/activity.repository';
+import { ActivityService } from '@activity/service/activity.service';
+
+import { User } from '@user/entity/user.entity';
+import { UserService } from '@user/service/user.service';
+
+import { ActivityFixture } from '@test/config/common/fixture/activity.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+
+describe(`${ActivityService.name} Unit Test`, () => {
+  let activityService: ActivityService;
+  let activityRepository: jest.Mocked<
+    Pick<ActivityRepository, 'upsertByUserId' | 'findActivitiesByUserIdAndYear'>
+  >;
+  let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
+
+  beforeEach(async () => {
+    activityRepository = {
+      upsertByUserId: jest.fn(),
+      findActivitiesByUserIdAndYear: jest.fn(),
+    };
+    userService = {
+      getUser: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ActivityService,
+        { provide: ActivityRepository, useValue: activityRepository },
+        { provide: UserService, useValue: userService },
+      ],
+    }).compile();
+
+    activityService = module.get(ActivityService);
+  });
+
+  describe('readActivities', () => {
+    let user: User;
+    const userId = 1;
+    const year = 2024;
+
+    beforeEach(() => {
+      user = UserFixture.createUserFixture();
+      userService.getUser.mockResolvedValue(user);
+    });
+
+    it('조회된 활동을 날짜별 DTO로 매핑하고 사용자 스트릭 정보와 함께 반환한다.', async () => {
+      // given
+      const activities = ActivityFixture.createActivitiesFixture(user, 3);
+      activityRepository.findActivitiesByUserIdAndYear.mockResolvedValue(
+        activities,
+      );
+
+      // when
+      const result = await activityService.readActivities(userId, year);
+
+      // then
+      expect(result).toEqual({
+        dailyActivities: activities.map((activity) => ({
+          date: activity.activityDate.toISOString().split('T')[0],
+          viewCount: activity.viewCount,
+        })),
+        maxStreak: user.maxStreak,
+        currentStreak: user.currentStreak,
+        totalViews: user.totalViews,
+      });
+    });
+
+    it('userId와 year를 그대로 의존성에 위임한다.', async () => {
+      // given
+      activityRepository.findActivitiesByUserIdAndYear.mockResolvedValue([]);
+
+      // when
+      await activityService.readActivities(userId, year);
+
+      // then
+      expect(userService.getUser).toHaveBeenCalledWith(userId);
+      expect(
+        activityRepository.findActivitiesByUserIdAndYear,
+      ).toHaveBeenCalledWith(userId, year);
+    });
+
+    it('활동이 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      activityRepository.findActivitiesByUserIdAndYear.mockResolvedValue([]);
+
+      // when
+      const result = await activityService.readActivities(userId, year);
+
+      // then
+      expect(result.dailyActivities).toStrictEqual([]);
+    });
+
+    it('존재하지 않는 사용자면 NotFoundException을 전파하고 활동을 조회하지 않는다.', async () => {
+      // given
+      userService.getUser.mockRejectedValue(
+        new NotFoundException('존재하지 않는 유저입니다.'),
+      );
+
+      // when & then
+      await expect(
+        activityService.readActivities(userId, year),
+      ).rejects.toThrow(NotFoundException);
+      expect(
+        activityRepository.findActivitiesByUserIdAndYear,
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('upsertActivity', () => {
+    it('userId로 활동 upsert를 위임한다.', async () => {
+      // given
+      const userId = 1;
+      activityRepository.upsertByUserId.mockResolvedValue();
+
+      // when
+      await activityService.upsertActivity(userId);
+
+      // then
+      expect(activityRepository.upsertByUserId).toHaveBeenCalledWith(userId);
+    });
+  });
+});

--- a/server/test/admin/unit/admin.service.unit.spec.ts
+++ b/server/test/admin/unit/admin.service.unit.spec.ts
@@ -1,0 +1,197 @@
+import { ConflictException, UnauthorizedException } from '@nestjs/common';
+
+import { Request, Response } from 'express';
+
+import { SESSION_TTL } from '@admin/constant/admin.constant';
+import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
+import { AdminRepository } from '@admin/repository/admin.repository';
+import { AdminService } from '@admin/service/admin.service';
+
+import { cookieConfig } from '@common/cookie/cookie.config';
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import {
+  ADMIN_DEFAULT_PASSWORD,
+  AdminFixture,
+} from '@test/config/common/fixture/admin.fixture';
+
+describe(`${AdminService.name} Unit Test`, () => {
+  let adminService: AdminService;
+  let adminRepository: jest.Mocked<Pick<AdminRepository, 'findOne' | 'save'>>;
+  let redisService: jest.Mocked<Pick<RedisService, 'get' | 'set' | 'del'>>;
+
+  const createResponse = () =>
+    ({
+      cookie: jest.fn(),
+      clearCookie: jest.fn(),
+    }) as unknown as Response;
+
+  const createRequest = (cookies: Record<string, string> = {}) =>
+    ({ cookies }) as unknown as Request;
+
+  beforeEach(() => {
+    adminRepository = { findOne: jest.fn(), save: jest.fn() };
+    redisService = { get: jest.fn(), set: jest.fn(), del: jest.fn() };
+
+    adminService = new AdminService(
+      adminRepository as unknown as AdminRepository,
+      redisService as unknown as RedisService,
+    );
+  });
+
+  describe('loginAdmin', () => {
+    const loginDto = {
+      loginId: 'admin-id',
+      password: ADMIN_DEFAULT_PASSWORD,
+    };
+
+    it('존재하지 않는 아이디면 UnauthorizedException을 던진다.', async () => {
+      // given
+      adminRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        adminService.loginAdmin(loginDto, createResponse(), createRequest()),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('비밀번호가 일치하지 않으면 UnauthorizedException을 던진다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        loginId: loginDto.loginId,
+      });
+      adminRepository.findOne.mockResolvedValue(admin);
+
+      // when & then
+      await expect(
+        adminService.loginAdmin(
+          { ...loginDto, password: 'wrong-password!' },
+          createResponse(),
+          createRequest(),
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('로그인에 성공하면 세션을 발급하고 쿠키를 설정한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        loginId: loginDto.loginId,
+      });
+      adminRepository.findOne.mockResolvedValue(admin);
+      redisService.get.mockResolvedValue(null);
+      const cookie = jest.fn();
+      const response = { cookie } as unknown as Response;
+
+      // when
+      await adminService.loginAdmin(loginDto, response, createRequest());
+
+      // then
+      expect(redisService.set).toHaveBeenCalledTimes(2);
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.ADMIN_AUTH_KEY),
+        admin.loginId,
+        'EX',
+        SESSION_TTL,
+      );
+      expect(cookie).toHaveBeenCalledWith(
+        'sessionId',
+        expect.any(String),
+        cookieConfig[process.env.NODE_ENV],
+      );
+    });
+
+    it('기존 세션과 쿠키 세션이 있으면 모두 무효화한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        loginId: loginDto.loginId,
+      });
+      adminRepository.findOne.mockResolvedValue(admin);
+      redisService.get.mockResolvedValue('prev-session-id');
+
+      // when
+      await adminService.loginAdmin(
+        loginDto,
+        createResponse(),
+        createRequest({ sessionId: 'cookie-session-id' }),
+      );
+
+      // then
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_AUTH_KEY}:cookie-session-id`,
+        `${REDIS_KEYS.ADMIN_AUTH_KEY}:prev-session-id`,
+      );
+    });
+  });
+
+  describe('logoutAdmin', () => {
+    it('세션과 로그인 매핑을 모두 삭제하고 쿠키를 제거한다.', async () => {
+      // given
+      redisService.get.mockResolvedValue('admin-id');
+      const clearCookie = jest.fn();
+      const response = { clearCookie } as unknown as Response;
+
+      // when
+      await adminService.logoutAdmin(
+        createRequest({ sessionId: 'sid-1' }),
+        response,
+      );
+
+      // then
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_AUTH_KEY}:sid-1`,
+      );
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_SESSION_BY_LOGIN}:admin-id`,
+      );
+      expect(clearCookie).toHaveBeenCalledWith('sessionId');
+    });
+
+    it('세션에 매핑된 로그인 아이디가 없으면 로그인 매핑은 삭제하지 않는다.', async () => {
+      // given
+      redisService.get.mockResolvedValue(null);
+
+      // when
+      await adminService.logoutAdmin(
+        createRequest({ sessionId: 'sid-1' }),
+        createResponse(),
+      );
+
+      // then
+      expect(redisService.del).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('createAdmin', () => {
+    const registerDto = new RegisterAdminRequestDto({
+      loginId: 'new-admin',
+      password: ADMIN_DEFAULT_PASSWORD,
+    });
+
+    it('이미 존재하는 아이디면 ConflictException을 던진다.', async () => {
+      // given
+      adminRepository.findOne.mockResolvedValue(
+        await AdminFixture.createAdminCryptFixture(),
+      );
+
+      // when & then
+      await expect(adminService.createAdmin(registerDto)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(adminRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('비밀번호를 해시한 뒤 저장한다.', async () => {
+      // given
+      adminRepository.findOne.mockResolvedValue(null);
+
+      // when
+      await adminService.createAdmin(registerDto);
+
+      // then
+      const saved = adminRepository.save.mock.calls[0][0] as { password: string };
+      expect(adminRepository.save).toHaveBeenCalledTimes(1);
+      expect(saved.password).not.toBe(ADMIN_DEFAULT_PASSWORD);
+    });
+  });
+});

--- a/server/test/chat/unit/chat.service.unit.spec.ts
+++ b/server/test/chat/unit/chat.service.unit.spec.ts
@@ -1,0 +1,88 @@
+import { CHAT_HISTORY_LIMIT } from '@chat/constant/constant';
+import { RedisMessagePayload } from '@chat/constant/type';
+import { ChatService } from '@chat/service/chat.service';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+describe(`${ChatService.name} Unit Test`, () => {
+  let chatService: ChatService;
+  let redisService: jest.Mocked<
+    Pick<RedisService, 'lrange' | 'lpush' | 'ltrim'>
+  >;
+
+  const ROOM = 'room-1';
+
+  const createMessage = (
+    overwrites: Partial<RedisMessagePayload> = {},
+  ): RedisMessagePayload => ({
+    userId: 'user-1',
+    userName: 'tester',
+    message: 'hello',
+    timestamp: '2025-01-01T00:00:00.000Z',
+    room: ROOM,
+    ...overwrites,
+  });
+
+  beforeEach(() => {
+    redisService = { lrange: jest.fn(), lpush: jest.fn(), ltrim: jest.fn() };
+    chatService = new ChatService(redisService as unknown as RedisService);
+  });
+
+  describe('getChatHistory', () => {
+    it('최근 메시지를 파싱한 뒤 역순으로 반환한다.', async () => {
+      // given
+      const messages = [
+        createMessage({ message: 'newest' }),
+        createMessage({ message: 'oldest' }),
+      ];
+      redisService.lrange.mockResolvedValue(
+        messages.map((m) => JSON.stringify(m)),
+      );
+
+      // when
+      const result = await chatService.getChatHistory(ROOM);
+
+      // then
+      expect(redisService.lrange).toHaveBeenCalledWith(
+        REDIS_KEYS.CHAT_HISTORY_KEY(ROOM),
+        0,
+        CHAT_HISTORY_LIMIT - 1,
+      );
+      expect(result.map((m) => m.message)).toStrictEqual(['oldest', 'newest']);
+    });
+
+    it('저장된 메시지가 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      redisService.lrange.mockResolvedValue([]);
+
+      // when
+      const result = await chatService.getChatHistory(ROOM);
+
+      // then
+      expect(result).toStrictEqual([]);
+    });
+  });
+
+  describe('saveMessageToRedis', () => {
+    it('메시지를 lpush하고 히스토리 길이를 ltrim으로 제한한다.', async () => {
+      // given
+      const message = createMessage();
+      const key = REDIS_KEYS.CHAT_HISTORY_KEY(ROOM);
+
+      // when
+      await chatService.saveMessageToRedis(message);
+
+      // then
+      expect(redisService.lpush).toHaveBeenCalledWith(
+        key,
+        JSON.stringify(message),
+      );
+      expect(redisService.ltrim).toHaveBeenCalledWith(
+        key,
+        0,
+        CHAT_HISTORY_LIMIT - 1,
+      );
+    });
+  });
+});

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -1,0 +1,177 @@
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+import { DataSource } from 'typeorm';
+
+import { CommentService } from '@comment/service/comment.service';
+import { GetCommentResponseDto } from '@comment/dto/response/getComment.dto';
+import { Comment } from '@comment/entity/comment.entity';
+import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { Payload } from '@common/guard/jwt.guard';
+
+import { FeedService } from '@feed/service/feed.service';
+
+describe(`${CommentService.name} Unit Test`, () => {
+  let commentService: CommentService;
+  let commentRepository: jest.Mocked<
+    Pick<CommentRepository, 'findOne' | 'getCommentInformation' | 'save'>
+  >;
+  let feedService: jest.Mocked<Pick<FeedService, 'getFeed'>>;
+  let manager: { save: jest.Mock; remove: jest.Mock };
+  let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+
+  const user: Payload = {
+    id: 1,
+    email: 'user@test.com',
+    userName: 'tester',
+    role: 'user',
+  };
+
+  beforeEach(() => {
+    commentRepository = {
+      findOne: jest.fn(),
+      getCommentInformation: jest.fn(),
+      save: jest.fn(),
+    };
+    feedService = { getFeed: jest.fn() };
+    manager = { save: jest.fn(), remove: jest.fn() };
+    dataSource = {
+      transaction: jest.fn((cb: any) => cb(manager)),
+    } as any;
+
+    commentService = new CommentService(
+      commentRepository as unknown as CommentRepository,
+      dataSource as unknown as DataSource,
+      feedService as unknown as FeedService,
+    );
+  });
+
+  describe('get', () => {
+    it('피드 존재를 확인하고 댓글 목록을 응답으로 변환한다.', async () => {
+      // given
+      const dto = { feedId: 10 };
+      const comments = [
+        {
+          id: 1,
+          comment: 'c',
+          date: new Date('2025-01-01'),
+          user: { id: 1, userName: 'tester', profileImage: null },
+        },
+      ] as any;
+      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+      commentRepository.getCommentInformation.mockResolvedValue(comments);
+
+      // when
+      const result = await commentService.get(dto);
+
+      // then
+      expect(feedService.getFeed).toHaveBeenCalledWith(10);
+      expect(commentRepository.getCommentInformation).toHaveBeenCalledWith(10);
+      expect(result).toEqual(
+        GetCommentResponseDto.toResponseDtoArray(comments),
+      );
+    });
+  });
+
+  describe('create', () => {
+    it('트랜잭션 안에서 댓글 수를 증가시키고 댓글을 저장한다.', async () => {
+      // given
+      const feed = { id: 10, commentCount: 2 };
+      feedService.getFeed.mockResolvedValue(feed as any);
+      const dto = { comment: '새 댓글' };
+
+      // when
+      await commentService.create(user, 10, dto);
+
+      // then
+      expect(feed.commentCount).toBe(3);
+      expect(manager.save).toHaveBeenCalledWith(feed);
+      expect(manager.save).toHaveBeenCalledWith(Comment, {
+        comment: '새 댓글',
+        feed,
+        user: { id: user.id },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    const dto = { commentId: 5 };
+
+    it('존재하지 않는 댓글이면 NotFoundException을 던진다.', async () => {
+      // given
+      commentRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(commentService.delete(user, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('본인 댓글이 아니면 UnauthorizedException을 던진다.', async () => {
+      // given
+      commentRepository.findOne.mockResolvedValue({
+        id: 5,
+        user: { id: 999 },
+        feed: { id: 10, commentCount: 3 },
+      } as any);
+
+      // when & then
+      await expect(commentService.delete(user, dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('본인 댓글이면 댓글 수를 감소시키고 댓글을 제거한다.', async () => {
+      // given
+      const feed = { id: 10, commentCount: 3 };
+      const comment = { id: 5, user: { id: user.id }, feed } as any;
+      commentRepository.findOne.mockResolvedValue(comment);
+
+      // when
+      await commentService.delete(user, dto);
+
+      // then
+      expect(feed.commentCount).toBe(2);
+      expect(manager.save).toHaveBeenCalledWith(feed);
+      expect(manager.remove).toHaveBeenCalledWith(comment);
+    });
+  });
+
+  describe('update', () => {
+    it('본인 댓글의 내용을 수정하고 저장한다.', async () => {
+      // given
+      const comment = {
+        id: 5,
+        comment: '이전',
+        user: { id: user.id },
+        feed: { id: 10 },
+      };
+      commentRepository.findOne.mockResolvedValue(comment as any);
+      const dto = { newComment: '수정됨' };
+
+      // when
+      await commentService.update(user, 5, dto);
+
+      // then
+      expect(comment.comment).toBe('수정됨');
+      expect(commentRepository.save).toHaveBeenCalledWith(comment);
+    });
+
+    it('본인 댓글이 아니면 UnauthorizedException을 던지고 저장하지 않는다.', async () => {
+      // given
+      commentRepository.findOne.mockResolvedValue({
+        id: 5,
+        user: { id: 999 },
+        feed: { id: 10 },
+      } as any);
+
+      // when & then
+      await expect(
+        commentService.update(user, 5, {
+          newComment: '수정됨',
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(commentRepository.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/test/config/integration/jest/jest.config.ts
+++ b/server/test/config/integration/jest/jest.config.ts
@@ -1,29 +1,16 @@
 import type { Config } from '@jest/types';
-import { pathsToModuleNameMapper } from 'ts-jest';
-
-import tsconfig from '../../../../tsconfig.json';
 
 const config: Config.InitialOptions = {
-  moduleFileExtensions: ['js', 'json', 'ts'],
-  testEnvironment: 'node',
   rootDir: '../../../../',
-  testRegex: 'test/.*\\.(e2e-spec|spec).ts$',
-  transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
-  },
+  projects: [
+    '<rootDir>/test/config/dto/jest/jest.config.ts',
+    '<rootDir>/test/config/unit/jest/jest.config.ts',
+    '<rootDir>/test/config/e2e/jest/jest.config.ts',
+  ],
+  maxWorkers: '50%',
   coverageDirectory: './coverage/integration',
   coverageReporters: ['json-summary', 'text', 'lcov'],
-  setupFilesAfterEnv: ['./test/config/e2e/env/jest.setup.ts'],
-  globalSetup: './test/config/e2e/global/e2e-test-global-setup.ts',
-  globalTeardown: './test/config/e2e/global/e2e-test-global-teardown.ts',
-  maxWorkers: '50%',
-  testTimeout: 20000,
-  testPathIgnorePatterns: ['test/sample/'],
   coveragePathIgnorePatterns: ['test', 'src/common/database/migration'],
-  moduleNameMapper: pathsToModuleNameMapper(
-    tsconfig.compilerOptions?.paths ?? {},
-    { prefix: '<rootDir>/' },
-  ),
 };
 
 export default config;

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -1,0 +1,357 @@
+import { NotFoundException } from '@nestjs/common';
+
+import axios from 'axios';
+import { Request, Response } from 'express';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
+import { SearchFeedRequestDto } from '@feed/dto/request/searchFeed.dto';
+import { GetFeedDetailResponseDto } from '@feed/dto/response/getFeedDetail';
+import {
+  FeedRepository,
+  FeedViewRepository,
+} from '@feed/repository/feed.repository';
+import { FeedService } from '@feed/service/feed.service';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe(`${FeedService.name} Unit Test`, () => {
+  let feedService: FeedService;
+  let feedRepository: jest.Mocked<
+    Pick<FeedRepository, 'findOneBy' | 'searchFeedList' | 'update' | 'delete'>
+  >;
+  let feedViewRepository: jest.Mocked<
+    Pick<FeedViewRepository, 'findOneBy' | 'findFeedPagination'>
+  >;
+  let redisService: jest.Mocked<
+    Pick<
+      RedisService,
+      'keys' | 'lrange' | 'sismember' | 'sadd' | 'zincrby' | 'executePipeline'
+    >
+  >;
+
+  const createResponse = () => ({ cookie: jest.fn() }) as unknown as Response;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    feedRepository = {
+      findOneBy: jest.fn(),
+      searchFeedList: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    };
+    feedViewRepository = {
+      findOneBy: jest.fn(),
+      findFeedPagination: jest.fn(),
+    };
+    redisService = {
+      keys: jest.fn(),
+      lrange: jest.fn(),
+      sismember: jest.fn(),
+      sadd: jest.fn(),
+      zincrby: jest.fn(),
+      executePipeline: jest.fn(),
+    };
+
+    feedService = new FeedService(
+      feedRepository as unknown as FeedRepository,
+      feedViewRepository as unknown as FeedViewRepository,
+      redisService as unknown as RedisService,
+    );
+  });
+
+  describe('getFeed', () => {
+    it('존재하지 않으면 NotFoundException을 던진다.', async () => {
+      feedRepository.findOneBy.mockResolvedValue(null);
+      await expect(feedService.getFeed(1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('존재하면 피드를 반환한다.', async () => {
+      const feed = { id: 1 } as any;
+      feedRepository.findOneBy.mockResolvedValue(feed);
+      await expect(feedService.getFeed(1)).resolves.toBe(feed);
+    });
+  });
+
+  describe('getFeedByView', () => {
+    it('존재하지 않으면 NotFoundException을 던진다.', async () => {
+      feedViewRepository.findOneBy.mockResolvedValue(null);
+      await expect(feedService.getFeedByView(1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('readFeedPagination', () => {
+    it('limit보다 많이 조회되면 hasMore=true로 마지막 1건을 잘라낸다.', async () => {
+      // given
+      const dto = { limit: 2 } as ReadFeedPaginationRequestDto;
+      const feedList = [{ feedId: 1 }, { feedId: 2 }, { feedId: 3 }] as any[];
+      feedViewRepository.findFeedPagination.mockResolvedValue(feedList);
+      redisService.keys.mockResolvedValue(['feed:recent:2']);
+
+      // when
+      const result = await feedService.readFeedPagination(dto);
+
+      // then
+      expect(result.hasMore).toBe(true);
+      expect(result.lastId).toBe(2);
+      expect(result.result).toHaveLength(2);
+      expect(result.result.find((f) => f.id === 2).isNew).toBe(true);
+      expect(result.result.find((f) => f.id === 1).isNew).toBe(false);
+    });
+
+    it('limit 이하면 hasMore=false이고 잘라내지 않는다.', async () => {
+      // given
+      const dto = { limit: 5 } as ReadFeedPaginationRequestDto;
+      feedViewRepository.findFeedPagination.mockResolvedValue([
+        { feedId: 1 },
+      ] as any);
+      redisService.keys.mockResolvedValue([]);
+
+      // when
+      const result = await feedService.readFeedPagination(dto);
+
+      // then
+      expect(result.hasMore).toBe(false);
+      expect(result.lastId).toBe(1);
+      expect(result.result).toHaveLength(1);
+    });
+  });
+
+  describe('readTrendFeedList', () => {
+    it('트렌드 ID 목록으로 피드를 조회하고 null을 제외한다.', async () => {
+      // given
+      redisService.lrange.mockResolvedValue(['1', '2']);
+      feedViewRepository.findOneBy.mockImplementation((where) =>
+        Promise.resolve(
+          (where as { feedId: number }).feedId === 1
+            ? ({ feedId: 1, tag: [] } as any)
+            : null,
+        ),
+      );
+
+      // when
+      const result = await feedService.readTrendFeedList();
+
+      // then
+      expect(redisService.lrange).toHaveBeenCalledWith(
+        REDIS_KEYS.FEED_ORIGIN_TREND_KEY,
+        0,
+        -1,
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(1);
+    });
+  });
+
+  describe('searchFeedList', () => {
+    it('offset과 totalPages를 계산하고 검색을 위임한다.', async () => {
+      // given
+      const dto = {
+        find: 'nest',
+        page: 2,
+        limit: 10,
+        type: 'title',
+      } as SearchFeedRequestDto;
+      feedRepository.searchFeedList.mockResolvedValue([[], 25] as any);
+
+      // when
+      const result = await feedService.searchFeedList(dto);
+
+      // then
+      expect(feedRepository.searchFeedList).toHaveBeenCalledWith(
+        'nest',
+        10,
+        'title',
+        10, // offset = (2-1)*10
+      );
+      expect(result.totalCount).toBe(25);
+      expect(result.totalPages).toBe(3); // ceil(25/10)
+    });
+  });
+
+  describe('updateFeedViewCount', () => {
+    const dto = { feedId: 10 };
+
+    const createRequest = (
+      overwrites: Partial<{ cookie: string; xff: string }> = {},
+    ) =>
+      ({
+        headers: {
+          cookie: overwrites.cookie,
+          'x-forwarded-for': overwrites.xff ?? '1.2.3.4',
+        },
+        socket: { remoteAddress: '1.2.3.4' },
+      }) as unknown as Request;
+
+    it('이미 조회 쿠키가 있으면 조회수를 증가시키지 않는다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({ id: 10 } as any);
+      const request = createRequest({ cookie: 'View_count_10=10' });
+
+      // when
+      await feedService.updateFeedViewCount(dto, request, createResponse());
+
+      // then
+      expect(feedRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('IP 플래그가 있으면 쿠키만 발급하고 조회수는 증가시키지 않는다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({ id: 10 } as any);
+      redisService.sismember.mockResolvedValue(1);
+      const cookie = jest.fn();
+      const response = { cookie } as unknown as Response;
+
+      // when
+      await feedService.updateFeedViewCount(dto, createRequest(), response);
+
+      // then
+      expect(cookie).toHaveBeenCalled();
+      expect(feedRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('신규 조회면 IP를 등록하고 조회수와 트렌드 점수를 증가시킨다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({ id: 10 } as any);
+      redisService.sismember.mockResolvedValue(0);
+      const response = createResponse();
+
+      // when
+      await feedService.updateFeedViewCount(dto, createRequest(), response);
+
+      // then
+      expect(redisService.sadd).toHaveBeenCalledWith('feed:10:ip', '1.2.3.4');
+      expect(feedRepository.update).toHaveBeenCalledWith(10, {
+        viewCount: expect.any(Function),
+      });
+      expect(redisService.zincrby).toHaveBeenCalledWith(
+        REDIS_KEYS.FEED_TREND_KEY,
+        1,
+        '10',
+      );
+    });
+  });
+
+  describe('readRecentFeedList', () => {
+    it('최근 피드 키가 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      redisService.keys.mockResolvedValue([]);
+
+      // when
+      const result = await feedService.readRecentFeedList();
+
+      // then
+      expect(result).toStrictEqual([]);
+      expect(redisService.executePipeline).not.toHaveBeenCalled();
+    });
+
+    it('파이프라인 결과를 최신순으로 정렬하고 태그를 분리한다.', async () => {
+      // given
+      redisService.keys.mockResolvedValue(['feed:recent:1', 'feed:recent:2']);
+      redisService.executePipeline.mockResolvedValue([
+        [null, { id: '1', createdAt: '2025-01-01', tagList: 'a,b' }],
+        [null, { id: '2', createdAt: '2025-02-01', tagList: 'c' }],
+      ] as any);
+
+      // when
+      const result = await feedService.readRecentFeedList();
+
+      // then
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(2);
+    });
+  });
+
+  describe('getFeedDetail', () => {
+    it('피드 뷰를 조회하고 상세 응답으로 변환한다.', async () => {
+      // given
+      const feed = { feedId: 10, title: 'detail', tag: ['a'] } as any;
+      feedViewRepository.findOneBy.mockResolvedValue(feed);
+
+      // when
+      const result = await feedService.getFeedDetail({
+        feedId: 10,
+      });
+
+      // then
+      expect(feedViewRepository.findOneBy).toHaveBeenCalledWith({ feedId: 10 });
+      expect(result).toEqual(GetFeedDetailResponseDto.toResponseDto(feed));
+    });
+  });
+
+  describe('deleteCheckFeed', () => {
+    const dto = { feedId: 10 };
+
+    it('원본이 404면 피드를 삭제하고 NotFoundException을 던진다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({
+        id: 10,
+        path: 'https://blog.test/post',
+      } as any);
+      mockedAxios.get.mockResolvedValue({ status: 404 });
+
+      // when & then
+      await expect(feedService.deleteCheckFeed(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(feedRepository.delete).toHaveBeenCalledWith({ id: 10 });
+    });
+
+    it('원본이 살아있으면 삭제하지 않는다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({
+        id: 10,
+        path: 'https://blog.test/post',
+      } as any);
+      mockedAxios.get.mockResolvedValue({ status: 200 });
+
+      // when
+      await feedService.deleteCheckFeed(dto);
+
+      // then
+      expect(feedRepository.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  // getIp는 헤더 문자열 파싱만 하는 순수 로직이라 e2e 대신 단위로 격리 검증한다.
+  // (실제 헤더가 Express→서비스로 흐르는지는 up-view-count e2e가 Redis 상태로 검증)
+  describe('getIp (private)', () => {
+    const getIp = (request: unknown) =>
+      (feedService as unknown as { getIp(request: unknown): string }).getIp(
+        request,
+      );
+
+    const createRequest = (
+      xff: string | string[] | undefined,
+      remoteAddress = '127.0.0.1',
+    ) => ({
+      headers: { 'x-forwarded-for': xff },
+      socket: { remoteAddress },
+    });
+
+    it('x-forwarded-for 단일 IP면 해당 IP를 반환한다.', () => {
+      expect(getIp(createRequest('203.0.113.1'))).toBe('203.0.113.1');
+    });
+
+    it('x-forwarded-for에 여러 IP가 있으면 첫 번째 IP를 trim해 반환한다.', () => {
+      expect(getIp(createRequest('203.0.113.1, 198.51.100.1'))).toBe(
+        '203.0.113.1',
+      );
+    });
+
+    it('x-forwarded-for가 없으면 socket.remoteAddress를 반환한다.', () => {
+      expect(getIp(createRequest(undefined, '10.0.0.5'))).toBe('10.0.0.5');
+    });
+
+    it('x-forwarded-for가 배열(문자열 아님)이면 socket.remoteAddress로 폴백한다.', () => {
+      expect(getIp(createRequest(['203.0.113.1'], '10.0.0.5'))).toBe(
+        '10.0.0.5',
+      );
+    });
+  });
+});

--- a/server/test/file/unit/file.service.unit.spec.ts
+++ b/server/test/file/unit/file.service.unit.spec.ts
@@ -1,0 +1,179 @@
+import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+
+import * as fs from 'fs/promises';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { FileUploadType } from '@file/constant/file.constant';
+import { FileRepository } from '@file/repository/file.repository';
+import { FileService } from '@file/service/file.service';
+
+import { FileFixture } from '@test/config/common/fixture/file.fixture';
+
+jest.mock('fs/promises');
+
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+describe(`${FileService.name} Unit Test`, () => {
+  let fileService: FileService;
+  let fileRepository: jest.Mocked<
+    Pick<FileRepository, 'save' | 'findOne' | 'delete'>
+  >;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'warn'>>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    fileRepository = { save: jest.fn(), findOne: jest.fn(), delete: jest.fn() };
+    logger = { warn: jest.fn() };
+
+    fileService = new FileService(
+      fileRepository as unknown as FileRepository,
+      logger as unknown as WinstonLoggerService,
+    );
+  });
+
+  describe('handleUpload', () => {
+    it('디렉터리를 생성하고 파일을 쓴 뒤 메타데이터를 저장한다.', async () => {
+      // given
+      const multerFile = {
+        originalname: 'avatar.png',
+        mimetype: 'image/png',
+        size: 2048,
+        buffer: Buffer.from('data'),
+      } as Express.Multer.File;
+      const savedFile = FileFixture.createFileFixture({
+        id: 1,
+        user: { id: 7 } as any,
+      });
+      fileRepository.save.mockResolvedValue(savedFile);
+
+      // when
+      const result = await fileService.handleUpload(
+        multerFile,
+        FileUploadType.PROFILE_IMAGE,
+        7,
+      );
+
+      // then
+      expect(mockedFs.mkdir).toHaveBeenCalledWith(expect.any(String), {
+        recursive: true,
+      });
+      expect(mockedFs.writeFile).toHaveBeenCalledWith(
+        expect.any(String),
+        multerFile.buffer,
+      );
+      expect(fileRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          originalName: 'avatar.png',
+          mimetype: 'image/png',
+          size: 2048,
+          user: { id: 7 },
+        }),
+      );
+      expect(result.id).toBe(savedFile.id);
+      expect(result.userId).toBe(7);
+      expect(typeof result.url).toBe('string');
+    });
+  });
+
+  describe('findById', () => {
+    it('존재하지 않는 파일이면 NotFoundException을 던진다.', async () => {
+      // given
+      fileRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(fileService.findById(1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('존재하는 파일을 반환한다.', async () => {
+      // given
+      const file = FileFixture.createFileFixture({ id: 1 });
+      fileRepository.findOne.mockResolvedValue(file);
+
+      // when
+      const result = await fileService.findById(1);
+
+      // then
+      expect(result).toBe(file);
+    });
+  });
+
+  describe('deleteFile', () => {
+    it('파일 주인이 아니면 UnauthorizedException을 던진다.', async () => {
+      // given
+      fileRepository.findOne.mockResolvedValue(
+        FileFixture.createFileFixture({ id: 1, user: { id: 7 } as any }),
+      );
+
+      // when & then
+      await expect(fileService.deleteFile(1, 999)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      expect(fileRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('파일 주인이면 물리 파일을 지우고 레코드를 삭제한다.', async () => {
+      // given
+      const file = FileFixture.createFileFixture({
+        id: 1,
+        path: '/app/objects/a.png',
+        user: { id: 7 } as any,
+      });
+      fileRepository.findOne.mockResolvedValue(file);
+
+      // when
+      await fileService.deleteFile(1, 7);
+
+      // then
+      expect(mockedFs.access).toHaveBeenCalledWith(file.path);
+      expect(mockedFs.unlink).toHaveBeenCalledWith(file.path);
+      expect(fileRepository.delete).toHaveBeenCalledWith(1);
+    });
+
+    it('물리 파일 삭제에 실패해도 경고만 남기고 레코드는 삭제한다.', async () => {
+      // given
+      const file = FileFixture.createFileFixture({
+        id: 1,
+        path: '/app/objects/missing.png',
+        user: { id: 7 } as any,
+      });
+      fileRepository.findOne.mockResolvedValue(file);
+      mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+
+      // when
+      await fileService.deleteFile(1, 7);
+
+      // then
+      expect(logger.warn).toHaveBeenCalled();
+      expect(fileRepository.delete).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('deleteByPath', () => {
+    it('경로에 해당하는 파일이 없으면 NotFoundException을 던진다.', async () => {
+      // given
+      fileRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(fileService.deleteByPath('/app/objects/x.png')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('파일을 찾으면 물리 파일과 레코드를 삭제한다.', async () => {
+      // given
+      const file = FileFixture.createFileFixture({
+        id: 2,
+        path: '/app/objects/y.png',
+      });
+      fileRepository.findOne.mockResolvedValue(file);
+
+      // when
+      await fileService.deleteByPath(file.path);
+
+      // then
+      expect(mockedFs.unlink).toHaveBeenCalledWith(file.path);
+      expect(fileRepository.delete).toHaveBeenCalledWith(file.id);
+    });
+  });
+});

--- a/server/test/like/unit/like.service.unit.spec.ts
+++ b/server/test/like/unit/like.service.unit.spec.ts
@@ -1,0 +1,145 @@
+import { ConflictException, NotFoundException } from '@nestjs/common';
+
+import { DataSource } from 'typeorm';
+
+import { Payload } from '@common/guard/jwt.guard';
+
+import { FeedService } from '@feed/service/feed.service';
+
+import { GetLikeResponseDto } from '@like/dto/response/getLike.dto';
+import { Like } from '@like/entity/like.entity';
+import { LikeRepository } from '@like/repository/like.repository';
+import { LikeService } from '@like/service/like.service';
+
+describe(`${LikeService.name} Unit Test`, () => {
+  let likeService: LikeService;
+  let likeRepository: jest.Mocked<Pick<LikeRepository, 'findOneBy'>>;
+  let feedService: jest.Mocked<Pick<FeedService, 'getFeed'>>;
+  let manager: { save: jest.Mock; delete: jest.Mock };
+  let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+
+  const user: Payload = {
+    id: 1,
+    email: 'user@test.com',
+    userName: 'tester',
+    role: 'user',
+  };
+  const dto = { feedId: 10 };
+
+  beforeEach(() => {
+    likeRepository = { findOneBy: jest.fn() };
+    feedService = { getFeed: jest.fn() };
+    manager = { save: jest.fn(), delete: jest.fn() };
+    dataSource = {
+      transaction: jest.fn((cb: any) => cb(manager)),
+    } as any;
+
+    likeService = new LikeService(
+      likeRepository as unknown as LikeRepository,
+      feedService as unknown as FeedService,
+      dataSource as unknown as DataSource,
+    );
+  });
+
+  describe('get', () => {
+    it('비로그인 사용자는 좋아요 조회 없이 false를 반환한다.', async () => {
+      // given
+      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+
+      // when
+      const result = await likeService.get(null, dto);
+
+      // then
+      expect(likeRepository.findOneBy).not.toHaveBeenCalled();
+      expect(result).toEqual(GetLikeResponseDto.toResponseDto(false));
+    });
+
+    it('로그인 사용자가 좋아요를 눌렀으면 true를 반환한다.', async () => {
+      // given
+      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+      likeRepository.findOneBy.mockResolvedValue({ id: 1 } as any);
+
+      // when
+      const result = await likeService.get(user, dto);
+
+      // then
+      expect(result).toEqual(GetLikeResponseDto.toResponseDto(true));
+    });
+
+    it('로그인 사용자가 좋아요를 누르지 않았으면 false를 반환한다.', async () => {
+      // given
+      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+      likeRepository.findOneBy.mockResolvedValue(null);
+
+      // when
+      const result = await likeService.get(user, dto);
+
+      // then
+      expect(result).toEqual(GetLikeResponseDto.toResponseDto(false));
+    });
+  });
+
+  describe('create', () => {
+    it('이미 좋아요한 상태면 ConflictException을 던진다.', async () => {
+      // given
+      feedService.getFeed.mockResolvedValue({ id: 10, likeCount: 0 } as any);
+      likeRepository.findOneBy.mockResolvedValue({ id: 1 } as any);
+
+      // when & then
+      await expect(likeService.create(user, dto)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(manager.save).not.toHaveBeenCalled();
+    });
+
+    it('좋아요 수를 증가시키고 좋아요를 저장한다.', async () => {
+      // given
+      const feed = { id: 10, likeCount: 2 };
+      feedService.getFeed.mockResolvedValue(feed as any);
+      likeRepository.findOneBy.mockResolvedValue(null);
+
+      // when
+      await likeService.create(user, dto);
+
+      // then
+      expect(feed.likeCount).toBe(3);
+      expect(manager.save).toHaveBeenCalledWith(feed);
+      expect(manager.save).toHaveBeenCalledWith(Like, {
+        user: { id: user.id },
+        feed: { id: dto.feedId },
+      });
+    });
+  });
+
+  describe('delete', () => {
+    it('좋아요하지 않은 상태면 NotFoundException을 던진다.', async () => {
+      // given
+      feedService.getFeed.mockResolvedValue({ id: 10, likeCount: 1 } as any);
+      likeRepository.findOneBy.mockResolvedValue(null);
+
+      // when & then
+      await expect(likeService.delete(user, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(manager.delete).not.toHaveBeenCalled();
+    });
+
+    it('좋아요 수를 감소시키고 좋아요를 삭제한다.', async () => {
+      // given
+      const feed = { id: 10, likeCount: 2 };
+      feedService.getFeed.mockResolvedValue(feed as any);
+      likeRepository.findOneBy.mockResolvedValue({ id: 1 } as any);
+
+      // when
+      await likeService.delete(user, dto);
+
+      // then
+      expect(feed.likeCount).toBe(1);
+      expect(manager.save).toHaveBeenCalledWith(feed);
+      expect(manager.delete).toHaveBeenCalledWith(Like, {
+        user: { id: user.id },
+        feed: { id: dto.feedId },
+      });
+    });
+  });
+});

--- a/server/test/oauth/unit/oauth.service.unit.spec.ts
+++ b/server/test/oauth/unit/oauth.service.unit.spec.ts
@@ -1,0 +1,206 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { Request, Response } from 'express';
+import { DataSource } from 'typeorm';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+import { RedisService } from '@common/redis/redis.service';
+
+import {
+  OAUTH_URL_PATH,
+  OAuthType,
+} from '@user/constant/oauth.constant';
+import { OAuthCallbackRequestDto } from '@user/dto/request/oAuthCallbackDto';
+import { ProviderRepository } from '@user/repository/provider.repository';
+import { UserRepository } from '@user/repository/user.repository';
+import { OAuthService } from '@user/service/oAuth.service';
+import { UserService } from '@user/service/user.service';
+
+describe(`${OAuthService.name} Unit Test`, () => {
+  let oAuthService: OAuthService;
+  let userRepository: jest.Mocked<Pick<UserRepository, 'findOne'>>;
+  let providerRepository: jest.Mocked<
+    Pick<ProviderRepository, 'findByProviderTypeAndId' | 'save'>
+  >;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'log' | 'error'>>;
+  let redisService: jest.Mocked<Pick<RedisService, 'eval'>>;
+  let userService: jest.Mocked<Pick<UserService, 'createToken'>>;
+  let googleProvider: {
+    getAuthUrl: jest.Mock;
+    getTokens: jest.Mock;
+    getUserInfo: jest.Mock;
+  };
+  let manager: { save: jest.Mock };
+  let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+
+  const createResponse = () =>
+    ({ cookie: jest.fn(), clearCookie: jest.fn() }) as unknown as Response;
+
+  const createRequest = (csrfCookie?: string) =>
+    ({ cookies: { oauth_csrf_token: csrfCookie } }) as unknown as Request;
+
+  const encodeState = (data: object) =>
+    Buffer.from(JSON.stringify(data)).toString('base64');
+
+  beforeEach(() => {
+    userRepository = { findOne: jest.fn() };
+    providerRepository = {
+      findByProviderTypeAndId: jest.fn(),
+      save: jest.fn(),
+    };
+    logger = { log: jest.fn(), error: jest.fn() };
+    redisService = { eval: jest.fn() };
+    userService = { createToken: jest.fn().mockReturnValue('service-refresh') };
+    googleProvider = {
+      getAuthUrl: jest.fn(),
+      getTokens: jest.fn(),
+      getUserInfo: jest.fn(),
+    };
+    manager = {
+      save: jest.fn((_entity: any, data: any) =>
+        Promise.resolve({ id: 1, ...data }),
+      ),
+    };
+    dataSource = {
+      transaction: jest.fn((cb: any) => cb(manager)),
+    } as any;
+
+    oAuthService = new OAuthService(
+      userRepository as unknown as UserRepository,
+      providerRepository as unknown as ProviderRepository,
+      logger as unknown as WinstonLoggerService,
+      redisService as unknown as RedisService,
+      userService as unknown as UserService,
+      { [OAuthType.Google]: googleProvider },
+      dataSource as unknown as DataSource,
+    );
+  });
+
+  describe('getAuthUrl', () => {
+    it('CSRF 토큰 쿠키를 설정하고 provider의 인증 URL을 반환한다.', async () => {
+      // given
+      googleProvider.getAuthUrl.mockResolvedValue('https://auth.url');
+      const cookie = jest.fn();
+      const res = { cookie } as unknown as Response;
+
+      // when
+      const result = await oAuthService.getAuthUrl(OAuthType.Google, res);
+
+      // then
+      expect(cookie).toHaveBeenCalledWith(
+        'oauth_csrf_token',
+        expect.any(String),
+        expect.anything(),
+      );
+      expect(googleProvider.getAuthUrl).toHaveBeenCalledWith(expect.any(String));
+      expect(result).toBe('https://auth.url');
+    });
+  });
+
+  describe('callback', () => {
+    it('state 형식이 잘못되면 BadRequestException을 던진다.', async () => {
+      // given
+      const dto = {
+        state: '!!!not-base64-json!!!',
+        code: 'code',
+      } as OAuthCallbackRequestDto;
+
+      // when & then
+      await expect(
+        oAuthService.callback(dto, createResponse(), createRequest('csrf')),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('CSRF 쿠키가 state와 다르면 signin으로 리다이렉트한다.', async () => {
+      // given
+      const dto = {
+        state: encodeState({ provider: OAuthType.Google, csrfToken: 'key-1' }),
+        code: 'code',
+      } as OAuthCallbackRequestDto;
+
+      // when
+      const result = await oAuthService.callback(
+        dto,
+        createResponse(),
+        createRequest('different-cookie'),
+      );
+
+      // then
+      expect(result).toBe(`${OAUTH_URL_PATH.BASE_URL}/signin`);
+    });
+
+    it('Redis CSRF 값이 일치하지 않으면 signin으로 리다이렉트한다.', async () => {
+      // given
+      const dto = {
+        state: encodeState({ provider: OAuthType.Google, csrfToken: 'key-1' }),
+        code: 'code',
+      } as OAuthCallbackRequestDto;
+      redisService.eval.mockResolvedValue('wrong-value');
+
+      // when
+      const result = await oAuthService.callback(
+        dto,
+        createResponse(),
+        createRequest('key-1'),
+      );
+
+      // then
+      expect(result).toBe(`${OAUTH_URL_PATH.BASE_URL}/signin`);
+    });
+
+    it('인증에 성공하면 신규 사용자를 생성하고 refresh 쿠키 설정 후 성공 URL을 반환한다.', async () => {
+      // given
+      const dto = {
+        state: encodeState({ provider: OAuthType.Google, csrfToken: 'key-1' }),
+        code: 'auth-code',
+      } as OAuthCallbackRequestDto;
+      redisService.eval.mockResolvedValue(`${OAuthType.Google}-CSRF`);
+      googleProvider.getTokens.mockResolvedValue({
+        access_token: 'at',
+        refresh_token: 'rt',
+      });
+      googleProvider.getUserInfo.mockResolvedValue({
+        id: 'provider-uid',
+        email: 'oauth@test.com',
+        name: 'oauth-user',
+        picture: null,
+      });
+      providerRepository.findByProviderTypeAndId.mockResolvedValue(null);
+      userRepository.findOne.mockResolvedValue(null);
+      const cookie = jest.fn();
+      const res = { cookie, clearCookie: jest.fn() } as unknown as Response;
+
+      // when
+      const result = await oAuthService.callback(dto, res, createRequest('key-1'));
+
+      // then
+      expect(manager.save).toHaveBeenCalledTimes(2); // User + Provider
+      expect(cookie).toHaveBeenCalledWith(
+        'refresh_token',
+        'service-refresh',
+        expect.anything(),
+      );
+      expect(result).toBe(`${OAUTH_URL_PATH.BASE_URL}/oauth-success`);
+    });
+  });
+
+  describe('e2eCallback', () => {
+    it('테스트용 OAuth 로그인을 처리하고 refresh 쿠키를 설정한다.', async () => {
+      // given
+      providerRepository.findByProviderTypeAndId.mockResolvedValue(null);
+      userRepository.findOne.mockResolvedValue(null);
+      const cookie = jest.fn();
+      const res = { cookie } as unknown as Response;
+
+      // when
+      await oAuthService.e2eCallback(OAuthType.Google, res);
+
+      // then
+      expect(cookie).toHaveBeenCalledWith(
+        'refresh_token',
+        'service-refresh',
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -1,0 +1,345 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+
+import axios from 'axios';
+import { DataSource } from 'typeorm';
+
+import { EmailProducer } from '@common/email/email.producer';
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
+import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
+import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
+import { ReadRssRejectHistoryResponseDto } from '@rss/dto/response/readRssRejectHistory.dto';
+import {
+  RssAcceptRepository,
+  RssRejectRepository,
+  RssRepository,
+} from '@rss/repository/rss.repository';
+import { RssService } from '@rss/service/rss.service';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe(`${RssService.name} Unit Test`, () => {
+  let rssService: RssService;
+  let rssRepository: jest.Mocked<
+    Pick<RssRepository, 'findOne' | 'find' | 'insert' | 'delete'>
+  >;
+  let rssAcceptRepository: jest.Mocked<
+    Pick<RssAcceptRepository, 'findOne' | 'find' | 'delete'>
+  >;
+  let rssRejectRepository: jest.Mocked<Pick<RssRejectRepository, 'find'>>;
+  let emailProducer: jest.Mocked<
+    Pick<
+      EmailProducer,
+      'produceRssRegistration' | 'produceRssRemoval'
+    >
+  >;
+  let manager: { save: jest.Mock; remove: jest.Mock; delete: jest.Mock };
+  let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+  let redisService: jest.Mocked<Pick<RedisService, 'rpush' | 'set' | 'get' | 'del'>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rssRepository = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      insert: jest.fn(),
+      delete: jest.fn(),
+    };
+    rssAcceptRepository = { findOne: jest.fn(), find: jest.fn(), delete: jest.fn() };
+    rssRejectRepository = { find: jest.fn() };
+    emailProducer = {
+      produceRssRegistration: jest.fn(),
+      produceRssRemoval: jest.fn(),
+    };
+    manager = { save: jest.fn(), remove: jest.fn(), delete: jest.fn() };
+    dataSource = {
+      transaction: jest.fn((cb: any) => cb(manager)),
+    } as any;
+    redisService = { rpush: jest.fn(), set: jest.fn(), get: jest.fn(), del: jest.fn() };
+
+    rssService = new RssService(
+      rssRepository as unknown as RssRepository,
+      rssAcceptRepository as unknown as RssAcceptRepository,
+      rssRejectRepository as unknown as RssRejectRepository,
+      emailProducer as unknown as EmailProducer,
+      dataSource as unknown as DataSource,
+      redisService as unknown as RedisService,
+    );
+  });
+
+  describe('createRss', () => {
+    const dto = {
+      blog: 'My Blog',
+      rssUrl: 'https://blog.test/rss',
+      toEntity: () => ({ name: 'My Blog', rssUrl: 'https://blog.test/rss' }),
+    } as unknown as RegisterRssRequestDto;
+
+    it('이미 신청된 RSS가 있으면 ConflictException을 던진다.', async () => {
+      // given
+      rssRepository.findOne.mockResolvedValue({
+        rssUrl: 'https://blog.test/rss',
+        name: 'My Blog',
+      } as any);
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(rssService.createRss(dto)).rejects.toThrow(ConflictException);
+      expect(rssRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('중복이 없으면 RSS를 저장한다.', async () => {
+      // given
+      rssRepository.findOne.mockResolvedValue(null);
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+
+      // when
+      await rssService.createRss(dto);
+
+      // then
+      expect(rssRepository.insert).toHaveBeenCalledWith(dto.toEntity());
+    });
+  });
+
+  describe('readAllRss', () => {
+    it('신청 목록을 조회하고 응답으로 변환한다.', async () => {
+      // given
+      const rssList = [] as any;
+      rssRepository.find.mockResolvedValue(rssList);
+
+      // when
+      const result = await rssService.readAllRss();
+
+      // then
+      expect(rssRepository.find).toHaveBeenCalled();
+      expect(result).toEqual(ReadRssResponseDto.toResponseDtoArray(rssList));
+    });
+  });
+
+  describe('readAcceptHistory', () => {
+    it('승인 이력을 id 내림차순으로 조회한다.', async () => {
+      // given
+      const list = [] as any;
+      rssAcceptRepository.find.mockResolvedValue(list);
+
+      // when
+      const result = await rssService.readAcceptHistory();
+
+      // then
+      expect(rssAcceptRepository.find).toHaveBeenCalledWith({
+        order: { id: 'DESC' },
+      });
+      expect(result).toEqual(
+        ReadRssAcceptHistoryResponseDto.toResponseDtoArray(list),
+      );
+    });
+  });
+
+  describe('readRejectHistory', () => {
+    it('거절 이력을 id 내림차순으로 조회한다.', async () => {
+      // given
+      const list = [] as any;
+      rssRejectRepository.find.mockResolvedValue(list);
+
+      // when
+      const result = await rssService.readRejectHistory();
+
+      // then
+      expect(rssRejectRepository.find).toHaveBeenCalledWith({
+        order: { id: 'DESC' },
+      });
+      expect(result).toEqual(
+        ReadRssRejectHistoryResponseDto.toResponseDtoArray(list),
+      );
+    });
+  });
+
+  describe('acceptRss', () => {
+    const param = { id: 1 };
+
+    it('신청이 없으면 NotFoundException을 던진다.', async () => {
+      // given
+      rssRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(rssService.acceptRss(param)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('RSS URL이 유효하지 않으면 BadRequestException을 던진다.', async () => {
+      // given
+      rssRepository.findOne.mockResolvedValue({
+        id: 1,
+        rssUrl: 'https://invalid.test/rss',
+      } as any);
+      mockedAxios.get.mockRejectedValue(new Error('network'));
+
+      // when & then
+      await expect(rssService.acceptRss(param)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('유효하면 승인 처리 후 크롤 큐에 적재하고 승인 메일을 발송한다.', async () => {
+      // given
+      rssRepository.findOne.mockResolvedValue({
+        id: 1,
+        rssUrl: 'https://velog.test/rss',
+        name: 'blog',
+        userName: 'tester',
+        email: 'a@test.com',
+      } as any);
+      mockedAxios.get.mockResolvedValue({ status: 200 });
+      manager.save.mockResolvedValue({ id: 100 });
+
+      // when
+      await rssService.acceptRss(param);
+
+      // then
+      expect(redisService.rpush).toHaveBeenCalledWith(
+        REDIS_KEYS.FULL_FEED_CRAWL_QUEUE,
+        expect.any(String),
+      );
+      expect(emailProducer.produceRssRegistration).toHaveBeenCalledWith(
+        { id: 100 },
+        true,
+      );
+    });
+  });
+
+  describe('rejectRss', () => {
+    const param = { id: 1 };
+    const body = { description: '품질 미달' };
+
+    it('신청이 없으면 NotFoundException을 던진다.', async () => {
+      rssRepository.findOne.mockResolvedValue(null);
+      await expect(rssService.rejectRss(param, body)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('거절 시 사유와 함께 거절 메일을 발송한다.', async () => {
+      // given
+      const rss = { id: 1, rssUrl: 'https://blog.test/rss' };
+      rssRepository.findOne.mockResolvedValue(rss as any);
+      manager.remove.mockResolvedValue(rss);
+
+      // when
+      await rssService.rejectRss(param, body);
+
+      // then
+      expect(emailProducer.produceRssRegistration).toHaveBeenCalledWith(
+        rss,
+        false,
+        '품질 미달',
+      );
+    });
+  });
+
+  describe('requestRemove', () => {
+    const dto = {
+      blogUrl: 'https://blog.test/rss',
+      email: 'a@test.com',
+    };
+
+    it('해당 RSS 데이터가 없으면 NotFoundException을 던진다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+      rssRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(rssService.requestRemove(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('인증 코드를 저장하고 삭제 인증 메일을 발송한다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue({
+        userName: 'tester',
+      } as any);
+      rssRepository.findOne.mockResolvedValue(null);
+
+      // when
+      await rssService.requestRemove(dto);
+
+      // then
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.RSS_REMOVE_KEY),
+        dto.blogUrl,
+        'EX',
+        300,
+      );
+      expect(emailProducer.produceRssRemoval).toHaveBeenCalledWith(
+        'tester',
+        dto.email,
+        dto.blogUrl,
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('deleteRss', () => {
+    const dto = { code: 'cert-code' };
+    const redisKey = `${REDIS_KEYS.RSS_REMOVE_KEY}:cert-code`;
+
+    it('인증 코드가 만료되었으면 NotFoundException을 던진다.', async () => {
+      // given
+      redisService.get.mockResolvedValue(null);
+
+      // when & then
+      await expect(rssService.deleteRss(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(redisService.del).not.toHaveBeenCalled();
+    });
+
+    it('이미 삭제된 RSS면 NotFoundException을 던지고 인증 코드는 정리한다.', async () => {
+      // given
+      redisService.get.mockResolvedValue('https://blog.test/rss');
+      rssAcceptRepository.delete.mockResolvedValue({ affected: 0 } as any);
+      rssRepository.delete.mockResolvedValue({ affected: 0 } as any);
+
+      // when & then
+      await expect(rssService.deleteRss(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(redisService.del).toHaveBeenCalledWith(redisKey);
+    });
+
+    it('삭제에 성공하면 인증 코드를 정리한다.', async () => {
+      // given
+      redisService.get.mockResolvedValue('https://blog.test/rss');
+      rssAcceptRepository.delete.mockResolvedValue({ affected: 1 } as any);
+      rssRepository.delete.mockResolvedValue({ affected: 0 } as any);
+
+      // when
+      await rssService.deleteRss(dto);
+
+      // then
+      expect(redisService.del).toHaveBeenCalledWith(redisKey);
+    });
+  });
+
+  describe('identifyPlatformFromRssUrl (private)', () => {
+    it.each([
+      ['https://medium.com/feed', 'medium'],
+      ['https://blog.tistory.com/rss', 'tistory'],
+      ['https://v2.velog.io/rss', 'velog'],
+      ['https://user.github.io/feed', 'github'],
+      ['https://unknown.dev/rss', 'etc'],
+    ])('%s → %s 플랫폼으로 식별한다.', (url, expected) => {
+      const svc = rssService as unknown as {
+        identifyPlatformFromRssUrl(rssUrl: string): string;
+      };
+      expect(svc.identifyPlatformFromRssUrl(url)).toBe(expected);
+    });
+  });
+});

--- a/server/test/statistic/unit/statistic.service.unit.spec.ts
+++ b/server/test/statistic/unit/statistic.service.unit.spec.ts
@@ -1,0 +1,125 @@
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { ReadStatisticRequestDto } from '@statistic/dto/request/readStatistic.dto';
+import { ReadStatisticAllResponseDto } from '@statistic/dto/response/readStatisticAll.dto';
+import { ReadStatisticPlatformResponseDto } from '@statistic/dto/response/readStatisticPlatform.dto';
+import { ReadStatisticTodayResponseDto } from '@statistic/dto/response/readStatisticToday.dto';
+import { StatisticService } from '@statistic/service/statistic.service';
+
+describe(`${StatisticService.name} Unit Test`, () => {
+  let statisticService: StatisticService;
+  let redisService: jest.Mocked<Pick<RedisService, 'zrevrange'>>;
+  let feedRepository: jest.Mocked<
+    Pick<FeedRepository, 'findOne' | 'findAllStatisticsOrderByViewCount'>
+  >;
+  let rssAcceptRepository: jest.Mocked<
+    Pick<RssAcceptRepository, 'countByBlogPlatform'>
+  >;
+
+  beforeEach(() => {
+    redisService = { zrevrange: jest.fn() };
+    feedRepository = {
+      findOne: jest.fn(),
+      findAllStatisticsOrderByViewCount: jest.fn(),
+    };
+    rssAcceptRepository = { countByBlogPlatform: jest.fn() };
+
+    statisticService = new StatisticService(
+      redisService as unknown as RedisService,
+      feedRepository as unknown as FeedRepository,
+      rssAcceptRepository as unknown as RssAcceptRepository,
+    );
+  });
+
+  describe('readTodayStatistic', () => {
+    const queryDto = { limit: 5 } as ReadStatisticRequestDto;
+
+    it('zrevrange 결과(id/score 평탄 배열)를 2칸씩 묶어 피드를 조회하고 응답으로 변환한다.', async () => {
+      // given
+      redisService.zrevrange.mockResolvedValue(['1', '10', '2', '5']);
+      feedRepository.findOne.mockImplementation((options) => {
+        const id = (options.where as { id: number }).id;
+        return Promise.resolve({ id, title: `title-${id}` } as Feed);
+      });
+
+      // when
+      const result = await statisticService.readTodayStatistic(queryDto);
+
+      // then
+      expect(redisService.zrevrange).toHaveBeenCalledWith(
+        REDIS_KEYS.FEED_TREND_KEY,
+        0,
+        queryDto.limit - 1,
+        'WITHSCORES',
+      );
+      expect(feedRepository.findOne).toHaveBeenCalledTimes(2);
+      expect(result).toEqual(
+        ReadStatisticTodayResponseDto.toResponseDtoArray([
+          { id: 1, title: 'title-1', viewCount: 10 },
+          { id: 2, title: 'title-2', viewCount: 5 },
+        ]),
+      );
+    });
+
+    it('랭킹이 비어 있으면 빈 응답을 반환한다.', async () => {
+      // given
+      redisService.zrevrange.mockResolvedValue([]);
+
+      // when
+      const result = await statisticService.readTodayStatistic(queryDto);
+
+      // then
+      expect(feedRepository.findOne).not.toHaveBeenCalled();
+      expect(result).toEqual(
+        ReadStatisticTodayResponseDto.toResponseDtoArray([]),
+      );
+    });
+  });
+
+  describe('readAllStatistic', () => {
+    it('limit으로 통계를 조회하고 응답으로 변환한다.', async () => {
+      // given
+      const queryDto = { limit: 3 } as ReadStatisticRequestDto;
+      const ranking = [{ id: 1, title: 'a', viewCount: 100 }] as any;
+      feedRepository.findAllStatisticsOrderByViewCount.mockResolvedValue(
+        ranking,
+      );
+
+      // when
+      const result = await statisticService.readAllStatistic(queryDto);
+
+      // then
+      expect(
+        feedRepository.findAllStatisticsOrderByViewCount,
+      ).toHaveBeenCalledWith(queryDto.limit);
+      expect(result).toEqual(
+        ReadStatisticAllResponseDto.toResponseDtoArray(ranking),
+      );
+    });
+  });
+
+  describe('readPlatformStatistic', () => {
+    it('플랫폼별 집계를 조회하고 응답으로 변환한다.', async () => {
+      // given
+      const platformStatistics = [{ platform: 'velog', count: 7 }] as any;
+      rssAcceptRepository.countByBlogPlatform.mockResolvedValue(
+        platformStatistics,
+      );
+
+      // when
+      const result = await statisticService.readPlatformStatistic();
+
+      // then
+      expect(rssAcceptRepository.countByBlogPlatform).toHaveBeenCalled();
+      expect(result).toEqual(
+        ReadStatisticPlatformResponseDto.toResponseDtoArray(platformStatistics),
+      );
+    });
+  });
+});

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -1,0 +1,521 @@
+import {
+  ConflictException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+
+import { Response } from 'express';
+
+import { EmailProducer } from '@common/email/email.producer';
+import { Payload } from '@common/guard/jwt.guard';
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { FileService } from '@file/service/file.service';
+
+import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
+import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
+import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+import { UserService } from '@user/service/user.service';
+
+import {
+  USER_DEFAULT_PASSWORD,
+  UserFixture,
+} from '@test/config/common/fixture/user.fixture';
+
+describe(`${UserService.name} Unit Test`, () => {
+  let userService: UserService;
+  let userRepository: jest.Mocked<
+    Pick<UserRepository, 'findOneBy' | 'findOne' | 'save' | 'remove'>
+  >;
+  let redisService: jest.Mocked<
+    Pick<RedisService, 'set' | 'get' | 'del' | 'setex'>
+  >;
+  let emailProducer: jest.Mocked<
+    Pick<
+      EmailProducer,
+      | 'produceUserCertification'
+      | 'producePasswordReset'
+      | 'produceAccountDeletion'
+    >
+  >;
+  let jwtService: jest.Mocked<Pick<JwtService, 'sign'>>;
+  let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
+  let fileService: jest.Mocked<Pick<FileService, 'deleteByPath'>>;
+
+  const createResponse = () => ({ cookie: jest.fn() }) as unknown as Response;
+
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const midnightToday = () => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  };
+  const daysAgo = (days: number) =>
+    new Date(midnightToday().getTime() - days * DAY_MS);
+
+  beforeEach(() => {
+    userRepository = {
+      findOneBy: jest.fn(),
+      findOne: jest.fn(),
+      save: jest.fn(),
+      remove: jest.fn(),
+    };
+    redisService = {
+      set: jest.fn(),
+      get: jest.fn(),
+      del: jest.fn(),
+      setex: jest.fn(),
+    };
+    emailProducer = {
+      produceUserCertification: jest.fn(),
+      producePasswordReset: jest.fn(),
+      produceAccountDeletion: jest.fn(),
+    };
+    jwtService = { sign: jest.fn().mockReturnValue('signed-token') };
+    configService = { get: jest.fn().mockReturnValue('14d') };
+    fileService = { deleteByPath: jest.fn() };
+
+    userService = new UserService(
+      userRepository as unknown as UserRepository,
+      redisService as unknown as RedisService,
+      emailProducer as unknown as EmailProducer,
+      jwtService as unknown as JwtService,
+      configService as unknown as ConfigService,
+      fileService as unknown as FileService,
+    );
+  });
+
+  describe('getUser', () => {
+    it('존재하지 않으면 NotFoundException을 던진다.', async () => {
+      userRepository.findOneBy.mockResolvedValue(null);
+      await expect(userService.getUser(1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('존재하면 사용자를 반환한다.', async () => {
+      const user = UserFixture.createUserFixture();
+      userRepository.findOneBy.mockResolvedValue(user);
+      await expect(userService.getUser(1)).resolves.toBe(user);
+    });
+  });
+
+  describe('updateUserActivity', () => {
+    const arrangeUser = (overwrites: Partial<User>) => {
+      const user = UserFixture.createUserFixture(overwrites);
+      userRepository.findOneBy.mockResolvedValue(user);
+      return user;
+    };
+
+    it('첫 활동(lastActiveDate 없음)이면 currentStreak을 1로 설정한다.', async () => {
+      const user = arrangeUser({
+        lastActiveDate: null,
+        currentStreak: 7,
+        maxStreak: 15,
+      });
+      await userService.updateUserActivity(user.id);
+      expect(user.currentStreak).toBe(1);
+      expect(user.maxStreak).toBe(15);
+    });
+
+    it('어제 활동(daysDiff === 1)이면 currentStreak을 1 증가시킨다.', async () => {
+      const user = arrangeUser({
+        lastActiveDate: daysAgo(1),
+        currentStreak: 7,
+        maxStreak: 15,
+      });
+      await userService.updateUserActivity(user.id);
+      expect(user.currentStreak).toBe(8);
+    });
+
+    it('같은 날 재활동(daysDiff === 0)이면 currentStreak을 유지한다.', async () => {
+      const user = arrangeUser({
+        lastActiveDate: daysAgo(0),
+        currentStreak: 7,
+        maxStreak: 15,
+      });
+      await userService.updateUserActivity(user.id);
+      expect(user.currentStreak).toBe(7);
+    });
+
+    it('하루를 건너뛰면(daysDiff > 1) currentStreak을 1로 초기화한다.', async () => {
+      const user = arrangeUser({
+        lastActiveDate: daysAgo(3),
+        currentStreak: 7,
+        maxStreak: 15,
+      });
+      await userService.updateUserActivity(user.id);
+      expect(user.currentStreak).toBe(1);
+    });
+
+    it('currentStreak이 maxStreak을 넘으면 maxStreak을 갱신한다.', async () => {
+      const user = arrangeUser({
+        lastActiveDate: daysAgo(1),
+        currentStreak: 15,
+        maxStreak: 15,
+      });
+      await userService.updateUserActivity(user.id);
+      expect(user.currentStreak).toBe(16);
+      expect(user.maxStreak).toBe(16);
+    });
+
+    it('스트릭이 끊겨도 maxStreak은 유지한다.', async () => {
+      const user = arrangeUser({
+        lastActiveDate: daysAgo(3),
+        currentStreak: 7,
+        maxStreak: 15,
+      });
+      await userService.updateUserActivity(user.id);
+      expect(user.currentStreak).toBe(1);
+      expect(user.maxStreak).toBe(15);
+    });
+
+    it('호출 시 totalViews를 1 증가시키고 lastActiveDate를 오늘로 갱신한 뒤 저장한다.', async () => {
+      const user = arrangeUser({
+        lastActiveDate: daysAgo(1),
+        totalViews: 120,
+      });
+      await userService.updateUserActivity(user.id);
+      expect(user.totalViews).toBe(121);
+      expect(user.lastActiveDate).toStrictEqual(midnightToday());
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+    });
+
+    it('존재하지 않는 사용자면 NotFoundException을 던지고 저장하지 않는다.', async () => {
+      userRepository.findOneBy.mockResolvedValue(null);
+      await expect(
+        userService.updateUserActivity(Number.MAX_SAFE_INTEGER),
+      ).rejects.toThrow(NotFoundException);
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkEmailDuplication', () => {
+    it('이메일이 존재하면 exists=true 응답을 반환한다.', async () => {
+      userRepository.findOne.mockResolvedValue(UserFixture.createUserFixture());
+      const result = await userService.checkEmailDuplication('a@test.com');
+      expect(result).toEqual(CheckEmailDuplicationResponseDto.toResponseDto(true));
+    });
+
+    it('이메일이 없으면 exists=false 응답을 반환한다.', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+      const result = await userService.checkEmailDuplication('a@test.com');
+      expect(result).toEqual(
+        CheckEmailDuplicationResponseDto.toResponseDto(false),
+      );
+    });
+  });
+
+  describe('registerUser', () => {
+    const dto = {
+      email: 'new@test.com',
+      password: USER_DEFAULT_PASSWORD,
+      toEntity: () => UserFixture.createUserFixture({ email: 'new@test.com' }),
+    } as unknown as RegisterUserRequestDto;
+
+    it('이미 존재하는 이메일이면 ConflictException을 던진다.', async () => {
+      userRepository.findOne.mockResolvedValue(UserFixture.createUserFixture());
+      await expect(userService.registerUser(dto)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('신규 이메일이면 인증 정보를 Redis에 저장하고 인증 메일을 발송한다.', async () => {
+      // given
+      userRepository.findOne.mockResolvedValue(null);
+
+      // when
+      await userService.registerUser(dto);
+
+      // then
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.USER_AUTH_KEY),
+        expect.any(String),
+        'EX',
+        600,
+      );
+      expect(emailProducer.produceUserCertification).toHaveBeenCalled();
+    });
+  });
+
+  describe('certificateUser', () => {
+    it('인증 정보가 없으면 NotFoundException을 던진다.', async () => {
+      redisService.get.mockResolvedValue(null);
+      await expect(userService.certificateUser('uuid')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('인증에 성공하면 Redis 키를 지우고 사용자를 저장한다.', async () => {
+      // given
+      redisService.get.mockResolvedValue(JSON.stringify({ email: 'a@test.com' }));
+
+      // when
+      await userService.certificateUser('uuid');
+
+      // then
+      expect(redisService.del).toHaveBeenCalled();
+      expect(userRepository.save).toHaveBeenCalledWith({ email: 'a@test.com' });
+    });
+  });
+
+  describe('loginUser', () => {
+    const dto = {
+      email: 'a@test.com',
+      password: USER_DEFAULT_PASSWORD,
+    };
+
+    it('비밀번호가 틀리면 UnauthorizedException을 던진다.', async () => {
+      const user = await UserFixture.createUserCryptFixture();
+      userRepository.findOne.mockResolvedValue(user);
+      await expect(
+        userService.loginUser(
+          { ...dto, password: 'wrong!' },
+          createResponse(),
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('로그인에 성공하면 refresh 쿠키를 설정하고 access token을 반환한다.', async () => {
+      // given
+      const user = await UserFixture.createUserCryptFixture();
+      userRepository.findOne.mockResolvedValue(user);
+      const cookie = jest.fn();
+      const response = { cookie } as unknown as Response;
+
+      // when
+      const result = await userService.loginUser(dto, response);
+
+      // then
+      expect(cookie).toHaveBeenCalledWith(
+        'refresh_token',
+        'signed-token',
+        expect.anything(),
+      );
+      expect(result).toEqual(
+        CreateAccessTokenResponseDto.toResponseDto('signed-token'),
+      );
+    });
+  });
+
+  describe('updateUser', () => {
+    const userId = 1;
+
+    it('프로필 이미지가 변경되면 기존 파일을 삭제하고 교체한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({
+        profileImage: 'old.png',
+      });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.updateUser(userId, {
+        profileImage: 'new.png',
+      });
+
+      // then
+      expect(fileService.deleteByPath).toHaveBeenCalledWith('old.png');
+      expect(user.profileImage).toBe('new.png');
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+    });
+
+    it('동일한 프로필 이미지면 파일을 삭제하지 않는다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ profileImage: 'same.png' });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.updateUser(userId, {
+        profileImage: 'same.png',
+      });
+
+      // then
+      expect(fileService.deleteByPath).not.toHaveBeenCalled();
+    });
+
+    it('userName만 들어오면 이름만 변경한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ userName: 'old' });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.updateUser(userId, {
+        userName: 'new',
+      });
+
+      // then
+      expect(user.userName).toBe('new');
+      expect(fileService.deleteByPath).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('사용자가 없으면 조용히 종료한다.', async () => {
+      // given
+      userRepository.findOne.mockResolvedValue(null);
+
+      // when
+      await userService.forgotPassword('a@test.com');
+
+      // then
+      expect(redisService.set).not.toHaveBeenCalled();
+      expect(emailProducer.producePasswordReset).not.toHaveBeenCalled();
+    });
+
+    it('사용자가 있으면 인증 코드를 저장하고 메일을 발송한다.', async () => {
+      // given
+      userRepository.findOne.mockResolvedValue(
+        UserFixture.createUserFixture({ id: 1 }),
+      );
+
+      // when
+      await userService.forgotPassword('a@test.com');
+
+      // then
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.USER_RESET_PASSWORD_KEY),
+        expect.any(String),
+        'EX',
+        600,
+      );
+      expect(emailProducer.producePasswordReset).toHaveBeenCalled();
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('인증 코드가 유효하지 않으면 NotFoundException을 던진다.', async () => {
+      redisService.get.mockResolvedValue(null);
+      await expect(
+        userService.resetPassword('uuid', 'newPass1!'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('인증에 성공하면 비밀번호를 해시해 저장하고 코드를 정리한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture();
+      redisService.get.mockResolvedValue('1');
+      userRepository.findOne.mockResolvedValue(user);
+
+      // when
+      await userService.resetPassword('uuid', 'newPass1!');
+
+      // then
+      expect(user.password).not.toBe('newPass1!');
+      expect(redisService.del).toHaveBeenCalled();
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+    });
+  });
+
+  describe('refreshAccessToken', () => {
+    it('access token을 재발급해 응답으로 반환한다.', () => {
+      // given
+      const payload: Payload = {
+        id: 1,
+        email: 'a@test.com',
+        userName: 'tester',
+        role: 'user',
+      };
+
+      // when
+      const result = userService.refreshAccessToken(payload);
+
+      // then
+      expect(jwtService.sign).toHaveBeenCalled();
+      expect(result).toEqual(
+        CreateAccessTokenResponseDto.toResponseDto('signed-token'),
+      );
+    });
+  });
+
+  describe('requestDeleteAccount', () => {
+    it('존재하지 않는 사용자면 NotFoundException을 던진다.', async () => {
+      // given
+      userRepository.findOneBy.mockResolvedValue(null);
+
+      // when & then
+      await expect(userService.requestDeleteAccount(1)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(redisService.set).not.toHaveBeenCalled();
+      expect(emailProducer.produceAccountDeletion).not.toHaveBeenCalled();
+    });
+
+    it('탈퇴 인증 코드를 저장하고 탈퇴 확인 메일을 발송한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ id: 1 });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.requestDeleteAccount(1);
+
+      // then
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.USER_DELETE_ACCOUNT_KEY),
+        '1',
+        'EX',
+        600,
+      );
+      expect(emailProducer.produceAccountDeletion).toHaveBeenCalledWith(
+        user,
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('confirmDeleteAccount', () => {
+    it('토큰이 유효하지 않으면 NotFoundException을 던진다.', async () => {
+      redisService.get.mockResolvedValue(null);
+      await expect(userService.confirmDeleteAccount('token')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('탈퇴를 확정하면 토큰을 무효화하고 사용자와 프로필을 제거한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({
+        id: 1,
+        profileImage: 'avatar.png',
+      });
+      redisService.get.mockResolvedValue('1');
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.confirmDeleteAccount('token');
+
+      // then
+      expect(fileService.deleteByPath).toHaveBeenCalledWith('avatar.png');
+      expect(redisService.setex).toHaveBeenCalledWith(
+        `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:1`,
+        14 * 86400, // parseTimeToSeconds('14d')
+        '1',
+      );
+      expect(userRepository.remove).toHaveBeenCalledWith(user);
+    });
+  });
+
+  describe('parseTimeToSeconds (private)', () => {
+    const parse = (time: string) =>
+      (
+        userService as unknown as {
+          parseTimeToSeconds(time: string): number;
+        }
+      ).parseTimeToSeconds(time);
+
+    it.each([
+      ['30s', 30],
+      ['15m', 15 * 60],
+      ['2h', 2 * 3600],
+      ['7d', 7 * 86400],
+    ])('%s를 %i초로 변환한다.', (input, expected) => {
+      expect(parse(input)).toBe(expected);
+    });
+
+    it('형식이 맞지 않고 fallback도 동일하면 기본값 3600을 반환한다.', () => {
+      configService.get.mockReturnValue('invalid');
+      expect(parse('invalid')).toBe(3600);
+    });
+  });
+});


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #496

### 단위 테스트 작성

-   서버의 각 도메인 서비스 계층(activity, admin, chat, comment, feed, file, like, oauth, rss, statistic, user)에 대한 단위 테스트를 작성했습니다.
-   통합 테스트와 단위 테스트를 명확히 분리하기 위해, 서비스 로직만을 독립적으로 검증하는 단위 테스트를 별도로 구성했습니다.
-   외부 의존성(Repository, 외부 서비스 등)은 mocking 처리하여 서비스 로직 자체의 동작에 집중하도록 했습니다.

### Jest 설정 변경

-   통합 테스트 설정 파일을 Jest `projects` 구조로 변경하여 단위 테스트와 통합 테스트를 분리 실행할 수 있도록 구성했습니다.

# 📋 작업 내용

-   `server/test/*/unit/*.service.unit.spec.ts` 단위 테스트 파일 추가 (11개 도메인)
-   `server/test/config/integration/jest/jest.config.ts` Jest `projects` 구조로 변경