### PR TITLE
✨ feat: 관리자 마이페이지 및 계정 수정 기능 구현

### DIFF
--- a/client/src/api/services/admin/auth.ts
+++ b/client/src/api/services/admin/auth.ts
@@ -1,7 +1,13 @@
 import { ADMIN } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
-import { AdminAuthRequest, AdminAuthResponse, AdminProfileResponse } from "@/types/auth";
+import {
+  AdminAuthRequest,
+  AdminAuthResponse,
+  AdminProfileResponse,
+  AdminUpdateRequest,
+  AdminUpdateResponse,
+} from "@/types/auth";
 
 export const auth = {
   login: async (data: AdminAuthRequest): Promise<AdminAuthResponse> => {
@@ -11,6 +17,10 @@ export const auth = {
   me: async (): Promise<AdminProfileResponse["data"]> => {
     const response = await axiosInstance.get<AdminProfileResponse>(ADMIN.ME);
     return response.data.data;
+  },
+  updateProfile: async (data: AdminUpdateRequest): Promise<AdminUpdateResponse> => {
+    const response = await axiosInstance.patch<AdminUpdateResponse>(ADMIN.UPDATE_ME, data);
+    return response.data;
   },
   logout: async (): Promise<{ message: string }> => {
     const response = await axiosInstance.post<{ message: string }>(ADMIN.LOGOUT);

--- a/client/src/api/services/admin/auth.ts
+++ b/client/src/api/services/admin/auth.ts
@@ -26,4 +26,12 @@ export const auth = {
     const response = await axiosInstance.post<{ message: string }>(ADMIN.LOGOUT);
     return response.data;
   },
+  requestWithdraw: async (): Promise<{ message: string }> => {
+    const response = await axiosInstance.post<{ message: string }>(ADMIN.WITHDRAW_REQUEST);
+    return response.data;
+  },
+  confirmWithdraw: async (token: string): Promise<{ message: string }> => {
+    const response = await axiosInstance.delete<{ message: string }>(ADMIN.WITHDRAW_CONFIRM(token));
+    return response.data;
+  },
 };

--- a/client/src/components/admin/layout/AdminHeader.tsx
+++ b/client/src/components/admin/layout/AdminHeader.tsx
@@ -1,7 +1,12 @@
-import { LogOut, User } from "lucide-react";
+import { ChevronDown, LogOut, User } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 import logo from "@/assets/logo-denamu-main.svg";
 
@@ -12,12 +17,10 @@ export const AdminHeader = ({
   setLogin,
   handleTap,
   name,
-  parent,
 }: {
   setLogin: () => void;
-  handleTap: (tap: "RSS" | "MEMBER") => void;
+  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE") => void;
   name?: string;
-  parent?: { email: string; name: string } | null;
 }) => {
   const handleLogout = () => {
     auth.logout();
@@ -37,29 +40,24 @@ export const AdminHeader = ({
 
           {/* Right Side Menu */}
           <div className="flex items-center space-x-4">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div className="flex items-center space-x-2 cursor-help">
-                    <User className="h-5 w-5" />
-                    {name && <span className="text-sm font-medium">{name}</span>}
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {parent ? (
-                    <span>
-                      상위 계정: {parent.name} ({parent.email})
-                    </span>
-                  ) : (
-                    <span>Root 계정이라 부모 계정이 없습니다.</span>
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <Button variant="ghost" className="text-red-600" onClick={handleLogout}>
-              <LogOut className="h-4 w-4" />
-              로그아웃
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger className="flex items-center space-x-2 rounded-md px-2 py-1.5 outline-none hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring">
+                <User className="h-5 w-5" />
+                {name && <span className="text-sm font-medium">{name}</span>}
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => handleTap("MYPAGE")}>
+                  <User className="mr-2 h-4 w-4" />
+                  프로필
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={handleLogout}>
+                  <LogOut className="mr-2 h-4 w-4" />
+                  로그아웃
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/client/src/components/admin/layout/AdminMyPage.tsx
+++ b/client/src/components/admin/layout/AdminMyPage.tsx
@@ -3,13 +3,24 @@ import { useEffect, useState } from "react";
 import { AxiosError } from "axios";
 import { ArrowLeft, Eye, EyeOff } from "lucide-react";
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Toggle } from "@/components/ui/toggle";
 
-import { useAdminCheck, useAdminUpdate } from "@/hooks/queries/useAdminAuth";
+import { useAdminCheck, useAdminUpdate, useAdminWithdraw } from "@/hooks/queries/useAdminAuth";
 
 import { AdminUpdateResponse } from "@/types/auth";
 
@@ -50,6 +61,11 @@ export default function AdminMyPage({ onBack }: { onBack: () => void }) {
   }, onError);
 
   const { mutate: updateNotification } = useAdminUpdate(() => {}, onError);
+
+  const { mutate: withdraw, isPending: isWithdrawing } = useAdminWithdraw(
+    (res) => alert(res.message),
+    (error) => alert(`회원 탈퇴 요청 실패: ${extractErrorMessage(error)}`)
+  );
 
   const handleSubmit = () => {
     if (!isEditing) {
@@ -183,6 +199,37 @@ export default function AdminMyPage({ onBack }: { onBack: () => void }) {
             <span className="text-xs text-muted-foreground">알림 이메일 수신을 켜거나 끕니다.</span>
           </div>
           <Switch id="MP-Notification" checked={data.emailNotification} onCheckedChange={handleNotificationChange} />
+        </div>
+
+        <div className="flex items-center justify-between border-t border-destructive/30 pt-6">
+          <div className="flex flex-col">
+            <Label className="text-destructive">회원 탈퇴</Label>
+            <span className="text-xs text-muted-foreground">
+              탈퇴 시 본인이 생성한 하위 관리자 계정도 함께 삭제되며, 되돌릴 수 없습니다.
+            </span>
+          </div>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive" disabled={isWithdrawing}>
+                회원 탈퇴
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>관리자 회원 탈퇴</AlertDialogTitle>
+                <AlertDialogDescription>
+                  <br />
+                  정말 탈퇴하시겠습니까? 입력한 이메일({data.email})로 인증 메일이 발송됩니다.
+                  <br />
+                  인증을 완료하면 본인 계정과 하위 관리자 계정이 모두 삭제되며, 되돌릴 수 없습니다.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction onClick={() => withdraw()}>인증 메일 발송</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </div>
       </div>
     </div>

--- a/client/src/components/admin/layout/AdminMyPage.tsx
+++ b/client/src/components/admin/layout/AdminMyPage.tsx
@@ -105,25 +105,17 @@ export default function AdminMyPage({ onBack }: { onBack: () => void }) {
 
   return (
     <div className="w-full max-w-2xl mx-auto py-4">
-      <div className="flex items-center justify-between mb-2">
-        <div className="flex items-center gap-2">
-          <Button variant="ghost" size="icon" aria-label="뒤로가기" onClick={onBack}>
-            <ArrowLeft className="h-5 w-5" />
-          </Button>
-          <h1 className="text-2xl font-bold">관리자 마이페이지</h1>
-        </div>
-        <div className="flex gap-2">
-          {isEditing && (
-            <Button variant="outline" onClick={handleCancel} disabled={isPending}>
-              취소
-            </Button>
-          )}
-          <Button onClick={handleSubmit} disabled={isPending}>
-            {isEditing ? "수정 완료" : "수정하기"}
-          </Button>
-        </div>
-      </div>
-      <p className="text-sm text-muted-foreground mb-8 pl-12">본인 계정 정보를 확인하고 수정합니다.</p>
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onBack}
+        className="-ml-3 mb-4 gap-1.5 text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        뒤로가기
+      </Button>
+      <h1 className="text-2xl font-bold">관리자 마이페이지</h1>
+      <p className="text-sm text-muted-foreground mt-1 mb-8">본인 계정 정보를 확인하고 수정합니다.</p>
 
       <div className="flex flex-col gap-6">
         <div className="flex flex-col gap-2">
@@ -191,6 +183,17 @@ export default function AdminMyPage({ onBack }: { onBack: () => void }) {
             autoCapitalize="off"
             spellCheck="false"
           />
+        </div>
+
+        <div className="flex justify-end gap-2">
+          {isEditing && (
+            <Button variant="outline" onClick={handleCancel} disabled={isPending}>
+              취소
+            </Button>
+          )}
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isEditing ? "수정 완료" : "수정하기"}
+          </Button>
         </div>
 
         <div className="flex items-center justify-between border-t pt-6">

--- a/client/src/components/admin/layout/AdminMyPage.tsx
+++ b/client/src/components/admin/layout/AdminMyPage.tsx
@@ -78,7 +78,6 @@ export default function AdminMyPage({ onBack }: { onBack: () => void }) {
     }
 
     if (password && password !== passwordConfirm) {
-      alert("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
       return;
     }
 
@@ -100,6 +99,7 @@ export default function AdminMyPage({ onBack }: { onBack: () => void }) {
   };
 
   const passwordError = password.length > 0 && !isValidPassword(password);
+  const passwordConfirmError = passwordConfirm.length > 0 && password !== passwordConfirm;
 
   if (!data) return null;
 
@@ -183,6 +183,7 @@ export default function AdminMyPage({ onBack }: { onBack: () => void }) {
             autoCapitalize="off"
             spellCheck="false"
           />
+          {passwordConfirmError && <p className="text-xs text-red-600">비밀번호와 비밀번호 확인이 일치하지 않습니다.</p>}
         </div>
 
         <div className="flex justify-end gap-2">

--- a/client/src/components/admin/layout/AdminMyPage.tsx
+++ b/client/src/components/admin/layout/AdminMyPage.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from "react";
+
+import { AxiosError } from "axios";
+import { ArrowLeft, Eye, EyeOff } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Toggle } from "@/components/ui/toggle";
+
+import { useAdminCheck, useAdminUpdate } from "@/hooks/queries/useAdminAuth";
+
+import { AdminUpdateResponse } from "@/types/auth";
+
+const PASSWORD_REG = /^(?=.*[!@#$%^&*()_+])[A-Za-z0-9!@#$%^&*()_+]+$/;
+const isValidPassword = (value: string) => PASSWORD_REG.test(value) && value.length >= 6 && value.length <= 60;
+const PASSWORD_RULE_MESSAGE = "6자 이상 60자 이하, 특수문자(!@#$%^&*()_+) 1개 이상 포함해야 합니다.";
+
+const extractErrorMessage = (error: AxiosError) => {
+  const data = error.response?.data as { message?: string | string[] } | string | undefined;
+  if (typeof data === "string") return data;
+  const message = data?.message;
+  if (Array.isArray(message)) return message.join("\n");
+  return message ?? error.message;
+};
+
+export default function AdminMyPage({ onBack }: { onBack: () => void }) {
+  const { data } = useAdminCheck();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [viewPassword, setViewPassword] = useState(false);
+
+  useEffect(() => {
+    if (data?.name) setName(data.name);
+  }, [data?.name]);
+
+  const onError = (error: AxiosError) => {
+    alert(`수정 실패: ${extractErrorMessage(error)}`);
+  };
+
+  const { mutate: updateProfile, isPending } = useAdminUpdate((res: AdminUpdateResponse) => {
+    alert(res.message);
+    setIsEditing(false);
+    setPassword("");
+    setPasswordConfirm("");
+  }, onError);
+
+  const { mutate: updateNotification } = useAdminUpdate(() => {}, onError);
+
+  const handleSubmit = () => {
+    if (!isEditing) {
+      setIsEditing(true);
+      return;
+    }
+
+    if (password && !isValidPassword(password)) {
+      return;
+    }
+
+    if (password && password !== passwordConfirm) {
+      alert("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+      return;
+    }
+
+    updateProfile({
+      name: name.trim(),
+      ...(password ? { password } : {}),
+    });
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setName(data?.name ?? "");
+    setPassword("");
+    setPasswordConfirm("");
+  };
+
+  const handleNotificationChange = (checked: boolean) => {
+    updateNotification({ emailNotification: checked });
+  };
+
+  const passwordError = password.length > 0 && !isValidPassword(password);
+
+  if (!data) return null;
+
+  return (
+    <div className="w-full max-w-2xl mx-auto py-4">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="icon" aria-label="뒤로가기" onClick={onBack}>
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+          <h1 className="text-2xl font-bold">관리자 마이페이지</h1>
+        </div>
+        <div className="flex gap-2">
+          {isEditing && (
+            <Button variant="outline" onClick={handleCancel} disabled={isPending}>
+              취소
+            </Button>
+          )}
+          <Button onClick={handleSubmit} disabled={isPending}>
+            {isEditing ? "수정 완료" : "수정하기"}
+          </Button>
+        </div>
+      </div>
+      <p className="text-sm text-muted-foreground mb-8 pl-12">본인 계정 정보를 확인하고 수정합니다.</p>
+
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="MP-Email">이메일</Label>
+          <Input id="MP-Email" type="email" value={data.email} disabled readOnly />
+          <p className="text-xs text-muted-foreground">이메일은 변경할 수 없습니다.</p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="MP-Name">이름</Label>
+          <Input
+            id="MP-Name"
+            type="text"
+            value={name}
+            disabled={!isEditing}
+            onChange={(e) => setName(e.target.value)}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck="false"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label>부모 계정 닉네임</Label>
+          <Input type="text" value={data.parent ? data.parent.name : "Root 계정"} disabled readOnly />
+        </div>
+
+        <div className="flex flex-col gap-2 relative">
+          <Label htmlFor="MP-Password">비밀번호</Label>
+          <Input
+            id="MP-Password"
+            type={viewPassword ? "text" : "password"}
+            value={password}
+            disabled={!isEditing}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder={isEditing ? "변경할 경우에만 입력" : ""}
+            autoComplete="new-password"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck="false"
+          />
+          <Toggle
+            aria-label="비밀번호 표시 전환"
+            variant="outline"
+            disabled={!isEditing}
+            className="absolute right-1 bottom-0 hover:bg-transparent active:bg-transparent focus:bg-transparent"
+            onPressedChange={setViewPassword}
+          >
+            {viewPassword ? <Eye /> : <EyeOff />}
+          </Toggle>
+          {passwordError && <p className="text-xs text-red-600">{PASSWORD_RULE_MESSAGE}</p>}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="MP-PasswordConfirm">비밀번호 확인</Label>
+          <Input
+            id="MP-PasswordConfirm"
+            type={viewPassword ? "text" : "password"}
+            value={passwordConfirm}
+            disabled={!isEditing}
+            onChange={(e) => setPasswordConfirm(e.target.value)}
+            autoComplete="new-password"
+            autoCorrect="off"
+            autoCapitalize="off"
+            spellCheck="false"
+          />
+        </div>
+
+        <div className="flex items-center justify-between border-t pt-6">
+          <div className="flex flex-col">
+            <Label htmlFor="MP-Notification">이메일 수신 여부</Label>
+            <span className="text-xs text-muted-foreground">알림 이메일 수신을 켜거나 끕니다.</span>
+          </div>
+          <Switch id="MP-Notification" checked={data.emailNotification} onCheckedChange={handleNotificationChange} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -10,6 +10,8 @@ export const ADMIN = {
   CERTIFICATE: "/api/admins/email-verifications",
   CHILDREN: "/api/admins/children",
   DELETE_CHILD: (id: number) => `/api/admins/children/${id}`,
+  WITHDRAW_REQUEST: "/api/admins/me/deletion-requests",
+  WITHDRAW_CONFIRM: (token: string) => `/api/admins/deletion-requests/${token}`,
   GET: {
     RSS: "/api/rss",
     ACCEPT: "/api/rss/history/accept",

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -4,6 +4,7 @@ export const CHAT_SERVER_URL = import.meta.env.VITE_DENAMU_URL;
 export const ADMIN = {
   LOGIN: "/api/admins/login",
   ME: "/api/admins/me",
+  UPDATE_ME: "/api/admins/me",
   LOGOUT: "/api/admins/logout",
   REGISTER: "/api/admins/registrations",
   CERTIFICATE: "/api/admins/email-verifications",

--- a/client/src/hooks/common/useAdminWithdrawCertification.ts
+++ b/client/src/hooks/common/useAdminWithdrawCertification.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+import axios from "axios";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast";
+
+import { auth } from "@/api/services/admin/auth";
+
+export const useAdminWithdrawCertification = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const { toast } = useCustomToast();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  useEffect(() => {
+    const withdrawAdmin = async () => {
+      if (!token) {
+        toast({
+          title: "탈퇴 실패",
+          description: "유효하지 않은 인증 링크입니다.",
+          variant: "destructive",
+        });
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        await auth.confirmWithdraw(token);
+        setIsSuccess(true);
+        toast({
+          title: "탈퇴 완료",
+          description: "관리자 계정이 삭제되었습니다.",
+        });
+      } catch (error: unknown) {
+        if (axios.isAxiosError(error)) {
+          toast({
+            title: "탈퇴 실패",
+            description: error.response?.data?.message || "탈퇴 처리 중 오류가 발생했습니다.",
+            variant: "destructive",
+          });
+        } else {
+          toast({
+            title: "탈퇴 실패",
+            description: "탈퇴 처리 중 오류가 발생했습니다.",
+            variant: "destructive",
+          });
+        }
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    withdrawAdmin();
+  }, [token, toast]);
+
+  return { isLoading, isSuccess };
+};

--- a/client/src/hooks/queries/useAdminAuth.ts
+++ b/client/src/hooks/queries/useAdminAuth.ts
@@ -50,6 +50,17 @@ export const useAdminUpdate = (
   });
 };
 
+export const useAdminWithdraw = (
+  onSuccess: (data: { message: string }) => void,
+  onError: (error: AxiosError<unknown, unknown>) => void
+): UseMutationResult<{ message: string }, AxiosError<unknown, unknown>, void, unknown> => {
+  return useMutation<{ message: string }, AxiosError<unknown, unknown>, void>({
+    mutationFn: () => auth.requestWithdraw(),
+    onSuccess,
+    onError,
+  });
+};
+
 export const useAdminRegister = (
   onSuccess: (data: RegisterResponse) => void,
   onError: (error: AxiosError<unknown, unknown>) => void

--- a/client/src/hooks/queries/useAdminAuth.ts
+++ b/client/src/hooks/queries/useAdminAuth.ts
@@ -4,7 +4,7 @@ import { auth } from "@/api/services/admin/auth";
 import { register } from "@/api/services/admin/register";
 import { useAuthStore } from "@/store/useAuthStore";
 import { DeleteChildResponse, RegisterRequest, RegisterResponse } from "@/types/admin";
-import { AdminAuthRequest, AdminAuthResponse } from "@/types/auth";
+import { AdminAuthRequest, AdminAuthResponse, AdminUpdateRequest, AdminUpdateResponse } from "@/types/auth";
 import { useMutation, UseMutationResult, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useAdminAuth = (
@@ -33,6 +33,21 @@ export const useAdminCheck = () => {
     retry: 1,
   });
   return { status, isLoading, error, data };
+};
+
+export const useAdminUpdate = (
+  onSuccess: (data: AdminUpdateResponse) => void,
+  onError: (error: AxiosError<unknown, unknown>) => void
+): UseMutationResult<AdminUpdateResponse, AxiosError<unknown, unknown>, AdminUpdateRequest, unknown> => {
+  const queryClient = useQueryClient();
+  return useMutation<AdminUpdateResponse, AxiosError<unknown, unknown>, AdminUpdateRequest>({
+    mutationFn: (data) => auth.updateProfile(data),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["adminCheck"] });
+      onSuccess(data);
+    },
+    onError,
+  });
 };
 
 export const useAdminRegister = (

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -4,6 +4,7 @@ import { Loader } from "lucide-react";
 
 import { AdminHeader } from "@/components/admin/layout/AdminHeader";
 import AdminMember from "@/components/admin/layout/AdminMember";
+import AdminMyPage from "@/components/admin/layout/AdminMyPage";
 import { AdminTabs } from "@/components/admin/layout/AdminTabs";
 import AdminLogin from "@/components/admin/login/AdminLoginModal";
 import { RssRequestSearchBar } from "@/components/admin/rss/RssSearchBar";
@@ -13,7 +14,7 @@ import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
 export default function Admin() {
   const [isLogin, setIsLogin] = useState<boolean>(false);
   const { status, isLoading, data } = useAdminCheck();
-  const [tap, setTap] = useState<"RSS" | "MEMBER">("RSS");
+  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE">("RSS");
 
   useEffect(() => {
     setIsLogin(status === "success");
@@ -28,6 +29,9 @@ export default function Admin() {
         </>
       );
     }
+    if (tap === "MYPAGE") {
+      return <AdminMyPage onBack={() => setTap("RSS")} />;
+    }
     return <AdminMember />;
   };
 
@@ -40,7 +44,7 @@ export default function Admin() {
 
   return isLogin ? (
     <main className="min-h-screen bg-background">
-      <AdminHeader setLogin={() => setIsLogin(false)} handleTap={setTap} name={data?.name} parent={data?.parent} />
+      <AdminHeader setLogin={() => setIsLogin(false)} handleTap={setTap} name={data?.name} />
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 h-full">{renderContent()} </div>
     </main>
   ) : (

--- a/client/src/pages/AdminWithdraw.tsx
+++ b/client/src/pages/AdminWithdraw.tsx
@@ -1,0 +1,56 @@
+import { useNavigate } from "react-router-dom";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { useAdminWithdrawCertification } from "@/hooks/common/useAdminWithdrawCertification";
+
+export default function AdminWithdraw() {
+  const navigate = useNavigate();
+  const { isLoading, isSuccess } = useAdminWithdrawCertification();
+
+  const handleGoToAdmin = () => {
+    navigate("/admin");
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <Card className="w-[450px]">
+        <CardHeader>
+          <CardTitle>{isLoading ? "탈퇴 처리 중..." : isSuccess ? "탈퇴 완료" : "탈퇴 실패"}</CardTitle>
+          <CardDescription>
+            {isLoading
+              ? "관리자 회원탈퇴를 처리하고 있습니다."
+              : isSuccess
+                ? "관리자 계정 탈퇴가 완료되었습니다."
+                : "관리자 회원탈퇴에 실패했습니다."}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="flex justify-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+            </div>
+          ) : isSuccess ? (
+            <div className="text-center text-green-600">
+              <p>그동안 Denamu를 이용해 주셔서 감사합니다.</p>
+              <p>본인이 생성한 하위 관리자 계정도 함께 삭제되었습니다.</p>
+            </div>
+          ) : (
+            <div className="text-center text-red-600">
+              <p>인증 링크가 만료되었거나 유효하지 않습니다.</p>
+              <p>관리자 페이지에서 탈퇴를 다시 요청해주세요.</p>
+            </div>
+          )}
+        </CardContent>
+        <CardFooter className="flex justify-center">
+          {!isLoading && (
+            <Button onClick={handleGoToAdmin} disabled={isLoading}>
+              관리자 페이지로 가기
+            </Button>
+          )}
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -14,6 +14,7 @@ const SignIn = lazy(() => import("@/pages/SignIn"));
 const SignUp = lazy(() => import("@/pages/SignUp"));
 const UserCertificate = lazy(() => import("@/pages/UserCertificate"));
 const AdminCertificate = lazy(() => import("@/pages/AdminCertificate"));
+const AdminWithdraw = lazy(() => import("@/pages/AdminWithdraw"));
 const OAuthSuccessPage = lazy(() => import("@/pages/OAuthSuccessPage"));
 const OAuthSignUpPage = lazy(() => import("@/pages/OAuthSignUpPage"));
 
@@ -95,6 +96,14 @@ export const AppRouter = ({ location, state }: RouterProps) => {
           element={
             <Suspense fallback={<Loading />}>
               <AdminCertificate />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/admins/deletion-requests/confirm"
+          element={
+            <Suspense fallback={<Loading />}>
+              <AdminWithdraw />
             </Suspense>
           }
         />

--- a/client/src/types/auth.ts
+++ b/client/src/types/auth.ts
@@ -10,9 +10,21 @@ export type AdminAuthResponse = {
 export type AdminProfileResponse = {
   message: string;
   data: {
+    email: string;
     name: string;
+    emailNotification: boolean;
     parent: { email: string; name: string } | null;
   };
+};
+
+export type AdminUpdateRequest = {
+  name?: string;
+  password?: string;
+  emailNotification?: boolean;
+};
+
+export type AdminUpdateResponse = {
+  message: string;
 };
 
 export interface UserSignUpRequest {

--- a/email-worker/src/email/constant.ts
+++ b/email-worker/src/email/constant.ts
@@ -6,4 +6,5 @@ export const EmailPayloadConstant = {
   PASSWORD_RESET: 'passwordReset',
   ACCOUNT_DELETION: 'accountDeletion',
   ADMIN_CERTIFICATION: 'adminCertification',
+  ADMIN_ACCOUNT_DELETION: 'adminAccountDeletion',
 } as const;

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -112,6 +112,10 @@ export class EmailConsumer {
         await this.emailService.sendAdminCertificationMail(payload.data);
         break;
 
+      case EmailPayloadConstant.ADMIN_ACCOUNT_DELETION:
+        await this.emailService.sendAdminDeleteAccountMail(payload.data);
+        break;
+
       default:
         logger.info(`처리할 수 없는 이메일 타입이 입력되었습니다.`);
     }

--- a/email-worker/src/email/email.content.ts
+++ b/email-worker/src/email/email.content.ts
@@ -165,6 +165,45 @@ export function createAdminVerificationMailContent(
 `;
 }
 
+export function createAdminDeleteAccountContent(
+  name: string,
+  verificationLink: string,
+  serviceAddress: string,
+) {
+  return `
+  <div style="font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', sans-serif; margin: 0; padding: 1px; background-color: #f4f4f4;">
+    <div style="max-width: 600px; margin: 20px auto; background-color: #ffffff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
+      <div style="text-align: center; padding: 20px 0; border-bottom: 2px solid #f0f0f0;">
+        <img src="https://denamu.dev/files/Denamu_Logo_KOR.png" alt="Denamu Logo" width="244" height="120">
+      </div>
+      <div style="padding: 20px 0;">
+        <div style="color: #dc3545; font-size: 24px; font-weight: bold; margin-bottom: 20px; text-align: center;">관리자 회원탈퇴 요청을 확인해주세요</div>
+          <div style="background-color: #f8f9fa; padding: 15px; border-radius: 4px; margin: 15px 0;">
+            <p><strong>안녕하세요, ${name}님!</strong></p>
+            <p>Denamu 관리자 계정 회원탈퇴 요청이 접수되었습니다.</p>
+            <p>정말 탈퇴하시려면 아래 버튼을 클릭하여 회원탈퇴를 완료해 주세요.</p>
+            <p style="color: #dc3545; font-weight: bold; margin-top: 15px;">⚠️ 탈퇴 시 본인이 생성한 하위 관리자 계정도 함께 삭제되며, 복구할 수 없습니다.</p>
+          </div>
+          <center>
+            <a href="${verificationLink}" style="display: inline-block; padding: 12px 24px; background-color: #dc3545; color: #ffffff; text-decoration: none; border-radius: 4px; margin: 20px 0; font-weight: bold;">회원탈퇴 확인</a>
+          </center>
+          <div style="font-size: 14px; color: #6c757d; margin-top: 20px; text-align: center;">
+            <p>버튼이 작동하지 않는 경우, 아래 링크를 복사하여 브라우저에 붙여넣기 해주세요:</p>
+            <p style="word-break: break-all; background-color: #f8f9fa; padding: 10px; border-radius: 4px;">${verificationLink}</p>
+            <p>이 링크는 10분 동안 유효합니다.</p>
+            <p style="margin-top: 15px;">본인이 요청하지 않은 경우, 이 메일을 무시하시기 바랍니다.</p>
+          </div>
+        </div>
+      </div>
+      <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; border-top: 2px solid #f0f0f0; color: #6c757d; font-size: 14px; height: 100px;">
+        <p>본 메일은 발신전용입니다.</p>
+        <p>문의사항이 있으시다면 ${serviceAddress}로 연락주세요.</p>
+      </div>
+    </div>
+  </div>
+`;
+}
+
 export function createRssRemoveCertificateContent(
   userName: string,
   certificateCode: string,

--- a/email-worker/src/email/email.service.ts
+++ b/email-worker/src/email/email.service.ts
@@ -15,6 +15,7 @@ import {
 } from '@common/types';
 
 import {
+  createAdminDeleteAccountContent,
   createAdminVerificationMailContent,
   createDeleteAccountContent,
   createPasswordResetMailContent,
@@ -90,6 +91,29 @@ export class EmailService {
       to: admin.email,
       subject: `[🎋 Denamu] 관리자 계정 인증 메일`,
       html: createAdminVerificationMailContent(
+        admin.name,
+        redirectUrl,
+        this.emailUser,
+      ),
+    };
+  }
+
+  async sendAdminDeleteAccountMail(admin: AdminCertification): Promise<void> {
+    const mailOptions = this.createAdminDeleteAccountMail(admin);
+
+    await this.sendMail(mailOptions);
+  }
+
+  private createAdminDeleteAccountMail(
+    admin: AdminCertification,
+  ): nodemailer.SendMailOptions {
+    const redirectUrl = `${PRODUCT_DOMAIN}/admins/deletion-requests/confirm?token=${admin.uuid}`;
+
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: admin.email,
+      subject: `[🎋 Denamu] 관리자 회원탈퇴 확인 메일`,
+      html: createAdminDeleteAccountContent(
         admin.name,
         redirectUrl,
         this.emailUser,

--- a/email-worker/src/email/types.ts
+++ b/email-worker/src/email/types.ts
@@ -24,6 +24,10 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.ADMIN_CERTIFICATION;
       data: AdminCertification;
+    }
+  | {
+      type: typeof EmailPayloadConstant.ADMIN_ACCOUNT_DELETION;
+      data: AdminCertification;
     };
 
 export type NodeMailerError = Error & {

--- a/server/src/admin/api-docs/confirmDeleteAdmin.api-docs.ts
+++ b/server/src/admin/api-docs/confirmDeleteAdmin.api-docs.ts
@@ -1,0 +1,18 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiConfirmDeleteAdmin() {
+  return applyDecorators(
+    ApiOperation({ summary: '관리자 본인 회원탈퇴 인증 API' }),
+    ApiParam({ name: 'token', description: '회원탈퇴 인증 토큰' }),
+    ApiMessageResponse('회원탈퇴가 완료되었습니다.'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiNotFoundDoc('유효하지 않거나 만료된 토큰입니다.'),
+  );
+}

--- a/server/src/admin/api-docs/requestDeleteAdmin.api-docs.ts
+++ b/server/src/admin/api-docs/requestDeleteAdmin.api-docs.ts
@@ -1,0 +1,20 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiRequestDeleteAdmin() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '관리자 본인 회원탈퇴 요청 API' }),
+    ApiMessageResponse(
+      '회원탈퇴 신청이 성공적으로 처리되었습니다. 이메일을 확인해주세요.',
+    ),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않는 관리자 계정입니다.'),
+  );
+}

--- a/server/src/admin/api-docs/updateAdminProfile.api-docs.ts
+++ b/server/src/admin/api-docs/updateAdminProfile.api-docs.ts
@@ -1,0 +1,22 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiConflictDoc,
+  ApiMessageResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiUpdateAdminProfile() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({
+      summary: '관리자 본인 정보 수정 API',
+      description:
+        '이름, 비밀번호, 이메일 수신 여부를 수정합니다. 이메일은 변경할 수 없습니다.',
+    }),
+    ApiMessageResponse('관리자 정보가 성공적으로 수정되었습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiConflictDoc('이미 존재하는 이름입니다.'),
+  );
+}

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -7,6 +7,7 @@ import {
   HttpStatus,
   Param,
   ParseIntPipe,
+  Patch,
   Post,
   Req,
   Res,
@@ -23,9 +24,11 @@ import { ApiGetCurrentAdmin } from '@admin/api-docs/getCurrentAdmin.api-docs';
 import { ApiLoginAdmin } from '@admin/api-docs/loginAdmin.api-docs';
 import { ApiLogoutAdmin } from '@admin/api-docs/logoutAdmin.api-docs';
 import { ApiRegisterAdmin } from '@admin/api-docs/registerAdmin.api-docs';
+import { ApiUpdateAdminProfile } from '@admin/api-docs/updateAdminProfile.api-docs';
 import { CertificateAdminRequestDto } from '@admin/dto/request/certificateAdmin.dto';
 import { LoginAdminRequestDto } from '@admin/dto/request/loginAdmin.dto';
 import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
+import { UpdateAdminProfileRequestDto } from '@admin/dto/request/updateAdminProfile.dto';
 import { AdminService } from '@admin/service/admin.service';
 
 import { CurrentAdmin } from '@common/decorator/current-admin.decorator';
@@ -126,6 +129,20 @@ export class AdminController {
     return ApiResponse.responseWithData(
       '현재 로그인한 관리자 프로필입니다.',
       profile,
+    );
+  }
+
+  @ApiUpdateAdminProfile()
+  @Patch('/me')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(AdminAuthGuard)
+  async updateAdminProfile(
+    @CurrentAdmin() email: string,
+    @Body() updateAdminProfileBodyDto: UpdateAdminProfileRequestDto,
+  ) {
+    await this.adminService.updateAdminProfile(email, updateAdminProfileBodyDto);
+    return ApiResponse.responseWithNoContent(
+      '관리자 정보가 성공적으로 수정되었습니다.',
     );
   }
 }

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -18,14 +18,17 @@ import { ApiTags } from '@nestjs/swagger';
 import { Request, Response } from 'express';
 
 import { ApiCertificateAdmin } from '@admin/api-docs/certificateAdmin.api-docs';
+import { ApiConfirmDeleteAdmin } from '@admin/api-docs/confirmDeleteAdmin.api-docs';
 import { ApiDeleteChildAdmin } from '@admin/api-docs/deleteChildAdmin.api-docs';
 import { ApiGetChildrenAdmin } from '@admin/api-docs/getChildrenAdmin.api-docs';
 import { ApiGetCurrentAdmin } from '@admin/api-docs/getCurrentAdmin.api-docs';
 import { ApiLoginAdmin } from '@admin/api-docs/loginAdmin.api-docs';
 import { ApiLogoutAdmin } from '@admin/api-docs/logoutAdmin.api-docs';
 import { ApiRegisterAdmin } from '@admin/api-docs/registerAdmin.api-docs';
+import { ApiRequestDeleteAdmin } from '@admin/api-docs/requestDeleteAdmin.api-docs';
 import { ApiUpdateAdminProfile } from '@admin/api-docs/updateAdminProfile.api-docs';
 import { CertificateAdminRequestDto } from '@admin/dto/request/certificateAdmin.dto';
+import { ConfirmDeleteAdminParamRequestDto } from '@admin/dto/request/confirmDeleteAdminParam.dto';
 import { LoginAdminRequestDto } from '@admin/dto/request/loginAdmin.dto';
 import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
 import { UpdateAdminProfileRequestDto } from '@admin/dto/request/updateAdminProfile.dto';
@@ -118,6 +121,27 @@ export class AdminController {
     return ApiResponse.responseWithNoContent(
       '관리자 계정이 성공적으로 삭제되었습니다.',
     );
+  }
+
+  @ApiRequestDeleteAdmin()
+  @UseGuards(AdminAuthGuard)
+  @Post('/me/deletion-requests')
+  @HttpCode(HttpStatus.OK)
+  async requestDeleteAdmin(@CurrentAdmin() email: string) {
+    await this.adminService.requestDeleteAccount(email);
+    return ApiResponse.responseWithNoContent(
+      '회원탈퇴 신청이 성공적으로 처리되었습니다. 이메일을 확인해주세요.',
+    );
+  }
+
+  @ApiConfirmDeleteAdmin()
+  @Delete('/deletion-requests/:token')
+  @HttpCode(HttpStatus.OK)
+  async confirmDeleteAdmin(
+    @Param() paramDto: ConfirmDeleteAdminParamRequestDto,
+  ) {
+    await this.adminService.confirmDeleteAccount(paramDto.token);
+    return ApiResponse.responseWithNoContent('회원탈퇴가 완료되었습니다.');
   }
 
   @ApiGetCurrentAdmin()

--- a/server/src/admin/dto/request/confirmDeleteAdminParam.dto.ts
+++ b/server/src/admin/dto/request/confirmDeleteAdminParam.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class ConfirmDeleteAdminParamRequestDto {
+  @ApiProperty({
+    example: 'd2ba0d98-95ce-4905-87fc-384965ffe7c9',
+    description: '관리자 회원탈퇴 인증 토큰',
+  })
+  @IsNotEmpty({ message: '인증 토큰을 입력해주세요.' })
+  @IsUUID(4, { message: 'UUID v4 형식이어야 합니다.' })
+  token: string;
+
+  constructor(partial: Partial<ConfirmDeleteAdminParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/admin/dto/request/updateAdminProfile.dto.ts
+++ b/server/src/admin/dto/request/updateAdminProfile.dto.ts
@@ -1,0 +1,54 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import {
+  IsBoolean,
+  IsOptional,
+  IsString,
+  Length,
+  Matches,
+} from 'class-validator';
+
+const PASSWORD_REG = /^(?=.*[!@#$%^&*()_+])[A-Za-z0-9!@#$%^&*()_+]+$/;
+
+export class UpdateAdminProfileRequestDto {
+  @ApiPropertyOptional({
+    example: '홍길동',
+    description: '변경할 관리자 이름. 미입력 시 기존 이름 유지',
+  })
+  @IsOptional()
+  @IsString({
+    message: '문자열을 입력해주세요',
+  })
+  @Length(1, 255, {
+    message: '이름의 길이는 1자 이상, 255자 이하로 작성해주세요.',
+  })
+  name?: string;
+
+  @ApiPropertyOptional({
+    example: 'test1234!',
+    description:
+      '변경할 비밀번호. 미입력 시 기존 비밀번호 유지. (최소 6자, 특수문자 1개 이상 포함)',
+  })
+  @IsOptional()
+  @IsString({
+    message: '문자열을 입력해주세요',
+  })
+  @Matches(PASSWORD_REG, {
+    message:
+      '영문, 숫자, 특수문자로 이루어질 수 있으며 특수문자는 1개 이상 포함해주세요.',
+  })
+  @Length(6, 60, {
+    message: '패스워드의 길이는 6자 이상, 60자 이하로 작성해주세요.',
+  })
+  password?: string;
+
+  @ApiPropertyOptional({
+    example: true,
+    description: '이메일 수신 여부',
+  })
+  @IsOptional()
+  @IsBoolean({
+    message: '불리언 값을 입력해주세요',
+  })
+  emailNotification?: boolean;
+}

--- a/server/src/admin/dto/response/getAdminProfile.dto.ts
+++ b/server/src/admin/dto/response/getAdminProfile.dto.ts
@@ -13,10 +13,22 @@ class ParentAdminDto {
 
 export class GetAdminProfileResponseDto {
   @ApiProperty({
+    example: 'admin@example.com',
+    description: '관리자 이메일 (변경 불가)',
+  })
+  email: string;
+
+  @ApiProperty({
     example: '홍길동',
     description: '관리자 이름',
   })
   name: string;
+
+  @ApiProperty({
+    example: true,
+    description: '이메일 수신 여부',
+  })
+  emailNotification: boolean;
 
   @ApiProperty({
     type: ParentAdminDto,
@@ -29,7 +41,17 @@ export class GetAdminProfileResponseDto {
     Object.assign(this, partial);
   }
 
-  static toResponseDto(name: string, parent: ParentAdminDto | null) {
-    return new GetAdminProfileResponseDto({ name, parent });
+  static toResponseDto(
+    email: string,
+    name: string,
+    emailNotification: boolean,
+    parent: ParentAdminDto | null,
+  ) {
+    return new GetAdminProfileResponseDto({
+      email,
+      name,
+      emailNotification,
+      parent,
+    });
   }
 }

--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -14,6 +14,7 @@ import { In } from 'typeorm';
 import { SESSION_TTL } from '@admin/constant/admin.constant';
 import { LoginAdminRequestDto } from '@admin/dto/request/loginAdmin.dto';
 import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
+import { UpdateAdminProfileRequestDto } from '@admin/dto/request/updateAdminProfile.dto';
 import { GetAdminProfileResponseDto } from '@admin/dto/response/getAdminProfile.dto';
 import { GetChildAdminResponseDto } from '@admin/dto/response/getChildAdmin.dto';
 import { Admin } from '@admin/entity/admin.entity';
@@ -246,6 +247,54 @@ export class AdminService {
       }
     }
 
-    return GetAdminProfileResponseDto.toResponseDto(admin.name, parent);
+    return GetAdminProfileResponseDto.toResponseDto(
+      admin.email,
+      admin.name,
+      admin.emailNotification,
+      parent,
+    );
+  }
+
+  async updateAdminProfile(
+    email: string,
+    updateAdminProfileDto: UpdateAdminProfileRequestDto,
+  ) {
+    const admin = await this.adminRepository.findOne({
+      where: { email },
+    });
+
+    if (!admin) {
+      throw new NotFoundException('존재하지 않는 관리자 계정입니다.');
+    }
+
+    const { name, password, emailNotification } = updateAdminProfileDto;
+
+    if (name !== undefined && name !== admin.name) {
+      const existingName = await this.adminRepository.findOne({
+        where: { name },
+      });
+      if (existingName) {
+        throw new ConflictException('이미 존재하는 이름입니다.');
+      }
+      admin.name = name;
+    }
+
+    if (password !== undefined) {
+      const saltRounds = 10;
+      admin.password = await bcrypt.hash(password, saltRounds);
+    }
+
+    if (emailNotification !== undefined) {
+      admin.emailNotification = emailNotification;
+    }
+
+    try {
+      await this.adminRepository.save(admin);
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ER_DUP_ENTRY') {
+        throw new ConflictException('이미 존재하는 이름입니다.');
+      }
+      throw error;
+    }
   }
 }

--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -214,6 +214,65 @@ export class AdminService {
     );
   }
 
+  async requestDeleteAccount(email: string) {
+    const admin = await this.adminRepository.findOne({
+      where: { email },
+    });
+
+    if (!admin) {
+      throw new NotFoundException('존재하지 않는 관리자 계정입니다.');
+    }
+
+    const deleteCode = uuid.v4();
+
+    await this.redisService.set(
+      `${REDIS_KEYS.ADMIN_DELETE_ACCOUNT_KEY}:${deleteCode}`,
+      admin.id.toString(),
+      'EX',
+      ADMIN_REGISTER_TTL,
+    );
+    await this.emailProducer.produceAdminAccountDeletion(
+      admin.email,
+      admin.name,
+      deleteCode,
+    );
+  }
+
+  async confirmDeleteAccount(token: string) {
+    const deleteRequestKey = `${REDIS_KEYS.ADMIN_DELETE_ACCOUNT_KEY}:${token}`;
+
+    const data = await this.redisService.get(deleteRequestKey);
+
+    if (!data) {
+      throw new NotFoundException('유효하지 않거나 만료된 토큰입니다.');
+    }
+
+    const adminId = parseInt(data, 10);
+    const admin = await this.adminRepository.findOne({
+      where: { id: adminId },
+    });
+
+    if (!admin) {
+      await this.redisService.del(deleteRequestKey);
+      throw new NotFoundException('존재하지 않는 관리자 계정입니다.');
+    }
+
+    const emailsToInvalidate = await this.collectSubtreeEmails(admin);
+
+    await this.adminRepository.delete({ id: admin.id });
+    await this.redisService.del(deleteRequestKey);
+
+    await Promise.all(
+      emailsToInvalidate.map((targetEmail) =>
+        this.redisService.setex(
+          `${REDIS_KEYS.ADMIN_INVALIDATED_PREFIX}:${targetEmail}`,
+          SESSION_TTL,
+          '1',
+        ),
+      ),
+    );
+  }
+
   private async collectSubtreeEmails(root: Admin): Promise<string[]> {
     const emails = [root.email];
     let frontier = [root.id];

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -66,6 +66,23 @@ export class EmailProducer {
     await this.produceMessage(payload);
   }
 
+  async produceAdminAccountDeletion(
+    email: string,
+    name: string,
+    uuid: string,
+  ) {
+    const payload = {
+      type: EmailPayloadConstant.ADMIN_ACCOUNT_DELETION,
+      data: {
+        email,
+        name,
+        uuid,
+      },
+    };
+
+    await this.produceMessage(payload);
+  }
+
   async produceRssRegistration(
     rss: Rss,
     approveFlag: boolean,

--- a/server/src/common/email/email.type.ts
+++ b/server/src/common/email/email.type.ts
@@ -43,6 +43,7 @@ export const EmailPayloadConstant = {
   PASSWORD_RESET: 'passwordReset',
   ACCOUNT_DELETION: 'accountDeletion',
   ADMIN_CERTIFICATION: 'adminCertification',
+  ADMIN_ACCOUNT_DELETION: 'adminAccountDeletion',
 } as const;
 
 export type EmailPayload =
@@ -60,5 +61,9 @@ export type EmailPayload =
   | { type: typeof EmailPayloadConstant.ACCOUNT_DELETION; data: User }
   | {
       type: typeof EmailPayloadConstant.ADMIN_CERTIFICATION;
+      data: AdminCertification;
+    }
+  | {
+      type: typeof EmailPayloadConstant.ADMIN_ACCOUNT_DELETION;
       data: AdminCertification;
     };

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -12,6 +12,7 @@ export const REDIS_KEYS = {
   ADMIN_SESSION_BY_EMAIL: 'auth:email',
   ADMIN_INVALIDATED_PREFIX: 'admin:invalidated',
   ADMIN_REGISTER_KEY: 'admin:signup',
+  ADMIN_DELETE_ACCOUNT_KEY: 'admin:delete-account',
   RSS_REMOVE_KEY: 'rss:remove',
   CHAT_HISTORY_KEY: (roomId: string) => `chat:history:${roomId}`,
   FULL_FEED_CRAWL_QUEUE: `feed:full-crawl:queue`,

--- a/server/test/admin/dto/updateAdminProfile.dto.spec.ts
+++ b/server/test/admin/dto/updateAdminProfile.dto.spec.ts
@@ -1,0 +1,80 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { UpdateAdminProfileRequestDto } from '@admin/dto/request/updateAdminProfile.dto';
+
+describe(`${UpdateAdminProfileRequestDto.name} Test`, () => {
+  const toDto = (partial: Partial<UpdateAdminProfileRequestDto>) =>
+    plainToInstance(UpdateAdminProfileRequestDto, partial);
+
+  it('모든 필드가 없어도 유효성 검사에 성공한다. (부분 수정)', async () => {
+    // when
+    const errors = await validate(toDto({}));
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('정책에 부합하는 값이면 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(
+      toDto({ name: '홍길동', password: 'test1234!', emailNotification: true }),
+    );
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('name', () => {
+    it('이름이 빈 문자열이면 유효성 검사에 실패한다.', async () => {
+      // when
+      const errors = await validate(toDto({ name: '' }));
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isLength');
+    });
+
+    it('이름이 255자를 초과하면 유효성 검사에 실패한다.', async () => {
+      // when
+      const errors = await validate(toDto({ name: 'a'.repeat(256) }));
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isLength');
+    });
+  });
+
+  describe('password', () => {
+    it('비밀번호 길이가 6 미만이면 유효성 검사에 실패한다.', async () => {
+      // when
+      const errors = await validate(toDto({ password: 'a1!' }));
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isLength');
+    });
+
+    it('특수문자가 없으면 유효성 검사에 실패한다.', async () => {
+      // when
+      const errors = await validate(toDto({ password: 'testAdminPassword' }));
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('matches');
+    });
+  });
+
+  describe('emailNotification', () => {
+    it('불리언이 아니면 유효성 검사에 실패한다.', async () => {
+      // when
+      const errors = await validate(
+        toDto({ emailNotification: 'true' as unknown as boolean }),
+      );
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isBoolean');
+    });
+  });
+});

--- a/server/test/admin/e2e/me.e2e-spec.ts
+++ b/server/test/admin/e2e/me.e2e-spec.ts
@@ -27,12 +27,14 @@ describe(`GET ${URL} E2E Test`, () => {
   });
 
   let registeredName: string;
+  let registeredEmail: string;
 
   beforeEach(async () => {
     const admin = await adminRepository.save(
       await AdminFixture.createAdminCryptFixture(),
     );
     registeredName = admin.name;
+    registeredEmail = admin.email;
     await redisService.set(redisKeyMake(sessionKey), admin.email);
   });
 
@@ -79,7 +81,12 @@ describe(`GET ${URL} E2E Test`, () => {
     // Http then
     const { data } = response.body;
     expect(response.status).toBe(HttpStatus.OK);
-    expect(data).toEqual({ name: registeredName, parent: null });
+    expect(data).toEqual({
+      email: registeredEmail,
+      name: registeredName,
+      emailNotification: true,
+      parent: null,
+    });
 
     // DB, Redis when
     const savedSession = await redisService.get(redisKeyMake(sessionKey));
@@ -110,7 +117,9 @@ describe(`GET ${URL} E2E Test`, () => {
     const { data } = response.body;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data).toEqual({
+      email: child.email,
       name: child.name,
+      emailNotification: true,
       parent: { email: parent.email, name: parent.name },
     });
   });

--- a/server/test/admin/e2e/update.e2e-spec.ts
+++ b/server/test/admin/e2e/update.e2e-spec.ts
@@ -1,0 +1,118 @@
+import { HttpStatus } from '@nestjs/common';
+
+import * as bcrypt from 'bcrypt';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/admins/me';
+
+describe(`PATCH ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  const sessionKey = 'admin-session-update-key';
+  const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+  });
+
+  let adminId: number;
+  let adminEmail: string;
+
+  beforeEach(async () => {
+    const admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    adminId = admin.id;
+    adminEmail = admin.email;
+    await redisService.set(redisKeyMake(sessionKey), admin.email);
+  });
+
+  it('[401] 로그인 쿠키가 없으면 수정에 실패한다.', async () => {
+    // when
+    const response = await agent.patch(URL).send({ name: '새이름' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[200] 이름을 수정하면 DB에 반영된다.', async () => {
+    // when
+    const response = await agent
+      .patch(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send({ name: 'updated-name' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const updated = await adminRepository.findOne({ where: { id: adminId } });
+    expect(updated.name).toBe('updated-name');
+  });
+
+  it('[200] 비밀번호를 수정하면 해시된 값으로 DB에 반영된다.', async () => {
+    // when
+    const response = await agent
+      .patch(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send({ password: 'newPass1!' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const updated = await adminRepository.findOne({ where: { id: adminId } });
+    expect(updated.password).not.toBe('newPass1!');
+    expect(await bcrypt.compare('newPass1!', updated.password)).toBe(true);
+  });
+
+  it('[200] 이메일 수신 여부를 끄면 DB에 반영된다.', async () => {
+    // when
+    const response = await agent
+      .patch(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send({ emailNotification: false });
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const updated = await adminRepository.findOne({ where: { id: adminId } });
+    expect(updated.emailNotification).toBe(false);
+  });
+
+  it('[409] 이미 존재하는 이름으로 수정하면 실패한다.', async () => {
+    // given
+    const other = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+
+    // when
+    const response = await agent
+      .patch(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send({ name: other.name });
+
+    // then
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+    const updated = await adminRepository.findOne({ where: { id: adminId } });
+    expect(updated.email).toBe(adminEmail);
+  });
+
+  it('[400] 비밀번호 정책에 맞지 않으면 실패한다.', async () => {
+    // when
+    const response = await agent
+      .patch(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send({ password: 'nospecialchar' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+});

--- a/server/test/admin/unit/admin.service.unit.spec.ts
+++ b/server/test/admin/unit/admin.service.unit.spec.ts
@@ -5,10 +5,12 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 
+import * as bcrypt from 'bcrypt';
 import { Request, Response } from 'express';
 
 import { SESSION_TTL } from '@admin/constant/admin.constant';
 import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
+import { Admin } from '@admin/entity/admin.entity';
 import { AdminRepository } from '@admin/repository/admin.repository';
 import { AdminService } from '@admin/service/admin.service';
 
@@ -377,6 +379,183 @@ describe(`${AdminService.name} Unit Test`, () => {
         SESSION_TTL,
         '1',
       );
+    });
+  });
+
+  describe('getAdminProfile', () => {
+    it('Root 계정이면 parent가 null인 프로필을 반환한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email: 'root-admin@test.com',
+        name: 'root',
+        emailNotification: true,
+        parentAdminId: null,
+      });
+      adminRepository.findOne.mockResolvedValue(admin);
+
+      // when
+      const result = await adminService.getAdminProfile('root-admin@test.com');
+
+      // then
+      expect(result).toEqual({
+        email: 'root-admin@test.com',
+        name: 'root',
+        emailNotification: true,
+        parent: null,
+      });
+    });
+
+    it('부모가 있으면 부모의 이메일과 이름을 함께 반환한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email: 'child-admin@test.com',
+        name: 'child',
+        emailNotification: false,
+        parentAdminId: 7,
+      });
+      const parent = await AdminFixture.createAdminCryptFixture({
+        email: 'parent-admin@test.com',
+        name: 'parent',
+      });
+      parent.id = 7;
+      adminRepository.findOne
+        .mockResolvedValueOnce(admin)
+        .mockResolvedValueOnce(parent);
+
+      // when
+      const result = await adminService.getAdminProfile('child-admin@test.com');
+
+      // then
+      expect(result).toEqual({
+        email: 'child-admin@test.com',
+        name: 'child',
+        emailNotification: false,
+        parent: { email: 'parent-admin@test.com', name: 'parent' },
+      });
+    });
+  });
+
+  describe('updateAdminProfile', () => {
+    const email = 'admin@test.com';
+
+    it('존재하지 않는 관리자면 NotFoundException을 던진다.', async () => {
+      // given
+      adminRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        adminService.updateAdminProfile(email, { name: 'new-name' }),
+      ).rejects.toThrow(NotFoundException);
+      expect(adminRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('이름만 변경하면 중복 검사 후 저장한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email,
+        name: 'old-name',
+      });
+      adminRepository.findOne
+        .mockResolvedValueOnce(admin)
+        .mockResolvedValueOnce(null);
+
+      // when
+      await adminService.updateAdminProfile(email, { name: 'new-name' });
+
+      // then
+      expect(adminRepository.findOne).toHaveBeenNthCalledWith(2, {
+        where: { name: 'new-name' },
+      });
+      const saved = adminRepository.save.mock.calls[0][0] as Admin;
+      expect(saved.name).toBe('new-name');
+    });
+
+    it('이미 존재하는 이름으로 변경하면 ConflictException을 던진다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email,
+        name: 'old-name',
+      });
+      const other = await AdminFixture.createAdminCryptFixture({
+        name: 'taken-name',
+      });
+      adminRepository.findOne
+        .mockResolvedValueOnce(admin)
+        .mockResolvedValueOnce(other);
+
+      // when & then
+      await expect(
+        adminService.updateAdminProfile(email, { name: 'taken-name' }),
+      ).rejects.toThrow(ConflictException);
+      expect(adminRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('이름이 기존과 동일하면 중복 검사를 하지 않는다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email,
+        name: 'same-name',
+      });
+      adminRepository.findOne.mockResolvedValueOnce(admin);
+
+      // when
+      await adminService.updateAdminProfile(email, { name: 'same-name' });
+
+      // then
+      expect(adminRepository.findOne).toHaveBeenCalledTimes(1);
+      expect(adminRepository.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('비밀번호를 변경하면 해시해서 저장한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({ email });
+      adminRepository.findOne.mockResolvedValueOnce(admin);
+
+      // when
+      await adminService.updateAdminProfile(email, {
+        password: 'newPass1!',
+      });
+
+      // then
+      const saved = adminRepository.save.mock.calls[0][0] as Admin;
+      expect(saved.password).not.toBe('newPass1!');
+      expect(await bcrypt.compare('newPass1!', saved.password)).toBe(true);
+    });
+
+    it('이메일 수신 여부만 변경하면 해당 값만 저장한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email,
+        emailNotification: true,
+      });
+      adminRepository.findOne.mockResolvedValueOnce(admin);
+
+      // when
+      await adminService.updateAdminProfile(email, {
+        emailNotification: false,
+      });
+
+      // then
+      expect(adminRepository.findOne).toHaveBeenCalledTimes(1);
+      const saved = adminRepository.save.mock.calls[0][0] as Admin;
+      expect(saved.emailNotification).toBe(false);
+    });
+
+    it('저장 시 이름 중복 제약을 위반하면 ConflictException으로 변환한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email,
+        name: 'old-name',
+      });
+      adminRepository.findOne
+        .mockResolvedValueOnce(admin)
+        .mockResolvedValueOnce(null);
+      adminRepository.save.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
+
+      // when & then
+      await expect(
+        adminService.updateAdminProfile(email, { name: 'race-name' }),
+      ).rejects.toThrow(ConflictException);
     });
   });
 });

--- a/server/test/admin/unit/admin.service.unit.spec.ts
+++ b/server/test/admin/unit/admin.service.unit.spec.ts
@@ -33,7 +33,10 @@ describe(`${AdminService.name} Unit Test`, () => {
     Pick<RedisService, 'get' | 'set' | 'del' | 'setex'>
   >;
   let emailProducer: jest.Mocked<
-    Pick<EmailProducer, 'produceAdminCertification'>
+    Pick<
+      EmailProducer,
+      'produceAdminCertification' | 'produceAdminAccountDeletion'
+    >
   >;
 
   const createResponse = () =>
@@ -60,6 +63,7 @@ describe(`${AdminService.name} Unit Test`, () => {
     };
     emailProducer = {
       produceAdminCertification: jest.fn(),
+      produceAdminAccountDeletion: jest.fn(),
     };
 
     adminService = new AdminService(
@@ -376,6 +380,114 @@ describe(`${AdminService.name} Unit Test`, () => {
       expect(redisService.setex).toHaveBeenCalledTimes(1);
       expect(redisService.setex).toHaveBeenCalledWith(
         `${REDIS_KEYS.ADMIN_INVALIDATED_PREFIX}:child-admin@test.com`,
+        SESSION_TTL,
+        '1',
+      );
+    });
+  });
+
+  describe('requestDeleteAccount', () => {
+    it('존재하지 않는 관리자면 NotFoundException을 던진다.', async () => {
+      // given
+      adminRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        adminService.requestDeleteAccount('ghost@test.com'),
+      ).rejects.toThrow(NotFoundException);
+      expect(redisService.set).not.toHaveBeenCalled();
+      expect(emailProducer.produceAdminAccountDeletion).not.toHaveBeenCalled();
+    });
+
+    it('관리자 ID를 Redis에 저장하고 탈퇴 인증 메일을 발행한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email: 'self-admin@test.com',
+      });
+      admin.id = 7;
+      adminRepository.findOne.mockResolvedValue(admin);
+
+      // when
+      await adminService.requestDeleteAccount('self-admin@test.com');
+
+      // then
+      const [redisKey, storedValue] = redisService.set.mock.calls[0];
+      expect(redisKey).toContain(REDIS_KEYS.ADMIN_DELETE_ACCOUNT_KEY);
+      expect(storedValue).toBe('7');
+      expect(emailProducer.produceAdminAccountDeletion).toHaveBeenCalledWith(
+        admin.email,
+        admin.name,
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('confirmDeleteAccount', () => {
+    it('존재하지 않거나 만료된 토큰이면 NotFoundException을 던진다.', async () => {
+      // given
+      redisService.get.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        adminService.confirmDeleteAccount('expired-token'),
+      ).rejects.toThrow(NotFoundException);
+      expect(adminRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('토큰은 유효하지만 관리자가 없으면 키를 삭제하고 NotFoundException을 던진다.', async () => {
+      // given
+      redisService.get.mockResolvedValue('7');
+      adminRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        adminService.confirmDeleteAccount('valid-token'),
+      ).rejects.toThrow(NotFoundException);
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_DELETE_ACCOUNT_KEY}:valid-token`,
+      );
+      expect(adminRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('본인과 하위 트리 전체 세션을 무효화하고 계정을 삭제한다.', async () => {
+      // given
+      redisService.get.mockResolvedValue('7');
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email: 'self-admin@test.com',
+      });
+      admin.id = 7;
+      const child = await AdminFixture.createAdminCryptFixture({
+        email: 'child-admin@test.com',
+      });
+      child.id = 8;
+      child.parentAdminId = 7;
+      const grandChild = await AdminFixture.createAdminCryptFixture({
+        email: 'grandchild-admin@test.com',
+      });
+      grandChild.id = 9;
+      grandChild.parentAdminId = 8;
+      adminRepository.findOne.mockResolvedValue(admin);
+      adminRepository.find
+        .mockResolvedValueOnce([child])
+        .mockResolvedValueOnce([grandChild])
+        .mockResolvedValueOnce([]);
+
+      // when
+      await adminService.confirmDeleteAccount('valid-token');
+
+      // then
+      expect(adminRepository.delete).toHaveBeenCalledWith({ id: 7 });
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_DELETE_ACCOUNT_KEY}:valid-token`,
+      );
+      expect(redisService.setex).toHaveBeenCalledTimes(3);
+      expect(redisService.setex).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_INVALIDATED_PREFIX}:self-admin@test.com`,
+        SESSION_TTL,
+        '1',
+      );
+      expect(redisService.setex).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_INVALIDATED_PREFIX}:grandchild-admin@test.com`,
         SESSION_TTL,
         '1',
       );

--- a/server/test/config/integration/jest/jest.config.ts
+++ b/server/test/config/integration/jest/jest.config.ts
@@ -8,6 +8,7 @@ const config: Config.InitialOptions = {
     '<rootDir>/test/config/e2e/jest/jest.config.ts',
   ],
   maxWorkers: '50%',
+  testTimeout: 20000,
   coverageDirectory: './coverage/integration',
   coverageReporters: ['json-summary', 'text', 'lcov'],
   coveragePathIgnorePatterns: ['test', 'src/common/database/migration'],


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #730
-   close #731

### 관리자 계정 수정 API (BE)

-   `PATCH /admin/me` 엔드포인트 추가. 이름, 비밀번호, 이메일 수신 여부를 부분 수정할 수 있도록 모든 필드를 `@IsOptional()`로 설계해 미입력 필드는 기존 값 유지.
-   이름 중복 검사를 사전 조회로 1차 방어하되, 동시 요청으로 인한 race condition을 대비해 `save()` 시 `ER_DUP_ENTRY` 에러를 `ConflictException`으로 변환하는 2차 방어를 두었습니다.
-   비밀번호는 `bcrypt`로 해싱(saltRounds=10) 후 저장.

### 관리자 마이페이지 (FE)

-   마이페이지 탭에서 계정 정보를 조회/수정할 수 있도록 `AdminMyPage` 컴포넌트 구현.
-   `useAdminAuth` 쿼리 훅 및 endpoint 경로 추가로 API 연동.

# 📋 작업 내용

-   `PATCH /admin/me` 컨트롤러/서비스/DTO 추가
-   `UpdateAdminProfileRequestDto` 검증 규칙 추가 (이름 길이, 비밀번호 정규식/길이, 불리언)
-   `GetAdminProfileResponseDto`에 email, emailNotification 필드 포함
-   FE 관리자 마이페이지 탭 및 헤더 구성
-   Swagger api-docs 추가
-   DTO/unit/e2e 테스트 추가

# 📷 스크린 샷(선택 사항)

<img width="1271" height="906" alt="image" src="https://github.com/user-attachments/assets/7b684c79-a92b-4358-ade4-de80b2c878e9" />
