### PR TITLE
♻️ refactor: 소유권 없는 요청에 401 대신 403 응답

### DIFF
--- a/server/src/comment/api-docs/deleteComment.api-docs.ts
+++ b/server/src/comment/api-docs/deleteComment.api-docs.ts
@@ -3,6 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
 
 import {
   ApiBadRequestDoc,
+  ApiForbiddenDoc,
   ApiMessageResponse,
   ApiNotFoundDoc,
   ApiUnauthorizedDoc,
@@ -17,6 +18,7 @@ export function ApiDeleteComment() {
     ApiMessageResponse('댓글 삭제 성공'),
     ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
     ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiForbiddenDoc('본인이 작성한 댓글이 아닙니다.'),
     ApiNotFoundDoc('존재하지 않는 댓글입니다.'),
   );
 }

--- a/server/src/comment/api-docs/updateComment.api-docs.ts
+++ b/server/src/comment/api-docs/updateComment.api-docs.ts
@@ -3,6 +3,7 @@ import { ApiBearerAuth, ApiBody, ApiOperation, ApiParam } from '@nestjs/swagger'
 
 import {
   ApiBadRequestDoc,
+  ApiForbiddenDoc,
   ApiMessageResponse,
   ApiNotFoundDoc,
   ApiUnauthorizedDoc,
@@ -19,6 +20,7 @@ export function ApiUpdateComment() {
     ApiMessageResponse('댓글 수정 성공'),
     ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
     ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiForbiddenDoc('본인이 작성한 댓글이 아닙니다.'),
     ApiNotFoundDoc('존재하지 않는 댓글입니다.'),
   );
 }

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -1,7 +1,7 @@
 import {
+  ForbiddenException,
   Injectable,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 
 import { DataSource } from 'typeorm';
@@ -42,7 +42,7 @@ export class CommentService {
     }
 
     if (userInformation.id !== commentObj.user.id) {
-      throw new UnauthorizedException('본인이 작성한 댓글이 아닙니다.');
+      throw new ForbiddenException('본인이 작성한 댓글이 아닙니다.');
     }
 
     return commentObj;

--- a/server/src/file/api-docs/deleteFile.api-docs.ts
+++ b/server/src/file/api-docs/deleteFile.api-docs.ts
@@ -3,6 +3,7 @@ import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
 
 import {
   ApiBadRequestDoc,
+  ApiForbiddenDoc,
   ApiMessageResponse,
   ApiNotFoundDoc,
   ApiUnauthorizedDoc,
@@ -25,5 +26,6 @@ export function ApiDeleteFile() {
     ApiBadRequestDoc('잘못된 요청'),
     ApiNotFoundDoc('파일을 찾을 수 없음'),
     ApiUnauthorizedDoc('인증되지 않은 사용자'),
+    ApiForbiddenDoc('파일 삭제 권한이 없습니다.'),
   );
 }

--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -1,7 +1,7 @@
 import {
+  ForbiddenException,
   Injectable,
   NotFoundException,
-  UnauthorizedException,
 } from '@nestjs/common';
 
 import * as fs from 'fs/promises';
@@ -82,7 +82,7 @@ export class FileService {
     const file = await this.findById(id);
 
     if (file.user.id !== userId) {
-      throw new UnauthorizedException('파일 삭제 권한이 없습니다.');
+      throw new ForbiddenException('파일 삭제 권한이 없습니다.');
     }
 
     try {

--- a/server/test/comment/e2e/delete.e2e-spec.ts
+++ b/server/test/comment/e2e/delete.e2e-spec.ts
@@ -91,30 +91,7 @@ describe(`DELETE ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
-  it('[401] 본인의 계정 정보가 삭제됐을 경우 댓글 삭제를 실패한다.', async () => {
-    // given
-    accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
-
-    // Http when
-    const response = await agent
-      .delete(`${BASE_URL}/${feed.id}/comments/${comment.id}`)
-      .set('Authorization', `Bearer ${accessToken}`);
-
-    // Http then
-    const { data } = response.body;
-    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
-    expect(data).toBeUndefined();
-
-    // DB, Redis when
-    const savedComment = await commentRepository.findOneBy({
-      id: comment.id,
-    });
-
-    // DB, Redis then
-    expect(savedComment.comment).toBe(comment.comment);
-  });
-
-  it('[401] 본인이 작성한 댓글이 아닐 경우 댓글 삭제를 실패한다.', async () => {
+  it('[403] 본인이 작성한 댓글이 아닐 경우 댓글 삭제를 실패한다.', async () => {
     // given
     accessToken = createAccessToken({ id: user2.id });
 
@@ -125,7 +102,7 @@ describe(`DELETE ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
 
     // Http then
     const { data } = response.body;
-    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
     expect(data).toBeUndefined();
 
     // DB, Redis when

--- a/server/test/comment/e2e/update.e2e-spec.ts
+++ b/server/test/comment/e2e/update.e2e-spec.ts
@@ -100,31 +100,7 @@ describe(`PATCH ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
     expect(savedComment.comment).toBe(comment.comment);
   });
 
-  it('[401] 본인의 계정 정보가 삭제됐을 경우 댓글 수정을 실패한다.', async () => {
-    // given
-    accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
-
-    // Http when
-    const response = await agent
-      .patch(`${BASE_URL}/${feed.id}/comments/${comment.id}`)
-      .set('Authorization', `Bearer ${accessToken}`)
-      .send({ newComment: 'newComment' });
-
-    // Http then
-    const { data } = response.body;
-    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
-    expect(data).toBeUndefined();
-
-    // DB, Redis when
-    const savedComment = await commentRepository.findOneBy({
-      id: comment.id,
-    });
-
-    // DB, Redis then
-    expect(savedComment.comment).toBe(comment.comment);
-  });
-
-  it('[401] 본인이 작성한 댓글이 아닐 경우 댓글 수정을 실패한다.', async () => {
+  it('[403] 본인이 작성한 댓글이 아닐 경우 댓글 수정을 실패한다.', async () => {
     // given
     accessToken = createAccessToken({ id: user2.id });
 
@@ -136,7 +112,7 @@ describe(`PATCH ${BASE_URL}/:feedId/comments/:commentId E2E Test`, () => {
 
     // Http then
     const { data } = response.body;
-    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
     expect(data).toBeUndefined();
 
     // DB, Redis when

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 
 import { DataSource } from 'typeorm';
 
@@ -107,7 +107,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       );
     });
 
-    it('본인 댓글이 아니면 UnauthorizedException을 던진다.', async () => {
+    it('본인 댓글이 아니면 ForbiddenException을 던진다.', async () => {
       // given
       commentRepository.findOne.mockResolvedValue({
         id: 5,
@@ -117,7 +117,7 @@ describe(`${CommentService.name} Unit Test`, () => {
 
       // when & then
       await expect(commentService.delete(user, dto)).rejects.toThrow(
-        UnauthorizedException,
+        ForbiddenException,
       );
     });
 
@@ -157,7 +157,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(commentRepository.save).toHaveBeenCalledWith(comment);
     });
 
-    it('본인 댓글이 아니면 UnauthorizedException을 던지고 저장하지 않는다.', async () => {
+    it('본인 댓글이 아니면 ForbiddenException을 던지고 저장하지 않는다.', async () => {
       // given
       commentRepository.findOne.mockResolvedValue({
         id: 5,
@@ -170,7 +170,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         commentService.update(user, 5, {
           newComment: '수정됨',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+      ).rejects.toThrow(ForbiddenException);
       expect(commentRepository.save).not.toHaveBeenCalled();
     });
   });

--- a/server/test/file/e2e/delete.e2e-spec.ts
+++ b/server/test/file/e2e/delete.e2e-spec.ts
@@ -57,7 +57,7 @@ describe(`DELETE ${URL}/{fileId} E2E Test`, () => {
     expect(savedFile).not.toBeNull();
   });
 
-  it('[401] 파일 소유자가 아닌 다른 사용자가 삭제 요청할 경우 파일 삭제를 실패한다.', async () => {
+  it('[403] 파일 소유자가 아닌 다른 사용자가 삭제 요청할 경우 파일 삭제를 실패한다.', async () => {
     // given
     const otherUser = await userRepository.save(
       await UserFixture.createUserCryptFixture(),
@@ -71,7 +71,7 @@ describe(`DELETE ${URL}/{fileId} E2E Test`, () => {
 
     // Http then
     const { data } = response.body;
-    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
     expect(data).toBeUndefined();
 
     // DB, Redis when

--- a/server/test/file/unit/file.service.unit.spec.ts
+++ b/server/test/file/unit/file.service.unit.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 
 import * as fs from 'fs/promises';
 
@@ -99,7 +99,7 @@ describe(`${FileService.name} Unit Test`, () => {
   });
 
   describe('deleteFile', () => {
-    it('파일 주인이 아니면 UnauthorizedException을 던진다.', async () => {
+    it('파일 주인이 아니면 ForbiddenException을 던진다.', async () => {
       // given
       fileRepository.findOne.mockResolvedValue(
         FileFixture.createFileFixture({ id: 1, user: { id: 7 } as any }),
@@ -107,7 +107,7 @@ describe(`${FileService.name} Unit Test`, () => {
 
       // when & then
       await expect(fileService.deleteFile(1, 999)).rejects.toThrow(
-        UnauthorizedException,
+        ForbiddenException,
       );
       expect(fileRepository.delete).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #121 

### 인증(401) vs 인가(403) 의미 정합성

- 댓글 수정/삭제, 파일 삭제 시 **요청자가 리소스 소유자가 아닌 경우** 기존에는 `401 Unauthorized`를 반환했습니다.
- `401`은 "인증 실패(누구인지 모름)", `403`은 "인증은 되었으나 권한 없음"을 의미합니다.
- 해당 분기는 이미 인증된 사용자가 **타인의 리소스**에 접근한 상황이므로 의미상 `403 Forbidden`이 정확합니다.
- `UnauthorizedException` → `ForbiddenException`으로 교체하고 Swagger 문서(`ApiForbiddenDoc`)도 함께 반영했습니다.

# 📋 작업 내용

- `CommentService`: 본인이 작성한 댓글이 아닐 때 `401` → `403`
- `FileService`: 파일 삭제 권한이 없을 때 `401` → `403`
- `updateComment` / `deleteComment` / `deleteFile` API 문서에 `ApiForbiddenDoc` 추가
- 관련 e2e / unit 테스트 기대 상태 코드 `401` → `403` 수정

# 📷 스크린 샷(선택 사항)

해당 없음