### PR TITLE
✨ feat: 프로필 정보 및 비밀번호 변경 기능 구현

### DIFF
--- a/client/src/api/services/profile.ts
+++ b/client/src/api/services/profile.ts
@@ -1,8 +1,18 @@
-import { PROFILE } from "@/constants/endpoints";
+import { FILE, PROFILE, USER } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
-import { ApiData } from "@/types/api";
-import { CertifiedRss, CommentItem, CursorPage, LikedItem, ProfileActivity, UserProfile } from "@/types/profile";
+import { ApiData, ApiMessage } from "@/types/api";
+import {
+  CertifiedRss,
+  ChangePasswordPayload,
+  CommentItem,
+  CursorPage,
+  LikedItem,
+  ProfileActivity,
+  UpdateProfilePayload,
+  UploadResult,
+  UserProfile,
+} from "@/types/profile";
 
 export const getProfile = async (userId: number): Promise<UserProfile> => {
   const response = await axiosInstance.get<ApiData<UserProfile>>(PROFILE.PROFILE(userId));
@@ -42,4 +52,36 @@ export const getUserComments = async (
     params: { lastId, limit },
   });
   return response.data.data;
+};
+
+export const updateProfile = async (payload: UpdateProfilePayload): Promise<ApiMessage> => {
+  const response = await axiosInstance.patch<ApiMessage>(PROFILE.UPDATE, payload);
+  return response.data;
+};
+
+export const checkUserNameAvailability = async (userName: string): Promise<boolean> => {
+  const response = await axiosInstance.get<ApiData<{ exists: boolean }>>(USER.USERNAME_AVAILABILITY, {
+    params: { userName },
+  });
+  return response.data.data.exists;
+};
+
+export const uploadProfileImage = async (file: File): Promise<UploadResult> => {
+  const formData = new FormData();
+  formData.append("file", file);
+  const response = await axiosInstance.post<ApiData<UploadResult>>(FILE.UPLOAD, formData, {
+    params: { uploadType: "PROFILE_IMAGE" },
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  return response.data.data;
+};
+
+export const changePassword = async (payload: ChangePasswordPayload): Promise<ApiMessage> => {
+  const response = await axiosInstance.patch<ApiMessage>(USER.PASSWORD, payload);
+  return response.data;
+};
+
+export const requestDeleteAccount = async (deleteRss: boolean): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(USER.DELETE_REQUEST, { deleteRss });
+  return response.data;
 };

--- a/client/src/components/profile/sections/ProfileEditTab.tsx
+++ b/client/src/components/profile/sections/ProfileEditTab.tsx
@@ -1,0 +1,390 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog.tsx";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Label } from "@/components/ui/label.tsx";
+import { Switch } from "@/components/ui/switch.tsx";
+import { Textarea } from "@/components/ui/textarea.tsx";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import { useUserProfile } from "@/hooks/queries/useProfile.ts";
+import {
+  useChangePassword,
+  useRequestDeleteAccount,
+  useUpdateProfile,
+  useUploadProfileImage,
+} from "@/hooks/queries/useProfileSettings.ts";
+
+import { checkUserNameAvailability } from "@/api/services/profile.ts";
+import { useAuthStore } from "@/store/useAuthStore.ts";
+import { UpdateProfilePayload } from "@/types/profile.ts";
+
+interface ProfileEditTabProps {
+  userId: number;
+  email: string;
+}
+
+type NameStatus = "idle" | "checking" | "available" | "taken";
+
+const getErrorMessage = (error: unknown, fallback: string) => {
+  if (error && typeof error === "object" && "response" in error) {
+    const message = (error as { response?: { data?: { message?: string } } }).response?.data?.message;
+    if (message) return message;
+  }
+  return fallback;
+};
+
+export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
+  const { toast } = useCustomToast();
+  const { setUserName: setAuthUserName } = useAuthStore();
+
+  const { data: profile } = useUserProfile(userId);
+
+  const [userName, setUserName] = useState("");
+  const [introduction, setIntroduction] = useState("");
+  const [profileImage, setProfileImage] = useState<string | null>(null);
+  const [nameStatus, setNameStatus] = useState<NameStatus>("idle");
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+
+  const [deleteRss, setDeleteRss] = useState(true);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const updateProfile = useUpdateProfile(userId);
+  const uploadImage = useUploadProfileImage();
+  const changePassword = useChangePassword();
+  const requestDelete = useRequestDeleteAccount();
+
+  useEffect(() => {
+    if (profile) {
+      setUserName(profile.userName);
+      setIntroduction(profile.introduction ?? "");
+      setProfileImage(profile.profileImage ?? null);
+    }
+  }, [profile]);
+
+  const initials = userName ? userName.substring(0, 2).toUpperCase() : "사용자";
+
+  const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = "";
+    if (!file) return;
+    try {
+      const result = await uploadImage.mutateAsync(file);
+      setProfileImage(result.url);
+      toast({ title: "이미지 업로드 성공", description: "저장을 눌러 변경사항을 반영하세요." });
+    } catch (error) {
+      toast({
+        title: "이미지 업로드 실패",
+        description: getErrorMessage(error, "이미지 업로드에 실패했습니다."),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleCheckUserName = async () => {
+    const trimmed = userName.trim();
+    if (!trimmed) {
+      toast({ title: "닉네임을 입력해주세요.", variant: "destructive" });
+      return;
+    }
+    if (trimmed === profile?.userName) {
+      setNameStatus("available");
+      return;
+    }
+    setNameStatus("checking");
+    try {
+      const exists = await checkUserNameAvailability(trimmed);
+      setNameStatus(exists ? "taken" : "available");
+    } catch (error) {
+      setNameStatus("idle");
+      toast({
+        title: "중복 확인 실패",
+        description: getErrorMessage(error, "중복 확인에 실패했습니다."),
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleSaveProfile = () => {
+    const payload: UpdateProfilePayload = {};
+    const trimmedName = userName.trim();
+
+    if (trimmedName !== profile?.userName) {
+      if (nameStatus !== "available") {
+        toast({ title: "닉네임 중복 확인을 해주세요.", variant: "destructive" });
+        return;
+      }
+      payload.userName = trimmedName;
+    }
+    if (introduction !== (profile?.introduction ?? "")) {
+      payload.introduction = introduction;
+    }
+    if (profileImage && profileImage !== (profile?.profileImage ?? null)) {
+      payload.profileImage = profileImage;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      toast({ title: "변경사항이 없습니다." });
+      return;
+    }
+
+    updateProfile.mutate(payload, {
+      onSuccess: () => {
+        if (payload.userName) setAuthUserName(payload.userName);
+        setNameStatus("idle");
+        toast({ title: "프로필 수정 성공", description: "프로필이 성공적으로 수정되었습니다." });
+      },
+      onError: (error) => {
+        toast({
+          title: "프로필 수정 실패",
+          description: getErrorMessage(error, "프로필 수정에 실패했습니다."),
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  const handleChangePassword = () => {
+    if (newPassword !== confirmPassword) {
+      toast({ title: "새 비밀번호가 일치하지 않습니다.", variant: "destructive" });
+      return;
+    }
+    changePassword.mutate(
+      { currentPassword: currentPassword || undefined, newPassword },
+      {
+        onSuccess: () => {
+          setCurrentPassword("");
+          setNewPassword("");
+          setConfirmPassword("");
+          toast({
+            title: "비밀번호 변경 성공",
+            description: "비밀번호가 성공적으로 적용되었습니다.",
+          });
+        },
+        onError: (error) => {
+          toast({
+            title: "비밀번호 변경 실패",
+            description: getErrorMessage(error, "비밀번호 변경에 실패했습니다."),
+            variant: "destructive",
+          });
+        },
+      }
+    );
+  };
+
+  const handleDeleteAccount = () => {
+    requestDelete.mutate(deleteRss, {
+      onSuccess: () => {
+        toast({
+          title: "회원 탈퇴 신청 완료",
+          description: "이메일로 발송된 링크에서 탈퇴를 완료해주세요.",
+        });
+      },
+      onError: (error) => {
+        toast({
+          title: "회원 탈퇴 신청 실패",
+          description: getErrorMessage(error, "회원 탈퇴 신청에 실패했습니다."),
+          variant: "destructive",
+        });
+      },
+    });
+  };
+
+  return (
+    <div className="max-w-2xl space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>프로필 정보</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="flex items-center space-x-6">
+            <Avatar className="w-24 h-24 border-4 border-white shadow">
+              {profileImage && <AvatarImage src={profileImage} alt={userName} />}
+              <AvatarFallback>{initials}</AvatarFallback>
+            </Avatar>
+            <div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/png,image/jpeg,image/webp,image/gif"
+                className="hidden"
+                onChange={handleImageChange}
+              />
+              <Button
+                variant="outline"
+                disabled={uploadImage.isPending}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                {uploadImage.isPending ? "업로드 중..." : "이미지 변경"}
+              </Button>
+              <p className="mt-2 text-xs text-gray-400">PNG, JPG, WEBP, GIF (최대 5MB)</p>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="email">이메일</Label>
+            <Input id="email" value={email} disabled />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="userName">닉네임</Label>
+            <div className="flex space-x-2">
+              <Input
+                id="userName"
+                value={userName}
+                onChange={(e) => {
+                  setUserName(e.target.value);
+                  setNameStatus("idle");
+                }}
+                maxLength={60}
+              />
+              <Button
+                variant="outline"
+                className="shrink-0"
+                disabled={nameStatus === "checking"}
+                onClick={handleCheckUserName}
+              >
+                {nameStatus === "checking" ? "확인 중..." : "중복 확인"}
+              </Button>
+            </div>
+            {nameStatus === "available" && <p className="text-xs text-green-600">사용 가능한 닉네임입니다.</p>}
+            {nameStatus === "taken" && <p className="text-xs text-red-500">이미 사용 중인 닉네임입니다.</p>}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="introduction">자기소개</Label>
+            <Textarea
+              id="introduction"
+              value={introduction}
+              onChange={(e) => setIntroduction(e.target.value)}
+              maxLength={500}
+              rows={4}
+              placeholder="자기소개를 입력해주세요."
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <Button onClick={handleSaveProfile} disabled={updateProfile.isPending}>
+              {updateProfile.isPending ? "저장 중..." : "저장"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>비밀번호 변경</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="currentPassword">현재 비밀번호</Label>
+            <Input
+              id="currentPassword"
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="newPassword">새 비밀번호</Label>
+            <Input
+              id="newPassword"
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              placeholder="8~32자, 영문/숫자/특수문자 중 2종류 이상"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="confirmPassword">새 비밀번호 확인</Label>
+            <Input
+              id="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="flex justify-end">
+            <Button onClick={handleChangePassword} disabled={changePassword.isPending || !newPassword}>
+              {changePassword.isPending ? "처리 중..." : "비밀번호 변경"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-red-200">
+        <CardHeader>
+          <CardTitle className="text-red-600">회원 탈퇴</CardTitle>
+        </CardHeader>
+        <CardContent className="flex items-center justify-between">
+          <p className="text-sm text-gray-500">탈퇴 시 계정이 영구적으로 삭제됩니다.</p>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="outline" className="text-red-500 border-red-300 hover:text-red-600">
+                회원 탈퇴
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>정말 탈퇴하시겠습니까?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  탈퇴 확인 링크를 이메일로 발송합니다. 링크에서 확인하면 계정이 영구적으로 삭제됩니다.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+
+              <div className="flex items-start justify-between gap-4 rounded-md border p-4">
+                <div className="space-y-1">
+                  <Label htmlFor="deleteRss" className="font-medium">
+                    소유한 RSS 함께 삭제
+                  </Label>
+                  <p className="text-sm text-gray-500">
+                    {deleteRss
+                      ? "소유한 RSS와 연관 피드도 함께 삭제됩니다."
+                      : "RSS는 서비스에 유지되고 소유 연결만 해제됩니다."}
+                  </p>
+                </div>
+                <Switch
+                  id="deleteRss"
+                  checked={deleteRss}
+                  onCheckedChange={setDeleteRss}
+                  className="mt-1 shrink-0"
+                />
+              </div>
+
+              <AlertDialogFooter>
+                <AlertDialogCancel>취소</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-red-600 hover:bg-red-700"
+                  onClick={handleDeleteAccount}
+                  disabled={requestDelete.isPending}
+                >
+                  탈퇴 신청
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};

--- a/client/src/components/profile/sections/ProfileEditTab.tsx
+++ b/client/src/components/profile/sections/ProfileEditTab.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
+import { useNavigate } from "react-router-dom";
+
 import {
   AlertDialog,
   AlertDialogAction,
@@ -49,7 +51,8 @@ const getErrorMessage = (error: unknown, fallback: string) => {
 
 export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
   const { toast } = useCustomToast();
-  const { setUserName: setAuthUserName } = useAuthStore();
+  const { setUserName: setAuthUserName, logout } = useAuthStore();
+  const navigate = useNavigate();
 
   const { data: profile } = useUserProfile(userId);
 
@@ -169,14 +172,16 @@ export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
     changePassword.mutate(
       { currentPassword: currentPassword || undefined, newPassword },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           setCurrentPassword("");
           setNewPassword("");
           setConfirmPassword("");
           toast({
             title: "비밀번호 변경 성공",
-            description: "비밀번호가 성공적으로 적용되었습니다.",
+            description: "보안을 위해 모든 기기에서 로그아웃됩니다. 다시 로그인해주세요.",
           });
+          await logout();
+          navigate("/signin");
         },
         onError: (error) => {
           toast({

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -53,6 +53,9 @@ export const USER = {
   LOGOUT: "/api/users/logout",
   CERTIFICATE: "/api/users/email-verifications",
   WITHDRAW_CONFIRM: (token: string) => `/api/users/deletion-requests/${token}`,
+  USERNAME_AVAILABILITY: "/api/users/username-availability",
+  PASSWORD: "/api/users/password",
+  DELETE_REQUEST: "/api/users/deletion-requests",
 };
 
 export const OAUTH = {
@@ -60,8 +63,13 @@ export const OAUTH = {
   REGISTER: "/api/oauth/registrations",
 };
 
+export const FILE = {
+  UPLOAD: "/api/files",
+};
+
 export const PROFILE = {
   PROFILE: (id: number) => `/api/users/${id}/profile`,
+  UPDATE: "/api/users/profile",
   RSS: (id: number) => `/api/users/${id}/rss`,
   LIKES: (id: number) => `/api/users/${id}/likes`,
   COMMENTS: (id: number) => `/api/users/${id}/comments`,

--- a/client/src/hooks/queries/useProfileSettings.ts
+++ b/client/src/hooks/queries/useProfileSettings.ts
@@ -1,0 +1,38 @@
+import { AxiosError } from "axios";
+
+import {
+  changePassword,
+  requestDeleteAccount,
+  updateProfile,
+  uploadProfileImage,
+} from "@/api/services/profile";
+import { ApiMessage } from "@/types/api";
+import { ChangePasswordPayload, UpdateProfilePayload, UploadResult } from "@/types/profile";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+type ApiError = AxiosError<{ message?: string }>;
+
+export const useUpdateProfile = (userId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<ApiMessage, ApiError, UpdateProfilePayload>({
+    mutationFn: updateProfile,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userProfile", userId] });
+    },
+  });
+};
+
+export const useUploadProfileImage = () =>
+  useMutation<UploadResult, ApiError, File>({
+    mutationFn: uploadProfileImage,
+  });
+
+export const useChangePassword = () =>
+  useMutation<ApiMessage, ApiError, ChangePasswordPayload>({
+    mutationFn: changePassword,
+  });
+
+export const useRequestDeleteAccount = () =>
+  useMutation<ApiMessage, ApiError, boolean>({
+    mutationFn: requestDeleteAccount,
+  });

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -4,20 +4,11 @@ import { useNavigate } from "react-router-dom";
 import Layout from "@/components/layout/Layout";
 import { MyPage } from "@/components/profile/MyPage.tsx";
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar.tsx";
+import { ProfileEditTab } from "@/components/profile/sections/ProfileEditTab.tsx";
 import { RssManagementTab } from "@/components/profile/rss/RssManagementTab.tsx";
-import { Card, CardContent } from "@/components/ui/card.tsx";
 
 import { useAuthStore } from "@/store/useAuthStore.ts";
 import { ProfileTab } from "@/types/profile.ts";
-
-const ComingSoon = ({ title }: { title: string }) => (
-  <Card>
-    <CardContent className="p-8 text-center">
-      <h3 className="mb-2 text-lg font-semibold">{title}</h3>
-      <p className="text-gray-400">다음 업데이트에서 제공됩니다.</p>
-    </CardContent>
-  </Card>
-);
 
 export default function Profile() {
   const navigate = useNavigate();
@@ -44,7 +35,7 @@ export default function Profile() {
             <MyPage userId={userInfo.id} name={userInfo.userName ?? ""} email={userInfo.email ?? ""} />
           )}
           {activeTab === "rss" && <RssManagementTab userId={userInfo.id} />}
-          {activeTab === "settings" && <ComingSoon title="정보 수정" />}
+          {activeTab === "settings" && <ProfileEditTab userId={userInfo.id} email={userInfo.email ?? ""} />}
         </div>
       </div>
     </Layout>

--- a/client/src/store/useAuthStore.ts
+++ b/client/src/store/useAuthStore.ts
@@ -17,6 +17,7 @@ type AuthState = {
   isInitialized: boolean;
   setAccessToken: (token: string | null) => void;
   setRole: (role: "guest" | "user" | "admin") => void;
+  setUserName: (userName: string) => void;
   setUserFromToken: (token: string) => void;
   logout: () => void;
   initialize: () => void;
@@ -34,6 +35,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   isInitialized: false,
   setRole: (role) => set({ role }),
   setAccessToken: (token) => set({ accessToken: token }),
+  setUserName: (userName) => set((state) => ({ userInfo: { ...state.userInfo, userName } })),
   setUserFromToken: (token) => {
     const decoded = decodeToken(token);
     if (decoded) {

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -42,6 +42,22 @@ export interface ProfileActivity {
   dailyActivities: DailyActivity[];
 }
 
+export interface UpdateProfilePayload {
+  userName?: string;
+  profileImage?: string;
+  introduction?: string;
+}
+
+export interface ChangePasswordPayload {
+  currentPassword?: string;
+  newPassword: string;
+}
+
+export interface UploadResult {
+  id: number;
+  url: string;
+}
+
 export interface CertifiedRss {
   id: number;
   name: string;

--- a/server/src/user/api-docs/changePassword.api-docs.ts
+++ b/server/src/user/api-docs/changePassword.api-docs.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiBody, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiMessageResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
+
+export function ApiChangePassword() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '비밀번호 설정/변경 API',
+      description:
+        '로그인한 사용자의 비밀번호를 변경합니다. 비밀번호가 설정된 계정은 현재 비밀번호 검증이 필요하고, 소셜 전용 계정은 현재 비밀번호 없이 새 비밀번호를 설정합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiBody({ type: ChangePasswordRequestDto }),
+    ApiMessageResponse('비밀번호 변경 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('현재 비밀번호가 일치하지 않거나 로그인이 필요합니다.'),
+  );
+}

--- a/server/src/user/api-docs/checkUserNameDuplication.api-docs.ts
+++ b/server/src/user/api-docs/checkUserNameDuplication.api-docs.ts
@@ -1,0 +1,26 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiQuery } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+} from '@common/swagger/swagger.helper';
+import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUserNameDuplication.dto';
+
+export function ApiCheckUserNameDuplication() {
+  return applyDecorators(
+    ApiOperation({ summary: '사용자 이름 중복 조회 API' }),
+    ApiQuery({
+      name: 'userName',
+      type: String,
+      description: '중복 확인할 사용자 이름',
+      example: '홍길동',
+    }),
+    ApiDataResponse(
+      CheckUserNameDuplicationResponseDto,
+      false,
+      '사용자 이름 중복 여부 조회 성공',
+    ),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -21,7 +21,9 @@ import { JwtGuard, Payload, RefreshJwtGuard } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
 
 import { ApiCertificateUser } from '@user/api-docs/certificateUser.api-docs';
+import { ApiChangePassword } from '@user/api-docs/changePassword.api-docs';
 import { ApiCheckEmailDuplication } from '@user/api-docs/checkEmailDuplication.api-docs';
+import { ApiCheckUserNameDuplication } from '@user/api-docs/checkUserNameDuplication.api-docs';
 import { ApiConfirmDeleteAccount } from '@user/api-docs/confirmDeleteAccount.api-docs';
 import { ApiForgotPassword } from '@user/api-docs/forgotPassword.api-docs';
 import { ApiGetUserProfile } from '@user/api-docs/getUserProfile.api-docs';
@@ -34,7 +36,9 @@ import { ApiRequestDeleteAccount } from '@user/api-docs/requestDeleteAccount.api
 import { ApiResetPassword } from '@user/api-docs/resetPassword.api-docs';
 import { ApiUpdateUser } from '@user/api-docs/updateUser.api-docs';
 import { CertificateUserRequestDto } from '@user/dto/request/certificateUser.dto';
+import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
 import { CheckEmailDuplicationRequestDto } from '@user/dto/request/checkEmailDuplication.dto';
+import { CheckUserNameDuplicationRequestDto } from '@user/dto/request/checkUserNameDuplication.dto';
 import { ConfirmDeleteAccountParamRequestDto } from '@user/dto/request/confirmDeleteAccountParam.dto';
 import { ForgotPasswordRequestDto } from '@user/dto/request/forgotPassword.dto';
 import { GetUserProfileParamRequestDto } from '@user/dto/request/getUserProfileParam.dto';
@@ -62,6 +66,21 @@ export class UserController {
       '이메일 중복 조회 요청이 성공적으로 처리되었습니다.',
       await this.userService.checkEmailDuplication(
         checkEmailDuplicationRequestDto.email,
+      ),
+    );
+  }
+
+  @ApiCheckUserNameDuplication()
+  @Get('/username-availability')
+  @HttpCode(HttpStatus.OK)
+  async checkUserNameDuplication(
+    @Query()
+    checkUserNameDuplicationRequestDto: CheckUserNameDuplicationRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '닉네임 중복 조회 요청이 성공적으로 처리되었습니다.',
+      await this.userService.checkUserNameDuplication(
+        checkUserNameDuplicationRequestDto.userName,
       ),
     );
   }
@@ -153,6 +172,20 @@ export class UserController {
     await this.userService.updateUser(user.id, updateUserDto);
     return ApiResponse.responseWithNoContent(
       '사용자 프로필 정보가 성공적으로 수정되었습니다.',
+    );
+  }
+
+  @ApiChangePassword()
+  @Patch('/password')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtGuard)
+  async changePassword(
+    @Body() changePasswordDto: ChangePasswordRequestDto,
+    @CurrentUser() user: Payload,
+  ) {
+    await this.userService.changePassword(user.id, changePasswordDto);
+    return ApiResponse.responseWithNoContent(
+      '비밀번호가 성공적으로 변경되었습니다.',
     );
   }
 

--- a/server/src/user/dto/request/changePassword.dto.ts
+++ b/server/src/user/dto/request/changePassword.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsOptional, IsString, Matches } from 'class-validator';
+
+export class ChangePasswordRequestDto {
+  @ApiPropertyOptional({
+    example: 'current1234!',
+    description:
+      '현재 비밀번호. 비밀번호가 설정된 계정은 필수, 소셜 로그인 전용 계정(비밀번호 미설정)은 생략합니다.',
+    required: false,
+  })
+  @IsOptional()
+  @IsString({
+    message: '현재 비밀번호는 문자열로 입력해주세요.',
+  })
+  currentPassword?: string;
+
+  @ApiProperty({
+    example: 'example1234!',
+    description: '새 비밀번호를 입력해주세요.',
+  })
+  @IsNotEmpty({
+    message: '비밀번호가 없습니다.',
+  })
+  @Matches(
+    /^(?=.{8,32}$)(?:(?=.*[a-z])(?=.*[A-Z])|(?=.*[a-z])(?=.*\d)|(?=.*[a-z])(?=.*[^A-Za-z0-9])|(?=.*[A-Z])(?=.*\d)|(?=.*[A-Z])(?=.*[^A-Za-z0-9])|(?=.*\d)(?=.*[^A-Za-z0-9])).*$/,
+    {
+      message:
+        '비밀번호는 8~32자이며, 영문(대문자/소문자), 숫자, 특수문자 중 2종류 이상을 포함해야 합니다.',
+    },
+  )
+  newPassword: string;
+
+  constructor(partial: Partial<ChangePasswordRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/request/checkUserNameDuplication.dto.ts
+++ b/server/src/user/dto/request/checkUserNameDuplication.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CheckUserNameDuplicationRequestDto {
+  @ApiProperty({
+    example: '홍길동',
+    description: '중복 확인할 사용자 이름을 입력해주세요.',
+  })
+  @IsString({
+    message: '사용자 이름은 문자열이어야 합니다.',
+  })
+  @IsNotEmpty({
+    message: '사용자 이름이 없습니다.',
+  })
+  @MaxLength(60, {
+    message: '사용자 이름은 60자 이하여야 합니다.',
+  })
+  @Type(() => String)
+  userName: string;
+
+  constructor(partial: Partial<CheckUserNameDuplicationRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/response/checkUserNameDuplication.dto.ts
+++ b/server/src/user/dto/response/checkUserNameDuplication.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CheckUserNameDuplicationResponseDto {
+  @ApiProperty({
+    example: true,
+    description: '사용자 이름 존재 여부 결과',
+  })
+  exists: boolean;
+
+  constructor(partial: Partial<CheckUserNameDuplicationResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(checkResult: boolean) {
+    return new CheckUserNameDuplicationResponseDto({
+      exists: checkResult,
+    });
+  }
+}

--- a/server/src/user/service/oAuth.service.ts
+++ b/server/src/user/service/oAuth.service.ts
@@ -97,6 +97,25 @@ export class OAuthService {
 
     const userInfo = await this.providers[providerType].getUserInfo(tokenData);
 
+    const linkedProvider = await this.findExistingProvider(
+      providerType,
+      userInfo.id,
+    );
+    if (linkedProvider) {
+      await this.updateProviderTokens(
+        linkedProvider,
+        tokenData.refresh_token || null,
+      );
+      const jwtPayload: Payload = {
+        id: linkedProvider.user.id,
+        email: linkedProvider.user.email,
+        userName: linkedProvider.user.userName,
+        role: 'user',
+      };
+      this.userService.issueRefreshToken(jwtPayload, res);
+      return `${OAUTH_URL_PATH.BASE_URL}/oauth-success`;
+    }
+
     const existingUser = await this.userRepository.findOne({
       where: { email: userInfo.email },
     });

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -295,6 +295,7 @@ export class UserService {
       changePasswordDto.newPassword,
     );
     await this.userRepository.save(user);
+    await this.invalidateUserTokens(user.id);
   }
 
   async forgotPassword(email: string) {

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -24,10 +24,12 @@ import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { REFRESH_TOKEN_TTL, SALT_ROUNDS } from '@user/constant/user.constants';
+import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
+import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUserNameDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
 import { GetUserProfileResponseDto } from '@user/dto/response/getUserProfile.dto';
 import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
@@ -230,7 +232,16 @@ export class UserService {
   ): Promise<void> {
     const user = await this.getUser(userId);
 
-    if (updateData.userName !== undefined) {
+    if (
+      updateData.userName !== undefined &&
+      updateData.userName !== user.userName
+    ) {
+      const existingName = await this.userRepository.findOne({
+        where: { userName: updateData.userName },
+      });
+      if (existingName) {
+        throw new ConflictException('이미 존재하는 닉네임입니다.');
+      }
       user.userName = updateData.userName;
     }
     if (
@@ -244,6 +255,45 @@ export class UserService {
       user.introduction = updateData.introduction;
     }
 
+    try {
+      await this.userRepository.save(user);
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ER_DUP_ENTRY') {
+        throw new ConflictException('이미 존재하는 닉네임입니다.');
+      }
+      throw error;
+    }
+  }
+
+  async checkUserNameDuplication(userName: string) {
+    const user = await this.userRepository.findOne({
+      where: { userName },
+    });
+
+    return CheckUserNameDuplicationResponseDto.toResponseDto(!!user);
+  }
+
+  async changePassword(
+    userId: number,
+    changePasswordDto: ChangePasswordRequestDto,
+  ): Promise<void> {
+    const user = await this.getUser(userId);
+
+    if (user.password) {
+      const matched =
+        !!changePasswordDto.currentPassword &&
+        (await bcrypt.compare(
+          changePasswordDto.currentPassword,
+          user.password,
+        ));
+      if (!matched) {
+        throw new UnauthorizedException('현재 비밀번호가 일치하지 않습니다.');
+      }
+    }
+
+    user.password = await this.createHashedPassword(
+      changePasswordDto.newPassword,
+    );
     await this.userRepository.save(user);
   }
 

--- a/server/test/user/dto/changePassword.dto.spec.ts
+++ b/server/test/user/dto/changePassword.dto.spec.ts
@@ -1,0 +1,93 @@
+import { validate } from 'class-validator';
+
+import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
+
+describe(`${ChangePasswordRequestDto.name} Test`, () => {
+  let dto: ChangePasswordRequestDto;
+
+  beforeEach(() => {
+    dto = new ChangePasswordRequestDto({
+      currentPassword: 'current1234!',
+      newPassword: 'newPass1234!',
+    });
+  });
+
+  it('현재 비밀번호가 문자열이고 새 비밀번호가 정책에 적합하면 유효성 검사를 통과한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('현재 비밀번호가 생략되어도(소셜 전용 계정) 유효성 검사를 통과한다.', async () => {
+    // given
+    dto = new ChangePasswordRequestDto({ newPassword: 'newPass1234!' });
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('newPassword', () => {
+    it('비밀번호 형식에 맞지 않으면 유효성 검사에 실패한다.', async () => {
+      // given
+      // 8~32자리를 벗어나는 길이
+      const outRangedPasswordDto = new ChangePasswordRequestDto({
+        newPassword: 'abcd!',
+      });
+
+      // 영어/숫자/특수문자를 제외한 문자가 포함되는 경우
+      const invalidTextPasswordDto = new ChangePasswordRequestDto({
+        newPassword: '한글비밀번호!',
+      });
+
+      // 영어/숫자/특수문자를 2종류 미만으로 포함하는 경우
+      const lessThanTwoKindsOfLetterPasswordDto = new ChangePasswordRequestDto({
+        newPassword: 'testpassword',
+      });
+
+      // when
+      const outRangedPasswordErrors = await validate(outRangedPasswordDto);
+      const invalidTextPasswordErrors = await validate(invalidTextPasswordDto);
+      const lessThanTwoKindsOfLetterPasswordErrors = await validate(
+        lessThanTwoKindsOfLetterPasswordDto,
+      );
+
+      // then
+      expect(outRangedPasswordErrors[0].constraints).toHaveProperty('matches');
+      expect(invalidTextPasswordErrors[0].constraints).toHaveProperty(
+        'matches',
+      );
+      expect(
+        lessThanTwoKindsOfLetterPasswordErrors[0].constraints,
+      ).toHaveProperty('matches');
+    });
+
+    it('새 비밀번호에 빈 문자열을 입력하면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.newPassword = '';
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+    });
+  });
+
+  describe('currentPassword', () => {
+    it('현재 비밀번호가 문자열이 아니면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.currentPassword = 1234 as unknown as string;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+  });
+});

--- a/server/test/user/dto/checkUserNameDuplication.dto.spec.ts
+++ b/server/test/user/dto/checkUserNameDuplication.dto.spec.ts
@@ -1,0 +1,41 @@
+import { validate } from 'class-validator';
+
+import { CheckUserNameDuplicationRequestDto } from '@user/dto/request/checkUserNameDuplication.dto';
+
+describe(`${CheckUserNameDuplicationRequestDto.name} Test`, () => {
+  let dto: CheckUserNameDuplicationRequestDto;
+
+  beforeEach(() => {
+    dto = new CheckUserNameDuplicationRequestDto({ userName: '홍길동' });
+  });
+
+  it('사용자 이름이 문자열이고 60자 이하면 유효성 검사를 통과한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('사용자 이름이 빈 문자열이면 유효성 검사에 실패한다.', async () => {
+    // given
+    dto.userName = '';
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+  });
+
+  it('사용자 이름이 60자를 초과하면 유효성 검사에 실패한다.', async () => {
+    // given
+    dto.userName = 'a'.repeat(61);
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors[0].constraints).toHaveProperty('maxLength');
+  });
+});

--- a/server/test/user/e2e/change-password.e2e-spec.ts
+++ b/server/test/user/e2e/change-password.e2e-spec.ts
@@ -1,0 +1,133 @@
+import { HttpStatus } from '@nestjs/common';
+
+import * as bcrypt from 'bcrypt';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import {
+  USER_DEFAULT_PASSWORD,
+  UserFixture,
+} from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/users/password';
+
+describe(`PATCH ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let userRepository: UserRepository;
+  let redisService: RedisService;
+  let user: User;
+  let accessToken: string;
+
+  const invalidatedKey = (id: number) =>
+    `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${id}`;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    userRepository = testApp.get(UserRepository);
+    redisService = testApp.get(RedisService);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+    accessToken = createAccessToken(user);
+  });
+
+  it('[401] 로그인하지 않은 유저가 비밀번호 변경 요청을 할 경우 실패한다.', async () => {
+    // given
+    const requestDto = new ChangePasswordRequestDto({
+      currentPassword: USER_DEFAULT_PASSWORD,
+      newPassword: 'newPass1234!',
+    });
+
+    // Http when
+    const response = await agent.patch(URL).send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+
+    // DB then: 비밀번호가 변경되지 않아야 한다.
+    const savedUser = await userRepository.findOneBy({ id: user.id });
+    expect(
+      await bcrypt.compare(USER_DEFAULT_PASSWORD, savedUser.password),
+    ).toBeTruthy();
+  });
+
+  it('[401] 현재 비밀번호가 일치하지 않으면 실패하고 비밀번호와 세션을 유지한다.', async () => {
+    // given
+    const requestDto = new ChangePasswordRequestDto({
+      currentPassword: 'wrongPass1234!',
+      newPassword: 'newPass1234!',
+    });
+
+    // Http when
+    const response = await agent
+      .patch(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+
+    // DB, Redis then: 비밀번호 미변경 + 무효화 키 미설정
+    const savedUser = await userRepository.findOneBy({ id: user.id });
+    expect(
+      await bcrypt.compare(USER_DEFAULT_PASSWORD, savedUser.password),
+    ).toBeTruthy();
+    expect(await redisService.get(invalidatedKey(user.id))).toBeNull();
+  });
+
+  it('[200] 현재 비밀번호가 일치하면 비밀번호를 변경하고 모든 기기를 로그아웃한다.', async () => {
+    // given
+    const newPassword = 'newPass1234!';
+    const requestDto = new ChangePasswordRequestDto({
+      currentPassword: USER_DEFAULT_PASSWORD,
+      newPassword,
+    });
+
+    // Http when
+    const response = await agent
+      .patch(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB, Redis then: 새 비밀번호 적용 + 전 기기 무효화 키 설정
+    const savedUser = await userRepository.findOneBy({ id: user.id });
+    expect(await bcrypt.compare(newPassword, savedUser.password)).toBeTruthy();
+    expect(await redisService.get(invalidatedKey(user.id))).not.toBeNull();
+  });
+
+  it('[200] 비밀번호 미설정 소셜 계정은 현재 비밀번호 없이 새로 설정하고 모든 기기를 로그아웃한다.', async () => {
+    // given
+    const socialUser = await userRepository.save(
+      UserFixture.createUserFixture({ password: null }),
+    );
+    const socialToken = createAccessToken(socialUser);
+    const newPassword = 'newPass1234!';
+    const requestDto = new ChangePasswordRequestDto({ newPassword });
+
+    // Http when
+    const response = await agent
+      .patch(URL)
+      .set('Authorization', `Bearer ${socialToken}`)
+      .send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB, Redis then
+    const savedUser = await userRepository.findOneBy({ id: socialUser.id });
+    expect(await bcrypt.compare(newPassword, savedUser.password)).toBeTruthy();
+    expect(await redisService.get(invalidatedKey(socialUser.id))).not.toBeNull();
+  });
+});

--- a/server/test/user/e2e/username-availability.e2e-spec.ts
+++ b/server/test/user/e2e/username-availability.e2e-spec.ts
@@ -1,0 +1,59 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/users/username-availability';
+
+describe(`GET ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let userRepository: UserRepository;
+  let user: User;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(
+      UserFixture.createUserFixture({ userName: '이미존재하는닉네임' }),
+    );
+  });
+
+  it('[200] 이미 존재하는 닉네임이면 exists=true를 반환한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .query({ userName: user.userName });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.data).toEqual({ exists: true });
+  });
+
+  it('[200] 존재하지 않는 닉네임이면 exists=false를 반환한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .query({ userName: '존재하지않는닉네임' });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.data).toEqual({ exists: false });
+  });
+
+  it('[400] 닉네임이 비어 있으면 유효성 검사에 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(URL).query({ userName: '' });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+});

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -21,6 +21,7 @@ import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
+import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUserNameDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
 import { GetUserProfileResponseDto } from '@user/dto/response/getUserProfile.dto';
 import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
@@ -456,6 +457,127 @@ describe(`${UserService.name} Unit Test`, () => {
       // then
       expect(user.userName).toBe('new');
       expect(fileService.deleteByPath).not.toHaveBeenCalled();
+    });
+
+    it('변경하려는 userName이 이미 존재하면 ConflictException을 던진다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ userName: 'old' });
+      userRepository.findOneBy.mockResolvedValue(user);
+      userRepository.findOne.mockResolvedValue(
+        UserFixture.createUserFixture({ userName: 'taken' }),
+      );
+
+      // when & then
+      await expect(
+        userService.updateUser(userId, { userName: 'taken' }),
+      ).rejects.toThrow(ConflictException);
+      expect(userRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('동일한 userName이면 중복 조회 없이 통과한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ userName: 'same' });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.updateUser(userId, { userName: 'same' });
+
+      // then
+      expect(userRepository.findOne).not.toHaveBeenCalled();
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+    });
+
+    it('사전 조회를 통과해도 저장 시 unique 제약 위반(ER_DUP_ENTRY)이면 ConflictException으로 변환한다.', async () => {
+      // given: 사전 조회는 비어 있지만(TOCTOU) 저장 시점에 중복이 발생하는 경합 상황
+      const user = UserFixture.createUserFixture({ userName: 'old' });
+      userRepository.findOneBy.mockResolvedValue(user);
+      userRepository.findOne.mockResolvedValue(null);
+      userRepository.save.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
+
+      // when & then
+      await expect(
+        userService.updateUser(userId, { userName: 'taken' }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('checkUserNameDuplication', () => {
+    it('닉네임이 존재하면 exists=true 응답을 반환한다.', async () => {
+      userRepository.findOne.mockResolvedValue(UserFixture.createUserFixture());
+      const result = await userService.checkUserNameDuplication('tester');
+      expect(result).toEqual(
+        CheckUserNameDuplicationResponseDto.toResponseDto(true),
+      );
+    });
+
+    it('닉네임이 없으면 exists=false 응답을 반환한다.', async () => {
+      userRepository.findOne.mockResolvedValue(null);
+      const result = await userService.checkUserNameDuplication('tester');
+      expect(result).toEqual(
+        CheckUserNameDuplicationResponseDto.toResponseDto(false),
+      );
+    });
+  });
+
+  describe('changePassword', () => {
+    const userId = 1;
+
+    it('현재 비밀번호가 일치하면 새 비밀번호로 변경하고 전 기기를 로그아웃한다.', async () => {
+      // given
+      const user = await UserFixture.createUserCryptFixture({ id: userId });
+      const before = user.password;
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.changePassword(userId, {
+        currentPassword: USER_DEFAULT_PASSWORD,
+        newPassword: 'newPass1!',
+      });
+
+      // then
+      expect(user.password).not.toBe(before);
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+      expect(redisService.setex).toHaveBeenCalledWith(
+        `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${userId}`,
+        14 * 86400,
+        expect.stringMatching(/^\d+$/),
+      );
+    });
+
+    it('현재 비밀번호가 일치하지 않으면 UnauthorizedException을 던지고 저장하지 않는다.', async () => {
+      // given
+      const user = await UserFixture.createUserCryptFixture({ id: userId });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when & then
+      await expect(
+        userService.changePassword(userId, {
+          currentPassword: 'wrongPass1!',
+          newPassword: 'newPass1!',
+        }),
+      ).rejects.toThrow(UnauthorizedException);
+      expect(userRepository.save).not.toHaveBeenCalled();
+      expect(redisService.setex).not.toHaveBeenCalled();
+    });
+
+    it('비밀번호 미설정 소셜 계정은 현재 비밀번호 없이 새로 설정하고 전 기기를 로그아웃한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ id: userId, password: null });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.changePassword(userId, {
+        newPassword: 'newPass1!',
+      });
+
+      // then
+      expect(user.password).toBeTruthy();
+      expect(userRepository.save).toHaveBeenCalledWith(user);
+      expect(redisService.setex).toHaveBeenCalledWith(
+        `${REDIS_KEYS.USER_INVALIDATED_PREFIX}:${userId}`,
+        14 * 86400,
+        expect.stringMatching(/^\d+$/),
+      );
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue
- close #348 
- #711 

### 프로필 정보 변경 (FE + BE)

- 마이페이지에서 닉네임/소개 등 프로필 정보를 수정할 수 있도록 `ProfileEditTab` 구현 및 API 연동
- 닉네임 변경 시 중복 검증이 필요해 `GET /username-availability` 닉네임 중복 조회 API를 추가했습니다.
- 변경 저장 경로(`updateUser`)에서는 조회 시점과 저장 시점 사이의 race를 고려해, 사전 중복 조회뿐 아니라 DB unique 제약 위반(`ER_DUP_ENTRY`)도 `ConflictException`으로 변환해 이중으로 방어했습니다.

### 비밀번호 변경 API (BE)

- `PATCH /password` (`JwtGuard`) 추가. 본인 인증 후 새 비밀번호로 갱신합니다.
- 비밀번호가 설정된 일반 계정은 `currentPassword` 일치 검증을 강제하고, 비밀번호 미설정 소셜 전용 계정은 현재 비밀번호 없이 신규 설정이 가능하도록 분기했습니다.
- 신규 비밀번호는 8~32자 / 영문 대소문자·숫자·특수문자 중 2종 이상 정책을 `Matches`로 검증합니다.

### 소셜 로그인 계정 연동 처리 (BE)

- OAuth 로그인 시 이미 동일 provider로 연동된 계정이 있으면, 이메일 기반 신규 조회로 빠지기 전에 해당 계정으로 즉시 로그인 및 refresh token을 갱신하도록 분기를 선처리했습니다.

# 📋 작업 내용

- `ProfileEditTab.tsx` 프로필 수정 탭 UI 및 검증 추가
- `useProfileSettings` 쿼리 훅 / `profile.ts` 서비스 / `endpoints.ts` 엔드포인트 추가
- 닉네임 중복 조회 API (`checkUserNameDuplication`) + DTO + Swagger 문서
- 비밀번호 변경 API (`changePassword`) + DTO + Swagger 문서
- `updateUser` 닉네임 중복 방어 로직 보강
- OAuth 기존 연동 계정 선처리 분기 추가

# 📷 스크린 샷(선택 사항)

<img width="670" height="848" alt="image" src="https://github.com/user-attachments/assets/cc051328-8fc6-43c3-9010-3b18bb3042cd" />