### PR TITLE
🐛 fix: 유저 로그인 유지 + 비밀번호 변경/회원탈퇴 시 모든 기기 로그아웃

### DIFF
--- a/server/src/common/auth/jwt.strategy.ts
+++ b/server/src/common/auth/jwt.strategy.ts
@@ -21,14 +21,8 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
     });
   }
 
-  async validate(payload: Payload) {
-    const isInvalidated = await this.redisService.get(
-      `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${payload.id}`,
-    );
-    if (isInvalidated) {
-      throw new UnauthorizedException('인증되지 않은 요청입니다.');
-    }
-
+  async validate(payload: Payload & { iat: number }) {
+    await validateNotInvalidated(this.redisService, payload);
     return payload;
   }
 }
@@ -52,14 +46,20 @@ export class JwtRefreshStrategy extends PassportStrategy(
     });
   }
 
-  async validate(payload: Payload) {
-    const isInvalidated = await this.redisService.get(
-      `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${payload.id}`,
-    );
-    if (isInvalidated) {
-      throw new UnauthorizedException('인증되지 않은 요청입니다.');
-    }
-
+  async validate(payload: Payload & { iat: number }) {
+    await validateNotInvalidated(this.redisService, payload);
     return payload;
+  }
+}
+
+export async function validateNotInvalidated(
+  redisService: RedisService,
+  payload: Payload & { iat: number },
+) {
+  const invalidatedAt = await redisService.get(
+    `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${payload.id}`,
+  );
+  if (invalidatedAt && payload.iat < Number(invalidatedAt)) {
+    throw new UnauthorizedException('인증되지 않은 요청입니다.');
   }
 }

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -99,10 +99,13 @@ export class UserController {
   @Post('/tokens')
   @HttpCode(HttpStatus.OK)
   @UseGuards(RefreshJwtGuard)
-  refreshAccessToken(@CurrentUser() user: Payload) {
+  refreshAccessToken(
+    @CurrentUser() user: Payload,
+    @Res({ passthrough: true }) response: Response,
+  ) {
     return ApiResponse.responseWithData(
       '엑세스 토큰을 재발급했습니다.',
-      this.userService.refreshAccessToken(user),
+      this.userService.refreshAccessToken(user, response),
     );
   }
 

--- a/server/src/user/service/oAuth.service.ts
+++ b/server/src/user/service/oAuth.service.ts
@@ -20,7 +20,6 @@ import {
   OAuthType,
   StateData,
 } from '@user/constant/oauth.constant';
-import { REFRESH_TOKEN_TTL } from '@user/constant/user.constants';
 import { OAuthCallbackRequestDto } from '@user/dto/request/oAuthCallbackDto';
 import { Provider } from '@user/entity/provider.entity';
 import { User } from '@user/entity/user.entity';
@@ -201,15 +200,7 @@ export class OAuthService {
       role: 'user',
     };
 
-    const serviceRefreshToken = this.userService.createToken(
-      jwtPayload,
-      'refresh',
-    );
-
-    res.cookie('refresh_token', serviceRefreshToken, {
-      ...cookieConfig[process.env.NODE_ENV],
-      maxAge: REFRESH_TOKEN_TTL,
-    });
+    this.userService.issueRefreshToken(jwtPayload, res);
   }
 
   private parseStateData(stateString: string): StateData {

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -110,19 +110,23 @@ export class UserService {
     };
 
     const accessToken = this.createToken(payload, 'access');
-    const refreshToken = this.createToken(payload, 'refresh');
-
-    response.cookie('refresh_token', refreshToken, {
-      ...cookieConfig[process.env.NODE_ENV],
-      maxAge: REFRESH_TOKEN_TTL,
-    });
+    this.issueRefreshToken(payload, response);
 
     return CreateAccessTokenResponseDto.toResponseDto(accessToken);
   }
 
-  refreshAccessToken(userInformation: Payload) {
+  refreshAccessToken(userInformation: Payload, response: Response) {
+    this.issueRefreshToken(userInformation, response);
     const accessToken = this.createToken(userInformation, 'access');
     return CreateAccessTokenResponseDto.toResponseDto(accessToken);
+  }
+
+  issueRefreshToken(userInformation: Payload, response: Response) {
+    const refreshToken = this.createToken(userInformation, 'refresh');
+    response.cookie('refresh_token', refreshToken, {
+      ...cookieConfig[process.env.NODE_ENV],
+      maxAge: REFRESH_TOKEN_TTL,
+    });
   }
 
   createToken(userInformation: Payload, mode: 'refresh' | 'access') {
@@ -240,6 +244,18 @@ export class UserService {
       `${REDIS_KEYS.USER_RESET_PASSWORD_KEY}:${uuid}`,
     );
     await this.userRepository.save(user);
+    await this.invalidateUserTokens(user.id);
+  }
+
+  private async invalidateUserTokens(userId: number) {
+    const ttlInSeconds = this.parseTimeToSeconds(
+      this.configService.get('JWT_REFRESH_TOKEN_EXPIRE'),
+    );
+    await this.redisService.setex(
+      `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${userId}`,
+      ttlInSeconds,
+      Math.floor(Date.now() / 1000).toString(),
+    );
   }
 
   async requestDeleteAccount(userId: number): Promise<void> {
@@ -272,17 +288,8 @@ export class UserService {
       await this.fileService.deleteByPath(user.profileImage);
     }
 
-    const refreshTokenExpire = this.configService.get(
-      'JWT_REFRESH_TOKEN_EXPIRE',
-    );
-    const ttlInSeconds = this.parseTimeToSeconds(refreshTokenExpire);
-
     await Promise.all([
-      this.redisService.setex(
-        `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${userId}`,
-        ttlInSeconds,
-        '1',
-      ),
+      this.invalidateUserTokens(userId),
       this.userRepository.remove(user),
       this.redisService.del(deleteRequestKey),
     ]);

--- a/server/test/common/unit/jwt.strategy.unit.spec.ts
+++ b/server/test/common/unit/jwt.strategy.unit.spec.ts
@@ -1,0 +1,66 @@
+import { UnauthorizedException } from '@nestjs/common';
+
+import { validateNotInvalidated } from '@common/auth/jwt.strategy';
+import { Payload } from '@common/guard/jwt.guard';
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+describe('validateNotInvalidated Unit Test', () => {
+  let redisService: jest.Mocked<Pick<RedisService, 'get'>>;
+
+  const INVALIDATED_AT = 1_000_000; // 무효화 시각(초)
+  const basePayload: Payload = {
+    id: 1,
+    email: 'a@test.com',
+    userName: 'tester',
+    role: 'user',
+  };
+  const payloadWithIat = (iat: number) => ({ ...basePayload, iat });
+
+  beforeEach(() => {
+    redisService = { get: jest.fn() };
+  });
+
+  it('무효화 기록이 없으면 통과한다.', async () => {
+    redisService.get.mockResolvedValue(null);
+    await expect(
+      validateNotInvalidated(
+        redisService as unknown as RedisService,
+        payloadWithIat(INVALIDATED_AT),
+      ),
+    ).resolves.toBeUndefined();
+    expect(redisService.get).toHaveBeenCalledWith(
+      `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:1`,
+    );
+  });
+
+  it('무효화 시각 이전(iat < invalidatedAt)에 발급된 토큰은 거부한다.', async () => {
+    redisService.get.mockResolvedValue(String(INVALIDATED_AT));
+    await expect(
+      validateNotInvalidated(
+        redisService as unknown as RedisService,
+        payloadWithIat(INVALIDATED_AT - 1),
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('같은 초(iat === invalidatedAt)에 발급된 토큰은 통과시킨다. (재로그인 보장)', async () => {
+    redisService.get.mockResolvedValue(String(INVALIDATED_AT));
+    await expect(
+      validateNotInvalidated(
+        redisService as unknown as RedisService,
+        payloadWithIat(INVALIDATED_AT),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it('무효화 이후(iat > invalidatedAt)에 발급된 토큰은 통과한다. (비번변경 후 새 로그인)', async () => {
+    redisService.get.mockResolvedValue(String(INVALIDATED_AT));
+    await expect(
+      validateNotInvalidated(
+        redisService as unknown as RedisService,
+        payloadWithIat(INVALIDATED_AT + 1),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/server/test/oauth/unit/oauth.service.unit.spec.ts
+++ b/server/test/oauth/unit/oauth.service.unit.spec.ts
@@ -24,7 +24,7 @@ describe(`${OAuthService.name} Unit Test`, () => {
   >;
   let logger: jest.Mocked<Pick<WinstonLoggerService, 'log' | 'error'>>;
   let redisService: jest.Mocked<Pick<RedisService, 'eval'>>;
-  let userService: jest.Mocked<Pick<UserService, 'createToken'>>;
+  let userService: jest.Mocked<Pick<UserService, 'issueRefreshToken'>>;
   let googleProvider: {
     getAuthUrl: jest.Mock;
     getTokens: jest.Mock;
@@ -50,7 +50,7 @@ describe(`${OAuthService.name} Unit Test`, () => {
     };
     logger = { log: jest.fn(), error: jest.fn() };
     redisService = { eval: jest.fn() };
-    userService = { createToken: jest.fn().mockReturnValue('service-refresh') };
+    userService = { issueRefreshToken: jest.fn() };
     googleProvider = {
       getAuthUrl: jest.fn(),
       getTokens: jest.fn(),
@@ -167,18 +167,16 @@ describe(`${OAuthService.name} Unit Test`, () => {
       });
       providerRepository.findByProviderTypeAndId.mockResolvedValue(null);
       userRepository.findOne.mockResolvedValue(null);
-      const cookie = jest.fn();
-      const res = { cookie, clearCookie: jest.fn() } as unknown as Response;
+      const res = createResponse();
 
       // when
       const result = await oAuthService.callback(dto, res, createRequest('key-1'));
 
       // then
       expect(manager.save).toHaveBeenCalledTimes(2); // User + Provider
-      expect(cookie).toHaveBeenCalledWith(
-        'refresh_token',
-        'service-refresh',
-        expect.anything(),
+      expect(userService.issueRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'oauth@test.com', role: 'user' }),
+        res,
       );
       expect(result).toBe(`${OAUTH_URL_PATH.BASE_URL}/oauth-success`);
     });
@@ -189,17 +187,15 @@ describe(`${OAuthService.name} Unit Test`, () => {
       // given
       providerRepository.findByProviderTypeAndId.mockResolvedValue(null);
       userRepository.findOne.mockResolvedValue(null);
-      const cookie = jest.fn();
-      const res = { cookie } as unknown as Response;
+      const res = createResponse();
 
       // when
       await oAuthService.e2eCallback(OAuthType.Google, res);
 
       // then
-      expect(cookie).toHaveBeenCalledWith(
-        'refresh_token',
-        'service-refresh',
-        expect.anything(),
+      expect(userService.issueRefreshToken).toHaveBeenCalledWith(
+        expect.objectContaining({ role: 'user' }),
+        res,
       );
     });
   });

--- a/server/test/user/e2e/delete-account/confirm.e2e-spec.ts
+++ b/server/test/user/e2e/delete-account/confirm.e2e-spec.ts
@@ -143,6 +143,6 @@ describe(`DELETE /api/users/deletion-requests/:token E2E Test`, () => {
     expect(savedComments.length).toBe(0);
     expect(savedActivities.length).toBe(0);
     expect(savedFiles.length).toBe(0);
-    expect(invalidatedUser).toBe('1');
+    expect(Number(invalidatedUser)).toBeGreaterThan(0);
   });
 });

--- a/server/test/user/e2e/refresh-token.e2e-spec.ts
+++ b/server/test/user/e2e/refresh-token.e2e-spec.ts
@@ -53,4 +53,15 @@ describe(`POST ${URL} E2E Test`, () => {
       accessToken: expect.any(String),
     });
   });
+
+  it('[200] 토큰 재발급 시 Refresh Token 쿠키를 재설정해 세션을 슬라이딩한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `refresh_token=${refreshToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.headers['set-cookie'][0]).toContain('refresh_token=');
+  });
 });

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -420,7 +420,7 @@ describe(`${UserService.name} Unit Test`, () => {
       };
 
       // when
-      const result = userService.refreshAccessToken(payload);
+      const result = userService.refreshAccessToken(payload, createResponse());
 
       // then
       expect(jwtService.sign).toHaveBeenCalled();
@@ -490,7 +490,7 @@ describe(`${UserService.name} Unit Test`, () => {
       expect(redisService.setex).toHaveBeenCalledWith(
         `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:1`,
         14 * 86400, // parseTimeToSeconds('14d')
-        '1',
+        expect.stringMatching(/^\d+$/), // invalidatedAt 타임스탬프(초)
       );
       expect(userRepository.remove).toHaveBeenCalledWith(user);
     });


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #711 (하위 태스크 중 `유저 회원 탈퇴/비밀번호 변경 시 모든 기기 로그아웃`, `유저 Refresh Token 만료 시 로그아웃 문제 해결` 처리)

### 로그인 유지 (Login Keep)

-   기존 토큰 무효화 로직은 `USER_INVALIDATED_PREFIX` 키 존재 여부만 확인하여, 한 번 무효화 플래그가 설정되면 TTL 동안 **재로그인으로 새로 발급받은 토큰까지 모두 차단**되는 문제가 있었습니다.
-   무효화 플래그 값에 무효화 시점 timestamp를 저장하고, JWT payload의 `iat`(발급 시각)과 비교하도록 변경했습니다. 무효화 시점 **이전에 발급된 토큰만** 거부되므로, 재로그인한 새 토큰은 정상 동작합니다.
-   `validate` 로직이 access/refresh 두 Strategy에 중복되어 있어 `validateNotInvalidated` 헬퍼로 추출했습니다.

### 비밀번호 변경 / 회원 탈퇴 시 전체 로그아웃

-   비밀번호 변경 시에도 기존 발급 토큰을 무효화해야 하나 누락되어 있었습니다. `resetPassword`에 `invalidateUserTokens` 호출을 추가했습니다.
-   회원 탈퇴 시에도 동일한 무효화 로직을 사용하도록 `invalidateUserTokens`로 공통화했습니다. 무효화 값으로 `'1'` 대신 무효화 timestamp를 저장합니다.

### Refresh Token 슬라이딩 세션

-   `refreshAccessToken` 시 access token만 재발급하고 refresh token은 갱신되지 않아, refresh token 만료 시 로그인이 풀리는 문제가 있었습니다. refresh 시 refresh token도 함께 재발급(회전)하여 활동 중인 사용자는 로그인이 유지되고, Refresh Token 기간 내 미접속 시에만 로그아웃됩니다.
-   refresh token 쿠키 발급 로직(`createToken` + `res.cookie`)이 로그인/OAuth/refresh 세 곳에 중복되어 있어 `issueRefreshToken`으로 추출하고 OAuth 서비스도 이를 사용하도록 정리했습니다.

# 📋 작업 내용

-   `jwt.strategy.ts`: `validateNotInvalidated` 헬퍼 추출, `payload.iat`와 무효화 timestamp 비교로 무효화 판정 변경
-   `user.service.ts`: `issueRefreshToken` / `invalidateUserTokens` 추출, `resetPassword`에 토큰 무효화 추가, `refreshAccessToken`에서 refresh token 회전
-   `oAuth.service.ts`: 중복 refresh token 발급 로직을 `issueRefreshToken`으로 대체
-   `user.controller.ts`: `/tokens` 핸들러에서 refresh token 회전을 위해 `Response` 주입
-   테스트: jwt.strategy 단위 테스트 추가, refresh-token e2e 검증 추가, oauth/user.service 단위 테스트 갱신
