### PR TITLE
✨ feat: 채팅 이모지 피커 추가

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -33,6 +33,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
+        "emoji-picker-react": "^4.19.1",
         "framer-motion": "^11.11.11",
         "jwt-decode": "^4.0.0",
         "lucide-react": "^0.577.0",
@@ -6504,6 +6505,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-picker-react": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/emoji-picker-react/-/emoji-picker-react-4.19.1.tgz",
+      "integrity": "sha512-BmDdqInKFVYJpv7qS9WI6L9656cDAC+FkDvUjJds56nKHbaVTBNeDmLwKBytRnzu37zWHs9Isg7gt5PT43y6xA==",
+      "license": "MIT",
+      "dependencies": {
+        "flairup": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -7655,6 +7671,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flairup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/flairup/-/flairup-1.0.0.tgz",
+      "integrity": "sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
+    "emoji-picker-react": "^4.19.1",
     "framer-motion": "^11.11.11",
     "jwt-decode": "^4.0.0",
     "lucide-react": "^0.577.0",

--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -1,18 +1,26 @@
 import { useState } from "react";
 
-import { Send } from "lucide-react";
+import EmojiPicker, { EmojiClickData, Theme } from "emoji-picker-react";
+import { Send, Smile } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SheetFooter } from "@/components/ui/sheet";
 
 import { useKeyboardShortcut } from "@/hooks/common/useKeyboardShortcut";
 
 import { useChatStore } from "@/store/useChatStore";
+import { useMediaStore } from "@/store/useMediaStore";
 
 export default function ChatFooter() {
   const [message, setMessage] = useState<string>("");
   const { sendMessage } = useChatStore();
+  const isMobile = useMediaStore((state) => state.isMobile);
+
+  const handleEmojiClick = (emojiData: EmojiClickData) => {
+    setMessage((prev) => prev + emojiData.emoji);
+  };
 
   const handleSendMessage = () => {
     if (message.trim() !== "") {
@@ -36,6 +44,22 @@ export default function ChatFooter() {
           onChange={(e) => setMessage(e.target.value)}
           className="border-none shadow-none bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 h-8 px-0 text-sm"
         />
+        {!isMobile && (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                size="icon"
+                variant="ghost"
+                className="rounded-lg shrink-0 h-8 w-8 text-muted-foreground hover:text-foreground"
+              >
+                <Smile className="!h-6 !w-6" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent side="top" align="end" className="w-auto border-none p-0 shadow-none">
+              <EmojiPicker onEmojiClick={handleEmojiClick} theme={Theme.AUTO} lazyLoadEmojis width={320} height={400} />
+            </PopoverContent>
+          </Popover>
+        )}
         <Button
           size="icon"
           className="rounded-lg shrink-0 bg-primary hover:bg-[#2ECC71] text-white h-8 w-8 transition-colors"


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 관련 이슈 없음

### 채팅 이모지 피커 추가

- 채팅 입력창에서 이모지를 손쉽게 입력할 수 있도록 `emoji-picker-react` 기반 이모지 피커를 추가했습니다.
- Input 우측에 Smile 아이콘 버튼을 두고, `Popover`로 피커를 띄우는 방식으로 기존 ChatFooter 레이아웃을 최소 변경했습니다.
- 선택한 이모지는 현재 입력 메시지 끝에 append 되도록 처리했습니다.

### 모바일 환경 분기

- 모바일에서는 OS 기본 이모지 키보드가 존재하고 화면 공간이 협소해 피커 UI가 중복/불편하므로, `useMediaStore`의 `isMobile` 기준으로 피커 버튼을 노출하지 않도록 분기했습니다.
- 테마는 `Theme.AUTO`로 설정해 라이트/다크 모드를 자동 추종합니다. 초기 렌더 비용을 줄이기 위해 `lazyLoadEmojis`를 적용했습니다.

# 📋 작업 내용

- `emoji-picker-react` 의존성 추가
- `ChatFooter`에 이모지 피커 Popover 및 트리거 버튼 추가
- 모바일 환경에서는 피커 버튼 미노출 처리

# 📷 스크린 샷(선택 사항)

<img width="430" height="463" alt="image" src="https://github.com/user-attachments/assets/285d40c1-20a0-4f48-b212-57147830e2c0" />