### PR TITLE
✨ feat: 관리자 이름(name) 기능 추가 및 관리자 페이지 표시

### DIFF
--- a/client/src/api/services/admin/auth.ts
+++ b/client/src/api/services/admin/auth.ts
@@ -1,16 +1,16 @@
 import { ADMIN } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
-import { AdminAuthRequest, AdminAuthResponse } from "@/types/auth";
+import { AdminAuthRequest, AdminAuthResponse, AdminSessionResponse } from "@/types/auth";
 
 export const auth = {
   login: async (data: AdminAuthRequest): Promise<AdminAuthResponse> => {
     const response = await axiosInstance.post<AdminAuthResponse>(ADMIN.LOGIN, data);
     return response.data;
   },
-  check: async (): Promise<number> => {
-    const response = await axiosInstance.get<AdminAuthResponse>(ADMIN.CHECK);
-    return response.status;
+  check: async (): Promise<{ name: string }> => {
+    const response = await axiosInstance.get<AdminSessionResponse>(ADMIN.CHECK);
+    return response.data.data;
   },
   logout: async (): Promise<{ message: string }> => {
     const response = await axiosInstance.post<{ message: string }>(ADMIN.LOGOUT);

--- a/client/src/components/admin/layout/AdminHeader.tsx
+++ b/client/src/components/admin/layout/AdminHeader.tsx
@@ -1,12 +1,6 @@
 import { LogOut, User } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 
 import logo from "@/assets/logo-denamu-main.svg";
 
@@ -16,9 +10,11 @@ import { auth } from "@/api/services/admin/auth";
 export const AdminHeader = ({
   setLogin,
   handleTap,
+  name,
 }: {
   setLogin: () => void;
   handleTap: (tap: "RSS" | "MEMBER") => void;
+  name?: string;
 }) => {
   const handleLogout = () => {
     auth.logout();
@@ -38,20 +34,14 @@ export const AdminHeader = ({
 
           {/* Right Side Menu */}
           <div className="flex items-center space-x-4">
-            {/* Notifications */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon">
-                  <User className="h-5 w-5" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem className="text-red-600" onClick={handleLogout}>
-                  <LogOut className="mr-2 h-4 w-4" />
-                  로그아웃
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <div className="flex items-center space-x-2">
+              <User className="h-5 w-5" />
+              {name && <span className="text-sm font-medium">{name}</span>}
+            </div>
+            <Button variant="ghost" className="text-red-600" onClick={handleLogout}>
+              <LogOut className="h-4 w-4" />
+              로그아웃
+            </Button>
           </div>
         </div>
       </div>

--- a/client/src/components/admin/layout/AdminMember.tsx
+++ b/client/src/components/admin/layout/AdminMember.tsx
@@ -15,11 +15,11 @@ import { RegisterResponse, RegisterRequest } from "@/types/admin";
 
 export default function AdminMember() {
   const [viewPassword, setViewPassword] = useState<boolean>(false);
-  const [formData, setFormData] = useState<RegisterRequest>({ loginId: "", password: "" });
+  const [formData, setFormData] = useState<RegisterRequest>({ loginId: "", password: "", name: "" });
 
   const onSuccess = (data: RegisterResponse) => {
     alert(`관리자 등록 성공: ${data.message}`);
-    setFormData({ loginId: "", password: "" });
+    setFormData({ loginId: "", password: "", name: "" });
   };
 
   const onError = (error: AxiosError) => {
@@ -61,6 +61,21 @@ export default function AdminMember() {
                 id="R-ID"
                 value={formData.loginId}
                 onChange={(e) => handleChange(e, "loginId")}
+                className="appearance-none"
+                autoCorrect="off"
+                autoCapitalize="off"
+                spellCheck="false"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="R-Name">이름</Label>
+              <Input
+                type="text"
+                required
+                autoComplete="off"
+                id="R-Name"
+                value={formData.name}
+                onChange={(e) => handleChange(e, "name")}
                 className="appearance-none"
                 autoCorrect="off"
                 autoCapitalize="off"

--- a/client/src/hooks/queries/useAdminAuth.ts
+++ b/client/src/hooks/queries/useAdminAuth.ts
@@ -5,37 +5,41 @@ import { register } from "@/api/services/admin/register";
 import { useAuthStore } from "@/store/useAuthStore";
 import { RegisterRequest, RegisterResponse } from "@/types/admin";
 import { AdminAuthRequest, AdminAuthResponse } from "@/types/auth";
-import { useMutation, UseMutationResult, useQuery } from "@tanstack/react-query";
+import { useMutation, UseMutationResult, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useAdminAuth = (
   onSuccess: (data: AdminAuthResponse) => void,
-  onError: (error: AxiosError<unknown, any>) => void
-): UseMutationResult<AdminAuthResponse, AxiosError<unknown, any>, AdminAuthRequest, unknown> => {
+  onError: (error: AxiosError<unknown, unknown>) => void
+): UseMutationResult<AdminAuthResponse, AxiosError<unknown, unknown>, AdminAuthRequest, unknown> => {
   const setRole = useAuthStore((state) => state.setRole);
-  return useMutation<AdminAuthResponse, AxiosError<unknown, any>, AdminAuthRequest>({
+  const queryClient = useQueryClient();
+  return useMutation<AdminAuthResponse, AxiosError<unknown, unknown>, AdminAuthRequest>({
     mutationFn: async (data) => {
       const response = await auth.login(data);
       setRole("admin");
       return response;
     },
-    onSuccess,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["adminCheck"] });
+      onSuccess(data);
+    },
     onError,
   });
 };
 export const useAdminCheck = () => {
-  const { status, isLoading, error } = useQuery({
+  const { status, isLoading, error, data } = useQuery({
     queryKey: ["adminCheck"],
     queryFn: auth.check,
     retry: 1,
   });
-  return { status, isLoading, error };
+  return { status, isLoading, error, data };
 };
 
 export const useAdminRegister = (
   onSuccess: (data: RegisterResponse) => void,
-  onError: (error: AxiosError<unknown, any>) => void
-): UseMutationResult<RegisterResponse, AxiosError<unknown, any>, RegisterRequest, unknown> => {
-  return useMutation<RegisterResponse, AxiosError<unknown, any>, RegisterRequest>({
+  onError: (error: AxiosError<unknown, unknown>) => void
+): UseMutationResult<RegisterResponse, AxiosError<unknown, unknown>, RegisterRequest, unknown> => {
+  return useMutation<RegisterResponse, AxiosError<unknown, unknown>, RegisterRequest>({
     mutationFn: async (data) => {
       const response = await register.register(data);
       return response;

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -12,7 +12,7 @@ import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
 
 export default function Admin() {
   const [isLogin, setIsLogin] = useState<boolean>(false);
-  const { status, isLoading } = useAdminCheck();
+  const { status, isLoading, data } = useAdminCheck();
   const [tap, setTap] = useState<"RSS" | "MEMBER">("RSS");
 
   useEffect(() => {
@@ -40,7 +40,7 @@ export default function Admin() {
 
   return isLogin ? (
     <main className="min-h-screen bg-background">
-      <AdminHeader setLogin={() => setIsLogin(false)} handleTap={setTap} />
+      <AdminHeader setLogin={() => setIsLogin(false)} handleTap={setTap} name={data?.name} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 h-full">{renderContent()} </div>
     </main>
   ) : (

--- a/client/src/types/admin.ts
+++ b/client/src/types/admin.ts
@@ -1,6 +1,7 @@
 export type RegisterRequest = {
   loginId: string;
   password: string;
+  name: string;
 };
 
 export type RegisterResponse = {

--- a/client/src/types/auth.ts
+++ b/client/src/types/auth.ts
@@ -7,6 +7,13 @@ export type AdminAuthResponse = {
   message: string;
 };
 
+export type AdminSessionResponse = {
+  message: string;
+  data: {
+    name: string;
+  };
+};
+
 export interface UserSignUpRequest {
   email: string;
   password: string;

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -4,6 +4,7 @@ CREATE TABLE `admin` (
   `id` int NOT NULL AUTO_INCREMENT,
   `login_id` varchar(255) NOT NULL,
   `password` varchar(60) NOT NULL,
+  `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 );
 
@@ -161,8 +162,8 @@ CREATE TABLE `provider` (
 
 -- denamu.admin insert data
 
-INSERT INTO admin (login_id, password) VALUES
-	('test1234','$2b$10$lmNFQaXm6yVo3hGMRJk5SuwV2Wn..ej9my29rXOSpiVj7iMrSWau.');
+INSERT INTO admin (login_id, password, name) VALUES
+	('test1234','$2b$10$lmNFQaXm6yVo3hGMRJk5SuwV2Wn..ej9my29rXOSpiVj7iMrSWau.', '테스트 계정');
 
 -- denamu.rss_accept insert data
 

--- a/server/src/admin/api-docs/getSessionIdAdmin.api-docs.ts
+++ b/server/src/admin/api-docs/getSessionIdAdmin.api-docs.ts
@@ -1,8 +1,10 @@
 import { applyDecorators } from '@nestjs/common';
 import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
 
+import { GetSessionAdminResponseDto } from '@admin/dto/response/getSessionAdmin.dto';
+
 import {
-  ApiMessageResponse,
+  ApiDataResponse,
   ApiUnauthorizedDoc,
 } from '@common/swagger/swagger.helper';
 
@@ -10,7 +12,11 @@ export function ApiGetSessionIdAdmin() {
   return applyDecorators(
     ApiCookieAuth('sessionId'),
     ApiOperation({ summary: '관리자 페이지 출력을 위한 sessionId 확인 API' }),
-    ApiMessageResponse('세션이 유효합니다.'),
+    ApiDataResponse(
+      GetSessionAdminResponseDto,
+      false,
+      '세션이 유효하며 관리자 이름을 반환합니다.',
+    ),
     ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
   );
 }

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -72,7 +72,13 @@ export class AdminController {
   @Get('/sessions')
   @HttpCode(HttpStatus.OK)
   @UseGuards(AdminAuthGuard)
-  getSessionIdAdmin() {
-    return ApiResponse.responseWithNoContent('정상적인 sessionId 입니다.');
+  async getSessionIdAdmin(@Req() request: Request) {
+    const sessionAdmin = await this.adminService.getAdminProfile(
+      (request['user'] as { loginId: string }).loginId,
+    );
+    return ApiResponse.responseWithData(
+      '정상적인 sessionId 입니다.',
+      sessionAdmin,
+    );
   }
 }

--- a/server/src/admin/dto/request/registerAdmin.dto.ts
+++ b/server/src/admin/dto/request/registerAdmin.dto.ts
@@ -42,6 +42,21 @@ export class RegisterAdminRequestDto {
   })
   password: string;
 
+  @ApiProperty({
+    example: '홍길동',
+    description: '관리자 이름을 입력해주세요.',
+  })
+  @IsNotEmpty({
+    message: '이름이 없습니다.',
+  })
+  @IsString({
+    message: '문자열을 입력해주세요',
+  })
+  @Length(1, 255, {
+    message: '이름의 길이는 1자 이상, 255자 이하로 작성해주세요.',
+  })
+  name: string;
+
   constructor(partial: Partial<RegisterAdminRequestDto>) {
     Object.assign(this, partial);
   }

--- a/server/src/admin/dto/response/getSessionAdmin.dto.ts
+++ b/server/src/admin/dto/response/getSessionAdmin.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetSessionAdminResponseDto {
+  @ApiProperty({
+    example: '홍길동',
+    description: '관리자 이름',
+  })
+  name: string;
+
+  constructor(partial: Partial<GetSessionAdminResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(name: string) {
+    return new GetSessionAdminResponseDto({ name });
+  }
+}

--- a/server/src/admin/entity/admin.entity.ts
+++ b/server/src/admin/entity/admin.entity.ts
@@ -19,4 +19,10 @@ export class Admin extends BaseEntity {
     nullable: false,
   })
   password: string;
+
+  @Column({
+    length: 255,
+    nullable: false,
+  })
+  name: string;
 }

--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -11,6 +11,7 @@ import { Request, Response } from 'express';
 import { SESSION_TTL } from '@admin/constant/admin.constant';
 import { LoginAdminRequestDto } from '@admin/dto/request/loginAdmin.dto';
 import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
+import { GetSessionAdminResponseDto } from '@admin/dto/response/getSessionAdmin.dto';
 import { AdminRepository } from '@admin/repository/admin.repository';
 
 import { cookieConfig } from '@common/cookie/cookie.config';
@@ -104,5 +105,13 @@ export class AdminService {
     );
 
     await this.adminRepository.save(registerAdminBodyDto.toEntity());
+  }
+
+  async getAdminProfile(loginId: string) {
+    const admin = await this.adminRepository.findOne({
+      where: { loginId },
+    });
+
+    return GetSessionAdminResponseDto.toResponseDto(admin.name);
   }
 }

--- a/server/src/common/database/migration/1780500000000-AddAdminName.ts
+++ b/server/src/common/database/migration/1780500000000-AddAdminName.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAdminName1780500000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`admin\` ADD COLUMN \`name\` varchar(255) NOT NULL DEFAULT '';`,
+    );
+    await queryRunner.query(
+      `UPDATE \`admin\` SET \`name\` = \`login_id\` WHERE \`name\` = '';`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`admin\` ALTER COLUMN \`name\` DROP DEFAULT;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE \`admin\` DROP COLUMN \`name\`;`);
+  }
+}

--- a/server/test/admin/dto/register.dto.spec.ts
+++ b/server/test/admin/dto/register.dto.spec.ts
@@ -142,4 +142,54 @@ describe(`${RegisterAdminRequestDto.name} Test`, () => {
       expect(errors[0].constraints).toHaveProperty('isNotEmpty');
     });
   });
+
+  describe('name', () => {
+    it('이름의 길이가 255 초과일 경우 유효성 검사에 실패한다.', async () => {
+      //given
+      dto.name = 'a'.repeat(256);
+
+      //when
+      const errors = await validate(dto);
+
+      //then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isLength');
+    });
+
+    it('이름이 없을 경우 유효성 검사에 실패한다.', async () => {
+      //given
+      dto.name = null;
+
+      //when
+      const errors = await validate(dto);
+
+      //then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('이름이 빈 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      //given
+      dto.name = '';
+
+      //when
+      const errors = await validate(dto);
+
+      //then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('이름이 문자열이 아니고 정수일 경우 유효성 검사에 실패한다.', async () => {
+      //given
+      dto.name = 1 as any;
+
+      //when
+      const errors = await validate(dto);
+
+      //then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+  });
 });

--- a/server/test/admin/e2e/register.e2e-spec.ts
+++ b/server/test/admin/e2e/register.e2e-spec.ts
@@ -40,6 +40,7 @@ describe(`POST ${URL} E2E Test`, () => {
     const newAdminDto = new RegisterAdminRequestDto({
       loginId: 'testNewAdminId',
       password: 'testNewAdminPassword!',
+      name: 'testNewAdminName',
     });
 
     // Http when
@@ -64,6 +65,7 @@ describe(`POST ${URL} E2E Test`, () => {
     const newAdminDto = new RegisterAdminRequestDto({
       loginId: 'testNewAdminId',
       password: 'testNewAdminPassword!',
+      name: 'testNewAdminName',
     });
 
     // Http when
@@ -94,6 +96,7 @@ describe(`POST ${URL} E2E Test`, () => {
     const newAdminDto = new RegisterAdminRequestDto({
       loginId: admin.loginId,
       password: 'testNewAdminPassword!',
+      name: 'testNewAdminName',
     });
 
     // Http when
@@ -121,6 +124,7 @@ describe(`POST ${URL} E2E Test`, () => {
     const newAdminDto = new RegisterAdminRequestDto({
       loginId: 'testNewAdminId',
       password: 'testNewAdminPassword!',
+      name: 'testNewAdminName',
     });
 
     // Http when

--- a/server/test/admin/e2e/session.e2e-spec.ts
+++ b/server/test/admin/e2e/session.e2e-spec.ts
@@ -26,10 +26,13 @@ describe(`GET ${URL} E2E Test`, () => {
     adminRepository = testApp.get(AdminRepository);
   });
 
+  let registeredName: string;
+
   beforeEach(async () => {
     const admin = await adminRepository.save(
       await AdminFixture.createAdminCryptFixture({ loginId: 'testAdminId' }),
     );
+    registeredName = admin.name;
     await redisService.set(redisKeyMake(sessionKey), admin.loginId);
   });
 
@@ -76,7 +79,7 @@ describe(`GET ${URL} E2E Test`, () => {
     // Http then
     const { data } = response.body;
     expect(response.status).toBe(HttpStatus.OK);
-    expect(data).toBeUndefined();
+    expect(data).toEqual({ name: registeredName });
 
     // DB, Redis when
     const savedSession = await redisService.get(redisKeyMake(sessionKey));

--- a/server/test/config/common/fixture/admin.fixture.ts
+++ b/server/test/config/common/fixture/admin.fixture.ts
@@ -12,6 +12,7 @@ export class AdminFixture {
     return {
       loginId: `test${uuid.v4()}`,
       password: ADMIN_DEFAULT_PASSWORD,
+      name: `name${uuid.v4()}`,
     };
   }
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #693 

### 관리자 이름(name) 속성 추가

- 운영상 어떤 관리자가 어떤 작업을 했는지 식별이 필요해 Admin에 `name` 속성을 추가했습니다.
- 회원가입 시 이름은 **필수** 입력이며, DTO에서 `@IsNotEmpty/@IsString/@Length(1,255)`로 검증합니다.
- 운영 중인 환경의 기존 관리자 행은 `name`이 없으므로, migration에서 `DEFAULT ''`로 컬럼을 추가한 뒤 `login_id` 값으로 백필하고 default를 제거해 `NOT NULL` 무결성을 유지했습니다.

### 세션 확인 API에 이름 응답 추가

- `GET /api/admins/sessions`가 세션 검증과 함께 관리자 `name`을 반환하도록 변경했습니다.
- 응답 형태를 명시하기 위해 `GetSessionAdminResponseDto` 응답 클래스를 도입하고 Swagger 문서(`ApiDataResponse`)에 반영했습니다.

### 관리자 페이지 UI 변경

- 관리자 헤더의 사용자 아이콘 오른쪽에 로그인한 관리자 `name`을 표시합니다.
- 로그아웃을 DropdownMenu에서 분리해 독립 버튼으로 변경했습니다 (기존 드롭다운은 항목이 로그아웃뿐이라 제거).
- 첫 로그인 시 이름이 표시되지 않던 문제를 로그인 성공 후 `adminCheck` 쿼리를 invalidate 하여 재조회하도록 수정했습니다.

# 📋 작업 내용

**Backend**
- `Admin` 엔티티에 `name` 컬럼 추가
- `RegisterAdminRequestDto`에 `name` 검증 추가
- migration `AddAdminName` 작성 (DEFAULT '' → login_id 백필 → DROP DEFAULT)
- `init.sql` 예제 관리자 데이터에 name 반영
- `getSessionIdAdmin`가 `GetSessionAdminResponseDto`로 name 반환
- 단위/E2E 테스트 추가 (register dto, register e2e, session e2e, fixture)

**Frontend**
- 관리자 회원가입 폼에 이름 입력 필드 추가
- 세션 응답 타입(`AdminSessionResponse`) 및 `auth.check` 반환값 변경
- `useAdminCheck`가 name 데이터 노출, `AdminHeader`에서 표시
- 로그아웃 독립 버튼화
- 로그인 성공 시 `adminCheck` invalidate로 첫 로그인부터 이름 표시

# 📷 스크린 샷(선택 사항)
- 변경 전
<img width="1247" height="103" alt="image" src="https://github.com/user-attachments/assets/f014a275-b0c9-4659-b342-b2a38fbe06de" />

- 변경 후
<img width="1228" height="72" alt="image" src="https://github.com/user-attachments/assets/7e407b67-694b-43c6-8e77-42cd1a0b82a8" />
