### PR TITLE
✨ feat: RSS 등록 신청 시 관리자 이메일·디스코드 알림

### DIFF
--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -5,6 +5,7 @@ CREATE TABLE `admin` (
   `email` varchar(255) NOT NULL,
   `password` varchar(60) NOT NULL,
   `name` varchar(255) NOT NULL,
+  `email_notification` tinyint NOT NULL DEFAULT 1,
   `parent_admin_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UQ_admin_email` (`email`),

--- a/email-worker/src/common/types.ts
+++ b/email-worker/src/common/types.ts
@@ -11,6 +11,11 @@ export interface RssRegistration {
   description?: string;
 }
 
+export interface RssRegistrationRequest {
+  rss: Rss;
+  adminEmail: string;
+}
+
 export interface User {
   email: string;
   userName: string;

--- a/email-worker/src/email/constant.ts
+++ b/email-worker/src/email/constant.ts
@@ -2,6 +2,7 @@ export const EmailPayloadConstant = {
   USER_CERTIFICATION: 'userCertification',
   RSS_REMOVAL: 'rssRemoval',
   RSS_REGISTRATION: 'rssRegistration',
+  RSS_REGISTRATION_REQUEST: 'rssRegistrationRequest',
   PASSWORD_RESET: 'passwordReset',
   ACCOUNT_DELETION: 'accountDeletion',
   ADMIN_CERTIFICATION: 'adminCertification',

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -92,6 +92,10 @@ export class EmailConsumer {
         await this.emailService.sendRssMail(payload.data);
         break;
 
+      case EmailPayloadConstant.RSS_REGISTRATION_REQUEST:
+        await this.emailService.sendRssRegistrationRequestMail(payload.data);
+        break;
+
       case EmailPayloadConstant.RSS_REMOVAL:
         await this.emailService.sendRssRemoveCertificationMail(payload.data);
         break;

--- a/email-worker/src/email/email.content.ts
+++ b/email-worker/src/email/email.content.ts
@@ -42,6 +42,39 @@ export function createRssRegistrationContent(
 `;
 }
 
+export function createRssRegistrationRequestContent(
+  rss: Rss,
+  serviceAddress: string,
+) {
+  return `
+  <div style="font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', sans-serif; margin: 0; padding: 1px; background-color: #f4f4f4;">
+    <div style="max-width: 600px; margin: 20px auto; background-color: #ffffff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
+      <div style="text-align: center; padding: 20px 0; border-bottom: 2px solid #f0f0f0;">
+        <img src="https://denamu.dev/files/Denamu_Logo_KOR.png" alt="Denamu Logo" width="244" height="120">
+      </div>
+      <div style="padding: 20px 0;">
+        <div style="color: #007bff; font-size: 24px; font-weight: bold; margin-bottom: 20px; text-align: center;">새로운 RSS 등록 신청이 접수되었습니다 📥</div>
+          <div style="background-color: #f8f9fa; padding: 15px; border-radius: 4px; margin: 15px 0;">
+            <p><strong>블로그 제목:</strong> ${rss.name}</p>
+            <p><strong>신청자 이름:</strong> ${rss.userName}</p>
+            <p><strong>신청자 이메일:</strong> ${rss.email}</p>
+            <p><strong>RSS 주소:</strong> ${rss.rssUrl}</p>
+          </div>
+          <p>관리자 페이지에서 신청 내용을 확인하고 승인 또는 거절을 진행해 주세요.</p>
+          <center>
+            <a href="${PRODUCT_DOMAIN}/admins" style="display: inline-block; padding: 12px 24px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 4px; margin: 20px 0; font-weight: bold;">관리자 페이지로 이동</a>
+          </center>
+        </div>
+      </div>
+      <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; border-top: 2px solid #f0f0f0; color: #6c757d; font-size: 14px; height: 100px;">
+        <p>본 메일은 발신전용입니다.</p>
+        <p>문의사항이 있으시다면 ${serviceAddress}로 연락주세요.</p>
+      </div>
+    </div>
+  </div>
+`;
+}
+
 function acceptContent() {
   return `
     <p>안녕하세요! 귀하의 블로그가 저희 서비스에 성공적으로 등록되었음을 알려드립니다.</p>

--- a/email-worker/src/email/email.service.ts
+++ b/email-worker/src/email/email.service.ts
@@ -9,6 +9,7 @@ import {
   AdminCertification,
   Rss,
   RssRegistration,
+  RssRegistrationRequest,
   RssRemoval,
   User,
 } from '@common/types';
@@ -18,6 +19,7 @@ import {
   createDeleteAccountContent,
   createPasswordResetMailContent,
   createRssRegistrationContent,
+  createRssRegistrationRequestContent,
   createRssRemoveCertificateContent,
   createVerificationMailContent,
   PRODUCT_DOMAIN,
@@ -103,6 +105,29 @@ export class EmailService {
     );
 
     await this.sendMail(mailOptions);
+  }
+
+  async sendRssRegistrationRequestMail(
+    rssRegistrationRequest: RssRegistrationRequest,
+  ): Promise<void> {
+    const mailOptions = this.createRssRegistrationRequestMail(
+      rssRegistrationRequest.rss,
+      rssRegistrationRequest.adminEmail,
+    );
+
+    await this.sendMail(mailOptions);
+  }
+
+  private createRssRegistrationRequestMail(
+    rss: Rss,
+    adminEmail: string,
+  ): nodemailer.SendMailOptions {
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: adminEmail,
+      subject: `[🎋 Denamu] 새로운 RSS 등록 신청이 접수되었습니다.`,
+      html: createRssRegistrationRequestContent(rss, this.emailUser),
+    };
   }
 
   async sendUserCertificationMail(user: User): Promise<void> {

--- a/email-worker/src/email/types.ts
+++ b/email-worker/src/email/types.ts
@@ -1,6 +1,7 @@
 import {
   AdminCertification,
   RssRegistration,
+  RssRegistrationRequest,
   RssRemoval,
   User,
 } from '@common/types';
@@ -13,6 +14,10 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.RSS_REGISTRATION;
       data: RssRegistration;
+    }
+  | {
+      type: typeof EmailPayloadConstant.RSS_REGISTRATION_REQUEST;
+      data: RssRegistrationRequest;
     }
   | { type: typeof EmailPayloadConstant.PASSWORD_RESET; data: User }
   | { type: typeof EmailPayloadConstant.ACCOUNT_DELETION; data: User }

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -37,6 +37,16 @@ This service communicates with:
 - email-worker via RabbitMQ (EmailExchange)
 - client via HTTP/WebSocket/SSE
 
+# Database Schema Changes
+
+When modifying a database entity, you MUST update all three of the following in the same change to keep the runtime schema and the fresh-DB bootstrap snapshot in sync:
+
+1. `*.entity.ts` — the TypeORM entity definition (`server/src/**/entity/`)
+2. `init.sql` — the fresh-DB bootstrap snapshot (`docker-compose/db/init.sql`)
+3. migration — a new TypeORM migration with `up`/`down` (`server/src/common/database/migration/`)
+
+Column definitions (type, nullability, default) MUST be identical across all three. Omitting any one causes schema drift between freshly bootstrapped and migrated databases.
+
 # Commands
 
 npm run \*

--- a/server/src/admin/entity/admin.entity.ts
+++ b/server/src/admin/entity/admin.entity.ts
@@ -35,6 +35,14 @@ export class Admin extends BaseEntity {
   email: string;
 
   @Column({
+    name: 'email_notification',
+    type: 'boolean',
+    nullable: false,
+    default: true,
+  })
+  emailNotification: boolean;
+
+  @Column({
     name: 'parent_admin_id',
     type: 'int',
     nullable: true,

--- a/server/src/admin/module/admin.module.ts
+++ b/server/src/admin/module/admin.module.ts
@@ -8,6 +8,6 @@ import { AdminService } from '@admin/service/admin.service';
   imports: [],
   controllers: [AdminController],
   providers: [AdminService, AdminRepository],
-  exports: [],
+  exports: [AdminRepository],
 })
 export class AdminModule {}

--- a/server/src/common/database/migration/1780900000000-AddAdminEmailNotification.ts
+++ b/server/src/common/database/migration/1780900000000-AddAdminEmailNotification.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAdminEmailNotification1780900000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`admin\` ADD COLUMN \`email_notification\` tinyint NOT NULL DEFAULT 1;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`admin\` DROP COLUMN \`email_notification\`;`,
+    );
+  }
+}

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -27,10 +27,14 @@ export class EmailProducer {
       stringifiedMessage,
     );
 
-    const email =
-      payload.type === EmailPayloadConstant.RSS_REGISTRATION
-        ? payload.data.rss.email
-        : payload.data.email;
+    let email: string;
+    if (payload.type === EmailPayloadConstant.RSS_REGISTRATION) {
+      email = payload.data.rss.email;
+    } else if (payload.type === EmailPayloadConstant.RSS_REGISTRATION_REQUEST) {
+      email = payload.data.adminEmail;
+    } else {
+      email = payload.data.email;
+    }
     this.logger.log(
       `이메일 메시지가 발행되었습니다.: type=${payload.type}, email=${email}`,
     );
@@ -73,6 +77,18 @@ export class EmailProducer {
         rss: rss,
         approveFlag: approveFlag,
         description: description ?? null,
+      },
+    };
+
+    await this.produceMessage(payload);
+  }
+
+  async produceRssRegistrationRequest(rss: Rss, adminEmail: string) {
+    const payload = {
+      type: EmailPayloadConstant.RSS_REGISTRATION_REQUEST,
+      data: {
+        rss,
+        adminEmail,
       },
     };
 

--- a/server/src/common/email/email.type.ts
+++ b/server/src/common/email/email.type.ts
@@ -11,6 +11,11 @@ export interface RssRegistration {
   description?: string;
 }
 
+export interface RssRegistrationRequest {
+  rss: Rss;
+  adminEmail: string;
+}
+
 export interface User {
   email: string;
   userName: string;
@@ -34,6 +39,7 @@ export const EmailPayloadConstant = {
   USER_CERTIFICATION: 'userCertification',
   RSS_REMOVAL: 'rssRemoval',
   RSS_REGISTRATION: 'rssRegistration',
+  RSS_REGISTRATION_REQUEST: 'rssRegistrationRequest',
   PASSWORD_RESET: 'passwordReset',
   ACCOUNT_DELETION: 'accountDeletion',
   ADMIN_CERTIFICATION: 'adminCertification',
@@ -45,6 +51,10 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.RSS_REGISTRATION;
       data: RssRegistration;
+    }
+  | {
+      type: typeof EmailPayloadConstant.RSS_REGISTRATION_REQUEST;
+      data: RssRegistrationRequest;
     }
   | { type: typeof EmailPayloadConstant.PASSWORD_RESET; data: User }
   | { type: typeof EmailPayloadConstant.ACCOUNT_DELETION; data: User }

--- a/server/src/rss/module/rss.module.ts
+++ b/server/src/rss/module/rss.module.ts
@@ -1,5 +1,9 @@
 import { Module } from '@nestjs/common';
 
+import { NotifierModule } from '@common/notification/notifier.module';
+
+import { AdminModule } from '@admin/module/admin.module';
+
 import { RssController } from '@rss/controller/rss.controller';
 import {
   RssAcceptRepository,
@@ -9,6 +13,7 @@ import {
 import { RssService } from '@rss/service/rss.service';
 
 @Module({
+  imports: [AdminModule, NotifierModule],
   controllers: [RssController],
   providers: [
     RssService,

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -5,11 +5,15 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 
-import axios from 'axios';
 import * as uuid from 'uuid';
+import axios from 'axios';
 import { DataSource } from 'typeorm';
 
+import { AdminRepository } from '@admin/repository/admin.repository';
+
 import { EmailProducer } from '@common/email/email.producer';
+import { WinstonLoggerService } from '@common/logger/logger.service';
+import { NotifierRegistry } from '@common/notification/notifier-registry';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
@@ -43,6 +47,9 @@ export class RssService {
     private readonly emailProducer: EmailProducer,
     private readonly dataSource: DataSource,
     private readonly redisService: RedisService,
+    private readonly adminRepository: AdminRepository,
+    private readonly notifierRegistry: NotifierRegistry,
+    private readonly logger: WinstonLoggerService,
   ) {}
 
   async createRss(rssRegisterBodyDto: RegisterRssRequestDto) {
@@ -63,7 +70,35 @@ export class RssService {
       throw new ConflictException(`이미 ${status}된 ${field}입니다.`);
     }
 
-    await this.rssRepository.insert(rssRegisterBodyDto.toEntity());
+    const rssEntity = rssRegisterBodyDto.toEntity();
+    await this.rssRepository.insert(rssEntity);
+
+    await this.notifyRssRegistrationRequest(rssEntity);
+  }
+
+  private async notifyRssRegistrationRequest(rss: Rss) {
+    void this.notifierRegistry.sendAlert(
+      `📥 새로운 RSS 등록 신청이 접수되었습니다.\n블로그: ${rss.name}\n신청자: ${rss.userName}\nRSS: ${rss.rssUrl}`,
+    );
+
+    try {
+      const admins = await this.adminRepository.find({
+        where: { emailNotification: true },
+        select: ['email'],
+      });
+
+      await Promise.all(
+        admins.map((admin) =>
+          this.emailProducer.produceRssRegistrationRequest(rss, admin.email),
+        ),
+      );
+    } catch (error) {
+      this.logger.error(
+        `RSS 등록 신청 알림 발송 실패: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
   }
 
   async readAllRss() {

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -8,8 +8,12 @@ import axios from 'axios';
 import { DataSource } from 'typeorm';
 
 import { EmailProducer } from '@common/email/email.producer';
+import { WinstonLoggerService } from '@common/logger/logger.service';
+import { NotifierRegistry } from '@common/notification/notifier-registry';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
 
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
@@ -37,12 +41,17 @@ describe(`${RssService.name} Unit Test`, () => {
   let emailProducer: jest.Mocked<
     Pick<
       EmailProducer,
-      'produceRssRegistration' | 'produceRssRemoval'
+      | 'produceRssRegistration'
+      | 'produceRssRegistrationRequest'
+      | 'produceRssRemoval'
     >
   >;
   let manager: { save: jest.Mock; remove: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
   let redisService: jest.Mocked<Pick<RedisService, 'rpush' | 'set' | 'get' | 'del'>>;
+  let adminRepository: jest.Mocked<Pick<AdminRepository, 'find'>>;
+  let notifierRegistry: jest.Mocked<Pick<NotifierRegistry, 'sendAlert'>>;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -56,6 +65,7 @@ describe(`${RssService.name} Unit Test`, () => {
     rssRejectRepository = { find: jest.fn() };
     emailProducer = {
       produceRssRegistration: jest.fn(),
+      produceRssRegistrationRequest: jest.fn(),
       produceRssRemoval: jest.fn(),
     };
     manager = { save: jest.fn(), remove: jest.fn(), delete: jest.fn() };
@@ -63,6 +73,9 @@ describe(`${RssService.name} Unit Test`, () => {
       transaction: jest.fn((cb: any) => cb(manager)),
     } as any;
     redisService = { rpush: jest.fn(), set: jest.fn(), get: jest.fn(), del: jest.fn() };
+    adminRepository = { find: jest.fn().mockResolvedValue([]) };
+    notifierRegistry = { sendAlert: jest.fn() };
+    logger = { error: jest.fn() };
 
     rssService = new RssService(
       rssRepository as unknown as RssRepository,
@@ -71,6 +84,9 @@ describe(`${RssService.name} Unit Test`, () => {
       emailProducer as unknown as EmailProducer,
       dataSource as unknown as DataSource,
       redisService as unknown as RedisService,
+      adminRepository as unknown as AdminRepository,
+      notifierRegistry as unknown as NotifierRegistry,
+      logger as unknown as WinstonLoggerService,
     );
   });
 
@@ -104,6 +120,45 @@ describe(`${RssService.name} Unit Test`, () => {
 
       // then
       expect(rssRepository.insert).toHaveBeenCalledWith(dto.toEntity());
+    });
+
+    it('저장 후 수신 동의한 관리자에게 메일을 발송하고 디스코드 알림을 보낸다.', async () => {
+      // given
+      rssRepository.findOne.mockResolvedValue(null);
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+      adminRepository.find.mockResolvedValue([
+        { email: 'a@denamu.dev' },
+        { email: 'b@denamu.dev' },
+      ] as any);
+
+      // when
+      await rssService.createRss(dto);
+
+      // then
+      expect(adminRepository.find).toHaveBeenCalledWith({
+        where: { emailNotification: true },
+        select: ['email'],
+      });
+      expect(emailProducer.produceRssRegistrationRequest).toHaveBeenCalledTimes(2);
+      expect(emailProducer.produceRssRegistrationRequest).toHaveBeenCalledWith(
+        dto.toEntity(),
+        'a@denamu.dev',
+      );
+      expect(notifierRegistry.sendAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it('알림 발송이 실패해도 신청 자체는 예외를 던지지 않는다.', async () => {
+      // given
+      rssRepository.findOne.mockResolvedValue(null);
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+      adminRepository.find.mockRejectedValue(new Error('DB down'));
+
+      // when & then
+      await expect(rssService.createRss(dto)).resolves.not.toThrow();
+      expect(rssRepository.insert).toHaveBeenCalled();
+      expect(logger.error).toHaveBeenCalled();
+      // 메일 경로가 실패해도 디스코드 알림은 발송되어야 한다.
+      expect(notifierRegistry.sendAlert).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #716 

### RSS 등록 신청 알림

-   기존에는 사용자가 RSS 등록을 신청해도 관리자가 이를 인지할 방법이 polling(어드민 페이지 직접 확인)뿐이었습니다. 신청 누락/지연 처리를 막기 위해 신청 즉시 관리자에게 **디스코드 + 이메일**로 알림을 보내도록 했습니다.
-   알림 발송이 RSS 등록 자체의 신뢰성을 해치면 안 된다는 점을 핵심 제약으로 두었습니다.
    -   디스코드 알림은 `void`로 fire-and-forget 처리하여 신청 흐름을 블로킹하지 않습니다.
    -   이메일 발송은 `try/catch`로 감싸 알림 실패가 RSS 등록 트랜잭션 실패로 전파되지 않도록 격리했습니다.

### 관리자별 이메일 수신 설정

-   모든 관리자에게 무조건 메일을 보내는 대신, `admin.email_notification`(boolean, default `true`) 컬럼을 추가해 수신 여부를 DB에서 제어합니다.
-   이메일 발송 대상은 `emailNotification: true`인 관리자로 한정합니다. (마이그레이션 포함)

### Email Worker 처리

-   `RSS_REGISTRATION_REQUEST` 타입을 신설하고, EmailProducer에 `produceRssRegistrationRequest`를 추가했습니다.
-   email-worker 측에 해당 타입 consumer/content/service를 추가하여 신청 알림 메일 템플릿을 렌더링·발송합니다.

# 📋 작업 내용

-   `Admin` 엔티티에 `emailNotification` 컬럼 추가 + 마이그레이션(`AddAdminEmailNotification`)
-   `init.sql` `admin` 테이블에 `email_notification` 컬럼 동기화 (fresh-DB 부트스트랩 스냅샷과 마이그레이션 간 스키마 드리프트 방지)
-   `server/CLAUDE.md`에 DB 스키마 변경 지침 추가: 엔티티 수정 시 `*.entity` / `init.sql` / migration 3개 파일을 동일하게 변경하도록 명문화
-   `RssService.createRss`에서 등록 신청 후 `notifyRssRegistrationRequest` 호출 (디스코드 + 이메일)
-   `EmailProducer.produceRssRegistrationRequest` 및 `RSS_REGISTRATION_REQUEST` 페이로드 타입 추가
-   email-worker: RSS 신청 알림 메일 consumer/content/service 구현
-   server / email-worker 단위 테스트 추가

# 📷 스크린 샷(선택 사항)

-