### PR TITLE
✨ feat: 유저 정보 조회 API 구현 (프로필 이미지/작성 댓글/좋아요)

### DIFF
--- a/server/src/comment/api-docs/getUserComments.api-docs.ts
+++ b/server/src/comment/api-docs/getUserComments.api-docs.ts
@@ -1,0 +1,23 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+  ApiNotFoundDoc,
+} from '@common/swagger/swagger.helper';
+import { GetUserCommentsResponseDto } from '@comment/dto/response/getUserComments.dto';
+
+export function ApiGetUserComments() {
+  return applyDecorators(
+    ApiOperation({ summary: '특정 유저가 작성한 댓글 목록 조회 API' }),
+    ApiParam({ name: 'userId', type: Number, description: '사용자 ID', example: 1 }),
+    ApiDataResponse(
+      GetUserCommentsResponseDto,
+      false,
+      '유저 댓글 목록 조회 성공',
+    ),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiNotFoundDoc('존재하지 않는 유저입니다.'),
+  );
+}

--- a/server/src/comment/controller/userComment.controller.ts
+++ b/server/src/comment/controller/userComment.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, HttpCode, HttpStatus, Param, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ApiGetUserComments } from '@comment/api-docs/getUserComments.api-docs';
+import { GetUserCommentsRequestDto } from '@comment/dto/request/getUserComments.dto';
+import { GetUserCommentsParamRequestDto } from '@comment/dto/request/getUserCommentsParam.dto';
+import { CommentService } from '@comment/service/comment.service';
+
+import { ApiResponse } from '@common/response/common.response';
+
+@ApiTags('Comment')
+@Controller('users/:userId/comments')
+export class UserCommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @ApiGetUserComments()
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getUserComments(
+    @Param() paramDto: GetUserCommentsParamRequestDto,
+    @Query() queryDto: GetUserCommentsRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '유저 댓글 조회를 성공했습니다.',
+      await this.commentService.getCommentsByUser(paramDto.userId, queryDto),
+    );
+  }
+}

--- a/server/src/comment/dto/request/getUserComments.dto.ts
+++ b/server/src/comment/dto/request/getUserComments.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class GetUserCommentsRequestDto {
+  @ApiPropertyOptional({
+    example: 1,
+    description: '마지막으로 조회한 댓글 ID (커서)',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'lastId 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  lastId?: number;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: '받아올 최대 댓글 개수',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'limit 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  limit?: number = 10;
+
+  constructor(partial: Partial<GetUserCommentsRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/comment/dto/request/getUserCommentsParam.dto.ts
+++ b/server/src/comment/dto/request/getUserCommentsParam.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class GetUserCommentsParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '댓글을 조회할 사용자 ID',
+  })
+  @IsInt({
+    message: '숫자로 입력해주세요.',
+  })
+  @Min(1, { message: '사용자 ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  userId: number;
+
+  constructor(partial: Partial<GetUserCommentsParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/comment/dto/response/getUserComments.dto.ts
+++ b/server/src/comment/dto/response/getUserComments.dto.ts
@@ -1,0 +1,91 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Comment } from '@comment/entity/comment.entity';
+
+export class UserCommentResult {
+  @ApiProperty({
+    example: 1,
+    description: '댓글 ID',
+  })
+  id: number;
+
+  @ApiProperty({
+    example: 'example content',
+    description: '댓글 내용',
+  })
+  comment: string;
+
+  @ApiProperty({
+    example: '2025-01-01T00:00:00.000Z',
+    description: '댓글 작성 날짜',
+  })
+  date: Date;
+
+  @ApiProperty({
+    example: {
+      id: 1,
+      title: 'example title',
+      path: 'https://example.com/feed',
+    },
+    description: '댓글이 작성된 게시글 정보 (path: 게시글 URL)',
+  })
+  feed: {
+    id: number;
+    title: string;
+    path: string;
+  };
+
+  private constructor(partial: Partial<UserCommentResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(comment: Comment) {
+    return new UserCommentResult({
+      id: comment.id,
+      comment: comment.comment,
+      date: comment.date,
+      feed: {
+        id: comment.feed.id,
+        title: comment.feed.title,
+        path: comment.feed.path,
+      },
+    });
+  }
+
+  static toResultDtoArray(comments: Comment[]) {
+    return comments.map((comment) => this.toResultDto(comment));
+  }
+}
+
+export class GetUserCommentsResponseDto {
+  @ApiProperty({ type: [UserCommentResult], description: '유저가 작성한 댓글 목록' })
+  result: UserCommentResult[];
+
+  @ApiProperty({
+    example: 1,
+    description: '마지막으로 조회한 댓글 ID (다음 요청의 커서)',
+  })
+  lastId: number;
+
+  @ApiProperty({
+    example: true,
+    description: '다음 페이지 존재 여부',
+  })
+  hasMore: boolean;
+
+  constructor(partial: Partial<GetUserCommentsResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(
+    comments: Comment[],
+    lastId: number,
+    hasMore: boolean,
+  ) {
+    return new GetUserCommentsResponseDto({
+      result: UserCommentResult.toResultDtoArray(comments),
+      lastId,
+      hasMore,
+    });
+  }
+}

--- a/server/src/comment/module/comment.module.ts
+++ b/server/src/comment/module/comment.module.ts
@@ -1,14 +1,17 @@
 import { Module } from '@nestjs/common';
 
 import { CommentController } from '@comment/controller/comment.controller';
+import { UserCommentController } from '@comment/controller/userComment.controller';
 import { CommentRepository } from '@comment/repository/comment.repository';
 import { CommentService } from '@comment/service/comment.service';
 
 import { FeedModule } from '@feed/module/feed.module';
 
+import { UserModule } from '@user/module/user.module';
+
 @Module({
-  imports: [FeedModule],
-  controllers: [CommentController],
+  imports: [FeedModule, UserModule],
+  controllers: [CommentController, UserCommentController],
   providers: [CommentRepository, CommentService],
   exports: [],
 })

--- a/server/src/comment/repository/comment.repository.ts
+++ b/server/src/comment/repository/comment.repository.ts
@@ -18,4 +18,21 @@ export class CommentRepository extends Repository<Comment> {
       .orderBy('comment.date', 'ASC')
       .getMany();
   }
+
+  async getCommentsByUser(userId: number, lastId: number, limit: number) {
+    const query = this.createQueryBuilder('comment')
+      .innerJoin('comment.feed', 'feed')
+      .select(['comment.id', 'comment.comment', 'comment.date'])
+      .addSelect(['feed.id', 'feed.title', 'feed.path'])
+      .where('comment.user_id = :userId', { userId });
+
+    if (lastId) {
+      query.andWhere('comment.id < :lastId', { lastId });
+    }
+
+    return await query
+      .orderBy('comment.id', 'DESC')
+      .take(limit + 1)
+      .getMany();
+  }
 }

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -9,8 +9,10 @@ import { DataSource } from 'typeorm';
 import { CommentParamRequestDto } from '@comment/dto/request/commentParam.dto';
 import { CreateCommentRequestDto } from '@comment/dto/request/createComment.dto';
 import { GetCommentRequestDto } from '@comment/dto/request/getComment.dto';
+import { GetUserCommentsRequestDto } from '@comment/dto/request/getUserComments.dto';
 import { UpdateCommentRequestDto } from '@comment/dto/request/updateComment.dto';
 import { GetCommentResponseDto } from '@comment/dto/response/getComment.dto';
+import { GetUserCommentsResponseDto } from '@comment/dto/response/getUserComments.dto';
 import { Comment } from '@comment/entity/comment.entity';
 import { CommentRepository } from '@comment/repository/comment.repository';
 
@@ -18,12 +20,15 @@ import { Payload } from '@common/guard/jwt.guard';
 
 import { FeedService } from '@feed/service/feed.service';
 
+import { UserService } from '@user/service/user.service';
+
 @Injectable()
 export class CommentService {
   constructor(
     private readonly commentRepository: CommentRepository,
     private readonly dataSource: DataSource,
     private readonly feedService: FeedService,
+    private readonly userService: UserService,
   ) {}
 
   private async getValidatedComment(
@@ -55,6 +60,25 @@ export class CommentService {
       commentDto.feedId,
     );
     return GetCommentResponseDto.toResponseDtoArray(comments);
+  }
+
+  async getCommentsByUser(
+    userId: number,
+    commentDto: GetUserCommentsRequestDto,
+  ) {
+    await this.userService.getUser(userId);
+
+    const comments = await this.commentRepository.getCommentsByUser(
+      userId,
+      commentDto.lastId,
+      commentDto.limit,
+    );
+
+    const hasMore = comments.length > commentDto.limit;
+    if (hasMore) comments.pop();
+    const lastId = comments.length ? comments[comments.length - 1].id : 0;
+
+    return GetUserCommentsResponseDto.toResponseDto(comments, lastId, hasMore);
   }
 
   async create(

--- a/server/src/like/api-docs/getUserLikes.api-docs.ts
+++ b/server/src/like/api-docs/getUserLikes.api-docs.ts
@@ -1,0 +1,20 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+  ApiNotFoundDoc,
+} from '@common/swagger/swagger.helper';
+
+import { GetUserLikesResponseDto } from '@like/dto/response/getUserLikes.dto';
+
+export function ApiGetUserLikes() {
+  return applyDecorators(
+    ApiOperation({ summary: '특정 유저가 좋아요를 누른 목록 조회 API' }),
+    ApiParam({ name: 'userId', type: Number, description: '사용자 ID', example: 1 }),
+    ApiDataResponse(GetUserLikesResponseDto, false, '유저 좋아요 목록 조회 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiNotFoundDoc('존재하지 않는 유저입니다.'),
+  );
+}

--- a/server/src/like/controller/userLike.controller.ts
+++ b/server/src/like/controller/userLike.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, HttpCode, HttpStatus, Param, Query } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiGetUserLikes } from '@like/api-docs/getUserLikes.api-docs';
+import { GetUserLikesRequestDto } from '@like/dto/request/getUserLikes.dto';
+import { GetUserLikesParamRequestDto } from '@like/dto/request/getUserLikesParam.dto';
+import { LikeService } from '@like/service/like.service';
+
+@ApiTags('Like')
+@Controller('users/:userId/likes')
+export class UserLikeController {
+  constructor(private readonly likeService: LikeService) {}
+
+  @ApiGetUserLikes()
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getUserLikes(
+    @Param() paramDto: GetUserLikesParamRequestDto,
+    @Query() queryDto: GetUserLikesRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '유저 좋아요 조회를 성공했습니다.',
+      await this.likeService.getLikesByUser(paramDto.userId, queryDto),
+    );
+  }
+}

--- a/server/src/like/dto/request/getUserLikes.dto.ts
+++ b/server/src/like/dto/request/getUserLikes.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class GetUserLikesRequestDto {
+  @ApiPropertyOptional({
+    example: 1,
+    description: '마지막으로 조회한 좋아요 ID (커서)',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'lastId 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  lastId?: number;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: '받아올 최대 좋아요 개수',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'limit 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  limit?: number = 10;
+
+  constructor(partial: Partial<GetUserLikesRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/like/dto/request/getUserLikesParam.dto.ts
+++ b/server/src/like/dto/request/getUserLikesParam.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class GetUserLikesParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '좋아요를 조회할 사용자 ID',
+  })
+  @IsInt({
+    message: '숫자로 입력해주세요.',
+  })
+  @Min(1, { message: '사용자 ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  userId: number;
+
+  constructor(partial: Partial<GetUserLikesParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/like/dto/response/getUserLikes.dto.ts
+++ b/server/src/like/dto/response/getUserLikes.dto.ts
@@ -1,0 +1,80 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Like } from '@like/entity/like.entity';
+
+export class UserLikeResult {
+  @ApiProperty({
+    example: 1,
+    description: '좋아요 ID',
+  })
+  id: number;
+
+  @ApiProperty({
+    example: '2025-01-01T00:00:00.000Z',
+    description: '좋아요 누른 날짜',
+  })
+  likeDate: Date;
+
+  @ApiProperty({
+    example: {
+      id: 1,
+      title: 'example title',
+      path: 'https://example.com/feed',
+    },
+    description: '좋아요를 누른 게시글 정보 (path: 게시글 URL)',
+  })
+  feed: {
+    id: number;
+    title: string;
+    path: string;
+  };
+
+  private constructor(partial: Partial<UserLikeResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(like: Like) {
+    return new UserLikeResult({
+      id: like.id,
+      likeDate: like.likeDate,
+      feed: {
+        id: like.feed.id,
+        title: like.feed.title,
+        path: like.feed.path,
+      },
+    });
+  }
+
+  static toResultDtoArray(likes: Like[]) {
+    return likes.map((like) => this.toResultDto(like));
+  }
+}
+
+export class GetUserLikesResponseDto {
+  @ApiProperty({ type: [UserLikeResult], description: '유저가 좋아요를 누른 목록' })
+  result: UserLikeResult[];
+
+  @ApiProperty({
+    example: 1,
+    description: '마지막으로 조회한 좋아요 ID (다음 요청의 커서)',
+  })
+  lastId: number;
+
+  @ApiProperty({
+    example: true,
+    description: '다음 페이지 존재 여부',
+  })
+  hasMore: boolean;
+
+  constructor(partial: Partial<GetUserLikesResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(likes: Like[], lastId: number, hasMore: boolean) {
+    return new GetUserLikesResponseDto({
+      result: UserLikeResult.toResultDtoArray(likes),
+      lastId,
+      hasMore,
+    });
+  }
+}

--- a/server/src/like/module/like.module.ts
+++ b/server/src/like/module/like.module.ts
@@ -5,12 +5,15 @@ import { JwtAuthModule } from '@common/auth/jwt.module';
 import { FeedModule } from '@feed/module/feed.module';
 
 import { LikeController } from '@like/controller/like.controller';
+import { UserLikeController } from '@like/controller/userLike.controller';
 import { LikeRepository } from '@like/repository/like.repository';
 import { LikeService } from '@like/service/like.service';
 
+import { UserModule } from '@user/module/user.module';
+
 @Module({
-  imports: [FeedModule, JwtAuthModule],
-  controllers: [LikeController],
+  imports: [FeedModule, JwtAuthModule, UserModule],
+  controllers: [LikeController, UserLikeController],
   providers: [LikeService, LikeRepository],
   exports: [],
 })

--- a/server/src/like/repository/like.repository.ts
+++ b/server/src/like/repository/like.repository.ts
@@ -9,4 +9,21 @@ export class LikeRepository extends Repository<Like> {
   constructor(private dataSource: DataSource) {
     super(Like, dataSource.createEntityManager());
   }
+
+  async getLikesByUser(userId: number, lastId: number, limit: number) {
+    const query = this.createQueryBuilder('like')
+      .innerJoin('like.feed', 'feed')
+      .select(['like.id', 'like.likeDate'])
+      .addSelect(['feed.id', 'feed.title', 'feed.path'])
+      .where('like.user_id = :userId', { userId });
+
+    if (lastId) {
+      query.andWhere('like.id < :lastId', { lastId });
+    }
+
+    return await query
+      .orderBy('like.id', 'DESC')
+      .take(limit + 1)
+      .getMany();
+  }
 }

--- a/server/src/like/service/like.service.ts
+++ b/server/src/like/service/like.service.ts
@@ -10,10 +10,14 @@ import { Payload } from '@common/guard/jwt.guard';
 
 import { FeedService } from '@feed/service/feed.service';
 
+import { GetUserLikesRequestDto } from '@like/dto/request/getUserLikes.dto';
 import { ManageLikeRequestDto } from '@like/dto/request/manageLike.dto';
 import { GetLikeResponseDto } from '@like/dto/response/getLike.dto';
+import { GetUserLikesResponseDto } from '@like/dto/response/getUserLikes.dto';
 import { Like } from '@like/entity/like.entity';
 import { LikeRepository } from '@like/repository/like.repository';
+
+import { UserService } from '@user/service/user.service';
 
 @Injectable()
 export class LikeService {
@@ -21,7 +25,24 @@ export class LikeService {
     private readonly likeRepository: LikeRepository,
     private readonly feedService: FeedService,
     private readonly dataSource: DataSource,
+    private readonly userService: UserService,
   ) {}
+
+  async getLikesByUser(userId: number, likeDto: GetUserLikesRequestDto) {
+    await this.userService.getUser(userId);
+
+    const likes = await this.likeRepository.getLikesByUser(
+      userId,
+      likeDto.lastId,
+      likeDto.limit,
+    );
+
+    const hasMore = likes.length > likeDto.limit;
+    if (hasMore) likes.pop();
+    const lastId = likes.length ? likes[likes.length - 1].id : 0;
+
+    return GetUserLikesResponseDto.toResponseDto(likes, lastId, hasMore);
+  }
 
   async get(
     userInformation: Payload | null,

--- a/server/src/user/api-docs/getUserProfileImage.api-docs.ts
+++ b/server/src/user/api-docs/getUserProfileImage.api-docs.ts
@@ -1,0 +1,32 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+  ApiNotFoundDoc,
+} from '@common/swagger/swagger.helper';
+
+import { GetUserProfileImageResponseDto } from '@user/dto/response/getUserProfileImage.dto';
+
+export function ApiGetUserProfileImage() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '사용자 프로필 이미지 조회 API',
+      description: '특정 사용자의 프로필 이미지 URL을 조회합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      type: Number,
+      description: '조회할 사용자 ID',
+      example: 1,
+    }),
+    ApiDataResponse(
+      GetUserProfileImageResponseDto,
+      false,
+      '프로필 이미지 조회 성공',
+    ),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiNotFoundDoc('존재하지 않는 유저입니다.'),
+  );
+}

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -24,6 +24,7 @@ import { ApiCertificateUser } from '@user/api-docs/certificateUser.api-docs';
 import { ApiCheckEmailDuplication } from '@user/api-docs/checkEmailDuplication.api-docs';
 import { ApiConfirmDeleteAccount } from '@user/api-docs/confirmDeleteAccount.api-docs';
 import { ApiForgotPassword } from '@user/api-docs/forgotPassword.api-docs';
+import { ApiGetUserProfileImage } from '@user/api-docs/getUserProfileImage.api-docs';
 import { ApiLoginUser } from '@user/api-docs/loginUser.api-docs';
 import { ApiLogoutUser } from '@user/api-docs/logoutUser.api-docs';
 import { ApiRefreshToken } from '@user/api-docs/refreshToken.api-docs';
@@ -35,6 +36,7 @@ import { CertificateUserRequestDto } from '@user/dto/request/certificateUser.dto
 import { CheckEmailDuplicationRequestDto } from '@user/dto/request/checkEmailDuplication.dto';
 import { ConfirmDeleteAccountParamRequestDto } from '@user/dto/request/confirmDeleteAccountParam.dto';
 import { ForgotPasswordRequestDto } from '@user/dto/request/forgotPassword.dto';
+import { GetUserProfileImageParamRequestDto } from '@user/dto/request/getUserProfileImageParam.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { ResetPasswordRequestDto } from '@user/dto/request/resetPassword.dto';
@@ -59,6 +61,18 @@ export class UserController {
       await this.userService.checkEmailDuplication(
         checkEmailDuplicationRequestDto.email,
       ),
+    );
+  }
+
+  @ApiGetUserProfileImage()
+  @Get('/:id/profile-image')
+  @HttpCode(HttpStatus.OK)
+  async getUserProfileImage(
+    @Param() paramDto: GetUserProfileImageParamRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '프로필 이미지 조회가 성공적으로 처리되었습니다.',
+      await this.userService.getUserProfileImage(paramDto.id),
     );
   }
 

--- a/server/src/user/dto/request/getUserProfileImageParam.dto.ts
+++ b/server/src/user/dto/request/getUserProfileImageParam.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class GetUserProfileImageParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '프로필 이미지를 조회할 사용자 ID',
+  })
+  @IsInt({
+    message: '숫자로 입력해주세요.',
+  })
+  @Min(1, { message: '사용자 ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  constructor(partial: Partial<GetUserProfileImageParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/response/getUserProfileImage.dto.ts
+++ b/server/src/user/dto/response/getUserProfileImage.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { User } from '@user/entity/user.entity';
+
+export class GetUserProfileImageResponseDto {
+  @ApiProperty({
+    example: 'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+    description: '프로필 이미지 URL (미설정 시 null)',
+    nullable: true,
+  })
+  profileImage: string | null;
+
+  constructor(partial: Partial<GetUserProfileImageResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(user: User) {
+    return new GetUserProfileImageResponseDto({
+      profileImage: user.profileImage ?? null,
+    });
+  }
+}

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -25,6 +25,7 @@ import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
+import { GetUserProfileImageResponseDto } from '@user/dto/response/getUserProfileImage.dto';
 import { UserRepository } from '@user/repository/user.repository';
 
 @Injectable()
@@ -46,6 +47,11 @@ export class UserService {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
     return user;
+  }
+
+  async getUserProfileImage(userId: number) {
+    const user = await this.getUser(userId);
+    return GetUserProfileImageResponseDto.toResponseDto(user);
   }
 
   async checkEmailDuplication(email: string) {

--- a/server/test/comment/dto/getUserComments.dto.spec.ts
+++ b/server/test/comment/dto/getUserComments.dto.spec.ts
@@ -1,0 +1,73 @@
+import { validate } from 'class-validator';
+
+import { GetUserCommentsRequestDto } from '@comment/dto/request/getUserComments.dto';
+
+describe(`${GetUserCommentsRequestDto.name} Test`, () => {
+  let dto: GetUserCommentsRequestDto;
+
+  beforeEach(() => {
+    dto = new GetUserCommentsRequestDto({
+      lastId: 1,
+      limit: 10,
+    });
+  });
+
+  it('lastId와 limit이 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('lastId와 limit은 선택값이므로 없어도 유효성 검사에 성공한다.', async () => {
+    // given
+    dto = new GetUserCommentsRequestDto({});
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('lastId', () => {
+    it('정수가 아니면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.lastId = 1.5;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('1 미만이면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.lastId = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+
+  describe('limit', () => {
+    it('1 미만이면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/comment/dto/getUserCommentsParam.dto.spec.ts
+++ b/server/test/comment/dto/getUserCommentsParam.dto.spec.ts
@@ -1,0 +1,59 @@
+import { validate } from 'class-validator';
+
+import { GetUserCommentsParamRequestDto } from '@comment/dto/request/getUserCommentsParam.dto';
+
+describe(`${GetUserCommentsParamRequestDto.name} Test`, () => {
+  let dto: GetUserCommentsParamRequestDto;
+
+  beforeEach(() => {
+    dto = new GetUserCommentsParamRequestDto({
+      userId: 1,
+    });
+  });
+
+  it('사용자 ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('userId', () => {
+    it('사용자 ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('사용자 ID가 정수가 아니고 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('사용자 ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/comment/e2e/getUserComments.e2e-spec.ts
+++ b/server/test/comment/e2e/getUserComments.e2e-spec.ts
@@ -1,0 +1,149 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Comment } from '@comment/entity/comment.entity';
+import { CommentRepository } from '@comment/repository/comment.repository';
+import { GetUserCommentsResponseDto } from '@comment/dto/response/getUserComments.dto';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { CommentFixture } from '@test/config/common/fixture/comment.fixture';
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/users';
+
+describe(`GET ${BASE_URL}/:userId/comments E2E Test`, () => {
+  let agent: TestAgent;
+  let commentRepository: CommentRepository;
+  let userRepository: UserRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+  let rssAccept: RssAccept;
+  let feed: Feed;
+  let user: User;
+  let comments: Comment[];
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    commentRepository = testApp.get(CommentRepository);
+    userRepository = testApp.get(UserRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  beforeEach(async () => {
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    [user, feed] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      feedRepository.save(FeedFixture.createFeedFixture(rssAccept)),
+    ]);
+
+    // 동일 유저가 작성한 댓글 3개를 id 오름차순으로 저장
+    comments = [];
+    for (let i = 0; i < 3; i++) {
+      comments.push(
+        await commentRepository.save(
+          CommentFixture.createCommentFixture(feed, user, {
+            comment: `comment ${i + 1}`,
+          }),
+        ),
+      );
+    }
+  });
+
+  it('[404] 존재하지 않는 유저일 경우 댓글 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/${Number.MAX_SAFE_INTEGER}/comments`,
+    );
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 유저가 작성한 댓글을 게시글 정보(path 포함)와 함께 최신순으로 조회한다.', async () => {
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${user.id}/comments`);
+
+    // Http then
+    const { data }: { data: GetUserCommentsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.hasMore).toBe(false);
+    expect(data.lastId).toBe(comments[0].id);
+    expect(data.result).toStrictEqual(
+      [...comments].reverse().map((comment) => ({
+        id: comment.id,
+        comment: comment.comment,
+        date: comment.date.toISOString(),
+        feed: {
+          id: feed.id,
+          title: feed.title,
+          path: feed.path,
+        },
+      })),
+    );
+  });
+
+  it('[200] limit으로 페이지 크기를 제한하고 hasMore와 커서(lastId)를 반환한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/${user.id}/comments?limit=2`,
+    );
+
+    // Http then
+    const { data }: { data: GetUserCommentsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toHaveLength(2);
+    expect(data.hasMore).toBe(true);
+    // 최신순 → comments[2], comments[1]
+    expect(data.result[0].id).toBe(comments[2].id);
+    expect(data.lastId).toBe(comments[1].id);
+  });
+
+  it('[200] lastId 커서 이후의 댓글만 조회한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/${user.id}/comments?lastId=${comments[1].id}`,
+    );
+
+    // Http then
+    const { data }: { data: GetUserCommentsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toHaveLength(1);
+    expect(data.result[0].id).toBe(comments[0].id);
+    expect(data.hasMore).toBe(false);
+  });
+
+  it('[200] 댓글이 없는 유저는 빈 목록과 lastId=0을 반환한다.', async () => {
+    // Http given
+    const otherUser = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${otherUser.id}/comments`);
+
+    // Http then
+    const { data }: { data: GetUserCommentsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toStrictEqual([]);
+    expect(data.lastId).toBe(0);
+    expect(data.hasMore).toBe(false);
+  });
+});

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -4,6 +4,7 @@ import { DataSource } from 'typeorm';
 
 import { CommentService } from '@comment/service/comment.service';
 import { GetCommentResponseDto } from '@comment/dto/response/getComment.dto';
+import { GetUserCommentsResponseDto } from '@comment/dto/response/getUserComments.dto';
 import { Comment } from '@comment/entity/comment.entity';
 import { CommentRepository } from '@comment/repository/comment.repository';
 
@@ -11,12 +12,18 @@ import { Payload } from '@common/guard/jwt.guard';
 
 import { FeedService } from '@feed/service/feed.service';
 
+import { UserService } from '@user/service/user.service';
+
 describe(`${CommentService.name} Unit Test`, () => {
   let commentService: CommentService;
   let commentRepository: jest.Mocked<
-    Pick<CommentRepository, 'findOne' | 'getCommentInformation' | 'save'>
+    Pick<
+      CommentRepository,
+      'findOne' | 'getCommentInformation' | 'getCommentsByUser' | 'save'
+    >
   >;
   let feedService: jest.Mocked<Pick<FeedService, 'getFeed'>>;
+  let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
   let manager: { save: jest.Mock; remove: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
 
@@ -31,9 +38,11 @@ describe(`${CommentService.name} Unit Test`, () => {
     commentRepository = {
       findOne: jest.fn(),
       getCommentInformation: jest.fn(),
+      getCommentsByUser: jest.fn(),
       save: jest.fn(),
     };
     feedService = { getFeed: jest.fn() };
+    userService = { getUser: jest.fn() };
     manager = { save: jest.fn(), remove: jest.fn() };
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
@@ -43,6 +52,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       commentRepository as unknown as CommentRepository,
       dataSource as unknown as DataSource,
       feedService as unknown as FeedService,
+      userService as unknown as UserService,
     );
   });
 
@@ -70,6 +80,85 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(result).toEqual(
         GetCommentResponseDto.toResponseDtoArray(comments),
       );
+    });
+  });
+
+  describe('getCommentsByUser', () => {
+    const makeComment = (id: number) =>
+      ({
+        id,
+        comment: `c${id}`,
+        date: new Date('2025-01-01'),
+        feed: { id, title: `t${id}`, path: `https://example.com/${id}` },
+      }) as any;
+
+    it('존재하지 않는 유저면 NotFoundException을 던진다.', async () => {
+      // given
+      userService.getUser.mockRejectedValue(
+        new NotFoundException('존재하지 않는 유저입니다.'),
+      );
+
+      // when & then
+      await expect(
+        commentService.getCommentsByUser(999, { limit: 10 }),
+      ).rejects.toThrow(NotFoundException);
+      expect(commentRepository.getCommentsByUser).not.toHaveBeenCalled();
+    });
+
+    it('limit+1개가 조회되면 마지막 항목을 잘라내고 hasMore=true로 응답한다.', async () => {
+      // given
+      const dto = { lastId: undefined, limit: 2 };
+      const rows = [makeComment(5), makeComment(4), makeComment(3)];
+      userService.getUser.mockResolvedValue({ id: 1 } as any);
+      commentRepository.getCommentsByUser.mockResolvedValue(rows);
+
+      // when
+      const result = await commentService.getCommentsByUser(1, dto);
+
+      // then
+      expect(userService.getUser).toHaveBeenCalledWith(1);
+      expect(commentRepository.getCommentsByUser).toHaveBeenCalledWith(
+        1,
+        undefined,
+        2,
+      );
+      expect(result).toEqual(
+        GetUserCommentsResponseDto.toResponseDto(
+          [makeComment(5), makeComment(4)],
+          4,
+          true,
+        ),
+      );
+    });
+
+    it('마지막 페이지면 hasMore=false, lastId는 마지막 댓글 ID로 응답한다.', async () => {
+      // given
+      const dto = { lastId: 6, limit: 2 };
+      const rows = [makeComment(5), makeComment(4)];
+      userService.getUser.mockResolvedValue({ id: 1 } as any);
+      commentRepository.getCommentsByUser.mockResolvedValue(rows);
+
+      // when
+      const result = await commentService.getCommentsByUser(1, dto);
+
+      // then
+      expect(result.hasMore).toBe(false);
+      expect(result.lastId).toBe(4);
+      expect(result.result).toHaveLength(2);
+    });
+
+    it('댓글이 없으면 빈 목록과 lastId=0으로 응답한다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: 1 } as any);
+      commentRepository.getCommentsByUser.mockResolvedValue([]);
+
+      // when
+      const result = await commentService.getCommentsByUser(1, { limit: 10 });
+
+      // then
+      expect(result.result).toEqual([]);
+      expect(result.lastId).toBe(0);
+      expect(result.hasMore).toBe(false);
     });
   });
 

--- a/server/test/like/dto/getUserLikes.dto.spec.ts
+++ b/server/test/like/dto/getUserLikes.dto.spec.ts
@@ -1,0 +1,73 @@
+import { validate } from 'class-validator';
+
+import { GetUserLikesRequestDto } from '@like/dto/request/getUserLikes.dto';
+
+describe(`${GetUserLikesRequestDto.name} Test`, () => {
+  let dto: GetUserLikesRequestDto;
+
+  beforeEach(() => {
+    dto = new GetUserLikesRequestDto({
+      lastId: 1,
+      limit: 10,
+    });
+  });
+
+  it('lastId와 limit이 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('lastId와 limit은 선택값이므로 없어도 유효성 검사에 성공한다.', async () => {
+    // given
+    dto = new GetUserLikesRequestDto({});
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('lastId', () => {
+    it('정수가 아니면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.lastId = 1.5;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('1 미만이면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.lastId = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+
+  describe('limit', () => {
+    it('1 미만이면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/like/dto/getUserLikesParam.dto.spec.ts
+++ b/server/test/like/dto/getUserLikesParam.dto.spec.ts
@@ -1,0 +1,59 @@
+import { validate } from 'class-validator';
+
+import { GetUserLikesParamRequestDto } from '@like/dto/request/getUserLikesParam.dto';
+
+describe(`${GetUserLikesParamRequestDto.name} Test`, () => {
+  let dto: GetUserLikesParamRequestDto;
+
+  beforeEach(() => {
+    dto = new GetUserLikesParamRequestDto({
+      userId: 1,
+    });
+  });
+
+  it('사용자 ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('userId', () => {
+    it('사용자 ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('사용자 ID가 정수가 아니고 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('사용자 ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/like/e2e/getUserLikes.e2e-spec.ts
+++ b/server/test/like/e2e/getUserLikes.e2e-spec.ts
@@ -1,0 +1,145 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { GetUserLikesResponseDto } from '@like/dto/response/getUserLikes.dto';
+import { Like } from '@like/entity/like.entity';
+import { LikeRepository } from '@like/repository/like.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/users';
+
+describe(`GET ${BASE_URL}/:userId/likes E2E Test`, () => {
+  let agent: TestAgent;
+  let likeRepository: LikeRepository;
+  let userRepository: UserRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+  let rssAccept: RssAccept;
+  let feeds: Feed[];
+  let user: User;
+  let likes: Like[];
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    likeRepository = testApp.get(LikeRepository);
+    userRepository = testApp.get(UserRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  beforeEach(async () => {
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+
+    // 동일 유저가 서로 다른 게시글 3개에 좋아요를 id 오름차순으로 저장
+    // (likes 테이블은 (user, feed) Unique 제약이 있으므로 게시글을 분리)
+    feeds = [];
+    likes = [];
+    for (let i = 0; i < 3; i++) {
+      const feed = await feedRepository.save(
+        FeedFixture.createFeedFixture(rssAccept, { title: `title ${i + 1}` }),
+      );
+      feeds.push(feed);
+      likes.push(await likeRepository.save({ user, feed }));
+    }
+  });
+
+  it('[404] 존재하지 않는 유저일 경우 좋아요 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/${Number.MAX_SAFE_INTEGER}/likes`,
+    );
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 유저가 좋아요한 게시글 정보(path 포함)를 최신순으로 조회한다.', async () => {
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${user.id}/likes`);
+
+    // Http then
+    const { data }: { data: GetUserLikesResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.hasMore).toBe(false);
+    expect(data.lastId).toBe(likes[0].id);
+
+    const reversed = [...likes].reverse();
+    expect(data.result).toHaveLength(3);
+    data.result.forEach((item, idx) => {
+      const like = reversed[idx];
+      const feed = feeds[likes.indexOf(like)];
+      expect(item.id).toBe(like.id);
+      expect(item.feed).toStrictEqual({
+        id: feed.id,
+        title: feed.title,
+        path: feed.path,
+      });
+      expect(item.likeDate).toBeDefined();
+    });
+  });
+
+  it('[200] limit으로 페이지 크기를 제한하고 hasMore와 커서(lastId)를 반환한다.', async () => {
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${user.id}/likes?limit=2`);
+
+    // Http then
+    const { data }: { data: GetUserLikesResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toHaveLength(2);
+    expect(data.hasMore).toBe(true);
+    // 최신순 → likes[2], likes[1]
+    expect(data.result[0].id).toBe(likes[2].id);
+    expect(data.lastId).toBe(likes[1].id);
+  });
+
+  it('[200] lastId 커서 이후의 좋아요만 조회한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/${user.id}/likes?lastId=${likes[1].id}`,
+    );
+
+    // Http then
+    const { data }: { data: GetUserLikesResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toHaveLength(1);
+    expect(data.result[0].id).toBe(likes[0].id);
+    expect(data.hasMore).toBe(false);
+  });
+
+  it('[200] 좋아요가 없는 유저는 빈 목록과 lastId=0을 반환한다.', async () => {
+    // Http given
+    const otherUser = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${otherUser.id}/likes`);
+
+    // Http then
+    const { data }: { data: GetUserLikesResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toStrictEqual([]);
+    expect(data.lastId).toBe(0);
+    expect(data.hasMore).toBe(false);
+  });
+});

--- a/server/test/like/unit/like.service.unit.spec.ts
+++ b/server/test/like/unit/like.service.unit.spec.ts
@@ -7,14 +7,20 @@ import { Payload } from '@common/guard/jwt.guard';
 import { FeedService } from '@feed/service/feed.service';
 
 import { GetLikeResponseDto } from '@like/dto/response/getLike.dto';
+import { GetUserLikesResponseDto } from '@like/dto/response/getUserLikes.dto';
 import { Like } from '@like/entity/like.entity';
 import { LikeRepository } from '@like/repository/like.repository';
 import { LikeService } from '@like/service/like.service';
 
+import { UserService } from '@user/service/user.service';
+
 describe(`${LikeService.name} Unit Test`, () => {
   let likeService: LikeService;
-  let likeRepository: jest.Mocked<Pick<LikeRepository, 'findOneBy'>>;
+  let likeRepository: jest.Mocked<
+    Pick<LikeRepository, 'findOneBy' | 'getLikesByUser'>
+  >;
   let feedService: jest.Mocked<Pick<FeedService, 'getFeed'>>;
+  let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
   let manager: { save: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
 
@@ -27,8 +33,9 @@ describe(`${LikeService.name} Unit Test`, () => {
   const dto = { feedId: 10 };
 
   beforeEach(() => {
-    likeRepository = { findOneBy: jest.fn() };
+    likeRepository = { findOneBy: jest.fn(), getLikesByUser: jest.fn() };
     feedService = { getFeed: jest.fn() };
+    userService = { getUser: jest.fn() };
     manager = { save: jest.fn(), delete: jest.fn() };
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
@@ -38,6 +45,7 @@ describe(`${LikeService.name} Unit Test`, () => {
       likeRepository as unknown as LikeRepository,
       feedService as unknown as FeedService,
       dataSource as unknown as DataSource,
+      userService as unknown as UserService,
     );
   });
 
@@ -140,6 +148,55 @@ describe(`${LikeService.name} Unit Test`, () => {
         user: { id: user.id },
         feed: { id: dto.feedId },
       });
+    });
+  });
+
+  describe('getLikesByUser', () => {
+    const makeLike = (id: number) =>
+      ({
+        id,
+        likeDate: new Date(),
+        feed: { id, title: `title${id}`, path: `https://e.com/${id}` },
+      }) as unknown as Like;
+
+    it('존재하지 않는 유저면 getUser에서 예외를 전파한다.', async () => {
+      // given
+      userService.getUser.mockRejectedValue(new NotFoundException());
+
+      // when & then
+      await expect(
+        likeService.getLikesByUser(999, { limit: 10 }),
+      ).rejects.toThrow(NotFoundException);
+      expect(likeRepository.getLikesByUser).not.toHaveBeenCalled();
+    });
+
+    it('limit보다 많이 조회되면 hasMore=true이고 초과분을 제거한다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: 1 } as any);
+      const likes = [makeLike(3), makeLike(2), makeLike(1)];
+      likeRepository.getLikesByUser.mockResolvedValue([...likes]);
+
+      // when
+      const result = await likeService.getLikesByUser(1, { limit: 2 });
+
+      // then
+      expect(result).toEqual(
+        GetUserLikesResponseDto.toResponseDto([likes[0], likes[1]], 2, true),
+      );
+    });
+
+    it('빈 결과면 lastId=0, hasMore=false를 반환한다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: 1 } as any);
+      likeRepository.getLikesByUser.mockResolvedValue([]);
+
+      // when
+      const result = await likeService.getLikesByUser(1, { limit: 10 });
+
+      // then
+      expect(result).toEqual(
+        GetUserLikesResponseDto.toResponseDto([], 0, false),
+      );
     });
   });
 });

--- a/server/test/user/dto/getUserProfileImageParam.dto.spec.ts
+++ b/server/test/user/dto/getUserProfileImageParam.dto.spec.ts
@@ -1,0 +1,45 @@
+import { validate } from 'class-validator';
+
+import { GetUserProfileImageParamRequestDto } from '@user/dto/request/getUserProfileImageParam.dto';
+
+describe(`${GetUserProfileImageParamRequestDto.name} Test`, () => {
+  let dto: GetUserProfileImageParamRequestDto;
+
+  beforeEach(() => {
+    dto = new GetUserProfileImageParamRequestDto({ id: 1 });
+  });
+
+  it('사용자 ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('id', () => {
+    it('사용자 ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('사용자 ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/user/e2e/get-profile-image.e2e-spec.ts
+++ b/server/test/user/e2e/get-profile-image.e2e-spec.ts
@@ -1,0 +1,77 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = (id: number | string) => `/api/users/${id}/profile-image`;
+
+describe(`GET /api/users/:id/profile-image E2E Test`, () => {
+  let agent: TestAgent;
+  let userRepository: UserRepository;
+  let user: User;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(
+      UserFixture.createUserFixture({
+        profileImage:
+          'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+      }),
+    );
+  });
+
+  it('[200] 프로필 이미지가 설정된 유저를 조회하면 이미지 URL을 반환한다.', async () => {
+    // Http when
+    const response = await agent.get(URL(user.id));
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toStrictEqual({ profileImage: user.profileImage });
+  });
+
+  it('[200] 프로필 이미지가 미설정인 유저를 조회하면 null을 반환한다.', async () => {
+    // given
+    const noImageUser = await userRepository.save(
+      UserFixture.createUserFixture({ profileImage: null }),
+    );
+
+    // Http when
+    const response = await agent.get(URL(noImageUser.id));
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toStrictEqual({ profileImage: null });
+  });
+
+  it('[404] 존재하지 않는 유저를 조회하면 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(URL(Number.MAX_SAFE_INTEGER));
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[400] id가 숫자가 아니면 검증에 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(URL('not-a-number'));
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+  });
+});

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -18,6 +18,7 @@ import { FileService } from '@file/service/file.service';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
+import { GetUserProfileImageResponseDto } from '@user/dto/response/getUserProfileImage.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 import { UserService } from '@user/service/user.service';
@@ -100,6 +101,46 @@ describe(`${UserService.name} Unit Test`, () => {
       const user = UserFixture.createUserFixture();
       userRepository.findOneBy.mockResolvedValue(user);
       await expect(userService.getUser(1)).resolves.toBe(user);
+    });
+  });
+
+  describe('getUserProfileImage', () => {
+    it('존재하지 않는 사용자면 NotFoundException을 던진다.', async () => {
+      userRepository.findOneBy.mockResolvedValue(null);
+      await expect(userService.getUserProfileImage(1)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('프로필 이미지가 있으면 해당 URL 응답을 반환한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({
+        profileImage: 'https://denamu.dev/objects/PROFILE_IMAGE/a.png',
+      });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      const result = await userService.getUserProfileImage(1);
+
+      // then
+      expect(result).toEqual(
+        GetUserProfileImageResponseDto.toResponseDto(user),
+      );
+      expect(result.profileImage).toBe(
+        'https://denamu.dev/objects/PROFILE_IMAGE/a.png',
+      );
+    });
+
+    it('프로필 이미지가 미설정이면 null을 반환한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ profileImage: null });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      const result = await userService.getUserProfileImage(1);
+
+      // then
+      expect(result.profileImage).toBeNull();
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #733

### 유저 프로필 이미지 조회 API

-   마이페이지/프로필 영역에서 특정 유저의 프로필 이미지를 단독으로 조회할 수 있어야 해 `GET /users/:id/profile-image` 엔드포인트를 추가했습니다.
-   기존 `UserService`에 조회 메서드를 더하는 방식으로, 모듈 경계를 늘리지 않고 응집도를 유지했습니다.

### 유저 작성 댓글 조회 API

-   특정 유저가 작성한 댓글 목록을 페이지네이션으로 조회하는 `GET /users/:userId/comments` 엔드포인트를 추가했습니다.
-   `users/:userId` 리소스 경로 하위로 묶기 위해 `UserCommentController`를 분리해 `users` 네임스페이스 일관성을 유지했습니다.
-   `Param` / `Query` DTO를 분리하고 `userId` 검증과 페이지네이션 파라미터 검증을 각각의 DTO 단위 테스트로 보장했습니다.

### 유저 좋아요 조회 API

-   특정 유저가 좋아요한 피드 목록을 페이지네이션으로 조회하는 `GET /users/:userId/likes` 엔드포인트를 추가했습니다.
-   댓글 조회와 동일한 패턴(`UserLikeController` 분리, Param/Query DTO 분리)으로 구현해 인지 부하를 낮췄습니다.

# 📋 작업 내용

-   `GET /users/:id/profile-image` — 유저 프로필 이미지 조회
-   `GET /users/:userId/comments` — 유저 작성 댓글 조회 (페이지네이션)
-   `GET /users/:userId/likes` — 유저 좋아요 피드 조회 (페이지네이션)
-   각 API에 대한 Swagger 문서, 요청/응답 DTO, DTO 단위 테스트, 서비스 단위 테스트, E2E 테스트 작성
-   Repository 계층에 조회 쿼리 추가

# 📷 스크린 샷(선택 사항)

Swagger 문서로 대체합니다.