### PR TITLE
✨ feat: 요약 실패 게시글 수동 AI 재요청 API 구현

### DIFF
--- a/feed-crawler/src/common/constant.ts
+++ b/feed-crawler/src/common/constant.ts
@@ -3,6 +3,7 @@ export const redisConstant = {
   FEED_RECENT_INDEX_KEY: 'feed:recent:index',
   FEED_AI_QUEUE: `feed:ai:queue`,
   FEED_AI_RETRY_QUEUE: `feed:ai-retry:queue`,
+  FEED_AI_RETRY_LOCK: `feed:ai-retry:lock`,
   FULL_FEED_CRAWL_QUEUE: `feed:full-crawl:queue`,
 };
 

--- a/feed-crawler/src/common/constant.ts
+++ b/feed-crawler/src/common/constant.ts
@@ -2,6 +2,7 @@ export const CONNECTION_LIMIT = 50;
 export const redisConstant = {
   FEED_RECENT_INDEX_KEY: 'feed:recent:index',
   FEED_AI_QUEUE: `feed:ai:queue`,
+  FEED_AI_RETRY_QUEUE: `feed:ai-retry:queue`,
   FULL_FEED_CRAWL_QUEUE: `feed:full-crawl:queue`,
 };
 

--- a/feed-crawler/src/common/types.ts
+++ b/feed-crawler/src/common/types.ts
@@ -49,6 +49,5 @@ export interface FullFeedCrawlMessage {
 
 export interface AiSummaryRetryMessage {
   feedId: number;
-
   deathCount: number;
 }

--- a/feed-crawler/src/common/types.ts
+++ b/feed-crawler/src/common/types.ts
@@ -46,3 +46,9 @@ export interface FullFeedCrawlMessage {
   timestamp: number;
   deathCount: number;
 }
+
+export interface AiSummaryRetryMessage {
+  feedId: number;
+
+  deathCount: number;
+}

--- a/feed-crawler/src/container.ts
+++ b/feed-crawler/src/container.ts
@@ -16,6 +16,7 @@ import { Rss20Parser } from '@common/parser/formats/rss20-parser';
 import { ParserUtil } from '@common/parser/utils/parser-util';
 import { RedisConnection } from '@common/redis-access';
 
+import { AiSummaryRetryEventWorker } from '@event_worker/workers/ai-summary-retry-event-worker';
 import { ClaudeEventWorker } from '@event_worker/workers/claude-event-worker';
 import { FullFeedCrawlEventWorker } from '@event_worker/workers/full-feed-crawl-event-worker';
 
@@ -44,6 +45,7 @@ container.registerSingleton(Atom10Parser);
 container.registerSingleton(FeedParserManager);
 container.registerSingleton(FeedCrawler);
 container.registerSingleton(FullFeedCrawlEventWorker);
+container.registerSingleton(AiSummaryRetryEventWorker);
 
 container.registerSingleton(DiscordNotifier);
 container.registerSingleton(NotifierRegistry);

--- a/feed-crawler/src/event_worker/workers/ai-summary-retry-event-worker.ts
+++ b/feed-crawler/src/event_worker/workers/ai-summary-retry-event-worker.ts
@@ -45,7 +45,9 @@ export class AiSummaryRetryEventWorker extends AbstractQueueWorker<AiSummaryRetr
   ): Promise<void> {
     const feedId = retryMessage.feedId;
 
-    logger.info(`${this.nameTag} feedId ${feedId} AI 요약 재요청을 시작합니다.`);
+    logger.info(
+      `${this.nameTag} feedId ${feedId} AI 요약 재요청을 시작합니다.`,
+    );
 
     try {
       await this.feedCrawler.requeueFeedForAiSummary(feedId);
@@ -81,6 +83,19 @@ export class AiSummaryRetryEventWorker extends AbstractQueueWorker<AiSummaryRetr
         : `재시도 불가능한 에러 (${error.name})`;
       logger.error(
         `${this.nameTag} feedId ${retryMessage.feedId} 영구 실패 - ${reason}`,
+      );
+      await this.releaseRetryLock(retryMessage.feedId);
+    }
+  }
+
+  private async releaseRetryLock(feedId: number): Promise<void> {
+    try {
+      await this.redisConnection.del(
+        `${redisConstant.FEED_AI_RETRY_LOCK}:${feedId}`,
+      );
+    } catch (error) {
+      logger.error(
+        `${this.nameTag} feedId ${feedId} AI 재요청 락 해제 실패: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/feed-crawler/src/event_worker/workers/ai-summary-retry-event-worker.ts
+++ b/feed-crawler/src/event_worker/workers/ai-summary-retry-event-worker.ts
@@ -1,0 +1,104 @@
+import { inject, injectable } from 'tsyringe';
+
+import { redisConstant } from '@common/constant';
+import logger from '@common/logger';
+import { RedisConnection } from '@common/redis-access';
+import { AiSummaryRetryMessage } from '@common/types';
+
+import { AbstractQueueWorker } from '@event_worker/abstract-queue-worker';
+
+import { FeedCrawler } from '../../feed-crawler';
+
+@injectable()
+export class AiSummaryRetryEventWorker extends AbstractQueueWorker<AiSummaryRetryMessage> {
+  constructor(
+    @inject(RedisConnection)
+    redisConnection: RedisConnection,
+    @inject(FeedCrawler)
+    private readonly feedCrawler: FeedCrawler,
+  ) {
+    super('[AI Summary Retry]', redisConnection);
+  }
+
+  protected async processQueue(): Promise<void> {
+    const message = await this.redisConnection.rpop(this.getQueueKey());
+
+    if (!message) {
+      logger.info('처리할 AI 요약 재요청이 없습니다.');
+      return;
+    }
+
+    const retryMessage = this.parseQueueMessage(message);
+    await this.processItem(retryMessage);
+  }
+
+  protected getQueueKey(): string {
+    return redisConstant.FEED_AI_RETRY_QUEUE;
+  }
+
+  protected parseQueueMessage(message: string): AiSummaryRetryMessage {
+    return JSON.parse(message);
+  }
+
+  protected async processItem(
+    retryMessage: AiSummaryRetryMessage,
+  ): Promise<void> {
+    const feedId = retryMessage.feedId;
+
+    logger.info(`${this.nameTag} feedId ${feedId} AI 요약 재요청을 시작합니다.`);
+
+    try {
+      await this.feedCrawler.requeueFeedForAiSummary(feedId);
+    } catch (error) {
+      await this.handleFailure(retryMessage, error as Error);
+    }
+  }
+
+  protected async handleFailure(
+    retryMessage: AiSummaryRetryMessage,
+    error: Error,
+  ): Promise<void> {
+    const shouldRetry = this.isRetryableError(error);
+
+    logger.error(
+      `${this.nameTag} feedId ${retryMessage.feedId} 처리 실패:
+      - 에러: ${error.name} - ${error.message}
+      - 재시도 가능: ${shouldRetry}
+      - 현재 deathCount: ${retryMessage.deathCount}`,
+    );
+
+    if (shouldRetry && retryMessage.deathCount < 3) {
+      retryMessage.deathCount++;
+      await this.redisConnection.rpush(redisConstant.FEED_AI_RETRY_QUEUE, [
+        JSON.stringify(retryMessage),
+      ]);
+      logger.warn(
+        `${this.nameTag} feedId ${retryMessage.feedId} 재시도 예약 (${retryMessage.deathCount}/3)`,
+      );
+    } else {
+      const reason = shouldRetry
+        ? `Death Count 3회 초과`
+        : `재시도 불가능한 에러 (${error.name})`;
+      logger.error(
+        `${this.nameTag} feedId ${retryMessage.feedId} 영구 실패 - ${reason}`,
+      );
+    }
+  }
+
+  private isRetryableError(error: Error): boolean {
+    const message = error.message.toLowerCase();
+
+    // 재시도하면 안 되는 케이스 (영구적 에러)
+    if (message.includes('찾을 수 없습니다')) return false; // 피드/RSS 없음, 노출 범위 이탈
+    if (message.includes('invalid') || message.includes('401')) return false;
+    if (message.includes('json') || message.includes('parse')) return false;
+
+    // 재시도해야 하는 케이스 (일시적 에러)
+    if (message.includes('rate limit') || message.includes('429')) return true;
+    if (message.includes('timeout') || message.includes('503')) return true;
+    if (message.includes('network') || message.includes('fetch')) return true;
+
+    // 기본값: 재시도
+    return true;
+  }
+}

--- a/feed-crawler/src/event_worker/workers/claude-event-worker.ts
+++ b/feed-crawler/src/event_worker/workers/claude-event-worker.ts
@@ -60,6 +60,7 @@ export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
     try {
       const aiData = await this.requestAI(feed);
       await this.saveAIResult(aiData);
+      await this.releaseRetryLock(feed.id);
     } catch (error) {
       await this.handleFailure(feed, error as Error);
       this.notifier.publish(NOTIFICATION_EVENT.AI_SUMMARY, {
@@ -195,6 +196,19 @@ export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
       logger.error(`${this.nameTag} ${feed.id} 영구 실패 - ${reason}`);
       this.aiMetrics.permanentFailure.inc();
       await this.feedRepository.updateNullSummary(feed.id);
+      await this.releaseRetryLock(feed.id);
+    }
+  }
+
+  private async releaseRetryLock(feedId: number): Promise<void> {
+    try {
+      await this.redisConnection.del(
+        `${redisConstant.FEED_AI_RETRY_LOCK}:${feedId}`,
+      );
+    } catch (error) {
+      logger.error(
+        `${this.nameTag} ${feedId} AI 재요청 락 해제 실패: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 

--- a/feed-crawler/src/feed-crawler.ts
+++ b/feed-crawler/src/feed-crawler.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { inject, injectable } from 'tsyringe';
 
 import logger from '@common/logger';
@@ -66,6 +67,64 @@ export class FeedCrawler {
     await this.feedRepository.saveAiQueue(insertedData);
 
     return insertedData;
+  }
+
+  async requeueFeedForAiSummary(feedId: number): Promise<void> {
+    const feed = await this.feedRepository.selectFeedById(feedId);
+    if (!feed) {
+      throw new Error(`피드를 찾을 수 없습니다: ${feedId}`);
+    }
+
+    const rssObj = await this.rssRepository.selectRssById(feed.blogId);
+    if (!rssObj) {
+      throw new Error(`RSS를 찾을 수 없습니다: blogId=${feed.blogId}`);
+    }
+
+    const allFeeds = await this.feedParserManager.fetchAndParseAll(rssObj);
+    const matched = allFeeds.find((parsed) => parsed.link === feed.path);
+    if (!matched) {
+      throw await this.buildMissingFeedError(feedId, feed.path);
+    }
+
+    await this.feedRepository.saveAiQueue([
+      { ...matched, id: feed.id, deathCount: 0 },
+    ]);
+    logger.info(
+      `[AI 재요청] feedId=${feedId} 게시글을 AI 큐에 다시 넣었습니다.`,
+    );
+  }
+
+  // RSS에서 게시글을 못 찾았을 때, 원본 URL 상태로 사유를 분류한다.
+  // 200(오래된 글)/404(삭제된 글)는 영구 스킵, 그 외(서버 오류/네트워크 실패)는 재시도.
+  private async buildMissingFeedError(
+    feedId: number,
+    path: string,
+  ): Promise<Error> {
+    const status = await this.probeOriginStatus(path);
+
+    if (status === 200) {
+      return new Error(
+        `RSS에서 찾을 수 없습니다 (원본 HTTP 200, RSS 노출 범위를 벗어난 오래된 게시글): feedId=${feedId}`,
+      );
+    }
+    if (status === 404) {
+      return new Error(
+        `RSS에서 찾을 수 없습니다 (원본 HTTP 404, 삭제된 게시글): feedId=${feedId}`,
+      );
+    }
+
+    return new Error(
+      `원본 게시글 상태 확인 실패 (HTTP ${status ?? 'NETWORK_ERROR'}), 일시적 서버 오류로 재시도 필요: feedId=${feedId}`,
+    );
+  }
+
+  private async probeOriginStatus(path: string): Promise<number | null> {
+    try {
+      const response = await axios.get(path, { validateStatus: () => true });
+      return response.status;
+    } catch {
+      return null;
+    }
   }
 
   private feedGroupByRss(

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -11,6 +11,7 @@ import { FeedMetrics } from '@common/metrics/feed-metrics';
 import { Notifier } from '@common/notification/notifier.interface';
 import { RedisConnection } from '@common/redis-access';
 
+import { AiSummaryRetryEventWorker } from '@event_worker/workers/ai-summary-retry-event-worker';
 import { ClaudeEventWorker } from '@event_worker/workers/claude-event-worker';
 import { FullFeedCrawlEventWorker } from '@event_worker/workers/full-feed-crawl-event-worker';
 
@@ -26,6 +27,7 @@ function initializeDependencies() {
     feedCrawler: container.resolve(FeedCrawler),
     claudeEventWorker: container.resolve(ClaudeEventWorker),
     fullFeedCrawlEventWorker: container.resolve(FullFeedCrawlEventWorker),
+    aiSummaryRetryEventWorker: container.resolve(AiSummaryRetryEventWorker),
     notifier: container.resolve<Notifier>(DEPENDENCY_SYMBOLS.Notifier),
     metrics: container.resolve(FeedMetrics),
   };
@@ -52,6 +54,11 @@ function registerSchedulers(
   schedule.scheduleJob('FULL FEED CRAWLING', '*/5 * * * *', () => {
     logger.info(`Full Feed Crawling Start: ${new Date().toISOString()}`);
     void dependencies.fullFeedCrawlEventWorker.start();
+  });
+
+  schedule.scheduleJob('AI SUMMARY RETRY', '*/1 * * * *', () => {
+    logger.info(`AI Summary Retry Start: ${new Date().toISOString()}`);
+    void dependencies.aiSummaryRetryEventWorker.start();
   });
 }
 

--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -139,6 +139,25 @@ export class FeedRepository {
     }
   }
 
+  public async selectFeedById(
+    feedId: number,
+  ): Promise<{ id: number; blogId: number; path: string } | null> {
+    const query = `SELECT id, blog_id as blogId, path FROM feed WHERE id = ?`;
+    this.dbMetrics.total.inc({ operation: 'select_feed_by_id' });
+    try {
+      const result = await this.dbConnection.executeQuery<{
+        id: number;
+        blogId: number;
+        path: string;
+      }>(query, [feedId]);
+      this.dbMetrics.success.inc({ operation: 'select_feed_by_id' });
+      return result && result.length > 0 ? result[0] : null;
+    } catch (error) {
+      this.dbMetrics.failure.inc({ operation: 'select_feed_by_id' });
+      throw error;
+    }
+  }
+
   public async updateSummary(feedId: number, summary: string) {
     const query = `
               UPDATE feed

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -5,6 +5,7 @@ export const REDIS_KEYS = {
   FEED_RECENT_ALL_KEY: 'feed:recent:*',
   FEED_RECENT_KEY: 'feed:recent',
   FEED_AI_QUEUE: `feed:ai:queue`,
+  FEED_AI_RETRY_QUEUE: `feed:ai-retry:queue`,
   USER_AUTH_KEY: 'signup',
   ADMIN_AUTH_KEY: 'auth',
   ADMIN_SESSION_BY_EMAIL: 'auth:email',

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -6,6 +6,7 @@ export const REDIS_KEYS = {
   FEED_RECENT_KEY: 'feed:recent',
   FEED_AI_QUEUE: `feed:ai:queue`,
   FEED_AI_RETRY_QUEUE: `feed:ai-retry:queue`,
+  FEED_AI_RETRY_LOCK: `feed:ai-retry:lock`,
   USER_AUTH_KEY: 'signup',
   ADMIN_AUTH_KEY: 'auth',
   ADMIN_SESSION_BY_EMAIL: 'auth:email',

--- a/server/src/feed/api-docs/requestAiSummary.api-docs.ts
+++ b/server/src/feed/api-docs/requestAiSummary.api-docs.ts
@@ -18,6 +18,6 @@ export function ApiRequestAiSummary() {
     ApiMessageResponse('AI 요약 재요청 접수 성공'),
     ApiUnauthorizedDoc('관리자 인증이 되지 않은 경우'),
     ApiNotFoundDoc('해당 ID의 피드가 존재하지 않는 경우'),
-    ApiConflictDoc('이미 AI 요약이 완료된 게시글인 경우'),
+    ApiConflictDoc('이미 AI 요약 큐에 포함되어 처리 중인 게시글인 경우'),
   );
 }

--- a/server/src/feed/api-docs/requestAiSummary.api-docs.ts
+++ b/server/src/feed/api-docs/requestAiSummary.api-docs.ts
@@ -1,0 +1,23 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiConflictDoc,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiRequestAiSummary() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'AI 요약 수동 재요청 API (관리자 전용)',
+      description:
+        'AI 요약에 실패했거나 요청이 전송되지 않은 게시글을 AI 요청 큐에 다시 넣습니다. 비동기로 처리되며 202 Accepted를 반환합니다.',
+    }),
+    ApiMessageResponse('AI 요약 재요청 접수 성공'),
+    ApiUnauthorizedDoc('관리자 인증이 되지 않은 경우'),
+    ApiNotFoundDoc('해당 ID의 피드가 존재하지 않는 경우'),
+    ApiConflictDoc('이미 AI 요약이 완료된 게시글인 경우'),
+  );
+}

--- a/server/src/feed/constant/feed.constant.ts
+++ b/server/src/feed/constant/feed.constant.ts
@@ -1,0 +1,3 @@
+// AI 요약 전체 처리 구간(재요청 큐 대기 → AI 큐 대기 → Claude 요약)을 덮는
+// 중복 차단 락 TTL(초). 워커 크래시 등으로 락 해제가 누락돼도 이 시간 뒤 자동 회수된다.
+export const AI_RETRY_LOCK_TTL_SECONDS = 1200;

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -19,6 +19,7 @@ import { Request, Response } from 'express';
 import { Observable } from 'rxjs';
 
 import { CurrentUser } from '@common/decorator/current-user.decorator';
+import { AdminAuthGuard } from '@common/guard/session.guard';
 import { OptionalJwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
 
@@ -27,6 +28,7 @@ import { ApiGetFeedDetail } from '@feed/api-docs/getFeedDetail.api-docs';
 import { ApiReadFeedPagination } from '@feed/api-docs/readFeedPagination.api-docs';
 import { ApiReadRecentFeedList } from '@feed/api-docs/readRecentFeedList.api-docs';
 import { ApiReadTrendFeedList } from '@feed/api-docs/readTrendFeedList.api-docs';
+import { ApiRequestAiSummary } from '@feed/api-docs/requestAiSummary.api-docs';
 import { ApiSearchFeedList } from '@feed/api-docs/searchFeedList.api-docs';
 import { ApiUpdateFeedViewCount } from '@feed/api-docs/updateFeedViewCount.api-docs';
 import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
@@ -112,6 +114,17 @@ export class FeedController {
     );
     return ApiResponse.responseWithNoContent(
       '요청이 성공적으로 처리되었습니다.',
+    );
+  }
+
+  @ApiRequestAiSummary()
+  @UseGuards(AdminAuthGuard)
+  @Post('/:feedId/ai-summary-requests')
+  @HttpCode(HttpStatus.ACCEPTED)
+  async requestAiSummary(@Param() aiSummaryParamDto: ManageFeedRequestDto) {
+    await this.feedService.requestAiSummary(aiSummaryParamDto.feedId);
+    return ApiResponse.responseWithNoContent(
+      'AI 요약 재요청이 접수되었습니다.',
     );
   }
 

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -31,6 +31,11 @@ import {
   FeedViewRepository,
 } from '@feed/repository/feed.repository';
 
+interface AiSummaryRetryMessage {
+  feedId: number;
+  deathCount: number;
+}
+
 @Injectable()
 export class FeedService {
   constructor(
@@ -46,6 +51,19 @@ export class FeedService {
     }
 
     return feed;
+  }
+
+  async requestAiSummary(feedId: number) {
+    await this.getFeed(feedId);
+
+    const message: AiSummaryRetryMessage = {
+      feedId,
+      deathCount: 0,
+    };
+    await this.redisService.rpush(
+      REDIS_KEYS.FEED_AI_RETRY_QUEUE,
+      JSON.stringify(message),
+    );
   }
 
   async getFeedByView(feedId: number) {

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -1,4 +1,9 @@
-import { HttpStatus, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  HttpStatus,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 
 import axios from 'axios';
 import { Request, Response } from 'express';
@@ -7,6 +12,7 @@ import { cookieConfig } from '@common/cookie/cookie.config';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
+import { AI_RETRY_LOCK_TTL_SECONDS } from '@feed/constant/feed.constant';
 import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
 import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
 import { SearchFeedRequestDto } from '@feed/dto/request/searchFeed.dto';
@@ -31,10 +37,10 @@ import {
   FeedViewRepository,
 } from '@feed/repository/feed.repository';
 
-interface AiSummaryRetryMessage {
+type AiSummaryRetryMessage = {
   feedId: number;
   deathCount: number;
-}
+};
 
 @Injectable()
 export class FeedService {
@@ -55,6 +61,20 @@ export class FeedService {
 
   async requestAiSummary(feedId: number) {
     await this.getFeed(feedId);
+
+    const lockKey = `${REDIS_KEYS.FEED_AI_RETRY_LOCK}:${feedId}`;
+    const acquired = await this.redisService.set(
+      lockKey,
+      '1',
+      'NX',
+      'EX',
+      AI_RETRY_LOCK_TTL_SECONDS,
+    );
+    if (!acquired) {
+      throw new ConflictException(
+        '현재 이 게시글은 AI 큐에 포함되어 요약을 진행중입니다.',
+      );
+    }
 
     const message: AiSummaryRetryMessage = {
       feedId,

--- a/server/test/feed/e2e/request-ai-summary.e2e-spec.ts
+++ b/server/test/feed/e2e/request-ai-summary.e2e-spec.ts
@@ -122,4 +122,24 @@ describe(`POST /api/feeds/{feedId}/ai-summary-requests E2E Test`, () => {
     expect(queued).toHaveLength(1);
     expect(JSON.parse(queued[0])).toMatchObject({ feedId: feed.id });
   });
+
+  it('[409] 이미 재요청해 처리 중인 피드를 다시 요청하면 충돌이 발생하고 큐에 중복 적재되지 않는다.', async () => {
+    // given
+    const feed: Feed = await createFeed(null);
+    const first = await agent
+      .post(URL(feed.id))
+      .set('Cookie', `sessionId=${sessionKey}`);
+    expect(first.status).toBe(HttpStatus.ACCEPTED);
+
+    // Http when
+    const second = await agent
+      .post(URL(feed.id))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(second.status).toBe(HttpStatus.CONFLICT);
+
+    // Redis then
+    expect(await readRetryQueue()).toHaveLength(1);
+  });
 });

--- a/server/test/feed/e2e/request-ai-summary.e2e-spec.ts
+++ b/server/test/feed/e2e/request-ai-summary.e2e-spec.ts
@@ -1,0 +1,125 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = (feedId: number | string) =>
+  `/api/feeds/${feedId}/ai-summary-requests`;
+const IN_PROGRESS = '아직 AI가 요약을 진행중인 게시글 이에요! 💭';
+
+describe(`POST /api/feeds/{feedId}/ai-summary-requests E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let feedRepository: FeedRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let adminRepository: AdminRepository;
+  let rssAccept: RssAccept;
+
+  const sessionKey = 'ai-summary-session-key';
+  const adminSessionKey = (sid: string) =>
+    `${REDIS_KEYS.ADMIN_AUTH_KEY}:${sid}`;
+
+  const readRetryQueue = () =>
+    redisService.lrange(REDIS_KEYS.FEED_AI_RETRY_QUEUE, 0, -1);
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    feedRepository = testApp.get(FeedRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    adminRepository = testApp.get(AdminRepository);
+  });
+
+  beforeEach(async () => {
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    const admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(adminSessionKey(sessionKey), admin.email);
+  });
+
+  const createFeed = (summary: string | null) =>
+    feedRepository.save(FeedFixture.createFeedFixture(rssAccept, { summary }));
+
+  it('[401] 관리자 인증 쿠키가 없으면 실패하고 큐에 넣지 않는다.', async () => {
+    // given
+    const feed: Feed = await createFeed(null);
+
+    // Http when
+    const response = await agent.post(URL(feed.id));
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+
+    // Redis then
+    expect(await readRetryQueue()).toHaveLength(0);
+  });
+
+  it('[404] 존재하지 않는 피드면 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL(Number.MAX_SAFE_INTEGER))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(await readRetryQueue()).toHaveLength(0);
+  });
+
+  it('[202] 요약이 NULL(영구 실패)인 피드를 deathCount 0으로 재요청 큐에 넣는다.', async () => {
+    // given
+    const feed: Feed = await createFeed(null);
+
+    // Http when
+    const response = await agent
+      .post(URL(feed.id))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.ACCEPTED);
+
+    // Redis then
+    const queued = await readRetryQueue();
+    expect(queued).toHaveLength(1);
+    expect(JSON.parse(queued[0])).toMatchObject({
+      feedId: feed.id,
+      deathCount: 0,
+    });
+  });
+
+  it('[202] 요약이 진행중 placeholder(요청 미전송)인 피드를 재요청 큐에 넣는다.', async () => {
+    // given
+    const feed: Feed = await createFeed(IN_PROGRESS);
+
+    // Http when
+    const response = await agent
+      .post(URL(feed.id))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.ACCEPTED);
+
+    // Redis then
+    const queued = await readRetryQueue();
+    expect(queued).toHaveLength(1);
+    expect(JSON.parse(queued[0])).toMatchObject({ feedId: feed.id });
+  });
+});

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -29,7 +29,13 @@ describe(`${FeedService.name} Unit Test`, () => {
   let redisService: jest.Mocked<
     Pick<
       RedisService,
-      'keys' | 'lrange' | 'sismember' | 'sadd' | 'zincrby' | 'executePipeline'
+      | 'keys'
+      | 'lrange'
+      | 'sismember'
+      | 'sadd'
+      | 'zincrby'
+      | 'executePipeline'
+      | 'rpush'
     >
   >;
 
@@ -54,6 +60,7 @@ describe(`${FeedService.name} Unit Test`, () => {
       sadd: jest.fn(),
       zincrby: jest.fn(),
       executePipeline: jest.fn(),
+      rpush: jest.fn(),
     };
 
     feedService = new FeedService(
@@ -82,6 +89,40 @@ describe(`${FeedService.name} Unit Test`, () => {
       await expect(feedService.getFeedByView(1)).rejects.toThrow(
         NotFoundException,
       );
+    });
+  });
+
+  describe('requestAiSummary', () => {
+    const parseEnqueued = () =>
+      JSON.parse(redisService.rpush.mock.calls[0][1] as string);
+
+    it('존재하지 않는 피드면 NotFoundException을 던지고 큐에 넣지 않는다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue(null);
+
+      // when & then
+      await expect(feedService.requestAiSummary(7)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(redisService.rpush).not.toHaveBeenCalled();
+    });
+
+    it('요약이 NULL(영구 실패)이면 deathCount 0으로 재요청 큐에 넣는다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({
+        id: 7,
+        summary: null,
+      } as any);
+
+      // when
+      await feedService.requestAiSummary(7);
+
+      // then
+      expect(redisService.rpush).toHaveBeenCalledWith(
+        REDIS_KEYS.FEED_AI_RETRY_QUEUE,
+        expect.any(String),
+      );
+      expect(parseEnqueued()).toMatchObject({ feedId: 7, deathCount: 0 });
     });
   });
 

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from '@nestjs/common';
+import { ConflictException, NotFoundException } from '@nestjs/common';
 
 import axios from 'axios';
 import { Request, Response } from 'express';
@@ -36,6 +36,7 @@ describe(`${FeedService.name} Unit Test`, () => {
       | 'zincrby'
       | 'executePipeline'
       | 'rpush'
+      | 'set'
     >
   >;
 
@@ -61,6 +62,7 @@ describe(`${FeedService.name} Unit Test`, () => {
       zincrby: jest.fn(),
       executePipeline: jest.fn(),
       rpush: jest.fn(),
+      set: jest.fn().mockResolvedValue('OK'),
     };
 
     feedService = new FeedService(
@@ -118,11 +120,33 @@ describe(`${FeedService.name} Unit Test`, () => {
       await feedService.requestAiSummary(7);
 
       // then
+      expect(redisService.set).toHaveBeenCalledWith(
+        `${REDIS_KEYS.FEED_AI_RETRY_LOCK}:7`,
+        '1',
+        'NX',
+        'EX',
+        expect.any(Number),
+      );
       expect(redisService.rpush).toHaveBeenCalledWith(
         REDIS_KEYS.FEED_AI_RETRY_QUEUE,
         expect.any(String),
       );
       expect(parseEnqueued()).toMatchObject({ feedId: 7, deathCount: 0 });
+    });
+
+    it('이미 처리 중(락 점유)이면 ConflictException을 던지고 큐에 넣지 않는다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({
+        id: 7,
+        summary: null,
+      } as any);
+      redisService.set.mockResolvedValue(null); // NX 실패 = 이미 락 존재
+
+      // when & then
+      await expect(feedService.requestAiSummary(7)).rejects.toThrow(
+        ConflictException,
+      );
+      expect(redisService.rpush).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #718

### AI 요약 수동 재요청 API (Server)

-   AI 요약에 실패했거나 요청이 누락된 게시글을, 관리자가 수동으로 다시 AI 큐에 태울 수 있는 진입점이 필요했습니다.
-   기존 `feed:ai:queue`를 직접 건드리지 않고 **신규 전용 큐 `feed:ai-retry:queue`** 를 분리했습니다. 정상 크롤링 흐름과 수동 재요청 흐름을 격리해, 한쪽의 장애나 폭주가 다른 쪽 처리에 영향을 주지 않도록 했습니다.
-   API는 큐에 적재만 하고 즉시 `202 Accepted`를 반환하는 비동기 설계입니다. 실제 재처리(RSS 재파싱 등)는 무거운 작업이라 요청-응답 사이클에 묶지 않았습니다.
-   적재 전 `getFeed(feedId)`로 존재 여부를 검증해, 없는 피드는 `404`로 조기 차단합니다(큐 오염 방지). 관리자 인증은 `AdminAuthGuard`로 강제합니다.

### 재요청 게시글 처리 워커 (Feed Crawler)

-   `feed:ai-retry:queue`를 **매 1분** 폴링하는 `AiSummaryRetryEventWorker`를 추가했습니다.
-   워커는 feedId로 원본 피드/RSS를 조회 → RSS를 재파싱해 해당 게시글(`link === feed.path`)을 찾고 → AI 큐에 다시 적재합니다.
-   **핵심 고민: RSS에서 게시글을 못 찾았을 때의 처리.** RSS 노출 범위를 벗어난 오래된 글과, 일시적 서버 장애를 구분하지 못하면 무한 재시도 또는 잘못된 영구 스킵이 발생합니다. 그래서 원본 URL의 HTTP 상태를 직접 프로빙하여 분류합니다.
    -   `200` (노출 범위 이탈한 오래된 글) / `404` (삭제된 글) → **영구 스킵** (재시도 무의미)
    -   그 외(`5xx`/네트워크 오류) → **일시적 오류로 간주, 재시도**
-   `deathCount` 기반으로 재시도 가능 에러에 한해 **최대 3회** 재시도 후 영구 실패 처리합니다. 재시도 불가 에러(피드/RSS 없음, parse 오류 등)는 즉시 종료합니다.

### 중복 재요청 차단 Lock (`feed:ai-retry:lock:{feedId}`)

**문제.** 관리자가 동일 게시글을 연타하거나, 아직 요약이 진행 중인 게시글을 다시 요청하면 `feed:ai-retry:queue` → `feed:ai:queue`에 같은 feedId가 중복 적재됩니다. 동일 글에 대해 AI(Claude) 호출이 여러 번 발생해 **비용 낭비 + 중복 처리**로 이어집니다. 기존엔 `getFeed`로 존재 여부만 검증할 뿐 멱등성 가드가 없었습니다.

**해결.** feedId 단위 분산 락을 Redis에 두고, **AI 요약 전체 처리 구간**(재요청 큐 대기 → AI 큐 대기 → Claude 요약 완료) 동안 락을 점유합니다. 점유 중 재요청은 `409 Conflict`로 거절합니다.

#### 1) 락 획득 — `SET NX EX` 원자적 처리

```ts
const lockKey = `${REDIS_KEYS.FEED_AI_RETRY_LOCK}:${feedId}`;
const acquired = await this.redisService.set(
  lockKey,
  '1',
  'NX',          // 키가 없을 때만 설정 (이미 있으면 설정 안 함)
  'EX',
  AI_RETRY_LOCK_TTL_SECONDS, // 1200초
);
if (!acquired) {
  throw new ConflictException(
    '현재 이 게시글은 AI 큐에 포함되어 요약을 진행중입니다.',
  );
}
```

-   **`NX`가 멱등성의 핵심.** 평범한 `SET`은 항상 덮어쓰고 `'OK'`를 반환하지만, `NX`를 붙이면 **키가 이미 있을 때 설정을 건너뛰고 `null`을 반환**합니다. 즉 반환값(`'OK'` vs `null`)이 곧 "락을 내가 잡았는지" 여부입니다.
-   `SET ... NX EX`는 **단일 원자 연산**이라, 두 요청이 동시에 들어와도 한쪽만 `'OK'`를 받습니다. (검사-후-설정 사이의 race condition 없음)
-   락 획득 성공 시에만 `feed:ai-retry:queue`에 적재합니다.

#### 2) 락 해제 — 종료 시점 3곳 (`DEL`)

처리가 **완전히 끝난 종료 상태**에서만 락을 해제합니다. 재시도로 다시 큐에 들어가는 경우는 아직 "진행 중"이므로 **유지**합니다.

| 시점 | 위치 | 처리 |
| --- | --- | --- |
| 요약 성공 | `ClaudeEventWorker.processItem` (`saveAIResult` 직후) | `DEL` |
| AI 영구 실패 | `ClaudeEventWorker.handleFailure` 의 `else` (`updateNullSummary` 후) | `DEL` |
| 재요청 영구 실패 | `AiSummaryRetryEventWorker.handleFailure` 의 `else` | `DEL` |
| 재시도 재투입 | (큐에 다시 push) | **유지** |

-   해제 `DEL`을 `handleFailure`의 **`else` 블록**에 둔 이유: 이 블록은 *재시도 불가 에러* 와 *`deathCount` 3회 소진* **두 종료 케이스를 모두** 커버합니다. 만약 "재시도 불가"로 분류된 경우에만 해제했다면, 재시도성 에러가 3회를 소진해 끝난 글의 락이 TTL이 끝날 때까지 누수됩니다.
-   재요청 워커가 **영구 실패**하면 게시글이 `feed:ai:queue`에 도달하지 못해 `ClaudeEventWorker`가 락을 풀 수 없으므로, 그 워커에서 직접 `DEL` 합니다.
-   `releaseRetryLock`은 정상 크롤링 피드(락 없음)에 대해 `DEL` 해도 no-op(0 반환)이며, 락 해제 실패가 요약 결과를 덮지 않도록 예외를 삼킵니다.

#### 3) TTL backstop — `AI_RETRY_LOCK_TTL_SECONDS = 1200`

-   명시적 `DEL`이 모든 happy/실패 경로를 처리하지만, **워커가 락 해제 전에 크래시**(예: `rpop` 후 저장 전 프로세스 다운)하면 락이 영구히 남아 해당 글이 다시는 재요청되지 않습니다.
-   TTL은 그 유일한 안전망입니다. 재요청 워커(deathCount 최대 3, 1분 주기) + AI 큐 backlog + Claude 워커(deathCount 최대 3, 1분 주기)의 **최악 지연을 덮도록** 넉넉히 `1200초(20분)`로 설정했습니다.
-   TTL이 실제 진행 중에 만료되면 중복이 슬쩍 통과할 수 있으므로, 누수 비용(한 글이 최대 20분 더 차단됨)을 감수하더라도 길게 잡는 것이 안전합니다. 수동 관리자 액션이라 빈도가 낮아 허용 가능한 트레이드오프입니다.

#### 동작 흐름

```mermaid
sequenceDiagram
    participant Admin as 관리자
    participant API as Server (FeedService)
    participant Redis
    participant RetryW as AiSummaryRetryEventWorker
    participant ClaudeW as ClaudeEventWorker

    Admin->>API: POST /feeds/{id}/ai-summary-requests
    API->>API: getFeed(id) — 없으면 404
    API->>Redis: SET lock:{id} NX EX 1200
    alt 락 획득 성공 ('OK')
        Redis-->>API: 'OK'
        API->>Redis: RPUSH feed:ai-retry:queue {id, deathCount:0}
        API-->>Admin: 202 Accepted
    else 이미 점유 중 (null)
        Redis-->>API: null
        API-->>Admin: 409 Conflict<br/>"요약을 진행중입니다"
    end

    Note over RetryW: 매 1분 폴링
    RetryW->>Redis: RPOP feed:ai-retry:queue
    alt RSS 재파싱 성공
        RetryW->>Redis: RPUSH feed:ai:queue (락 유지)
    else 영구 실패 (피드/RSS 없음 등)
        RetryW->>Redis: DEL lock:{id}
    end

    Note over ClaudeW: 매 1분 폴링
    ClaudeW->>Redis: RPOP feed:ai:queue
    alt 요약 성공
        ClaudeW->>Redis: DEL lock:{id}
    else 재시도 가능 & deathCount<3
        ClaudeW->>Redis: RPUSH feed:ai:queue (락 유지)
    else 영구 실패
        ClaudeW->>Redis: DEL lock:{id}
    end
```

> ⚠️ **알려진 한계**
> -   락은 **재요청 경로에만** 걸립니다. 정상 `feed:ai:queue`에서 대기 중인(락 없는) 피드를 관리자가 재요청하면 AI 큐에 중복 적재될 수 있습니다. (lock-on-request 구조의 본질적 한계)

# 📋 작업 내용

-   **Server**
    -   `POST /feed/:feedId/ai-summary-requests` 관리자 전용 API 추가 (`AdminAuthGuard`, `202 Accepted`)
    -   `FeedService.requestAiSummary`: 피드 존재 검증 → `feed:ai-retry:lock:{feedId}` `SET NX EX`로 멱등성 락 획득(실패 시 `409`) → `feed:ai-retry:queue`에 `{ feedId, deathCount: 0 }` 적재
    -   `REDIS_KEYS.FEED_AI_RETRY_QUEUE` / `FEED_AI_RETRY_LOCK` 상수, `AI_RETRY_LOCK_TTL_SECONDS` 상수(`@feed/constant`) 추가
    -   Swagger 문서(`ApiRequestAiSummary`) 추가 — `409` 응답 문서화
    -   e2e(`409` 충돌 케이스 포함) / 단위 테스트 작성
-   **Feed Crawler**
    -   `AiSummaryRetryEventWorker` 추가 (1분 주기 스케줄러 등록, DI 컨테이너 등록)
    -   `FeedCrawler.requeueFeedForAiSummary`: RSS 재파싱 후 AI 큐 재적재, 원본 HTTP 상태 기반 미발견 사유 분류
    -   `ClaudeEventWorker` / `AiSummaryRetryEventWorker`에 락 해제(`releaseRetryLock`) 로직 추가 — 요약 성공·영구 실패 시 `DEL`
    -   `FeedRepository.selectFeedById` 추가
    -   `AiSummaryRetryMessage` 타입 및 `FEED_AI_RETRY_QUEUE` / `FEED_AI_RETRY_LOCK` 상수 추가
