### PR TITLE
✨ feat: RSS 인증 수정/미리보기 API 및 RSS 관리 탭 구현

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -12,7 +12,7 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/variable/pretendardvariable.css"
     />
-    <link rel="canonical" href="https://denamu.site" />
+    <link rel="canonical" href="https://denamu.dev" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Denamu</title>
     <meta name="description" content="개발자들의 블로그허브 데나무" />
@@ -20,7 +20,7 @@
     <meta property="og:title" content="Denamu" />
     <meta property="og:description" content="개발자들의 블로그 허브 데나무" />
     <meta property="og:image" content="src/assets/logo-denamu-title.svg" />
-    <meta property="og:url" content="https://your-website-url.com" />
+    <meta property="og:url" content="https://denamu.dev" />
     <meta property="og:type" content="website" />
     <script
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js"

--- a/client/src/api/services/admin/auth.ts
+++ b/client/src/api/services/admin/auth.ts
@@ -1,6 +1,7 @@
 import { ADMIN } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
+import { ApiMessage } from "@/types/api";
 import {
   AdminAuthRequest,
   AdminAuthResponse,
@@ -22,16 +23,16 @@ export const auth = {
     const response = await axiosInstance.patch<AdminUpdateResponse>(ADMIN.UPDATE_ME, data);
     return response.data;
   },
-  logout: async (): Promise<{ message: string }> => {
-    const response = await axiosInstance.post<{ message: string }>(ADMIN.LOGOUT);
+  logout: async (): Promise<ApiMessage> => {
+    const response = await axiosInstance.post<ApiMessage>(ADMIN.LOGOUT);
     return response.data;
   },
-  requestWithdraw: async (): Promise<{ message: string }> => {
-    const response = await axiosInstance.post<{ message: string }>(ADMIN.WITHDRAW_REQUEST);
+  requestWithdraw: async (): Promise<ApiMessage> => {
+    const response = await axiosInstance.post<ApiMessage>(ADMIN.WITHDRAW_REQUEST);
     return response.data;
   },
-  confirmWithdraw: async (token: string): Promise<{ message: string }> => {
-    const response = await axiosInstance.delete<{ message: string }>(ADMIN.WITHDRAW_CONFIRM(token));
+  confirmWithdraw: async (token: string): Promise<ApiMessage> => {
+    const response = await axiosInstance.delete<ApiMessage>(ADMIN.WITHDRAW_CONFIRM(token));
     return response.data;
   },
 };

--- a/client/src/api/services/admin/rss.ts
+++ b/client/src/api/services/admin/rss.ts
@@ -21,12 +21,14 @@ export const admin = {
   },
   //rss 승인
   acceptRss: async (data: AdminRequest): Promise<AdminResponse> => {
-    const response = await axiosInstance.post(`${ADMIN.ACTION.ACCEPT}/${data.id}`);
+    const response = await axiosInstance.post<AdminResponse>(`${ADMIN.ACTION.ACCEPT}/${data.id}`);
     return response.data;
   },
   //rss 거부
   rejectRss: async (data: AdminRequest): Promise<AdminResponse> => {
-    const response = await axiosInstance.post(`${ADMIN.ACTION.REJECT}/${data.id}`, { description: data.rejectMessage });
+    const response = await axiosInstance.post<AdminResponse>(`${ADMIN.ACTION.REJECT}/${data.id}`, {
+      description: data.rejectMessage,
+    });
     return response.data;
   },
 };

--- a/client/src/api/services/profile.ts
+++ b/client/src/api/services/profile.ts
@@ -1,12 +1,8 @@
 import { PROFILE } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
+import { ApiData } from "@/types/api";
 import { CertifiedRss, CommentItem, CursorPage, LikedItem, ProfileActivity, UserProfile } from "@/types/profile";
-
-interface ApiData<T> {
-  message: string;
-  data: T;
-}
 
 export const getProfile = async (userId: number): Promise<UserProfile> => {
   const response = await axiosInstance.get<ApiData<UserProfile>>(PROFILE.PROFILE(userId));

--- a/client/src/api/services/rss.ts
+++ b/client/src/api/services/rss.ts
@@ -1,6 +1,8 @@
 import { BLOG } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
+import { ApiData, ApiMessage } from "@/types/api";
+import { CreateRssCertificationResult, RssCertificationPreview } from "@/types/profile";
 import { RegisterRss, RegisterResponse } from "@/types/rss";
 
 export const registerRss = async (data: RegisterRss): Promise<RegisterResponse> => {
@@ -8,12 +10,39 @@ export const registerRss = async (data: RegisterRss): Promise<RegisterResponse> 
   return response.data;
 };
 
-export const verifyRssCertification = async (code: string): Promise<{ message: string }> => {
-  const response = await axiosInstance.post<{ message: string }>(BLOG.RSS.CERTIFICATION_VERIFY, { code });
+export const previewRssCertification = async (blogName: string): Promise<RssCertificationPreview> => {
+  const response = await axiosInstance.get<ApiData<RssCertificationPreview>>(BLOG.RSS.CERTIFICATION_PREVIEW, {
+    params: { blogName },
+  });
+  return response.data.data;
+};
+
+export const createRssCertification = async (blogName: string): Promise<CreateRssCertificationResult> => {
+  const response = await axiosInstance.post<ApiData<CreateRssCertificationResult>>(BLOG.RSS.CERTIFICATION, {
+    blogName,
+  });
+  return response.data.data;
+};
+
+export const verifyRssCertification = async (code: string): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(BLOG.RSS.CERTIFICATION_VERIFY, { code });
   return response.data;
 };
 
-export const removeRss = async (code: string): Promise<{ message: string }> => {
-  const response = await axiosInstance.delete<{ message: string }>(BLOG.RSS.REMOVE_CONFIRM(code));
+export const updateRssCertification = async (
+  id: number,
+  data: { name: string; userName: string }
+): Promise<ApiMessage> => {
+  const response = await axiosInstance.patch<ApiMessage>(BLOG.RSS.CERTIFICATION_BY_ID(id), data);
+  return response.data;
+};
+
+export const deleteRssCertification = async (id: number): Promise<ApiMessage> => {
+  const response = await axiosInstance.delete<ApiMessage>(BLOG.RSS.CERTIFICATION_BY_ID(id));
+  return response.data;
+};
+
+export const removeRss = async (code: string): Promise<ApiMessage> => {
+  const response = await axiosInstance.delete<ApiMessage>(BLOG.RSS.REMOVE_CONFIRM(code));
   return response.data;
 };

--- a/client/src/api/services/search.ts
+++ b/client/src/api/services/search.ts
@@ -4,7 +4,7 @@ import { axiosInstance } from "@/api/instance";
 import { SearchRequest, SearchResponse } from "@/types/search";
 
 export const getSearch = async (data: SearchRequest): Promise<SearchResponse> => {
-  const response = await axiosInstance.get(SEARCH.GET_RESULT, {
+  const response = await axiosInstance.get<SearchResponse>(SEARCH.GET_RESULT, {
     params: {
       find: data.query,
       type: data.filter,

--- a/client/src/api/services/user.ts
+++ b/client/src/api/services/user.ts
@@ -3,10 +3,11 @@ import axios from "axios";
 import { USER, OAUTH } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
+import { ApiMessage } from "@/types/api";
 import { UserSignUpRequest, UserSignUpResponse, UserSignInRequest, UserSignInResponse } from "@/types/auth";
 
-export const completeOAuthRegistration = async (userName: string): Promise<{ message: string }> => {
-  const response = await axiosInstance.post<{ message: string }>(OAUTH.REGISTER, { userName });
+export const completeOAuthRegistration = async (userName: string): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(OAUTH.REGISTER, { userName });
   return response.data;
 };
 
@@ -39,14 +40,14 @@ export const refreshAccessToken = async (config = {}): Promise<UserSignInRespons
   return response.data;
 };
 
-export const logout = async (): Promise<{ message: string }> => {
-  const response = await axiosInstance.post<{ message: string }>(USER.LOGOUT);
+export const logout = async (): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(USER.LOGOUT);
   return response.data;
 };
 
-export const certificateUser = async (token: string): Promise<{ message: string }> => {
+export const certificateUser = async (token: string): Promise<ApiMessage> => {
   try {
-    const response = await axiosInstance.post<{ message: string }>(USER.CERTIFICATE, { uuid: token });
+    const response = await axiosInstance.post<ApiMessage>(USER.CERTIFICATE, { uuid: token });
     return response.data;
   } catch (error: unknown) {
     if (axios.isAxiosError(error)) {
@@ -56,7 +57,7 @@ export const certificateUser = async (token: string): Promise<{ message: string 
   }
 };
 
-export const confirmDeleteAccount = async (token: string): Promise<{ message: string }> => {
-  const response = await axiosInstance.delete<{ message: string }>(USER.WITHDRAW_CONFIRM(token));
+export const confirmDeleteAccount = async (token: string): Promise<ApiMessage> => {
+  const response = await axiosInstance.delete<ApiMessage>(USER.WITHDRAW_CONFIRM(token));
   return response.data;
 };

--- a/client/src/components/RssRegistration/PlatformBadge.tsx
+++ b/client/src/components/RssRegistration/PlatformBadge.tsx
@@ -8,22 +8,22 @@ interface PlatformBadgeProps {
 export function PlatformBadge({ platform, onClick }: PlatformBadgeProps) {
   if (!platform) return null;
 
-  const lowercasePlatform = platform.toLowerCase().replace(' ', '_');
-  const isKnownPlatform = ['tistory', 'velog', 'medium', 'naver_blog'].includes(lowercasePlatform);
-  
+  const lowercasePlatform = platform.toLowerCase().replace(" ", "_");
+  const isKnownPlatform = ["tistory", "velog", "medium", "naver_blog"].includes(lowercasePlatform);
+
   return (
     <div className="flex flex-col items-start gap-1 mt-2">
       <div className="flex items-center gap-2">
-        <Badge 
-          variant="secondary" 
-          className={`flex items-center gap-1 px-3 py-1.5 transition-all ${onClick ? 'cursor-pointer hover:bg-secondary/80 hover:shadow-md hover:scale-105 border border-transparent hover:border-primary/30' : ''}`}
+        <Badge
+          variant="secondary"
+          className={`flex items-center gap-1 px-3 py-1.5 transition-all ${onClick ? "cursor-pointer hover:bg-secondary/80 hover:shadow-md hover:scale-105 border border-transparent hover:border-primary/30" : ""}`}
           onClick={onClick}
         >
           {isKnownPlatform && (
-            <img 
-              src={`https://denamu.site/files/${lowercasePlatform}-icon.svg`} 
-              alt={platform} 
-              className="w-5 h-5 mr-1" 
+            <img
+              src={`https://denamu.dev/files/${lowercasePlatform}-icon.svg`}
+              alt={platform}
+              className="w-5 h-5 mr-1"
             />
           )}
           <span className="font-medium">{platform}</span>
@@ -31,4 +31,4 @@ export function PlatformBadge({ platform, onClick }: PlatformBadgeProps) {
       </div>
     </div>
   );
-} 
+}

--- a/client/src/components/profile/ProfileSidebar.tsx
+++ b/client/src/components/profile/ProfileSidebar.tsx
@@ -55,7 +55,11 @@ export const ProfileSidebar = ({ activeTab, onTabChange, isOwner }: ProfileSideb
                       onClick={() => onTabChange(tab.id)}
                       className={cn(
                         "flex items-center w-full p-3 rounded-lg transition-colors",
-                        isActive ? "bg-blue-50 text-blue-600 font-semibold" : "text-gray-600 hover:bg-gray-50"
+                        isActive
+                          ? tab.id === "rss"
+                            ? "bg-[#FF870D]/10 text-[#FF870D] font-semibold"
+                            : "bg-blue-50 text-blue-600 font-semibold"
+                          : "text-gray-600 hover:bg-gray-50"
                       )}
                     >
                       <Icon className="w-5 h-5 mr-3" />

--- a/client/src/components/profile/rss/OwnedRssCard.tsx
+++ b/client/src/components/profile/rss/OwnedRssCard.tsx
@@ -1,0 +1,54 @@
+import { Pencil, Trash2 } from "lucide-react";
+
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
+import { Badge } from "@/components/ui/badge.tsx";
+import { Button } from "@/components/ui/button.tsx";
+
+import { CertifiedRss } from "@/types/profile.ts";
+
+interface OwnedRssCardProps {
+  rss: CertifiedRss;
+  onEdit: (rss: CertifiedRss) => void;
+  onDelete: (rss: CertifiedRss) => void;
+}
+
+export const OwnedRssCard = ({ rss, onEdit, onDelete }: OwnedRssCardProps) => {
+  return (
+    <li className="flex items-center justify-between p-4 border border-gray-100 rounded-lg">
+      <div className="flex items-center min-w-0 space-x-3">
+        <PlatformIcon platform={rss.blogPlatform} className="flex-shrink-0 w-6 h-6" />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <p className="font-medium truncate">{rss.name}</p>
+            <Badge variant="secondary" className="flex-shrink-0">
+              {rss.blogPlatform}
+            </Badge>
+          </div>
+          <p className="text-sm text-gray-500 truncate">{rss.userName}</p>
+          <a
+            href={rss.rssUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-gray-400 truncate hover:underline"
+          >
+            {rss.rssUrl}
+          </a>
+        </div>
+      </div>
+      <div className="flex flex-shrink-0 gap-1 ml-3">
+        <Button variant="ghost" size="icon" onClick={() => onEdit(rss)} aria-label="RSS 정보 수정">
+          <Pencil className="w-4 h-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => onDelete(rss)}
+          aria-label="RSS 소유 해제"
+          className="text-red-500 hover:text-red-600"
+        >
+          <Trash2 className="w-4 h-4" />
+        </Button>
+      </div>
+    </li>
+  );
+};

--- a/client/src/components/profile/rss/OwnedRssCard.tsx
+++ b/client/src/components/profile/rss/OwnedRssCard.tsx
@@ -16,7 +16,7 @@ export const OwnedRssCard = ({ rss, onEdit, onDelete }: OwnedRssCardProps) => {
   return (
     <li className="flex items-center justify-between p-4 border border-gray-100 rounded-lg">
       <div className="flex items-center min-w-0 space-x-3">
-        <PlatformIcon platform={rss.blogPlatform} className="flex-shrink-0 w-6 h-6" />
+        <PlatformIcon platform={rss.blogPlatform} className="flex-shrink-0 w-10 h-10" />
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <p className="font-medium truncate">{rss.name}</p>

--- a/client/src/components/profile/rss/PlatformIcon.tsx
+++ b/client/src/components/profile/rss/PlatformIcon.tsx
@@ -1,0 +1,18 @@
+import { Rss } from "lucide-react";
+
+const KNOWN_PLATFORMS = ["tistory", "velog", "medium", "naver_blog"];
+
+interface PlatformIconProps {
+  platform: string;
+  className?: string;
+}
+
+export const PlatformIcon = ({ platform, className = "w-5 h-5" }: PlatformIconProps) => {
+  const key = platform.toLowerCase().replace(" ", "_");
+
+  if (KNOWN_PLATFORMS.includes(key)) {
+    return <img src={`https://denamu.site/files/${key}-icon.svg`} alt={platform} className={className} />;
+  }
+
+  return <Rss className={`${className} text-blue-500`} />;
+};

--- a/client/src/components/profile/rss/PlatformIcon.tsx
+++ b/client/src/components/profile/rss/PlatformIcon.tsx
@@ -11,7 +11,7 @@ export const PlatformIcon = ({ platform, className = "w-5 h-5" }: PlatformIconPr
   const key = platform.toLowerCase().replace(" ", "_");
 
   if (KNOWN_PLATFORMS.includes(key)) {
-    return <img src={`https://denamu.site/files/${key}-icon.svg`} alt={platform} className={className} />;
+    return <img src={`https://denamu.dev/files/${key}-icon.svg`} alt={platform} className={className} />;
   }
 
   return <Rss className={`${className} text-blue-500`} />;

--- a/client/src/components/profile/rss/RssClaimModal.tsx
+++ b/client/src/components/profile/rss/RssClaimModal.tsx
@@ -1,0 +1,205 @@
+import { useState } from "react";
+
+import { AxiosError } from "axios";
+
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import {
+  useCreateRssCertification,
+  useRssCertificationPreview,
+  useVerifyRssCertification,
+} from "@/hooks/queries/useRssCertification.ts";
+
+import { RssCertificationPreview } from "@/types/profile.ts";
+
+interface RssClaimModalProps {
+  open: boolean;
+  onClose: () => void;
+  userId: number;
+}
+
+type Step = "input" | "preview" | "verify";
+
+const getErrorMessage = (error: AxiosError<{ message?: string }>, fallback: string) =>
+  error.response?.data?.message ?? fallback;
+
+export const RssClaimModal = ({ open, onClose, userId }: RssClaimModalProps) => {
+  const { toast } = useCustomToast();
+  const [step, setStep] = useState<Step>("input");
+  const [blogName, setBlogName] = useState("");
+  const [code, setCode] = useState("");
+  const [preview, setPreview] = useState<RssCertificationPreview | null>(null);
+
+  const previewMutation = useRssCertificationPreview();
+  const createMutation = useCreateRssCertification(userId);
+  const verifyMutation = useVerifyRssCertification(userId);
+
+  const reset = () => {
+    setStep("input");
+    setBlogName("");
+    setCode("");
+    setPreview(null);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  const handlePreview = () => {
+    if (!blogName.trim()) return;
+    previewMutation.mutate(blogName.trim(), {
+      onSuccess: (data) => {
+        setPreview(data);
+        setStep("preview");
+      },
+      onError: (error) => {
+        toast({ title: "조회 실패", description: getErrorMessage(error, "RSS 정보를 찾을 수 없습니다.") });
+      },
+    });
+  };
+
+  const handleRegister = () => {
+    createMutation.mutate(blogName.trim(), {
+      onSuccess: (result) => {
+        if (result.certified) {
+          toast({ title: "등록 완료", description: "RSS 소유 인증이 완료되었습니다." });
+          handleClose();
+          return;
+        }
+        toast({
+          title: "인증 코드 발송",
+          description: "블로그에 등록된 이메일로 인증 코드를 발송했습니다.",
+        });
+        setStep("verify");
+      },
+      onError: (error) => {
+        toast({ title: "등록 실패", description: getErrorMessage(error, "다시 시도해주세요.") });
+      },
+    });
+  };
+
+  const handleVerify = () => {
+    if (!code.trim()) return;
+    verifyMutation.mutate(code.trim(), {
+      onSuccess: () => {
+        toast({ title: "인증 완료", description: "RSS 소유 인증이 완료되었습니다." });
+        handleClose();
+      },
+      onError: (error) => {
+        toast({ title: "인증 실패", description: getErrorMessage(error, "인증 코드를 확인해주세요.") });
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && handleClose()}>
+      <DialogContent className="sm:max-w-[425px]">
+        {step === "input" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-bold text-foreground">RSS 소유 등록</DialogTitle>
+              <DialogDescription className="text-muted-foreground">
+                소유한 블로그의 이름을 입력하세요.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor="blogName">블로그 이름</Label>
+              <Input
+                id="blogName"
+                value={blogName}
+                autoComplete="off"
+                placeholder="예) example 블로그"
+                onChange={(e) => setBlogName(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handlePreview()}
+              />
+            </div>
+            <DialogFooter>
+              <Button onClick={handlePreview} disabled={!blogName.trim() || previewMutation.isPending}>
+                확인
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === "preview" && preview && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-bold text-foreground">RSS 정보 확인</DialogTitle>
+              <DialogDescription className="text-muted-foreground">
+                아래 블로그의 소유자로 등록할까요?
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center gap-3 p-4 border rounded-lg border-gray-100">
+              <PlatformIcon platform={preview.blogPlatform} className="flex-shrink-0 w-12 h-12" />
+              <div className="min-w-0">
+                <p className="font-semibold truncate">{preview.name}</p>
+                <p className="text-sm text-gray-500 truncate">{preview.userName}</p>
+                <a
+                  href={preview.rssUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="block text-sm text-gray-400 truncate hover:underline"
+                >
+                  {preview.rssUrl}
+                </a>
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {preview.requiresEmailVerification
+                ? "로그인 이메일과 RSS 등록 이메일이 달라, 블로그에 등록된 이메일로 발송되는 인증 코드로 2차 인증이 필요합니다."
+                : "로그인 이메일과 RSS 등록 이메일이 일치하여 즉시 등록됩니다."}
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setStep("input")}>
+                뒤로
+              </Button>
+              <Button onClick={handleRegister} disabled={createMutation.isPending}>
+                확인
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+
+        {step === "verify" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-bold text-foreground">이메일 인증</DialogTitle>
+              <DialogDescription className="text-muted-foreground">
+                블로그에 등록된 이메일로 발송된 인증 코드를 입력하세요.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <Label htmlFor="rssCode">인증 코드</Label>
+              <Input
+                id="rssCode"
+                value={code}
+                autoComplete="off"
+                placeholder="인증 코드를 입력하세요"
+                onChange={(e) => setCode(e.target.value)}
+                onKeyDown={(e) => e.key === "Enter" && handleVerify()}
+              />
+            </div>
+            <DialogFooter>
+              <Button onClick={handleVerify} disabled={!code.trim() || verifyMutation.isPending}>
+                인증
+              </Button>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/src/components/profile/rss/RssEditModal.tsx
+++ b/client/src/components/profile/rss/RssEditModal.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from "react";
+
+import { AxiosError } from "axios";
+
+import { Button } from "@/components/ui/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import { useUpdateRssCertification } from "@/hooks/queries/useRssCertification.ts";
+
+import { CertifiedRss } from "@/types/profile.ts";
+
+interface RssEditModalProps {
+  target: CertifiedRss | null;
+  userId: number;
+  onClose: () => void;
+}
+
+const getErrorMessage = (error: AxiosError<{ message?: string }>, fallback: string) =>
+  error.response?.data?.message ?? fallback;
+
+export const RssEditModal = ({ target, userId, onClose }: RssEditModalProps) => {
+  const { toast } = useCustomToast();
+  const [name, setName] = useState("");
+  const [userName, setUserName] = useState("");
+
+  const updateMutation = useUpdateRssCertification(userId);
+
+  useEffect(() => {
+    if (target) {
+      setName(target.name);
+      setUserName(target.userName);
+    }
+  }, [target]);
+
+  const handleSave = () => {
+    if (!target || !name.trim() || !userName.trim()) return;
+    updateMutation.mutate(
+      { id: target.id, name: name.trim(), userName: userName.trim() },
+      {
+        onSuccess: () => {
+          toast({ title: "수정 완료", description: "RSS 정보가 수정되었습니다." });
+          onClose();
+        },
+        onError: (error) => {
+          toast({ title: "수정 실패", description: getErrorMessage(error, "다시 시도해주세요.") });
+        },
+      }
+    );
+  };
+
+  return (
+    <Dialog open={!!target} onOpenChange={(next) => !next && onClose()}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle className="font-bold text-foreground">RSS 정보 수정</DialogTitle>
+          <DialogDescription className="text-muted-foreground">
+            블로그 이름과 신청자 이름을 수정할 수 있습니다. (RSS 주소는 변경할 수 없습니다.)
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="editName">블로그 이름</Label>
+            <Input id="editName" value={name} autoComplete="off" onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="editUserName">신청자 이름</Label>
+            <Input
+              id="editUserName"
+              value={userName}
+              autoComplete="off"
+              onChange={(e) => setUserName(e.target.value)}
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            취소
+          </Button>
+          <Button onClick={handleSave} disabled={!name.trim() || !userName.trim() || updateMutation.isPending}>
+            저장
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/client/src/components/profile/rss/RssManagementTab.tsx
+++ b/client/src/components/profile/rss/RssManagementTab.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+
+import { Plus } from "lucide-react";
+
+import { AxiosError } from "axios";
+
+import { OwnedRssCard } from "@/components/profile/rss/OwnedRssCard.tsx";
+import { RssClaimModal } from "@/components/profile/rss/RssClaimModal.tsx";
+import { RssEditModal } from "@/components/profile/rss/RssEditModal.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Card, CardContent } from "@/components/ui/card.tsx";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import { useCertifiedRss } from "@/hooks/queries/useProfile.ts";
+import { useDeleteRssCertification } from "@/hooks/queries/useRssCertification.ts";
+
+import { CertifiedRss } from "@/types/profile.ts";
+
+interface RssManagementTabProps {
+  userId: number;
+}
+
+const getErrorMessage = (error: AxiosError<{ message?: string }>, fallback: string) =>
+  error.response?.data?.message ?? fallback;
+
+export const RssManagementTab = ({ userId }: RssManagementTabProps) => {
+  const { toast } = useCustomToast();
+  const { data: rssList = [], isLoading } = useCertifiedRss(userId);
+
+  const [claimOpen, setClaimOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<CertifiedRss | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<CertifiedRss | null>(null);
+
+  const deleteMutation = useDeleteRssCertification(userId);
+
+  const handleDelete = () => {
+    if (!deleteTarget) return;
+    deleteMutation.mutate(deleteTarget.id, {
+      onSuccess: () => {
+        toast({ title: "해제 완료", description: "RSS 소유 인증을 해제했습니다." });
+        setDeleteTarget(null);
+      },
+      onError: (error) => {
+        toast({ title: "해제 실패", description: getErrorMessage(error, "다시 시도해주세요.") });
+        setDeleteTarget(null);
+      },
+    });
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-lg font-semibold">RSS 관리</h3>
+          <Button onClick={() => setClaimOpen(true)} className="gap-1">
+            <Plus className="w-4 h-4" />
+            RSS 소유 등록
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <p className="text-sm text-gray-400">불러오는 중...</p>
+        ) : rssList.length === 0 ? (
+          <p className="text-sm text-gray-400">소유한 RSS가 없습니다. RSS 소유 등록을 통해 추가하세요.</p>
+        ) : (
+          <ul className="space-y-3">
+            {rssList.map((rss) => (
+              <OwnedRssCard key={rss.id} rss={rss} onEdit={setEditTarget} onDelete={setDeleteTarget} />
+            ))}
+          </ul>
+        )}
+      </CardContent>
+
+      <RssClaimModal open={claimOpen} onClose={() => setClaimOpen(false)} userId={userId} />
+      <RssEditModal target={editTarget} userId={userId} onClose={() => setEditTarget(null)} />
+
+      <AlertDialog open={!!deleteTarget} onOpenChange={(next) => !next && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>RSS 소유 해제</AlertDialogTitle>
+            <AlertDialogDescription>
+              '{deleteTarget?.name}'의 소유 인증을 해제할까요? RSS 데이터는 삭제되지 않고 소유 연결만 끊어집니다.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              disabled={deleteMutation.isPending}
+              className="bg-red-500 hover:bg-red-600"
+            >
+              해제
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+};

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -28,7 +28,10 @@ export const BLOG = {
   Trend: "/api/feeds/trend/sse",
   RSS: {
     REGISTRER_RSS: "/api/rss",
+    CERTIFICATION: "/api/rss/certifications",
+    CERTIFICATION_PREVIEW: "/api/rss/certifications/preview",
     CERTIFICATION_VERIFY: "/api/rss/certifications/verify",
+    CERTIFICATION_BY_ID: (id: number) => `/api/rss/certifications/${id}`,
     REMOVE_CONFIRM: (code: string) => `/api/rss/remove/${code}`,
   },
 };

--- a/client/src/hooks/queries/useRssCertification.ts
+++ b/client/src/hooks/queries/useRssCertification.ts
@@ -1,0 +1,59 @@
+import { AxiosError } from "axios";
+
+import {
+  createRssCertification,
+  deleteRssCertification,
+  previewRssCertification,
+  updateRssCertification,
+  verifyRssCertification,
+} from "@/api/services/rss";
+import { ApiMessage } from "@/types/api";
+import { CreateRssCertificationResult, RssCertificationPreview } from "@/types/profile";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+type ApiError = AxiosError<{ message?: string }>;
+
+const useInvalidateCertifiedRss = (userId: number) => {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: ["certifiedRss", userId] });
+};
+
+export const useRssCertificationPreview = () =>
+  useMutation<RssCertificationPreview, ApiError, string>({
+    mutationFn: previewRssCertification,
+  });
+
+export const useCreateRssCertification = (userId: number) => {
+  const invalidate = useInvalidateCertifiedRss(userId);
+  return useMutation<CreateRssCertificationResult, ApiError, string>({
+    mutationFn: createRssCertification,
+    onSuccess: (data) => {
+      // 즉시 인증(certified=true)된 경우에만 목록이 즉시 갱신된다.
+      if (data.certified) invalidate();
+    },
+  });
+};
+
+export const useVerifyRssCertification = (userId: number) => {
+  const invalidate = useInvalidateCertifiedRss(userId);
+  return useMutation<ApiMessage, ApiError, string>({
+    mutationFn: verifyRssCertification,
+    onSuccess: () => invalidate(),
+  });
+};
+
+export const useUpdateRssCertification = (userId: number) => {
+  const invalidate = useInvalidateCertifiedRss(userId);
+  return useMutation<ApiMessage, ApiError, { id: number; name: string; userName: string }>({
+    mutationFn: ({ id, name, userName }) => updateRssCertification(id, { name, userName }),
+    onSuccess: () => invalidate(),
+  });
+};
+
+export const useDeleteRssCertification = (userId: number) => {
+  const invalidate = useInvalidateCertifiedRss(userId);
+  return useMutation<ApiMessage, ApiError, number>({
+    mutationFn: deleteRssCertification,
+    onSuccess: () => invalidate(),
+  });
+};

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
 import { MyPage } from "@/components/profile/MyPage.tsx";
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar.tsx";
+import { RssManagementTab } from "@/components/profile/rss/RssManagementTab.tsx";
 import { Card, CardContent } from "@/components/ui/card.tsx";
 
 import { useAuthStore } from "@/store/useAuthStore.ts";
@@ -42,7 +43,7 @@ export default function Profile() {
           {activeTab === "mypage" && (
             <MyPage userId={userInfo.id} name={userInfo.userName ?? ""} email={userInfo.email ?? ""} />
           )}
-          {activeTab === "rss" && <ComingSoon title="RSS 관리" />}
+          {activeTab === "rss" && <RssManagementTab userId={userInfo.id} />}
           {activeTab === "settings" && <ComingSoon title="정보 수정" />}
         </div>
       </div>

--- a/client/src/types/admin.ts
+++ b/client/src/types/admin.ts
@@ -1,12 +1,12 @@
+import { ApiData, ApiMessage } from "@/types/api";
+
 export type RegisterRequest = {
   password: string;
   name: string;
   email: string;
 };
 
-export type RegisterResponse = {
-  message: string;
-};
+export type RegisterResponse = ApiMessage;
 
 export type ChildAdmin = {
   id: number;
@@ -14,11 +14,6 @@ export type ChildAdmin = {
   name: string;
 };
 
-export type ChildAdminResponse = {
-  message: string;
-  data: ChildAdmin[];
-};
+export type ChildAdminResponse = ApiData<ChildAdmin[]>;
 
-export type DeleteChildResponse = {
-  message: string;
-};
+export type DeleteChildResponse = ApiMessage;

--- a/client/src/types/api.ts
+++ b/client/src/types/api.ts
@@ -1,0 +1,7 @@
+export interface ApiMessage {
+  message: string;
+}
+
+export interface ApiData<T> extends ApiMessage {
+  data: T;
+}

--- a/client/src/types/auth.ts
+++ b/client/src/types/auth.ts
@@ -1,21 +1,18 @@
+import { ApiData, ApiMessage } from "@/types/api";
+
 export type AdminAuthRequest = {
   email: string;
   password: string;
 };
 
-export type AdminAuthResponse = {
-  message: string;
-};
+export type AdminAuthResponse = ApiMessage;
 
-export type AdminProfileResponse = {
-  message: string;
-  data: {
-    email: string;
-    name: string;
-    emailNotification: boolean;
-    parent: { email: string; name: string } | null;
-  };
-};
+export type AdminProfileResponse = ApiData<{
+  email: string;
+  name: string;
+  emailNotification: boolean;
+  parent: { email: string; name: string } | null;
+}>;
 
 export type AdminUpdateRequest = {
   name?: string;
@@ -23,9 +20,7 @@ export type AdminUpdateRequest = {
   emailNotification?: boolean;
 };
 
-export type AdminUpdateResponse = {
-  message: string;
-};
+export type AdminUpdateResponse = ApiMessage;
 
 export interface UserSignUpRequest {
   email: string;
@@ -33,17 +28,14 @@ export interface UserSignUpRequest {
   userName: string;
 }
 
-export interface UserSignUpResponse {
-  message: string;
-}
+export type UserSignUpResponse = ApiMessage;
 
 export interface UserSignInRequest {
   email: string;
   password: string;
 }
 
-export interface UserSignInResponse {
-  message: string;
+export interface UserSignInResponse extends ApiMessage {
   data?: {
     accessToken: string;
   };

--- a/client/src/types/chart.ts
+++ b/client/src/types/chart.ts
@@ -1,20 +1,16 @@
+import { ApiData } from "@/types/api";
+
 export type ChartType = {
   id: number;
   title: string;
   viewCount: number;
 };
-export type ChartResponse = {
-  message: string;
-  data: ChartType[];
-};
+export type ChartResponse = ApiData<ChartType[]>;
 export type ChartPlatform = {
   platform: string;
   count: number;
 };
-export type ChartPlatforms = {
-  message: string;
-  data: ChartPlatform[];
-};
+export type ChartPlatforms = ApiData<ChartPlatform[]>;
 export type ChartsType = {
   chartAll: ChartResponse;
   chartToday: ChartResponse;

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -1,3 +1,5 @@
+import { ApiData } from "@/types/api";
+
 export interface Post {
   id: number;
   createdAt: string;
@@ -13,27 +15,14 @@ export interface Post {
   summary: string;
 }
 
-export interface LatestPostsApiResponse {
-  message: string;
-  data: {
-    result: Post[];
-    hasMore: boolean;
-    lastId: number | null;
-  };
-}
-
-export interface TrendingPostsApiResponse {
-  message: string;
-  data: Post[];
-}
-
 export interface InfiniteScrollResponse<T> {
   result: T[];
   hasMore: boolean;
   lastId: number | null;
 }
 
-export interface PostDetailType {
-  message: string;
-  data: Post;
-}
+export type LatestPostsApiResponse = ApiData<InfiniteScrollResponse<Post>>;
+
+export type TrendingPostsApiResponse = ApiData<Post[]>;
+
+export type PostDetailType = ApiData<Post>;

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -50,6 +50,20 @@ export interface CertifiedRss {
   blogPlatform: string;
 }
 
+export interface RssCertificationPreview {
+  name: string;
+  userName: string;
+  rssUrl: string;
+  blogPlatform: string;
+  requiresEmailVerification: boolean;
+}
+
+export interface CreateRssCertificationResult {
+  blogPlatform: string;
+  userName: string;
+  certified: boolean;
+}
+
 export interface FeedRef {
   id: number;
   title: string;

--- a/client/src/types/rss.ts
+++ b/client/src/types/rss.ts
@@ -1,3 +1,5 @@
+import { ApiData, ApiMessage } from "@/types/api";
+
 export type RssRequestStatus = "pending" | "approved" | "rejected";
 
 export interface RssRequest {
@@ -21,14 +23,9 @@ export interface AdminRssData {
   rssUrl: string;
   description?: string;
 }
-export interface AdminRss {
-  message: string;
-  data: AdminRssData[];
-}
+export type AdminRss = ApiData<AdminRssData[]>;
 
-export type AdminResponse = {
-  message: string;
-};
+export type AdminResponse = ApiMessage;
 export type AdminRequest = {
   id: number;
   rejectMessage?: string;
@@ -42,6 +39,4 @@ export interface RegisterRss {
   blogType?: string; 
 }
 
-export interface RegisterResponse {
-  message: string; 
-}
+export type RegisterResponse = ApiMessage;

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -1,3 +1,5 @@
+import { ApiData } from "@/types/api";
+
 export interface SearchResult {
   id: number;
   title: string;
@@ -6,16 +8,13 @@ export interface SearchResult {
   createdAt: string;
 }
 
-interface SearchData {
+export interface SearchData {
   totalCount: number;
   result: SearchResult[];
   totalPages: number;
 }
 
-export interface SearchResponse {
-  data: SearchData;
-  message: string;
-}
+export type SearchResponse = ApiData<SearchData>;
 export interface SearchRequest {
   query: string;
   filter: FilterType;

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -180,11 +180,11 @@ INSERT INTO admin (email,password, name, parent_admin_id) VALUES
 
 -- denamu.rss_accept insert data
 
-INSERT INTO rss_accept (name,user_name,email,rss_url,blog_platform) VALUES
-	 ('seok3765.log','조민석','seok3765@naver.com','https://v2.velog.io/rss/@seok3765','velog'),
-	 ('나무보다 숲을','채준혁','cjh4302@gmail.com','https://laurent.tistory.com/rss','tistory'),
-	 ('월성참치','정명기','jmk101711@naver.com','https://tunaspace.tistory.com/rss','tistory'),
-	 ('해야지 뭐','안성윤','asn6878@gmail.com','https://asn6878.tistory.com/rss','tistory');
+INSERT INTO rss_accept (name,user_name,email,rss_url,blog_platform, user_id) VALUES
+	 ('seok3765.log','조민석','seok3765@naver.com','https://v2.velog.io/rss/@seok3765','velog', 1),
+	 ('나무보다 숲을','채준혁','cjh4302@gmail.com','https://laurent.tistory.com/rss','tistory', NULL),
+	 ('월성참치','정명기','jmk101711@naver.com','https://tunaspace.tistory.com/rss','tistory', NULL),
+	 ('해야지 뭐','안성윤','asn6878@gmail.com','https://asn6878.tistory.com/rss','tistory', NULL);
 
 -- denamu.rss_reject insert data
 

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -178,6 +178,11 @@ INSERT INTO admin (email,password, name, parent_admin_id) VALUES
 	('test1234@denamu.dev','$2b$10$lmNFQaXm6yVo3hGMRJk5SuwV2Wn..ej9my29rXOSpiVj7iMrSWau.', '테스트 계정', NULL),
 	('test5678@denamu.dev','$2b$10$lmNFQaXm6yVo3hGMRJk5SuwV2Wn..ej9my29rXOSpiVj7iMrSWau.', '테스트 계정의 자식', 1);
 
+-- denamu.user insert data
+-- id: test@test.com, password: test1234!
+INSERT INTO user (email, password, user_name, profile_image, introduction) VALUES
+	('test@test.com', '$2b$10$lmNFQaXm6yVo3hGMRJk5SuwV2Wn..ej9my29rXOSpiVj7iMrSWau.', '테스트 계정', NULL, '안녕하세요 테스트입니다.');
+
 -- denamu.rss_accept insert data
 
 INSERT INTO rss_accept (name,user_name,email,rss_url,blog_platform, user_id) VALUES
@@ -336,11 +341,6 @@ FE와 BE 개발 환경 공유 가능
 TypeScript 등으로 단점 극복 노력
 
 결국 상황에 맞는 도구를 선택하는 문제 해결력이 중요하다는 개발자의 통찰력 있는 회고입니다! 💡',1);
-
--- denamu.user insert data
--- id: test@test.com, password: test1234!
-INSERT INTO user (email, password, user_name, profile_image, introduction) VALUES
-	('test@test.com', '$2b$10$lmNFQaXm6yVo3hGMRJk5SuwV2Wn..ej9my29rXOSpiVj7iMrSWau.', '테스트 계정', NULL, '안녕하세요 테스트입니다.');
 
 -- denamu.tag insert data
 

--- a/feed-crawler/test/unit/parser.spec.ts
+++ b/feed-crawler/test/unit/parser.spec.ts
@@ -49,7 +49,7 @@ describe('Parser 모듈 테스트', () => {
       .spyOn(axios, 'get')
       .mockImplementation((url: string) => {
         // RSS/Atom 피드 URL
-        if (url.includes('/rss') || url.includes('denamu.site')) {
+        if (url.includes('/rss') || url.includes('denamu.dev')) {
           return Promise.resolve({
             data: RSS_20_SAMPLE,
             status: HttpStatusCode.Ok,

--- a/server/src/rss/api-docs/previewRssCertification.api-docs.ts
+++ b/server/src/rss/api-docs/previewRssCertification.api-docs.ts
@@ -1,0 +1,26 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiConflictDoc,
+  ApiDataResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+import { PreviewRssCertificationResponseDto } from '@rss/dto/response/previewRssCertification.dto';
+
+export function ApiPreviewRssCertification() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'RSS 소유 인증 미리보기 API',
+      description:
+        '블로그 이름으로 RSS를 찾아 인증 전 정보(플랫폼·신청자 이름·RSS URL)와 2차 이메일 인증 필요 여부를 반환합니다. 부작용 없이 조회만 수행합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiDataResponse(PreviewRssCertificationResponseDto),
+    ApiUnauthorizedDoc('인증이 필요합니다.'),
+    ApiNotFoundDoc('해당 이름의 RSS를 찾을 수 없습니다.'),
+    ApiConflictDoc('이미 인증된 RSS입니다.'),
+  );
+}

--- a/server/src/rss/api-docs/updateRssCertification.api-docs.ts
+++ b/server/src/rss/api-docs/updateRssCertification.api-docs.ts
@@ -1,0 +1,28 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiConflictDoc,
+  ApiForbiddenDoc,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiUpdateRssCertification() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '소유 RSS 정보 수정 API',
+      description:
+        '본인이 인증한 RSS의 블로그 이름과 신청자 이름을 수정합니다. RSS URL(크롤링 대상)은 변경할 수 없습니다.',
+    }),
+    ApiBearerAuth(),
+    ApiMessageResponse('소유 RSS 정보가 성공적으로 수정되었습니다.'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증이 필요합니다.'),
+    ApiForbiddenDoc('본인이 인증한 RSS가 아닙니다.'),
+    ApiNotFoundDoc('RSS를 찾을 수 없습니다.'),
+    ApiConflictDoc('이미 사용 중인 블로그 이름입니다.'),
+  );
+}

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -6,7 +6,9 @@ import {
   HttpCode,
   HttpStatus,
   Param,
+  Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -22,18 +24,23 @@ import { ApiCreateRssCertification } from '@rss/api-docs/createRssCertification.
 import { ApiDeleteCertificateRss } from '@rss/api-docs/deleteCertificateRss.api-docs';
 import { ApiDeleteRss } from '@rss/api-docs/deleteRss.api-docs';
 import { ApiDeleteRssCertification } from '@rss/api-docs/deleteRssCertification.api-docs';
+import { ApiPreviewRssCertification } from '@rss/api-docs/previewRssCertification.api-docs';
 import { ApiReadAllRss } from '@rss/api-docs/readAllRss.api-docs';
 import { ApiReadRssAcceptHistory } from '@rss/api-docs/readRssAcceptHistory.api-docs';
 import { ApiReadRssRejectHistory } from '@rss/api-docs/readRssRejectHistory.api-docs';
 import { ApiRejectRss } from '@rss/api-docs/rejectRss.api-docs';
+import { ApiUpdateRssCertification } from '@rss/api-docs/updateRssCertification.api-docs';
 import { ApiVerifyRssCertification } from '@rss/api-docs/verifyRssCertification.api-docs';
 import { CreateRssCertificationRequestDto } from '@rss/dto/request/createRssCertification.dto';
 import { DeleteCertificateRssRequestDto } from '@rss/dto/request/deleteCertificateRss.dto';
 import { DeleteRssCertificationParamRequestDto } from '@rss/dto/request/deleteRssCertificationParam.dto';
 import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
+import { PreviewRssCertificationRequestDto } from '@rss/dto/request/previewRssCertification.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
+import { UpdateRssCertificationRequestDto } from '@rss/dto/request/updateRssCertification.dto';
+import { UpdateRssCertificationParamRequestDto } from '@rss/dto/request/updateRssCertificationParam.dto';
 import { VerifyRssCertificationRequestDto } from '@rss/dto/request/verifyRssCertification.dto';
 import { RssService } from '@rss/service/rss.service';
 
@@ -120,6 +127,23 @@ export class RssController {
     return ApiResponse.responseWithNoContent('RSS 삭제를 성공했습니다.');
   }
 
+  @ApiPreviewRssCertification()
+  @UseGuards(JwtGuard)
+  @Get('certifications/preview')
+  @HttpCode(HttpStatus.OK)
+  async previewRssCertification(
+    @CurrentUser() user: Payload,
+    @Query() previewRssCertificationDto: PreviewRssCertificationRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      'RSS 소유 인증 미리보기를 처리했습니다.',
+      await this.rssService.previewRssCertification(
+        user,
+        previewRssCertificationDto.blogName,
+      ),
+    );
+  }
+
   @ApiCreateRssCertification()
   @UseGuards(JwtGuard)
   @Post('certifications')
@@ -150,6 +174,24 @@ export class RssController {
       verifyRssCertificationDto.code,
     );
     return ApiResponse.responseWithNoContent('RSS 소유 인증을 완료했습니다.');
+  }
+
+  @ApiUpdateRssCertification()
+  @UseGuards(JwtGuard)
+  @Patch('certifications/:id')
+  @HttpCode(HttpStatus.OK)
+  async updateRssCertification(
+    @CurrentUser() user: Payload,
+    @Param() updateRssCertificationParamDto: UpdateRssCertificationParamRequestDto,
+    @Body() updateRssCertificationDto: UpdateRssCertificationRequestDto,
+  ) {
+    await this.rssService.updateRssCertification(
+      user,
+      updateRssCertificationParamDto.id,
+      updateRssCertificationDto.name,
+      updateRssCertificationDto.userName,
+    );
+    return ApiResponse.responseWithNoContent('RSS 정보를 수정했습니다.');
   }
 
   @ApiDeleteRssCertification()

--- a/server/src/rss/dto/request/previewRssCertification.dto.ts
+++ b/server/src/rss/dto/request/previewRssCertification.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class PreviewRssCertificationRequestDto {
+  @ApiProperty({
+    description: '소유 인증할 블로그 이름을 입력해주세요.',
+    example: 'seok3765.log',
+  })
+  @IsNotEmpty({
+    message: '블로그 이름을 입력해주세요.',
+  })
+  @IsString({
+    message: '문자열로 입력해주세요.',
+  })
+  blogName: string;
+
+  constructor(partial: Partial<PreviewRssCertificationRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/request/updateRssCertification.dto.ts
+++ b/server/src/rss/dto/request/updateRssCertification.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class UpdateRssCertificationRequestDto {
+  @ApiProperty({
+    description: '수정할 블로그 이름을 입력해주세요.',
+    example: 'seok3765.log',
+  })
+  @IsNotEmpty({
+    message: '블로그 이름을 입력해주세요.',
+  })
+  @IsString({
+    message: '문자열로 입력해주세요.',
+  })
+  @MaxLength(255, {
+    message: '블로그 이름은 255자 이하로 입력해주세요.',
+  })
+  name: string;
+
+  @ApiProperty({
+    description: '수정할 신청자 이름을 입력해주세요.',
+    example: '조민석',
+  })
+  @IsNotEmpty({
+    message: '신청자 이름을 입력해주세요.',
+  })
+  @IsString({
+    message: '문자열로 입력해주세요.',
+  })
+  @MaxLength(50, {
+    message: '신청자 이름은 50자 이하로 입력해주세요.',
+  })
+  userName: string;
+
+  constructor(partial: Partial<UpdateRssCertificationRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/request/updateRssCertificationParam.dto.ts
+++ b/server/src/rss/dto/request/updateRssCertificationParam.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class UpdateRssCertificationParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '수정할 RSS(rss_accept) ID',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: 'RSS ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  constructor(partial: Partial<UpdateRssCertificationParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/response/previewRssCertification.dto.ts
+++ b/server/src/rss/dto/response/previewRssCertification.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+
+export class PreviewRssCertificationResponseDto {
+  @ApiProperty({
+    example: 'seok3765.log',
+    description: '인증 요청한 블로그 이름',
+  })
+  name: string;
+
+  @ApiProperty({
+    example: 'example_user',
+    description: '인증 요청한 블로그에 등록된 신청자 이름',
+  })
+  userName: string;
+
+  @ApiProperty({
+    example: 'https://v2.velog.io/rss/@seok3765',
+    description: '인증 요청한 블로그의 RSS URL',
+  })
+  rssUrl: string;
+
+  @ApiProperty({
+    example: 'velog',
+    description: '인증 요청한 블로그의 플랫폼 종류',
+  })
+  blogPlatform: string;
+
+  @ApiProperty({
+    example: false,
+    description:
+      '2차 이메일 인증 필요 여부. false면 RSS 등록 이메일과 로그인 이메일이 일치하여 즉시 인증되고, true면 RSS 등록 이메일로 발송되는 코드로 추가 인증이 필요합니다.',
+  })
+  requiresEmailVerification: boolean;
+
+  constructor(partial: Partial<PreviewRssCertificationResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(
+    rssAccept: RssAccept,
+    requiresEmailVerification: boolean,
+  ) {
+    return new PreviewRssCertificationResponseDto({
+      name: rssAccept.name,
+      userName: rssAccept.userName,
+      rssUrl: rssAccept.rssUrl,
+      blogPlatform: rssAccept.blogPlatform,
+      requiresEmailVerification,
+    });
+  }
+}

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -25,6 +25,7 @@ import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
 import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
+import { PreviewRssCertificationResponseDto } from '@rss/dto/response/previewRssCertification.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
 import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
 import { ReadRssRejectHistoryResponseDto } from '@rss/dto/response/readRssRejectHistory.dto';
@@ -325,6 +326,28 @@ export class RssService {
     return CreateRssCertificationResponseDto.toResponseDto(rssAccept, false);
   }
 
+  async previewRssCertification(user: Payload, blogName: string) {
+    const rssAccept = await this.rssAcceptRepository.findOne({
+      where: { name: blogName },
+    });
+
+    if (!rssAccept) {
+      throw new NotFoundException('해당 이름의 RSS를 찾을 수 없습니다.');
+    }
+
+    if (rssAccept.userId !== null) {
+      if (rssAccept.userId === user.id) {
+        throw new ConflictException('이미 본인이 인증한 RSS입니다.');
+      }
+      throw new ConflictException('다른 사용자가 이미 인증한 RSS입니다.');
+    }
+
+    return PreviewRssCertificationResponseDto.toResponseDto(
+      rssAccept,
+      rssAccept.email !== user.email,
+    );
+  }
+
   async verifyRssCertification(user: Payload, code: string) {
     const redisKey = `${REDIS_KEYS.RSS_CERTIFICATION_KEY}:${code}`;
     const stored = await this.redisService.get(redisKey);
@@ -362,6 +385,41 @@ export class RssService {
         '이미 인증되었거나 인증할 수 없는 RSS입니다.',
       );
     }
+  }
+
+  async updateRssCertification(
+    user: Payload,
+    rssAcceptId: number,
+    name: string,
+    userName: string,
+  ) {
+    const rssAccept = await this.rssAcceptRepository.findOne({
+      where: { id: rssAcceptId },
+    });
+
+    if (!rssAccept) {
+      throw new NotFoundException('RSS를 찾을 수 없습니다.');
+    }
+
+    if (rssAccept.userId !== user.id) {
+      throw new ForbiddenException('본인이 인증한 RSS가 아닙니다.');
+    }
+
+    if (name !== rssAccept.name) {
+      const [duplicateRss, duplicateAccept] = await Promise.all([
+        this.rssRepository.findOne({ where: { name } }),
+        this.rssAcceptRepository.findOne({ where: { name } }),
+      ]);
+
+      if (duplicateRss || duplicateAccept) {
+        throw new ConflictException('이미 사용 중인 블로그 이름입니다.');
+      }
+    }
+
+    await this.rssAcceptRepository.update(
+      { id: rssAcceptId },
+      { name, userName },
+    );
   }
 
   async deleteRssCertification(user: Payload, rssAcceptId: number) {

--- a/server/test/rss/e2e/certification/preview.e2e-spec.ts
+++ b/server/test/rss/e2e/certification/preview.e2e-spec.ts
@@ -1,0 +1,141 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { PreviewRssCertificationResponseDto } from '@rss/dto/response/previewRssCertification.dto';
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/rss/certifications/preview';
+
+describe(`GET ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let user: User;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+    accessToken = createAccessToken(user);
+  });
+
+  it('[401] 로그인하지 않은 유저는 미리보기를 조회할 수 없다.', async () => {
+    const response = await agent.get(URL).query({ blogName: 'any' });
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[404] 일치하는 블로그 이름의 RSS가 없으면 미리보기를 실패한다.', async () => {
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({ blogName: '존재하지않는블로그' });
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[200] RSS 이메일과 사용자 이메일이 같으면 2차 인증이 필요 없다고 반환한다.', async () => {
+    // given
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ email: user.email }),
+    );
+
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({ blogName: rssAccept.name });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: PreviewRssCertificationResponseDto } = response.body;
+    expect(data.name).toBe(rssAccept.name);
+    expect(data.userName).toBe(rssAccept.userName);
+    expect(data.rssUrl).toBe(rssAccept.rssUrl);
+    expect(data.blogPlatform).toBe(rssAccept.blogPlatform);
+    expect(data.requiresEmailVerification).toBe(false);
+  });
+
+  it('[200] RSS 이메일과 사용자 이메일이 다르면 2차 인증이 필요하다고 반환한다.', async () => {
+    // given
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ email: 'other@test.com' }),
+    );
+
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({ blogName: rssAccept.name });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: PreviewRssCertificationResponseDto } = response.body;
+    expect(data.requiresEmailVerification).toBe(true);
+  });
+
+  it('[200] 미리보기는 조회만 수행하고 소유 연결을 만들지 않는다.', async () => {
+    // given
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ email: user.email }),
+    );
+
+    // Http when
+    await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({ blogName: rssAccept.name });
+
+    // DB then - 부작용 없음
+    const saved = await rssAcceptRepository.findOneBy({ id: rssAccept.id });
+    expect(saved.userId).toBeNull();
+  });
+
+  it('[409] 본인이 이미 인증한 RSS면 미리보기를 실패한다.', async () => {
+    // given
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({ blogName: rssAccept.name });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+
+  it('[409] 다른 사용자가 이미 인증한 RSS면 미리보기를 실패한다.', async () => {
+    // given
+    const other = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const rssAccept: RssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: other.id }),
+    );
+
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .query({ blogName: rssAccept.name });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+});

--- a/server/test/rss/e2e/certification/update.e2e-spec.ts
+++ b/server/test/rss/e2e/certification/update.e2e-spec.ts
@@ -1,0 +1,119 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const makeURL = (id: number | string) => `/api/rss/certifications/${id}`;
+
+describe(`PATCH /api/rss/certifications/:id E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let user: User;
+  let rssAccept: RssAccept;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+    accessToken = createAccessToken(user);
+  });
+
+  it('[401] 로그인하지 않은 유저는 RSS 정보를 수정할 수 없다.', async () => {
+    const response = await agent
+      .patch(makeURL(rssAccept.id))
+      .send({ name: '새 블로그명', userName: '새 신청자' });
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[400] 블로그 이름이 비어 있으면 수정을 실패한다.', async () => {
+    const response = await agent
+      .patch(makeURL(rssAccept.id))
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ name: '', userName: '새 신청자' });
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[404] 존재하지 않는 RSS면 수정을 실패한다.', async () => {
+    const response = await agent
+      .patch(makeURL(99999999))
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ name: '새 블로그명', userName: '새 신청자' });
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[403] 본인이 인증한 RSS가 아니면 수정을 실패한다.', async () => {
+    // given - 다른 사용자가 인증한 RSS
+    const other = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const othersRss = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: other.id }),
+    );
+
+    // Http when
+    const response = await agent
+      .patch(makeURL(othersRss.id))
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ name: '새 블로그명', userName: '새 신청자' });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.FORBIDDEN);
+    const saved = await rssAcceptRepository.findOneBy({ id: othersRss.id });
+    expect(saved.name).toBe(othersRss.name);
+  });
+
+  it('[409] 다른 RSS와 블로그 이름이 중복되면 수정을 실패한다.', async () => {
+    // given - 이미 존재하는 이름
+    const existing = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+
+    // Http when
+    const response = await agent
+      .patch(makeURL(rssAccept.id))
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ name: existing.name, userName: '새 신청자' });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+
+  it('[200] 본인이 인증한 RSS면 블로그 이름과 신청자 이름을 수정하고 RSS URL은 유지한다.', async () => {
+    // given
+    const newName = `수정된 블로그 ${Date.now()}`;
+    const newUserName = '수정된 신청자';
+
+    // Http when
+    const response = await agent
+      .patch(makeURL(rssAccept.id))
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ name: newName, userName: newUserName });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const saved = await rssAcceptRepository.findOneBy({ id: rssAccept.id });
+    expect(saved.name).toBe(newName);
+    expect(saved.userName).toBe(newUserName);
+    expect(saved.rssUrl).toBe(rssAccept.rssUrl);
+    expect(saved.userId).toBe(user.id);
+  });
+});


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #734
- #348 

### RSS 인증 API (BE)

- 인증된 RSS에 대해 **수정(update)** 및 **미리보기(preview)** 기능이 없어 사용자가 등록 후 정보를 갱신할 수 없었습니다.
- `previewRssCertification`, `updateRssCertification` API를 추가하고, request/response DTO와 Swagger api-docs를 분리해 작성했습니다.
- 인증 소유권 검증 로직을 service 계층에 두어 controller는 얇게 유지했습니다.

### RSS 관리 탭 (FE)

- 마이페이지에 본인 소유 RSS를 관리할 수 있는 탭이 없었습니다.
- `RssManagementTab`, `OwnedRssCard`, `RssClaimModal`(소유권 주장), `RssEditModal`(수정), `PlatformIcon` 컴포넌트를 추가했습니다.
- `useRssCertification` 훅으로 미리보기/수정 API를 연동했습니다.

### 프론트엔드 타입 정리 (Refactor)

- `admin`, `auth`, `chart`, `post`, `rss`, `search` 등 흩어져 있던 타입 정의를 정돈했습니다.

### RSS 소유 인증 로직
1. 마이페이지에서 기존에 등록된 RSS 블로그 이름을 입력
2. 동일 Email 일 경우 2차 인증 없이 등록
3. RSS 신청 Email과 다른 Email 일 경우 RSS 신청 Email로 2차 인증 전송

# 📋 작업 내용

- BE: RSS 인증 `preview` / `update` API 추가 (DTO, api-docs, e2e 테스트 포함)
- FE: 마이페이지 RSS 관리 탭 및 소유권 주장/수정 모달 구현
- DB: `rss_accept`에 owner id 컬럼 추가 (`init.sql`)
- Refactor: 프론트엔드 타입 정의 정리
- Test: `preview.e2e-spec.ts`, `update.e2e-spec.ts` 추가

# 📷 스크린 샷(선택 사항)

<img width="1884" height="901" alt="image" src="https://github.com/user-attachments/assets/8bd7a90d-04f0-4c2f-9720-7963a43d5b96" />
<img width="1018" height="643" alt="image" src="https://github.com/user-attachments/assets/aa4c0540-dee9-4b00-b3b5-c4e66d6e20e0" />
<img width="1247" height="607" alt="image" src="https://github.com/user-attachments/assets/c26d6b3d-c870-4dfe-84e4-5dcd1f378ee5" />
