### PR TITLE
✨ feat: RSS 소유 인증 및 사용자-RSS 연동 기능 구현

### DIFF
--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -29,6 +29,25 @@ CREATE TABLE `rss` (
   UNIQUE KEY `UQ_af1d102908727aa95ef09e16065` (`rss_url`)
 );
 
+-- denamu.`user` definition
+
+CREATE TABLE `user` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `email` varchar(255) NOT NULL,
+  `password` varchar(60) DEFAULT NULL,
+  `user_name` varchar(60) NOT NULL,
+  `profile_image` varchar(255) DEFAULT NULL,
+  `introduction` varchar(255) DEFAULT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `totalViews` int NOT NULL DEFAULT '0',
+  `currentStreak` int NOT NULL DEFAULT '0',
+  `lastActiveDate` date DEFAULT NULL,
+  `maxStreak` int NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UQ_user_user_name` (`user_name`)
+);
+
 -- denamu.rss_accept definition
 
 CREATE TABLE `rss_accept` (
@@ -38,10 +57,13 @@ CREATE TABLE `rss_accept` (
   `email` varchar(255) NOT NULL,
   `rss_url` varchar(255) NOT NULL,
   `blog_platform` varchar(255) NOT NULL DEFAULT 'etc',
+  `user_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UQ_59f4be4de3817b3f975acff0766` (`name`),
   UNIQUE KEY `UQ_b3a5d4196368864d938dae4e9ff` (`rss_url`),
-  FULLTEXT KEY (`name`)
+  KEY `FK_rss_accept_user_id` (`user_id`),
+  FULLTEXT KEY (`name`),
+  CONSTRAINT `FK_rss_accept_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 -- denamu.rss_reject definition
@@ -74,25 +96,6 @@ CREATE TABLE `feed` (
   KEY `FK_7474d489d05b8051874b227f868` (`blog_id`),
   FULLTEXT KEY `IDX_7d93e66e624232af470d2f7bb3` (`title`) /*!50100 WITH PARSER `ngram` */ ,
   CONSTRAINT `FK_7474d489d05b8051874b227f868` FOREIGN KEY (`blog_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-);
-
--- denamu.`user` definition
-
-CREATE TABLE `user` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `email` varchar(255) NOT NULL,
-  `password` varchar(60) DEFAULT NULL,
-  `user_name` varchar(60) NOT NULL,
-  `profile_image` varchar(255) DEFAULT NULL,
-  `introduction` varchar(255) DEFAULT NULL,
-  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
-  `totalViews` int NOT NULL DEFAULT '0',
-  `currentStreak` int NOT NULL DEFAULT '0',
-  `lastActiveDate` date DEFAULT NULL,
-  `maxStreak` int NOT NULL DEFAULT '0',
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `UQ_user_user_name` (`user_name`)
 );
 
 -- denamu.activity definition

--- a/email-worker/src/common/types.ts
+++ b/email-worker/src/common/types.ts
@@ -29,6 +29,14 @@ export interface RssRemoval {
   certificateCode: string;
 }
 
+export interface RssCertification {
+  userName: string;
+  email: string;
+  blogName: string;
+  certificateCode: string;
+  userEmail: string;
+}
+
 export interface AdminCertification {
   email: string;
   name: string;

--- a/email-worker/src/email/constant.ts
+++ b/email-worker/src/email/constant.ts
@@ -1,6 +1,7 @@
 export const EmailPayloadConstant = {
   USER_CERTIFICATION: 'userCertification',
   RSS_REMOVAL: 'rssRemoval',
+  RSS_CERTIFICATION: 'rssCertification',
   RSS_REGISTRATION: 'rssRegistration',
   RSS_REGISTRATION_REQUEST: 'rssRegistrationRequest',
   PASSWORD_RESET: 'passwordReset',

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -100,6 +100,10 @@ export class EmailConsumer {
         await this.emailService.sendRssRemoveCertificationMail(payload.data);
         break;
 
+      case EmailPayloadConstant.RSS_CERTIFICATION:
+        await this.emailService.sendRssCertificationMail(payload.data);
+        break;
+
       case EmailPayloadConstant.PASSWORD_RESET:
         await this.emailService.sendPasswordResetEmail(payload.data);
         break;

--- a/email-worker/src/email/email.content.ts
+++ b/email-worker/src/email/email.content.ts
@@ -240,6 +240,50 @@ export function createRssRemoveCertificateContent(
 `;
 }
 
+export function createRssCertificationContent(
+  userName: string,
+  certificateCode: string,
+  serviceAddress: string,
+  blogName: string,
+  userEmail: string,
+  certificationLink: string,
+) {
+  return `
+        <div style="font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', sans-serif; margin: 0; padding: 1px; background-color: #f4f4f4;">
+            <div style="max-width: 600px; margin: 20px auto; background-color: #ffffff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
+              <div style="text-align: center; padding: 20px 0; border-bottom: 2px solid #f0f0f0;">
+                <img src="https://denamu.dev/files/Denamu_Logo_KOR.png" alt="Denamu Logo" width="244" height="120">
+              </div>
+              <div style="padding: 20px 0;">
+                <div style="color: #007bff; font-size: 24px; font-weight: bold; margin-bottom: 20px; text-align: center;">RSS 소유 인증을 완료해주세요</div>
+                  <div style="background-color: #f8f9fa; padding: 15px; border-radius: 4px; margin: 15px 0;">
+                    <p>안녕하세요, <b>${userName}</b>님!</p>
+                    <p>Denamu 서비스에서 <b><u>${blogName}</u></b> 블로그의 소유 인증이 요청되었습니다.</p>
+                    <p>신청자 이메일: <b>${userEmail}</b></p>
+                    <p>본인이 요청한 것이 맞다면 아래 인증 코드를 데나무 사이트에 입력해주세요.</p>
+                  </div>
+                  <center>
+                    <p style="background-color: #ffde4d; padding: 15px; border-radius: 4px; margin: 15px 200px;""><b>${certificateCode}</b></p>
+                  </center>
+                  <center>
+                    <a href="${certificationLink}" style="display: inline-block; padding: 12px 24px; background-color: #007bff; color: #ffffff; text-decoration: none; border-radius: 4px; margin: 20px 0; font-weight: bold;">소유 인증 완료하기</a>
+                  </center>
+                  <div style="font-size: 14px; color: #6c757d; margin-top: 20px; text-align: center;">
+                    <p>버튼이 작동하지 않는 경우, 위 인증 코드를 데나무 사이트에 직접 입력해주세요.</p>
+                    <p>이 코드는 5분 동안 유효합니다.</p>
+                    <p>본인이 요청하지 않은 경우, 이 메일을 무시하시기 바랍니다.</p>
+                  </div>
+                </div>
+              </div>
+              <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; border-top: 2px solid #f0f0f0; color: #6c757d; font-size: 14px; height: 100px;">
+                <p>본 메일은 발신전용입니다.</p>
+                <p>문의사항이 있으시다면 ${serviceAddress}로 연락주세요.</p>
+              </div>
+            </div>
+          </div>
+`;
+}
+
 export function createPasswordResetMailContent(
   userName: string,
   passwordResetLink: string,

--- a/email-worker/src/email/email.service.ts
+++ b/email-worker/src/email/email.service.ts
@@ -8,6 +8,7 @@ import { EmailMetrics } from '@common/metrics/email-metrics';
 import {
   AdminCertification,
   Rss,
+  RssCertification,
   RssRegistration,
   RssRegistrationRequest,
   RssRemoval,
@@ -19,6 +20,7 @@ import {
   createAdminVerificationMailContent,
   createDeleteAccountContent,
   createPasswordResetMailContent,
+  createRssCertificationContent,
   createRssRegistrationContent,
   createRssRegistrationRequestContent,
   createRssRemoveCertificateContent,
@@ -219,6 +221,40 @@ export class EmailService {
         certificateCode,
         this.emailUser,
         rssUrl,
+      ),
+    };
+  }
+
+  async sendRssCertificationMail(rssCertification: RssCertification) {
+    const mailOption = this.createRssCertificationMail(
+      rssCertification.userName,
+      rssCertification.email,
+      rssCertification.blogName,
+      rssCertification.certificateCode,
+      rssCertification.userEmail,
+    );
+    await this.sendMail(mailOption);
+  }
+
+  private createRssCertificationMail(
+    userName: string,
+    email: string,
+    blogName: string,
+    certificateCode: string,
+    userEmail: string,
+  ) {
+    const certificationLink = `${PRODUCT_DOMAIN}/rss/certifications/confirm?code=${certificateCode}`;
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: `${userName}<${email}>`,
+      subject: `[🎋 Denamu] RSS 소유 인증 메일입니다.`,
+      html: createRssCertificationContent(
+        userName,
+        certificateCode,
+        this.emailUser,
+        blogName,
+        userEmail,
+        certificationLink,
       ),
     };
   }

--- a/email-worker/src/email/types.ts
+++ b/email-worker/src/email/types.ts
@@ -1,5 +1,6 @@
 import {
   AdminCertification,
+  RssCertification,
   RssRegistration,
   RssRegistrationRequest,
   RssRemoval,
@@ -11,6 +12,10 @@ import { EmailPayloadConstant } from './constant';
 export type EmailPayload =
   | { type: typeof EmailPayloadConstant.USER_CERTIFICATION; data: User }
   | { type: typeof EmailPayloadConstant.RSS_REMOVAL; data: RssRemoval }
+  | {
+      type: typeof EmailPayloadConstant.RSS_CERTIFICATION;
+      data: RssCertification;
+    }
   | {
       type: typeof EmailPayloadConstant.RSS_REGISTRATION;
       data: RssRegistration;

--- a/email-worker/test/unit/consumer.spec.ts
+++ b/email-worker/test/unit/consumer.spec.ts
@@ -1,6 +1,11 @@
 import 'reflect-metadata';
 
-import { RssRegistration, RssRemoval, User } from '@common/types';
+import {
+  RssCertification,
+  RssRegistration,
+  RssRemoval,
+  User,
+} from '@common/types';
 
 import { EmailPayloadConstant } from '@email/constant';
 import { EmailConsumer } from '@email/email.consumer';
@@ -26,6 +31,7 @@ describe('email consumer unit test', () => {
     let sendUserCertificationMail: jest.Mock;
     let sendRssMail: jest.Mock;
     let sendRssRemoveCertificationMail: jest.Mock;
+    let sendRssCertificationMail: jest.Mock;
     let sendPasswordResetEmail: jest.Mock;
     let sendDeleteAccountMail: jest.Mock;
 
@@ -33,6 +39,7 @@ describe('email consumer unit test', () => {
       sendUserCertificationMail = jest.fn().mockResolvedValue(undefined);
       sendRssMail = jest.fn().mockResolvedValue(undefined);
       sendRssRemoveCertificationMail = jest.fn().mockResolvedValue(undefined);
+      sendRssCertificationMail = jest.fn().mockResolvedValue(undefined);
       sendPasswordResetEmail = jest.fn().mockResolvedValue(undefined);
       sendDeleteAccountMail = jest.fn().mockResolvedValue(undefined);
 
@@ -40,6 +47,7 @@ describe('email consumer unit test', () => {
         sendUserCertificationMail,
         sendRssMail,
         sendRssRemoveCertificationMail,
+        sendRssCertificationMail,
         sendPasswordResetEmail,
         sendDeleteAccountMail,
       } as any;
@@ -113,6 +121,27 @@ describe('email consumer unit test', () => {
       expect(sendRssRemoveCertificationMail).toHaveBeenCalledTimes(1);
       expect(sendRssRemoveCertificationMail).toHaveBeenCalledWith(
         rssRemovalData,
+      );
+    });
+
+    it('RSS_CERTIFICATION 타입일 때 sendRssCertificationMail을 호출한다', async () => {
+      const rssCertificationData: RssCertification = {
+        userName: 'tester',
+        email: 'test@test.com',
+        blogName: 'Test Blog',
+        certificateCode: 'cert-code-123',
+        userEmail: 'requester@test.com',
+      };
+      const payload: EmailPayload = {
+        type: EmailPayloadConstant.RSS_CERTIFICATION,
+        data: rssCertificationData,
+      };
+
+      await emailConsumer.handleEmailByType(payload);
+
+      expect(sendRssCertificationMail).toHaveBeenCalledTimes(1);
+      expect(sendRssCertificationMail).toHaveBeenCalledWith(
+        rssCertificationData,
       );
     });
 

--- a/email-worker/test/unit/emailService.spec.ts
+++ b/email-worker/test/unit/emailService.spec.ts
@@ -3,7 +3,12 @@ import 'reflect-metadata';
 import * as nodemailer from 'nodemailer';
 
 import { EmailMetrics } from '@common/metrics/email-metrics';
-import { RssRegistration, RssRemoval, User } from '@common/types';
+import {
+  RssCertification,
+  RssRegistration,
+  RssRemoval,
+  User,
+} from '@common/types';
 
 import { PRODUCT_DOMAIN } from '@email/email.content';
 import { EmailService } from '@email/email.service';
@@ -205,6 +210,38 @@ describe('EmailService unit test', () => {
       expect(callArgs.html).toContain(rssRemoval.userName);
       expect(callArgs.html).toContain(rssRemoval.certificateCode);
       expect(callArgs.html).toContain(rssRemoval.rssUrl);
+    });
+  });
+
+  describe('sendRssCertificationMail unit test', () => {
+    it('RSS 소유 인증 메일을 올바르게 전송한다', async () => {
+      const rssCertification: RssCertification = {
+        userName: 'tester',
+        email: 'tester@test.com',
+        blogName: 'Test Blog',
+        certificateCode: 'cert-uuid',
+        userEmail: 'requester@test.com',
+      };
+
+      await emailService.sendRssCertificationMail(rssCertification);
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: `${rssCertification.userName}<${rssCertification.email}>`,
+          subject: '[🎋 Denamu] RSS 소유 인증 메일입니다.',
+        }),
+      );
+
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(rssCertification.userName);
+      expect(callArgs.html).toContain(rssCertification.certificateCode);
+      expect(callArgs.html).toContain(rssCertification.blogName);
+      expect(callArgs.html).toContain(rssCertification.userEmail);
+      expect(callArgs.html).toContain(
+        `/rss/certifications/confirm?code=${rssCertification.certificateCode}`,
+      );
     });
   });
 

--- a/server/src/common/database/migration/1781000000000-AddRssAcceptUserId.ts
+++ b/server/src/common/database/migration/1781000000000-AddRssAcceptUserId.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRssAcceptUserId1781000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`rss_accept\` ADD COLUMN \`user_id\` int DEFAULT NULL;`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`rss_accept\` ADD CONSTRAINT \`FK_rss_accept_user_id\` FOREIGN KEY (\`user_id\`) REFERENCES \`user\` (\`id\`) ON DELETE SET NULL ON UPDATE CASCADE;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE \`rss_accept\` DROP FOREIGN KEY \`FK_rss_accept_user_id\`;`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE \`rss_accept\` DROP COLUMN \`user_id\`;`,
+    );
+  }
+}

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -153,4 +153,22 @@ export class EmailProducer {
     };
     await this.produceMessage(payload);
   }
+
+  async produceRssCertification(
+    userName: string,
+    email: string,
+    blogName: string,
+    certificateCode: string,
+  ) {
+    const payload = {
+      type: EmailPayloadConstant.RSS_CERTIFICATION,
+      data: {
+        userName,
+        email,
+        blogName,
+        certificateCode,
+      },
+    };
+    await this.produceMessage(payload);
+  }
 }

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -66,11 +66,7 @@ export class EmailProducer {
     await this.produceMessage(payload);
   }
 
-  async produceAdminAccountDeletion(
-    email: string,
-    name: string,
-    uuid: string,
-  ) {
+  async produceAdminAccountDeletion(email: string, name: string, uuid: string) {
     const payload = {
       type: EmailPayloadConstant.ADMIN_ACCOUNT_DELETION,
       data: {
@@ -156,17 +152,19 @@ export class EmailProducer {
 
   async produceRssCertification(
     userName: string,
-    email: string,
     blogName: string,
     certificateCode: string,
+    rssAcceptEmail: string,
+    userEmail: string,
   ) {
     const payload = {
       type: EmailPayloadConstant.RSS_CERTIFICATION,
       data: {
         userName,
-        email,
+        email: rssAcceptEmail,
         blogName,
         certificateCode,
+        userEmail,
       },
     };
     await this.produceMessage(payload);

--- a/server/src/common/email/email.type.ts
+++ b/server/src/common/email/email.type.ts
@@ -29,6 +29,13 @@ export interface RssRemoval {
   certificateCode: string;
 }
 
+export interface RssCertification {
+  userName: string;
+  email: string;
+  blogName: string;
+  certificateCode: string;
+}
+
 export interface AdminCertification {
   email: string;
   name: string;
@@ -38,6 +45,7 @@ export interface AdminCertification {
 export const EmailPayloadConstant = {
   USER_CERTIFICATION: 'userCertification',
   RSS_REMOVAL: 'rssRemoval',
+  RSS_CERTIFICATION: 'rssCertification',
   RSS_REGISTRATION: 'rssRegistration',
   RSS_REGISTRATION_REQUEST: 'rssRegistrationRequest',
   PASSWORD_RESET: 'passwordReset',
@@ -49,6 +57,10 @@ export const EmailPayloadConstant = {
 export type EmailPayload =
   | { type: typeof EmailPayloadConstant.USER_CERTIFICATION; data: User }
   | { type: typeof EmailPayloadConstant.RSS_REMOVAL; data: RssRemoval }
+  | {
+      type: typeof EmailPayloadConstant.RSS_CERTIFICATION;
+      data: RssCertification;
+    }
   | {
       type: typeof EmailPayloadConstant.RSS_REGISTRATION;
       data: RssRegistration;

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -14,6 +14,7 @@ export const REDIS_KEYS = {
   ADMIN_REGISTER_KEY: 'admin:signup',
   ADMIN_DELETE_ACCOUNT_KEY: 'admin:delete-account',
   RSS_REMOVE_KEY: 'rss:remove',
+  RSS_CERTIFICATION_KEY: 'rss:certification',
   CHAT_HISTORY_KEY: (roomId: string) => `chat:history:${roomId}`,
   FULL_FEED_CRAWL_QUEUE: `feed:full-crawl:queue`,
   USER_DELETE_ACCOUNT_KEY: 'user:delete-account',

--- a/server/src/rss/api-docs/createRssCertification.api-docs.ts
+++ b/server/src/rss/api-docs/createRssCertification.api-docs.ts
@@ -1,0 +1,28 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiConflictDoc,
+  ApiDataResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
+
+export function ApiCreateRssCertification() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'RSS 소유 인증 요청 API',
+      description:
+        '블로그 이름으로 RSS를 찾아 해당 블로그의 플랫폼·신청자 이름을 반환합니다. RSS에 등록된 이메일과 로그인한 사용자의 이메일이 같으면 즉시 인증(certified=true)되고, 다르면 RSS 등록 이메일로 인증 코드가 발송됩니다(certified=false).',
+    }),
+    ApiBearerAuth(),
+    ApiDataResponse(CreateRssCertificationResponseDto),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증이 필요합니다.'),
+    ApiNotFoundDoc('해당 이름의 RSS를 찾을 수 없습니다.'),
+    ApiConflictDoc('이미 인증된 RSS입니다.'),
+  );
+}

--- a/server/src/rss/api-docs/deleteRssCertification.api-docs.ts
+++ b/server/src/rss/api-docs/deleteRssCertification.api-docs.ts
@@ -1,0 +1,32 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiForbiddenDoc,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiDeleteRssCertification() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'RSS 소유 인증 해제 API',
+      description:
+        '본인이 인증한 RSS의 소유 연결을 해제합니다. RSS 데이터 자체는 삭제되지 않고 사용자와의 연결(user_id)만 끊어집니다.',
+    }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'id',
+      type: Number,
+      description: '인증을 해제할 RSS(rss_accept) ID',
+      example: 1,
+    }),
+    ApiMessageResponse('RSS 소유 인증 해제 완료'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증이 필요합니다.'),
+    ApiForbiddenDoc('본인이 인증한 RSS가 아닙니다.'),
+    ApiNotFoundDoc('RSS를 찾을 수 없습니다.'),
+  );
+}

--- a/server/src/rss/api-docs/verifyRssCertification.api-docs.ts
+++ b/server/src/rss/api-docs/verifyRssCertification.api-docs.ts
@@ -1,0 +1,28 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiConflictDoc,
+  ApiForbiddenDoc,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiVerifyRssCertification() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'RSS 소유 인증 코드 검증 API',
+      description:
+        '이메일로 발송된 인증 코드를 검증하여 로그인한 사용자에게 RSS 소유권을 연결합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiMessageResponse('RSS 소유 인증 완료'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증이 필요합니다.'),
+    ApiForbiddenDoc('본인의 RSS 인증 요청이 아닙니다.'),
+    ApiNotFoundDoc('RSS 인증 코드가 만료되었거나 찾을 수 없습니다.'),
+    ApiConflictDoc('이미 인증되었거나 인증할 수 없는 RSS입니다.'),
+  );
+}

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -11,22 +11,30 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
+import { CurrentUser } from '@common/decorator';
 import { AdminAuthGuard } from '@common/guard/session.guard';
+import { JwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
 
 import { ApiAcceptRss } from '@rss/api-docs/acceptRss.api-docs';
 import { ApiCreateRss } from '@rss/api-docs/createRss.api-docs';
+import { ApiCreateRssCertification } from '@rss/api-docs/createRssCertification.api-docs';
 import { ApiDeleteCertificateRss } from '@rss/api-docs/deleteCertificateRss.api-docs';
 import { ApiDeleteRss } from '@rss/api-docs/deleteRss.api-docs';
+import { ApiDeleteRssCertification } from '@rss/api-docs/deleteRssCertification.api-docs';
 import { ApiReadAllRss } from '@rss/api-docs/readAllRss.api-docs';
 import { ApiReadRssAcceptHistory } from '@rss/api-docs/readRssAcceptHistory.api-docs';
 import { ApiReadRssRejectHistory } from '@rss/api-docs/readRssRejectHistory.api-docs';
 import { ApiRejectRss } from '@rss/api-docs/rejectRss.api-docs';
+import { ApiVerifyRssCertification } from '@rss/api-docs/verifyRssCertification.api-docs';
+import { CreateRssCertificationRequestDto } from '@rss/dto/request/createRssCertification.dto';
 import { DeleteCertificateRssRequestDto } from '@rss/dto/request/deleteCertificateRss.dto';
+import { DeleteRssCertificationParamRequestDto } from '@rss/dto/request/deleteRssCertificationParam.dto';
 import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
+import { VerifyRssCertificationRequestDto } from '@rss/dto/request/verifyRssCertification.dto';
 import { RssService } from '@rss/service/rss.service';
 
 @ApiTags('RSS')
@@ -110,5 +118,52 @@ export class RssController {
   async deleteRss(@Param() deleteRssDto: DeleteCertificateRssRequestDto) {
     await this.rssService.deleteRss(deleteRssDto);
     return ApiResponse.responseWithNoContent('RSS 삭제를 성공했습니다.');
+  }
+
+  @ApiCreateRssCertification()
+  @UseGuards(JwtGuard)
+  @Post('certifications')
+  @HttpCode(HttpStatus.OK)
+  async createRssCertification(
+    @CurrentUser() user: Payload,
+    @Body() createRssCertificationDto: CreateRssCertificationRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      'RSS 소유 인증 요청을 처리했습니다.',
+      await this.rssService.createRssCertification(
+        user,
+        createRssCertificationDto.blogName,
+      ),
+    );
+  }
+
+  @ApiVerifyRssCertification()
+  @UseGuards(JwtGuard)
+  @Post('certifications/verify')
+  @HttpCode(HttpStatus.OK)
+  async verifyRssCertification(
+    @CurrentUser() user: Payload,
+    @Body() verifyRssCertificationDto: VerifyRssCertificationRequestDto,
+  ) {
+    await this.rssService.verifyRssCertification(
+      user,
+      verifyRssCertificationDto.code,
+    );
+    return ApiResponse.responseWithNoContent('RSS 소유 인증을 완료했습니다.');
+  }
+
+  @ApiDeleteRssCertification()
+  @UseGuards(JwtGuard)
+  @Delete('certifications/:id')
+  @HttpCode(HttpStatus.OK)
+  async deleteRssCertification(
+    @CurrentUser() user: Payload,
+    @Param() deleteRssCertificationDto: DeleteRssCertificationParamRequestDto,
+  ) {
+    await this.rssService.deleteRssCertification(
+      user,
+      deleteRssCertificationDto.id,
+    );
+    return ApiResponse.responseWithNoContent('RSS 소유 인증을 해제했습니다.');
   }
 }

--- a/server/src/rss/dto/request/createRssCertification.dto.ts
+++ b/server/src/rss/dto/request/createRssCertification.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class CreateRssCertificationRequestDto {
+  @ApiProperty({
+    description: '소유 인증할 블로그 이름을 입력해주세요.',
+    example: 'seok3765.log',
+  })
+  @IsNotEmpty({
+    message: '블로그 이름을 입력해주세요.',
+  })
+  @IsString({
+    message: '문자열로 입력해주세요.',
+  })
+  blogName: string;
+
+  constructor(partial: Partial<CreateRssCertificationRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/request/deleteRssCertificationParam.dto.ts
+++ b/server/src/rss/dto/request/deleteRssCertificationParam.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class DeleteRssCertificationParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '인증을 해제할 RSS(rss_accept) ID',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: 'RSS ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  constructor(partial: Partial<DeleteRssCertificationParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/request/verifyRssCertification.dto.ts
+++ b/server/src/rss/dto/request/verifyRssCertification.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class VerifyRssCertificationRequestDto {
+  @ApiProperty({
+    description: '이메일로 전송된 인증 코드를 입력해주세요.',
+    example: 'test code',
+  })
+  @IsNotEmpty({
+    message: '인증 코드를 입력해주세요.',
+  })
+  @IsString({
+    message: '문자열로 입력해주세요.',
+  })
+  code: string;
+
+  constructor(partial: Partial<VerifyRssCertificationRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/response/createRssCertification.dto.ts
+++ b/server/src/rss/dto/response/createRssCertification.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+
+export class CreateRssCertificationResponseDto {
+  @ApiProperty({
+    example: 'velog',
+    description: '인증 요청한 블로그의 플랫폼 종류',
+  })
+  blogPlatform: string;
+
+  @ApiProperty({
+    example: 'example_user',
+    description: '인증 요청한 블로그에 등록된 신청자 이름',
+  })
+  userName: string;
+
+  @ApiProperty({
+    example: false,
+    description:
+      '인증 완료 여부. true면 이메일이 일치하여 즉시 인증이 완료된 것이고, false면 이메일로 발송된 코드로 2차 인증이 필요합니다.',
+  })
+  certified: boolean;
+
+  constructor(partial: Partial<CreateRssCertificationResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(rssAccept: RssAccept, certified: boolean) {
+    return new CreateRssCertificationResponseDto({
+      blogPlatform: rssAccept.blogPlatform,
+      userName: rssAccept.userName,
+      certified,
+    });
+  }
+}

--- a/server/src/rss/entity/rss.entity.ts
+++ b/server/src/rss/entity/rss.entity.ts
@@ -3,11 +3,15 @@ import {
   Column,
   Entity,
   Index,
+  JoinColumn,
+  ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 
 import { Feed } from '@feed/entity/feed.entity';
+
+import { User } from '@user/entity/user.entity';
 
 export class RssInformation extends BaseEntity {
   @PrimaryGeneratedColumn()
@@ -78,6 +82,17 @@ export class RssAccept extends RssInformation {
 
   @Column({ name: 'blog_platform', default: 'etc', nullable: false })
   blogPlatform: string;
+
+  @Column({ name: 'user_id', type: 'int', nullable: true })
+  userId: number | null;
+
+  @ManyToOne(() => User, {
+    nullable: true,
+    onUpdate: 'CASCADE',
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({ name: 'user_id' })
+  user: User | null;
 
   static fromRss(rss: Rss, blogPlatform: string) {
     const blog = new RssAccept();

--- a/server/src/rss/module/rss.module.ts
+++ b/server/src/rss/module/rss.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 
+import { JwtAuthModule } from '@common/auth/jwt.module';
 import { NotifierModule } from '@common/notification/notifier.module';
 
 import { AdminModule } from '@admin/module/admin.module';
@@ -13,7 +14,7 @@ import {
 import { RssService } from '@rss/service/rss.service';
 
 @Module({
-  imports: [AdminModule, NotifierModule],
+  imports: [AdminModule, NotifierModule, JwtAuthModule],
   controllers: [RssController],
   providers: [
     RssService,

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -1,17 +1,19 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 
 import * as uuid from 'uuid';
 import axios from 'axios';
-import { DataSource } from 'typeorm';
+import { DataSource, IsNull } from 'typeorm';
 
 import { AdminRepository } from '@admin/repository/admin.repository';
 
 import { EmailProducer } from '@common/email/email.producer';
+import { Payload } from '@common/guard/jwt.guard';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { NotifierRegistry } from '@common/notification/notifier-registry';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
@@ -22,6 +24,7 @@ import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
+import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
 import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
 import { ReadRssRejectHistoryResponseDto } from '@rss/dto/response/readRssRejectHistory.dto';
@@ -281,5 +284,99 @@ export class RssService {
     } finally {
       await this.redisService.del(redisKey);
     }
+  }
+
+  async createRssCertification(user: Payload, blogName: string) {
+    const rssAccept = await this.rssAcceptRepository.findOne({
+      where: { name: blogName },
+    });
+
+    if (!rssAccept) {
+      throw new NotFoundException('해당 이름의 RSS를 찾을 수 없습니다.');
+    }
+
+    if (rssAccept.userId !== null) {
+      if (rssAccept.userId === user.id) {
+        throw new ConflictException('이미 본인이 인증한 RSS입니다.');
+      }
+      throw new ConflictException('다른 사용자가 이미 인증한 RSS입니다.');
+    }
+
+    if (rssAccept.email === user.email) {
+      await this.linkRssAcceptToUser(rssAccept.id, user.id);
+      return CreateRssCertificationResponseDto.toResponseDto(rssAccept, true);
+    }
+
+    const certificateCode = uuid.v4();
+    await this.redisService.set(
+      `${REDIS_KEYS.RSS_CERTIFICATION_KEY}:${certificateCode}`,
+      JSON.stringify({ rssAcceptId: rssAccept.id, userId: user.id }),
+      'EX',
+      300,
+    );
+    await this.emailProducer.produceRssCertification(
+      rssAccept.userName,
+      rssAccept.name,
+      certificateCode,
+      rssAccept.email,
+      user.email,
+    );
+
+    return CreateRssCertificationResponseDto.toResponseDto(rssAccept, false);
+  }
+
+  async verifyRssCertification(user: Payload, code: string) {
+    const redisKey = `${REDIS_KEYS.RSS_CERTIFICATION_KEY}:${code}`;
+    const stored = await this.redisService.get(redisKey);
+
+    if (!stored) {
+      throw new NotFoundException(
+        'RSS 인증 코드가 만료되었거나 찾을 수 없습니다.',
+      );
+    }
+
+    const { rssAcceptId, userId } = JSON.parse(stored) as {
+      rssAcceptId: number;
+      userId: number;
+    };
+
+    if (userId !== user.id) {
+      throw new ForbiddenException('본인의 RSS 인증 요청이 아닙니다.');
+    }
+
+    try {
+      await this.linkRssAcceptToUser(rssAcceptId, user.id);
+    } finally {
+      await this.redisService.del(redisKey);
+    }
+  }
+
+  private async linkRssAcceptToUser(rssAcceptId: number, userId: number) {
+    const result = await this.rssAcceptRepository.update(
+      { id: rssAcceptId, userId: IsNull() },
+      { userId },
+    );
+
+    if (result.affected === 0) {
+      throw new ConflictException(
+        '이미 인증되었거나 인증할 수 없는 RSS입니다.',
+      );
+    }
+  }
+
+  async deleteRssCertification(user: Payload, rssAcceptId: number) {
+    const rssAccept = await this.rssAcceptRepository.findOne({
+      where: { id: rssAcceptId },
+    });
+
+    if (!rssAccept) {
+      throw new NotFoundException('RSS를 찾을 수 없습니다.');
+    }
+
+    if (rssAccept.userId !== user.id) {
+      throw new ForbiddenException('본인이 인증한 RSS가 아닙니다.');
+    }
+
+    await this.rssAcceptRepository.update({ id: rssAcceptId }, { userId: null });
   }
 }

--- a/server/src/user/api-docs/getUserRss.api-docs.ts
+++ b/server/src/user/api-docs/getUserRss.api-docs.ts
@@ -1,0 +1,27 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+} from '@common/swagger/swagger.helper';
+
+import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
+
+export function ApiGetUserRss() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '특정 사용자 소유 RSS 조회 API',
+      description:
+        '특정 사용자가 소유 인증한 RSS 목록을 조회합니다. 이메일 등 민감 정보는 응답에서 제외됩니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      type: Number,
+      description: '소유 RSS를 조회할 사용자 ID',
+      example: 1,
+    }),
+    ApiDataResponse(GetUserRssResponseDto, true),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -25,6 +25,7 @@ import { ApiCheckEmailDuplication } from '@user/api-docs/checkEmailDuplication.a
 import { ApiConfirmDeleteAccount } from '@user/api-docs/confirmDeleteAccount.api-docs';
 import { ApiForgotPassword } from '@user/api-docs/forgotPassword.api-docs';
 import { ApiGetUserProfileImage } from '@user/api-docs/getUserProfileImage.api-docs';
+import { ApiGetUserRss } from '@user/api-docs/getUserRss.api-docs';
 import { ApiLoginUser } from '@user/api-docs/loginUser.api-docs';
 import { ApiLogoutUser } from '@user/api-docs/logoutUser.api-docs';
 import { ApiRefreshToken } from '@user/api-docs/refreshToken.api-docs';
@@ -39,6 +40,7 @@ import { ForgotPasswordRequestDto } from '@user/dto/request/forgotPassword.dto';
 import { GetUserProfileImageParamRequestDto } from '@user/dto/request/getUserProfileImageParam.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
+import { RequestDeleteAccountRequestDto } from '@user/dto/request/requestDeleteAccount.dto';
 import { ResetPasswordRequestDto } from '@user/dto/request/resetPassword.dto';
 import { ResetPasswordParamRequestDto } from '@user/dto/request/resetPasswordParam.dto';
 import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
@@ -73,6 +75,16 @@ export class UserController {
     return ApiResponse.responseWithData(
       '프로필 이미지 조회가 성공적으로 처리되었습니다.',
       await this.userService.getUserProfileImage(paramDto.id),
+    );
+  }
+
+  @ApiGetUserRss()
+  @Get('/:id/rss')
+  @HttpCode(HttpStatus.OK)
+  async getUserRss(@Param() paramDto: GetUserProfileImageParamRequestDto) {
+    return ApiResponse.responseWithData(
+      '사용자 소유 RSS 조회가 성공적으로 처리되었습니다.',
+      await this.userService.getUserRss(paramDto.id),
     );
   }
 
@@ -150,8 +162,14 @@ export class UserController {
   @Post('/deletion-requests')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtGuard)
-  async requestDeleteAccount(@CurrentUser() user: Payload) {
-    await this.userService.requestDeleteAccount(user.id);
+  async requestDeleteAccount(
+    @CurrentUser() user: Payload,
+    @Body() requestDeleteAccountDto: RequestDeleteAccountRequestDto,
+  ) {
+    await this.userService.requestDeleteAccount(
+      user.id,
+      requestDeleteAccountDto.deleteRss,
+    );
     return ApiResponse.responseWithNoContent(
       '회원탈퇴 신청이 성공적으로 처리되었습니다. 이메일을 확인해주세요.',
     );

--- a/server/src/user/dto/request/requestDeleteAccount.dto.ts
+++ b/server/src/user/dto/request/requestDeleteAccount.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class RequestDeleteAccountRequestDto {
+  @ApiProperty({
+    example: true,
+    description:
+      '회원 탈퇴 시 소유한 RSS도 함께 삭제할지 여부입니다. 생략하거나 true이면 소유 RSS(및 연관 피드)가 함께 삭제되고, false이면 RSS는 유지하고 소유 연결만 해제합니다.',
+    required: false,
+    default: true,
+  })
+  @IsOptional()
+  @IsBoolean({
+    message: 'deleteRss는 boolean으로 입력해주세요.',
+  })
+  deleteRss?: boolean = true;
+
+  constructor(partial: Partial<RequestDeleteAccountRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/response/getUserRss.dto.ts
+++ b/server/src/user/dto/response/getUserRss.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+
+export class GetUserRssResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: 'RSS(rss_accept) ID',
+  })
+  id: number;
+
+  @ApiProperty({
+    example: 'seok3765.log',
+    description: 'RSS 블로그 이름',
+  })
+  name: string;
+
+  @ApiProperty({
+    example: '조민석',
+    description: 'RSS 블로그에 등록된 신청자 이름',
+  })
+  userName: string;
+
+  @ApiProperty({
+    example: 'https://v2.velog.io/rss/@seok3765',
+    description: 'RSS URL',
+  })
+  rssUrl: string;
+
+  @ApiProperty({
+    example: 'velog',
+    description: 'RSS 블로그 플랫폼 종류',
+  })
+  blogPlatform: string;
+
+  constructor(partial: Partial<GetUserRssResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(rssAccept: RssAccept) {
+    return new GetUserRssResponseDto({
+      id: rssAccept.id,
+      name: rssAccept.name,
+      userName: rssAccept.userName,
+      rssUrl: rssAccept.rssUrl,
+      blogPlatform: rssAccept.blogPlatform,
+    });
+  }
+
+  static toResponseDtoArray(rssAcceptList: RssAccept[]) {
+    return rssAcceptList.map((rssAccept) => this.toResponseDto(rssAccept));
+  }
+}

--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -4,6 +4,8 @@ import { JwtAuthModule } from '@common/auth/jwt.module';
 
 import { FileModule } from '@file/module/file.module';
 
+import { RssModule } from '@rss/module/rss.module';
+
 import { OAuthController } from '@user/controller/oAuth.controller';
 import { UserController } from '@user/controller/user.controller';
 import { GithubOAuthProvider } from '@user/provider/github.provider';
@@ -15,7 +17,7 @@ import { OAuthService } from '@user/service/oAuth.service';
 import { UserService } from '@user/service/user.service';
 
 @Module({
-  imports: [JwtAuthModule, FileModule],
+  imports: [JwtAuthModule, FileModule, RssModule],
   controllers: [UserController, OAuthController],
   providers: [
     UserService,

--- a/server/src/user/service/oAuth.service.ts
+++ b/server/src/user/service/oAuth.service.ts
@@ -9,13 +9,15 @@ import {
 
 import * as uuid from 'uuid';
 import { Request, Response } from 'express';
-import { DataSource } from 'typeorm';
+import { DataSource, IsNull } from 'typeorm';
 
 import { cookieConfig } from '@common/cookie/cookie.config';
 import { Payload } from '@common/guard/jwt.guard';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
+
+import { RssAccept } from '@rss/entity/rss.entity';
 
 import {
   OAUTH_CSRF_TOKEN_TTL,
@@ -223,6 +225,12 @@ export class OAuthService {
           user,
         });
 
+        await entityManager.update(
+          RssAccept,
+          { email, userId: IsNull() },
+          { userId: user.id },
+        );
+
         this.logger.log(`새로운 OAuth 사용자 가입 완료: ${email}`);
 
         return user;
@@ -305,6 +313,11 @@ export class OAuthService {
             profileImage,
             provider: providerType,
           });
+          await entityManager.update(
+            RssAccept,
+            { email, userId: IsNull() },
+            { userId: user.id },
+          );
           this.logger.log(`새로운 사용자 가입 완료: ${email}`);
         }
 

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -10,6 +10,7 @@ import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import * as uuid from 'uuid';
 import { Response } from 'express';
+import { DataSource, IsNull } from 'typeorm';
 
 import { cookieConfig } from '@common/cookie/cookie.config';
 import { EmailProducer } from '@common/email/email.producer';
@@ -19,6 +20,9 @@ import { RedisService } from '@common/redis/redis.service';
 
 import { FileService } from '@file/service/file.service';
 
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
 import { REFRESH_TOKEN_TTL, SALT_ROUNDS } from '@user/constant/user.constants';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
@@ -26,6 +30,8 @@ import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
 import { GetUserProfileImageResponseDto } from '@user/dto/response/getUserProfileImage.dto';
+import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
+import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
 @Injectable()
@@ -37,6 +43,8 @@ export class UserService {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly fileService: FileService,
+    private readonly rssAcceptRepository: RssAcceptRepository,
+    private readonly dataSource: DataSource,
   ) {}
 
   async getUser(userId: number) {
@@ -106,13 +114,25 @@ export class UserService {
     await this.redisService.del(`${REDIS_KEYS.USER_AUTH_KEY}:${uuid}`);
 
     try {
-      await this.userRepository.save(JSON.parse(user));
+      const newUser = await this.userRepository.save(JSON.parse(user) as User);
+      await this.rssAcceptRepository.update(
+        { email: newUser.email, userId: IsNull() },
+        { userId: newUser.id },
+      );
     } catch (error) {
       if ((error as { code?: string })?.code === 'ER_DUP_ENTRY') {
         throw new ConflictException('이미 존재하는 이메일 또는 닉네임입니다.');
       }
       throw error;
     }
+  }
+
+  async getUserRss(userId: number) {
+    const rssList = await this.rssAcceptRepository.find({
+      where: { userId },
+      order: { id: 'DESC' },
+    });
+    return GetUserRssResponseDto.toResponseDtoArray(rssList);
   }
 
   async loginUser(loginDto: LoginUserRequestDto, response: Response) {
@@ -280,14 +300,14 @@ export class UserService {
     );
   }
 
-  async requestDeleteAccount(userId: number): Promise<void> {
+  async requestDeleteAccount(userId: number, deleteRss = true): Promise<void> {
     const user = await this.getUser(userId);
 
     const userDeleteCode = uuid.v4();
 
     await this.redisService.set(
       `${REDIS_KEYS.USER_DELETE_ACCOUNT_KEY}:${userDeleteCode}`,
-      user.id.toString(),
+      JSON.stringify({ userId: user.id, deleteRss }),
       'EX',
       600,
     );
@@ -303,16 +323,28 @@ export class UserService {
       throw new NotFoundException('유효하지 않거나 만료된 토큰입니다.');
     }
 
-    const userId = parseInt(data, 10);
+    const { userId, deleteRss } = JSON.parse(data) as {
+      userId: number;
+      deleteRss: boolean;
+    };
     const user = await this.getUser(userId);
 
     if (user.profileImage) {
       await this.fileService.deleteByPath(user.profileImage);
     }
 
+    // RSS 삭제(true)와 user 삭제는 반드시 순차 실행해야 한다.
+    // user를 먼저 지우면 FK ON DELETE SET NULL이 rss_accept.user_id를 NULL로 만들어
+    // 이후 user_id 기준 RSS 삭제가 0건이 된다. deleteRss=false면 SET NULL로 연결만 끊긴다.
+    await this.dataSource.transaction(async (manager) => {
+      if (deleteRss) {
+        await manager.delete(RssAccept, { userId });
+      }
+      await manager.remove(user);
+    });
+
     await Promise.all([
       this.invalidateUserTokens(userId),
-      this.userRepository.remove(user),
       this.redisService.del(deleteRequestKey),
     ]);
   }

--- a/server/test/oauth/e2e/registration.e2e-spec.ts
+++ b/server/test/oauth/e2e/registration.e2e-spec.ts
@@ -6,6 +6,8 @@ import TestAgent from 'supertest/lib/agent';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
 import {
   OAUTH_PENDING_TTL,
   OAuthType,
@@ -13,6 +15,7 @@ import {
 import { ProviderRepository } from '@user/repository/provider.repository';
 import { UserRepository } from '@user/repository/user.repository';
 
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
@@ -23,6 +26,7 @@ describe(`POST ${URL} E2E Test`, () => {
   let redisService: RedisService;
   let userRepository: UserRepository;
   let providerRepository: ProviderRepository;
+  let rssAcceptRepository: RssAcceptRepository;
 
   const pendingToken = 'oauth-pending-token';
 
@@ -46,6 +50,7 @@ describe(`POST ${URL} E2E Test`, () => {
     redisService = testApp.get(RedisService);
     userRepository = testApp.get(UserRepository);
     providerRepository = testApp.get(ProviderRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
   });
 
   it('[201] 닉네임 입력 시 사용자/Provider를 생성하고 refresh 쿠키를 설정한다.', async () => {
@@ -99,6 +104,31 @@ describe(`POST ${URL} E2E Test`, () => {
 
     // Http then
     expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+
+  it('[201] OAuth 가입 시 동일 이메일의 미연결 RSS에 user_id를 연결한다.', async () => {
+    // given
+    const email = 'oauth-blogger@test.com';
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ email }),
+    );
+    await stagePending(email);
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `oauth_pending_token=${pendingToken}`)
+      .send({ userName: 'oauth-blogger-nickname' });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB then
+    const [savedUser, savedRssAccept] = await Promise.all([
+      userRepository.findOne({ where: { email } }),
+      rssAcceptRepository.findOneBy({ id: rssAccept.id }),
+    ]);
+    expect(savedRssAccept.userId).toBe(savedUser.id);
   });
 
   it('[404] pending 쿠키가 없을 경우 회원가입을 실패한다.', async () => {

--- a/server/test/oauth/unit/oauth.service.unit.spec.ts
+++ b/server/test/oauth/unit/oauth.service.unit.spec.ts
@@ -32,7 +32,7 @@ describe(`${OAuthService.name} Unit Test`, () => {
     getTokens: jest.Mock;
     getUserInfo: jest.Mock;
   };
-  let manager: { save: jest.Mock };
+  let manager: { save: jest.Mock; update: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
 
   const createResponse = () =>
@@ -67,6 +67,7 @@ describe(`${OAuthService.name} Unit Test`, () => {
       save: jest.fn((_entity: any, data: any) =>
         Promise.resolve({ id: 1, ...data }),
       ),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
     };
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),

--- a/server/test/rss/e2e/certification/create.e2e-spec.ts
+++ b/server/test/rss/e2e/certification/create.e2e-spec.ts
@@ -1,0 +1,135 @@
+import { HttpStatus } from '@nestjs/common';
+
+import * as uuid from 'uuid';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/rss/certifications';
+
+describe(`POST ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let redisService: RedisService;
+  let user: User;
+  let accessToken: string;
+  const certificationCode = 'rss-certification-code';
+  const redisKeyMake = (code: string) =>
+    `${REDIS_KEYS.RSS_CERTIFICATION_KEY}:${code}`;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+    redisService = testApp.get(RedisService);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+    accessToken = createAccessToken(user);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('[401] 로그인하지 않은 유저는 RSS 소유 인증을 요청할 수 없다.', async () => {
+    const response = await agent.post(URL).send({ blogName: 'any' });
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[404] 일치하는 블로그 이름의 RSS가 없으면 인증을 실패한다.', async () => {
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ blogName: '존재하지않는블로그' });
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[200] RSS 이메일과 사용자 이메일이 같으면 즉시 인증되고 메일을 보내지 않는다.', async () => {
+    // given
+    jest.spyOn(uuid, 'v4').mockReturnValue(certificationCode as any);
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ email: user.email }),
+    );
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ blogName: rssAccept.name });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: CreateRssCertificationResponseDto } = response.body;
+    expect(data.certified).toBe(true);
+
+    // DB, Redis then
+    const [savedRssAccept, savedCode] = await Promise.all([
+      rssAcceptRepository.findOneBy({ id: rssAccept.id }),
+      redisService.get(redisKeyMake(certificationCode)),
+    ]);
+    expect(savedRssAccept.userId).toBe(user.id);
+    expect(savedCode).toBeNull();
+  });
+
+  it('[200] RSS 이메일과 사용자 이메일이 다르면 인증 코드를 저장하고 즉시 연결하지 않는다.', async () => {
+    // given
+    jest.spyOn(uuid, 'v4').mockReturnValue(certificationCode as any);
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ email: 'other@test.com' }),
+    );
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ blogName: rssAccept.name });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: CreateRssCertificationResponseDto } = response.body;
+    expect(data.certified).toBe(false);
+
+    // DB, Redis then
+    const [savedRssAccept, savedCode] = await Promise.all([
+      rssAcceptRepository.findOneBy({ id: rssAccept.id }),
+      redisService.get(redisKeyMake(certificationCode)),
+    ]);
+    expect(savedRssAccept.userId).toBeNull();
+    expect(savedCode).not.toBeNull();
+  });
+
+  it('[409] 다른 사용자가 이미 인증한 RSS면 인증을 실패한다.', async () => {
+    // given
+    const other = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const rssAccept: RssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: other.id }),
+    );
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ blogName: rssAccept.name });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+});

--- a/server/test/rss/e2e/certification/delete.e2e-spec.ts
+++ b/server/test/rss/e2e/certification/delete.e2e-spec.ts
@@ -1,0 +1,76 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const makeURL = (id: number | string) => `/api/rss/certifications/${id}`;
+
+describe(`DELETE /api/rss/certifications/:id E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let user: User;
+  let rssAccept: RssAccept;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+    accessToken = createAccessToken(user);
+  });
+
+  it('[401] 로그인하지 않은 유저는 인증을 해제할 수 없다.', async () => {
+    const response = await agent.delete(makeURL(rssAccept.id));
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[403] 본인이 인증한 RSS가 아니면 해제를 실패한다.', async () => {
+    // given - 다른 사용자가 인증한 RSS
+    const other = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const othersRss = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: other.id }),
+    );
+
+    // Http when
+    const response = await agent
+      .delete(makeURL(othersRss.id))
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+    const saved = await rssAcceptRepository.findOneBy({ id: othersRss.id });
+    expect(saved.userId).toBe(other.id);
+  });
+
+  it('[200] 본인이 인증한 RSS면 연결을 해제(user_id NULL)한다.', async () => {
+    // Http when
+    const response = await agent
+      .delete(makeURL(rssAccept.id))
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const saved = await rssAcceptRepository.findOneBy({ id: rssAccept.id });
+    expect(saved.userId).toBeNull();
+  });
+});

--- a/server/test/rss/e2e/certification/verify.e2e-spec.ts
+++ b/server/test/rss/e2e/certification/verify.e2e-spec.ts
@@ -1,0 +1,101 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/rss/certifications/verify';
+
+describe(`POST ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let redisService: RedisService;
+  let user: User;
+  let rssAccept: RssAccept;
+  let accessToken: string;
+  const code = 'rss-certification-verify-code';
+  const redisKeyMake = (code: string) =>
+    `${REDIS_KEYS.RSS_CERTIFICATION_KEY}:${code}`;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+    redisService = testApp.get(RedisService);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    accessToken = createAccessToken(user);
+  });
+
+  it('[404] 인증 코드가 만료되었거나 없으면 검증을 실패한다.', async () => {
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ code: 'wrong-code' });
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[403] 본인의 인증 요청이 아니면 검증을 실패한다.', async () => {
+    // given - 다른 유저의 인증 요청
+    await redisService.set(
+      redisKeyMake(code),
+      JSON.stringify({ rssAcceptId: rssAccept.id, userId: user.id + 999 }),
+    );
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ code });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+    const savedRssAccept = await rssAcceptRepository.findOneBy({
+      id: rssAccept.id,
+    });
+    expect(savedRssAccept.userId).toBeNull();
+  });
+
+  it('[200] 본인의 인증 코드면 RSS를 연결하고 인증 코드를 정리한다.', async () => {
+    // given
+    await redisService.set(
+      redisKeyMake(code),
+      JSON.stringify({ rssAcceptId: rssAccept.id, userId: user.id }),
+    );
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ code });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const [savedRssAccept, savedCode] = await Promise.all([
+      rssAcceptRepository.findOneBy({ id: rssAccept.id }),
+      redisService.get(redisKeyMake(code)),
+    ]);
+    expect(savedRssAccept.userId).toBe(user.id);
+    expect(savedCode).toBeNull();
+  });
+});

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -8,13 +8,13 @@ import {
 import axios from 'axios';
 import { DataSource } from 'typeorm';
 
+import { AdminRepository } from '@admin/repository/admin.repository';
+
 import { EmailProducer } from '@common/email/email.producer';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { NotifierRegistry } from '@common/notification/notifier-registry';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
-
-import { AdminRepository } from '@admin/repository/admin.repository';
 
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
@@ -50,7 +50,9 @@ describe(`${RssService.name} Unit Test`, () => {
   >;
   let manager: { save: jest.Mock; remove: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
-  let redisService: jest.Mocked<Pick<RedisService, 'rpush' | 'set' | 'get' | 'del'>>;
+  let redisService: jest.Mocked<
+    Pick<RedisService, 'rpush' | 'set' | 'get' | 'del'>
+  >;
   let adminRepository: jest.Mocked<Pick<AdminRepository, 'find'>>;
   let notifierRegistry: jest.Mocked<Pick<NotifierRegistry, 'sendAlert'>>;
   let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
@@ -80,7 +82,12 @@ describe(`${RssService.name} Unit Test`, () => {
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
     } as any;
-    redisService = { rpush: jest.fn(), set: jest.fn(), get: jest.fn(), del: jest.fn() };
+    redisService = {
+      rpush: jest.fn(),
+      set: jest.fn(),
+      get: jest.fn(),
+      del: jest.fn(),
+    };
     adminRepository = { find: jest.fn().mockResolvedValue([]) };
     notifierRegistry = { sendAlert: jest.fn() };
     logger = { error: jest.fn() };
@@ -114,7 +121,9 @@ describe(`${RssService.name} Unit Test`, () => {
       rssAcceptRepository.findOne.mockResolvedValue(null);
 
       // when & then
-      await expect(rssService.createRss(dto)).rejects.toThrow(ConflictException);
+      await expect(rssService.createRss(dto)).rejects.toThrow(
+        ConflictException,
+      );
       expect(rssRepository.insert).not.toHaveBeenCalled();
     });
 
@@ -147,7 +156,9 @@ describe(`${RssService.name} Unit Test`, () => {
         where: { emailNotification: true },
         select: ['email'],
       });
-      expect(emailProducer.produceRssRegistrationRequest).toHaveBeenCalledTimes(2);
+      expect(emailProducer.produceRssRegistrationRequest).toHaveBeenCalledTimes(
+        2,
+      );
       expect(emailProducer.produceRssRegistrationRequest).toHaveBeenCalledWith(
         dto.toEntity(),
         'a@denamu.dev',
@@ -470,9 +481,10 @@ describe(`${RssService.name} Unit Test`, () => {
       );
       expect(emailProducer.produceRssCertification).toHaveBeenCalledWith(
         'tester',
-        'other@test.com',
         'blog',
         expect.any(String),
+        'other@test.com',
+        user.email,
       );
       expect(rssAcceptRepository.update).not.toHaveBeenCalled();
       expect(result.certified).toBe(false);
@@ -547,9 +559,9 @@ describe(`${RssService.name} Unit Test`, () => {
     it('RSS가 없으면 NotFoundException을 던진다.', async () => {
       rssAcceptRepository.findOne.mockResolvedValue(null);
 
-      await expect(
-        rssService.deleteRssCertification(user, 1),
-      ).rejects.toThrow(NotFoundException);
+      await expect(rssService.deleteRssCertification(user, 1)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('본인이 인증한 RSS가 아니면 ForbiddenException을 던진다.', async () => {
@@ -558,9 +570,9 @@ describe(`${RssService.name} Unit Test`, () => {
         userId: 99,
       } as any);
 
-      await expect(
-        rssService.deleteRssCertification(user, 1),
-      ).rejects.toThrow(ForbiddenException);
+      await expect(rssService.deleteRssCertification(user, 1)).rejects.toThrow(
+        ForbiddenException,
+      );
       expect(rssAcceptRepository.update).not.toHaveBeenCalled();
     });
 

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
 
@@ -35,7 +36,7 @@ describe(`${RssService.name} Unit Test`, () => {
     Pick<RssRepository, 'findOne' | 'find' | 'insert' | 'delete'>
   >;
   let rssAcceptRepository: jest.Mocked<
-    Pick<RssAcceptRepository, 'findOne' | 'find' | 'delete'>
+    Pick<RssAcceptRepository, 'findOne' | 'find' | 'delete' | 'update'>
   >;
   let rssRejectRepository: jest.Mocked<Pick<RssRejectRepository, 'find'>>;
   let emailProducer: jest.Mocked<
@@ -44,6 +45,7 @@ describe(`${RssService.name} Unit Test`, () => {
       | 'produceRssRegistration'
       | 'produceRssRegistrationRequest'
       | 'produceRssRemoval'
+      | 'produceRssCertification'
     >
   >;
   let manager: { save: jest.Mock; remove: jest.Mock; delete: jest.Mock };
@@ -61,12 +63,18 @@ describe(`${RssService.name} Unit Test`, () => {
       insert: jest.fn(),
       delete: jest.fn(),
     };
-    rssAcceptRepository = { findOne: jest.fn(), find: jest.fn(), delete: jest.fn() };
+    rssAcceptRepository = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      delete: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
     rssRejectRepository = { find: jest.fn() };
     emailProducer = {
       produceRssRegistration: jest.fn(),
       produceRssRegistrationRequest: jest.fn(),
       produceRssRemoval: jest.fn(),
+      produceRssCertification: jest.fn(),
     };
     manager = { save: jest.fn(), remove: jest.fn(), delete: jest.fn() };
     dataSource = {
@@ -380,6 +388,194 @@ describe(`${RssService.name} Unit Test`, () => {
 
       // then
       expect(redisService.del).toHaveBeenCalledWith(redisKey);
+    });
+  });
+
+  describe('createRssCertification', () => {
+    const user = {
+      id: 10,
+      email: 'me@test.com',
+      userName: 'me',
+      role: 'user',
+    };
+
+    it('이름과 일치하는 RSS가 없으면 NotFoundException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        rssService.createRssCertification(user, 'blog'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('이미 본인이 인증한 RSS면 ConflictException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 10,
+      } as any);
+
+      await expect(
+        rssService.createRssCertification(user, 'blog'),
+      ).rejects.toThrow(ConflictException);
+      expect(rssAcceptRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('다른 사용자가 인증한 RSS면 ConflictException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 99,
+      } as any);
+
+      await expect(
+        rssService.createRssCertification(user, 'blog'),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('RSS 이메일과 사용자 이메일이 같으면 즉시 연결하고 메일을 보내지 않는다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: null,
+        email: 'me@test.com',
+        userName: 'tester',
+        blogPlatform: 'velog',
+      } as any);
+
+      const result = await rssService.createRssCertification(user, 'blog');
+
+      expect(rssAcceptRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1 }),
+        { userId: 10 },
+      );
+      expect(emailProducer.produceRssCertification).not.toHaveBeenCalled();
+      expect(redisService.set).not.toHaveBeenCalled();
+      expect(result.certified).toBe(true);
+    });
+
+    it('이메일이 다르면 인증 코드를 저장하고 인증 메일을 발송한다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: null,
+        email: 'other@test.com',
+        name: 'blog',
+        userName: 'tester',
+        blogPlatform: 'velog',
+      } as any);
+
+      const result = await rssService.createRssCertification(user, 'blog');
+
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.RSS_CERTIFICATION_KEY),
+        expect.any(String),
+        'EX',
+        300,
+      );
+      expect(emailProducer.produceRssCertification).toHaveBeenCalledWith(
+        'tester',
+        'other@test.com',
+        'blog',
+        expect.any(String),
+      );
+      expect(rssAcceptRepository.update).not.toHaveBeenCalled();
+      expect(result.certified).toBe(false);
+    });
+  });
+
+  describe('verifyRssCertification', () => {
+    const user = {
+      id: 10,
+      email: 'me@test.com',
+      userName: 'me',
+      role: 'user',
+    };
+    const code = 'cert-code';
+    const redisKey = `${REDIS_KEYS.RSS_CERTIFICATION_KEY}:${code}`;
+
+    it('인증 코드가 만료되었으면 NotFoundException을 던진다.', async () => {
+      redisService.get.mockResolvedValue(null);
+
+      await expect(
+        rssService.verifyRssCertification(user, code),
+      ).rejects.toThrow(NotFoundException);
+      expect(redisService.del).not.toHaveBeenCalled();
+    });
+
+    it('본인의 인증 요청이 아니면 ForbiddenException을 던진다.', async () => {
+      redisService.get.mockResolvedValue(
+        JSON.stringify({ rssAcceptId: 1, userId: 99 }),
+      );
+
+      await expect(
+        rssService.verifyRssCertification(user, code),
+      ).rejects.toThrow(ForbiddenException);
+      expect(rssAcceptRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('정상 검증 시 RSS를 연결하고 인증 코드를 정리한다.', async () => {
+      redisService.get.mockResolvedValue(
+        JSON.stringify({ rssAcceptId: 1, userId: 10 }),
+      );
+
+      await rssService.verifyRssCertification(user, code);
+
+      expect(rssAcceptRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 1 }),
+        { userId: 10 },
+      );
+      expect(redisService.del).toHaveBeenCalledWith(redisKey);
+    });
+
+    it('이미 인증된 RSS면 ConflictException을 던지고 인증 코드는 정리한다.', async () => {
+      redisService.get.mockResolvedValue(
+        JSON.stringify({ rssAcceptId: 1, userId: 10 }),
+      );
+      rssAcceptRepository.update.mockResolvedValue({ affected: 0 } as any);
+
+      await expect(
+        rssService.verifyRssCertification(user, code),
+      ).rejects.toThrow(ConflictException);
+      expect(redisService.del).toHaveBeenCalledWith(redisKey);
+    });
+  });
+
+  describe('deleteRssCertification', () => {
+    const user = {
+      id: 10,
+      email: 'me@test.com',
+      userName: 'me',
+      role: 'user',
+    };
+
+    it('RSS가 없으면 NotFoundException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        rssService.deleteRssCertification(user, 1),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('본인이 인증한 RSS가 아니면 ForbiddenException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 99,
+      } as any);
+
+      await expect(
+        rssService.deleteRssCertification(user, 1),
+      ).rejects.toThrow(ForbiddenException);
+      expect(rssAcceptRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('본인이 인증한 RSS면 연결을 해제한다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 1,
+        userId: 10,
+      } as any);
+
+      await rssService.deleteRssCertification(user, 1);
+
+      expect(rssAcceptRepository.update).toHaveBeenCalledWith(
+        { id: 1 },
+        { userId: null },
+      );
     });
   });
 

--- a/server/test/user/e2e/delete-account/confirm.e2e-spec.ts
+++ b/server/test/user/e2e/delete-account/confirm.e2e-spec.ts
@@ -74,7 +74,10 @@ describe(`DELETE /api/users/deletion-requests/:token E2E Test`, () => {
       commentRepository.insert(CommentFixture.createCommentFixture(feed, user)),
       likeRepository.insert({ feed, user }),
       fileRepository.insert(FileFixture.createFileFixture(user)),
-      redisService.set(redisKeyMake(userDeleteCode), user.id),
+      redisService.set(
+        redisKeyMake(userDeleteCode),
+        JSON.stringify({ userId: user.id, deleteRss: true }),
+      ),
     ]);
   });
 
@@ -107,7 +110,10 @@ describe(`DELETE /api/users/deletion-requests/:token E2E Test`, () => {
       await UserFixture.createUserCryptFixture(),
     );
 
-    await redisService.set(redisKeyMake(userDeleteCode), user.id.toString());
+    await redisService.set(
+      redisKeyMake(userDeleteCode),
+      JSON.stringify({ userId: user.id, deleteRss: true }),
+    );
 
     // Http when
     const response = await agent.delete(makeURL(userDeleteCode));
@@ -144,5 +150,76 @@ describe(`DELETE /api/users/deletion-requests/:token E2E Test`, () => {
     expect(savedActivities.length).toBe(0);
     expect(savedFiles.length).toBe(0);
     expect(Number(invalidatedUser)).toBeGreaterThan(0);
+  });
+
+  it('[200] deleteRss=true면 소유 RSS와 연관 데이터까지 함께 삭제한다.', async () => {
+    // given - 소유자가 연결된 RSS
+    const owner = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const ownedRssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: owner.id }),
+    );
+    const ownedFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(ownedRssAccept),
+    );
+    await redisService.set(
+      redisKeyMake(userDeleteCode),
+      JSON.stringify({ userId: owner.id, deleteRss: true }),
+    );
+
+    // Http when
+    const response = await agent.delete(makeURL(userDeleteCode));
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB when
+    const [savedUser, savedRssAccept, savedFeed] = await Promise.all([
+      userRepository.findOneBy({ id: owner.id }),
+      rssAcceptRepository.findOneBy({ id: ownedRssAccept.id }),
+      feedRepository.findOneBy({ id: ownedFeed.id }),
+    ]);
+
+    // DB then
+    expect(savedUser).toBeNull();
+    expect(savedRssAccept).toBeNull();
+    expect(savedFeed).toBeNull();
+  });
+
+  it('[200] deleteRss=false면 소유 RSS는 유지하고 연결만 해제(user_id NULL)한다.', async () => {
+    // given - 소유자가 연결된 RSS
+    const owner = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const ownedRssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: owner.id }),
+    );
+    const ownedFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(ownedRssAccept),
+    );
+    await redisService.set(
+      redisKeyMake(userDeleteCode),
+      JSON.stringify({ userId: owner.id, deleteRss: false }),
+    );
+
+    // Http when
+    const response = await agent.delete(makeURL(userDeleteCode));
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB when
+    const [savedUser, savedRssAccept, savedFeed] = await Promise.all([
+      userRepository.findOneBy({ id: owner.id }),
+      rssAcceptRepository.findOneBy({ id: ownedRssAccept.id }),
+      feedRepository.findOneBy({ id: ownedFeed.id }),
+    ]);
+
+    // DB then
+    expect(savedUser).toBeNull();
+    expect(savedRssAccept).not.toBeNull();
+    expect(savedRssAccept.userId).toBeNull();
+    expect(savedFeed).not.toBeNull();
   });
 });

--- a/server/test/user/e2e/delete-account/request.e2e-spec.ts
+++ b/server/test/user/e2e/delete-account/request.e2e-spec.ts
@@ -75,6 +75,31 @@ describe(`POST ${URL} E2E Test`, () => {
     );
 
     // DB, Redis then
-    expect(savedDeleteCode).toBe(user.id.toString());
+    expect(savedDeleteCode).toBe(
+      JSON.stringify({ userId: user.id, deleteRss: true }),
+    );
+  });
+
+  it('[200] deleteRss=false로 신청할 경우 해당 값이 저장된다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ deleteRss: false });
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedDeleteCode = await redisService.get(
+      redisKeyMake(userDeleteCode),
+    );
+
+    // DB, Redis then
+    expect(savedDeleteCode).toBe(
+      JSON.stringify({ userId: user.id, deleteRss: false }),
+    );
   });
 });

--- a/server/test/user/e2e/get-rss.e2e-spec.ts
+++ b/server/test/user/e2e/get-rss.e2e-spec.ts
@@ -1,0 +1,67 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const makeURL = (id: number | string) => `/api/users/${id}/rss`;
+
+describe(`GET /api/users/:id/rss E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let user: User;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+  });
+
+  it('[200] 소유 RSS가 없으면 빈 배열을 반환한다.', async () => {
+    const response = await agent.get(makeURL(user.id));
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data } = response.body;
+    expect(data).toEqual([]);
+  });
+
+  it('[200] 소유한 RSS 목록을 반환하며 email 등 민감 정보는 제외한다.', async () => {
+    // given
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+    // 다른 유저 소유 RSS는 포함되면 안 된다.
+    const other = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: other.id }),
+    );
+
+    // Http when
+    const response = await agent.get(makeURL(user.id));
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetUserRssResponseDto[] } = response.body;
+    expect(data).toHaveLength(1);
+    const [item] = data;
+    expect(item.id).toBe(rssAccept.id);
+    expect(item.name).toBe(rssAccept.name);
+    expect(item.blogPlatform).toBe(rssAccept.blogPlatform);
+    expect(item).not.toHaveProperty('email');
+  });
+});

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -7,6 +7,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 
 import { Response } from 'express';
+import { DataSource } from 'typeorm';
 
 import { EmailProducer } from '@common/email/email.producer';
 import { Payload } from '@common/guard/jwt.guard';
@@ -15,10 +16,14 @@ import { RedisService } from '@common/redis/redis.service';
 
 import { FileService } from '@file/service/file.service';
 
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
 import { GetUserProfileImageResponseDto } from '@user/dto/response/getUserProfileImage.dto';
+import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 import { UserService } from '@user/service/user.service';
@@ -47,6 +52,11 @@ describe(`${UserService.name} Unit Test`, () => {
   let jwtService: jest.Mocked<Pick<JwtService, 'sign'>>;
   let configService: jest.Mocked<Pick<ConfigService, 'get'>>;
   let fileService: jest.Mocked<Pick<FileService, 'deleteByPath'>>;
+  let rssAcceptRepository: jest.Mocked<
+    Pick<RssAcceptRepository, 'find' | 'update'>
+  >;
+  let manager: { remove: jest.Mock; delete: jest.Mock };
+  let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
 
   const createResponse = () => ({ cookie: jest.fn() }) as unknown as Response;
 
@@ -80,6 +90,11 @@ describe(`${UserService.name} Unit Test`, () => {
     jwtService = { sign: jest.fn().mockReturnValue('signed-token') };
     configService = { get: jest.fn().mockReturnValue('14d') };
     fileService = { deleteByPath: jest.fn() };
+    rssAcceptRepository = { find: jest.fn(), update: jest.fn() };
+    manager = { remove: jest.fn(), delete: jest.fn() };
+    dataSource = {
+      transaction: jest.fn((cb: any) => cb(manager)),
+    } as any;
 
     userService = new UserService(
       userRepository as unknown as UserRepository,
@@ -88,6 +103,8 @@ describe(`${UserService.name} Unit Test`, () => {
       jwtService as unknown as JwtService,
       configService as unknown as ConfigService,
       fileService as unknown as FileService,
+      rssAcceptRepository as unknown as RssAcceptRepository,
+      dataSource as unknown as DataSource,
     );
   });
 
@@ -293,6 +310,10 @@ describe(`${UserService.name} Unit Test`, () => {
     it('인증에 성공하면 Redis 키를 지우고 사용자를 저장한다.', async () => {
       // given
       redisService.get.mockResolvedValue(JSON.stringify({ email: 'a@test.com' }));
+      userRepository.save.mockResolvedValue({
+        id: 5,
+        email: 'a@test.com',
+      } as any);
 
       // when
       await userService.certificateUser('uuid');
@@ -300,6 +321,44 @@ describe(`${UserService.name} Unit Test`, () => {
       // then
       expect(redisService.del).toHaveBeenCalled();
       expect(userRepository.save).toHaveBeenCalledWith({ email: 'a@test.com' });
+    });
+
+    it('가입 완료 후 동일 이메일의 미연결 RSS에 user_id를 연결한다.', async () => {
+      // given
+      redisService.get.mockResolvedValue(JSON.stringify({ email: 'a@test.com' }));
+      userRepository.save.mockResolvedValue({
+        id: 5,
+        email: 'a@test.com',
+      } as any);
+
+      // when
+      await userService.certificateUser('uuid');
+
+      // then
+      expect(rssAcceptRepository.update).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 'a@test.com' }),
+        { userId: 5 },
+      );
+    });
+  });
+
+  describe('getUserRss', () => {
+    it('userId로 소유 RSS를 조회하고 응답으로 변환한다.', async () => {
+      // given
+      const rssList = [] as RssAccept[];
+      rssAcceptRepository.find.mockResolvedValue(rssList);
+
+      // when
+      const result = await userService.getUserRss(1);
+
+      // then
+      expect(rssAcceptRepository.find).toHaveBeenCalledWith({
+        where: { userId: 1 },
+        order: { id: 'DESC' },
+      });
+      expect(result).toEqual(
+        GetUserRssResponseDto.toResponseDtoArray(rssList),
+      );
     });
   });
 
@@ -495,13 +554,30 @@ describe(`${UserService.name} Unit Test`, () => {
       // then
       expect(redisService.set).toHaveBeenCalledWith(
         expect.stringContaining(REDIS_KEYS.USER_DELETE_ACCOUNT_KEY),
-        '1',
+        JSON.stringify({ userId: 1, deleteRss: true }),
         'EX',
         600,
       );
       expect(emailProducer.produceAccountDeletion).toHaveBeenCalledWith(
         user,
         expect.any(String),
+      );
+    });
+
+    it('deleteRss=false면 해당 값을 그대로 저장한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ id: 1 });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.requestDeleteAccount(1, false);
+
+      // then
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.USER_DELETE_ACCOUNT_KEY),
+        JSON.stringify({ userId: 1, deleteRss: false }),
+        'EX',
+        600,
       );
     });
   });
@@ -514,13 +590,15 @@ describe(`${UserService.name} Unit Test`, () => {
       );
     });
 
-    it('탈퇴를 확정하면 토큰을 무효화하고 사용자와 프로필을 제거한다.', async () => {
+    it('deleteRss=true면 트랜잭션에서 RSS를 먼저 삭제한 뒤 사용자를 제거한다.', async () => {
       // given
       const user = UserFixture.createUserFixture({
         id: 1,
         profileImage: 'avatar.png',
       });
-      redisService.get.mockResolvedValue('1');
+      redisService.get.mockResolvedValue(
+        JSON.stringify({ userId: 1, deleteRss: true }),
+      );
       userRepository.findOneBy.mockResolvedValue(user);
 
       // when
@@ -528,12 +606,33 @@ describe(`${UserService.name} Unit Test`, () => {
 
       // then
       expect(fileService.deleteByPath).toHaveBeenCalledWith('avatar.png');
+      expect(manager.delete).toHaveBeenCalledWith(RssAccept, { userId: 1 });
+      expect(manager.remove).toHaveBeenCalledWith(user);
+      // RSS 삭제가 user 제거보다 먼저 호출되어야 한다(FK SET NULL 함정 방지).
+      expect(manager.delete.mock.invocationCallOrder[0]).toBeLessThan(
+        manager.remove.mock.invocationCallOrder[0],
+      );
       expect(redisService.setex).toHaveBeenCalledWith(
         `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:1`,
-        14 * 86400, // parseTimeToSeconds('14d')
-        expect.stringMatching(/^\d+$/), // invalidatedAt 타임스탬프(초)
+        14 * 86400,
+        expect.stringMatching(/^\d+$/),
       );
-      expect(userRepository.remove).toHaveBeenCalledWith(user);
+    });
+
+    it('deleteRss=false면 RSS를 삭제하지 않고 사용자만 제거한다(FK SET NULL로 연결만 해제).', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ id: 1, profileImage: null });
+      redisService.get.mockResolvedValue(
+        JSON.stringify({ userId: 1, deleteRss: false }),
+      );
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.confirmDeleteAccount('token');
+
+      // then
+      expect(manager.delete).not.toHaveBeenCalled();
+      expect(manager.remove).toHaveBeenCalledWith(user);
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #734

### RSS 소유 인증 (1차 / 2차)

-   로그인한 사용자가 블로그 이름으로 본인 소유의 RSS를 인증할 수 있도록 구현했습니다.
-   `rss_accept.email`이 인증 요청자의 이메일과 일치하면 별도 메일 검증 없이 즉시 연동(1차 인증)합니다.
-   이메일이 다른 경우 `uuid` 인증 코드를 Redis에 TTL 300초로 저장하고, 등록 시점의 메일로 인증 메일을 발송하여 코드 입력으로 본인 확인(2차 인증)을 수행합니다.
-   2차 인증 시 `userId`가 본인인지 검증하고, 연동은 `userId IS NULL` 조건의 conditional update로 처리하여 동시 인증 race condition을 방지했습니다.

### 계정 삭제 시 RSS 처리

-   회원 탈퇴 신청 시 `deleteRss` 플래그를 받아, 소유 RSS를 함께 삭제할지 연결만 해제할지 선택할 수 있게 했습니다.
-   RSS 삭제(true)와 user 삭제는 반드시 순차 실행해야 합니다. user를 먼저 지우면 FK `ON DELETE SET NULL`이 `rss_accept.user_id`를 NULL로 만들어 이후 `user_id` 기준 삭제가 0건이 되기 때문입니다. 트랜잭션 내에서 RSS → user 순으로 처리했습니다.

### 회원가입 시 RSS 자동 연동

-   일반/OAuth 가입 완료 시 동일 이메일이면서 `userId IS NULL`인 `rss_accept`를 가입한 사용자에게 자동 연동합니다.

# 📋 작업 내용

### 신규 API

| Method | Path | Guard | 설명 |
| --- | --- | --- | --- |
| POST | `/rss/certifications` | JWT | RSS 소유 인증 요청 (1차 즉시 연동 또는 2차 메일 코드 발송) |
| POST | `/rss/certifications/verify` | JWT | 2차 인증 코드 검증 및 연동 |
| DELETE | `/rss/certifications/:id` | JWT | RSS 소유 인증 해제 |
| GET | `/user/:id/rss` | - | 사용자 소유 RSS 조회 |

### 기타

-   `rss_accept` 테이블에 `user_id` 컬럼 추가 (entity / init.sql / migration 3중 동기화)
-   위 신규 API에 대한 Swagger 문서 추가
-   회원 탈퇴 신청 DTO에 `deleteRss` 옵션 추가
-   email-worker에 RSS 인증 메일 발송 워커 및 컨텐츠 추가
-   관련 단위/E2E 테스트 추가

# 📷 스크린 샷(선택 사항)