### PR TITLE
✨ feat: 좋아요 버튼 프론트엔드 연동

### DIFF
--- a/client/src/api/services/likes.ts
+++ b/client/src/api/services/likes.ts
@@ -1,0 +1,19 @@
+import { BLOG } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+import { ApiData } from "@/types/api";
+
+type GetLikeResponse = ApiData<{ isLike: boolean }>;
+
+export const likes = {
+  get: async (feedId: number): Promise<boolean> => {
+    const response = await axiosInstance.get<GetLikeResponse>(BLOG.LIKE(feedId));
+    return response.data.data.isLike;
+  },
+  create: async (feedId: number): Promise<void> => {
+    await axiosInstance.post(BLOG.LIKE(feedId));
+  },
+  remove: async (feedId: number): Promise<void> => {
+    await axiosInstance.delete(BLOG.LIKE(feedId));
+  },
+};

--- a/client/src/components/auth/AuthSignInForm.tsx
+++ b/client/src/components/auth/AuthSignInForm.tsx
@@ -9,7 +9,12 @@ import { Input } from "@/components/ui/input";
 import { useSignIn } from "@/hooks/auth/useSignIn";
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 
-export const AuthSignInForm = () => {
+interface AuthSignInFormProps {
+  hideBackButton?: boolean;
+  onSuccess?: () => void;
+}
+
+export const AuthSignInForm = ({ hideBackButton = false, onSuccess }: AuthSignInFormProps = {}) => {
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useCustomToast();
@@ -23,6 +28,11 @@ export const AuthSignInForm = () => {
           description: result.message,
         });
 
+        if (onSuccess) {
+          onSuccess();
+          return;
+        }
+
         const from = location.state?.from || "/";
         navigate(from === "/signup" ? "/" : from);
       } else {
@@ -33,7 +43,7 @@ export const AuthSignInForm = () => {
         });
       }
     }
-  }, [result, toast, navigate, location.state]);
+  }, [result, toast, navigate, location.state, onSuccess]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -73,13 +83,15 @@ export const AuthSignInForm = () => {
           >
             계정이 없으신가요?
           </Button>
-          <Button
-            variant="link"
-            className="text-muted-foreground underline underline-offset-4 h-auto p-0"
-            onClick={() => navigate("/")}
-          >
-            메인 페이지로 돌아가기
-          </Button>
+          {!hideBackButton && (
+            <Button
+              variant="link"
+              className="text-muted-foreground underline underline-offset-4 h-auto p-0"
+              onClick={() => navigate("/")}
+            >
+              메인 페이지로 돌아가기
+            </Button>
+          )}
         </div>
       </AuthCard>
     </>

--- a/client/src/components/common/Card/detail/LikeButton.tsx
+++ b/client/src/components/common/Card/detail/LikeButton.tsx
@@ -1,41 +1,65 @@
 import { Heart } from "lucide-react";
 
-import { useCustomToast } from "@/hooks/common/useCustomToast";
+import { useLikeStatus, useToggleLike } from "@/hooks/queries/useLike";
 
-import { TOAST_MESSAGES } from "@/constants/messages";
-
+import { useAuthStore } from "@/store/useAuthStore";
 import { useMediaStore } from "@/store/useMediaStore";
+import { Post } from "@/types/post";
 
-export default function LikeButton() {
+export default function LikeButton({ post }: { post: Post }) {
   const isMobile = useMediaStore((state) => state.isMobile);
-  return isMobile ? <MobileButton /> : <DesktopButton />;
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  const { data: isLike = false } = useLikeStatus(post.id, isAuthenticated);
+  const { mutate: toggleLike, isPending } = useToggleLike(post.id);
+
+  const count = post.likes ?? 0;
+
+  const handleClick = () => {
+    if (!isAuthenticated) return;
+    toggleLike(isLike);
+  };
+
+  return isMobile ? (
+    <MobileButton isLike={isLike} count={count} disabled={isPending} onClick={handleClick} />
+  ) : (
+    <DesktopButton isLike={isLike} count={count} disabled={isPending} onClick={handleClick} />
+  );
 }
 
-const DesktopButton = () => {
-  const { toast } = useCustomToast();
+interface ButtonProps {
+  isLike: boolean;
+  count: number;
+  disabled: boolean;
+  onClick: () => void;
+}
 
-  return (
-    <button
-      className="flex items-center px-4 py-2 rounded-full bg-gray-100 hover:bg-gray-200 transition-colors"
-      onClick={() => toast(TOAST_MESSAGES.SERVICE_NOT_PREPARED)}
-    >
-      <Heart className="w-4 h-4 mr-2" />
-      좋아요
-    </button>
-  );
-};
-const MobileButton = () => {
-  const { toast } = useCustomToast();
+const DesktopButton = ({ isLike, count, disabled, onClick }: ButtonProps) => (
+  <button
+    className={`flex items-center px-4 py-2 rounded-full transition-colors disabled:opacity-60 ${
+      isLike ? "bg-pink-500 text-white hover:bg-pink-600" : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+    }`}
+    onClick={onClick}
+    disabled={disabled}
+  >
+    <Heart className={`w-4 h-4 mr-2 ${isLike ? "fill-white" : ""}`} />
+    좋아요 {count}
+  </button>
+);
 
-  return (
-    <button
-      className="flex flex-col items-center p-4 rounded-xl hover:bg-yellow-50 transition-colors"
-      onClick={() => toast(TOAST_MESSAGES.SERVICE_NOT_PREPARED)}
+const MobileButton = ({ isLike, count, disabled, onClick }: ButtonProps) => (
+  <button
+    className="flex flex-col items-center p-4 rounded-xl transition-colors disabled:opacity-60"
+    onClick={onClick}
+    disabled={disabled}
+  >
+    <div
+      className={`w-12 h-12 rounded-xl flex items-center justify-center mb-2 transition-colors ${
+        isLike ? "bg-pink-500 text-white" : "bg-gray-100 text-gray-700"
+      }`}
     >
-      <div className="w-12 h-12 bg-gray-100 rounded-xl flex items-center justify-center mb-2">
-        <Heart className="w-6 h-6" />
-      </div>
-      <span> 좋아요</span>
-    </button>
-  );
-};
+      <Heart className={`w-6 h-6 ${isLike ? "fill-white" : ""}`} />
+    </div>
+    <span>좋아요 {count}</span>
+  </button>
+);

--- a/client/src/components/common/Card/detail/LikeButton.tsx
+++ b/client/src/components/common/Card/detail/LikeButton.tsx
@@ -1,4 +1,9 @@
+import { useState } from "react";
+
 import { Heart } from "lucide-react";
+
+import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
 import { useLikeStatus, useToggleLike } from "@/hooks/queries/useLike";
 
@@ -9,6 +14,7 @@ import { Post } from "@/types/post";
 export default function LikeButton({ post }: { post: Post }) {
   const isMobile = useMediaStore((state) => state.isMobile);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const [loginPromptOpen, setLoginPromptOpen] = useState(false);
 
   const { data: isLike = false } = useLikeStatus(post.id, isAuthenticated);
   const { mutate: toggleLike, isPending } = useToggleLike(post.id);
@@ -16,14 +22,29 @@ export default function LikeButton({ post }: { post: Post }) {
   const count = post.likes ?? 0;
 
   const handleClick = () => {
-    if (!isAuthenticated) return;
+    if (!isAuthenticated) {
+      setLoginPromptOpen(true);
+      return;
+    }
     toggleLike(isLike);
   };
 
-  return isMobile ? (
-    <MobileButton isLike={isLike} count={count} disabled={isPending} onClick={handleClick} />
-  ) : (
-    <DesktopButton isLike={isLike} count={count} disabled={isPending} onClick={handleClick} />
+  return (
+    <>
+      {isMobile ? (
+        <MobileButton isLike={isLike} count={count} disabled={isPending} onClick={handleClick} />
+      ) : (
+        <DesktopButton isLike={isLike} count={count} disabled={isPending} onClick={handleClick} />
+      )}
+      <div onClick={(e) => e.stopPropagation()}>
+        <Dialog open={loginPromptOpen} onOpenChange={setLoginPromptOpen}>
+          <DialogContent className="z-[1000] max-w-md border-0 bg-transparent p-0 shadow-none">
+            <DialogTitle className="sr-only">로그인</DialogTitle>
+            <AuthSignInForm hideBackButton onSuccess={() => setLoginPromptOpen(false)} />
+          </DialogContent>
+        </Dialog>
+      </div>
+    </>
   );
 }
 

--- a/client/src/components/common/Card/detail/PostContent.tsx
+++ b/client/src/components/common/Card/detail/PostContent.tsx
@@ -52,7 +52,7 @@ export const PostContent = React.memo(({ post }: PostContentProps) => {
         )}
       </div>
       <div className="flex gap-3">
-        <LikeButton />
+        <LikeButton post={post} />
         <ShareButton post={post} />
       </div>
     </div>

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -26,6 +26,7 @@ export const ADMIN = {
 export const BLOG = {
   POST: "/api/feeds",
   Trend: "/api/feeds/trend/sse",
+  LIKE: (id: number) => `/api/feeds/${id}/likes`,
   RSS: {
     REGISTRER_RSS: "/api/rss",
     CERTIFICATION: "/api/rss/certifications",

--- a/client/src/hooks/queries/useLike.ts
+++ b/client/src/hooks/queries/useLike.ts
@@ -1,0 +1,51 @@
+import { likes } from "@/api/services/likes";
+import { PostDetailType } from "@/types/post";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+const likeKey = (feedId: number) => ["like", feedId];
+const detailKey = (feedId: number) => ["getDetail", feedId];
+
+export const useLikeStatus = (feedId: number, enabled: boolean) => {
+  return useQuery({
+    queryKey: likeKey(feedId),
+    queryFn: () => likes.get(feedId),
+    enabled: enabled && feedId > 0,
+  });
+};
+
+export const useToggleLike = (feedId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (isLike: boolean) => (isLike ? likes.remove(feedId) : likes.create(feedId)),
+    onMutate: async (isLike: boolean) => {
+      await queryClient.cancelQueries({ queryKey: likeKey(feedId) });
+      await queryClient.cancelQueries({ queryKey: detailKey(feedId) });
+
+      const prevIsLike = queryClient.getQueryData<boolean>(likeKey(feedId));
+      const prevDetail = queryClient.getQueryData<PostDetailType>(detailKey(feedId));
+
+      const nextIsLike = !isLike;
+      queryClient.setQueryData<boolean>(likeKey(feedId), nextIsLike);
+      queryClient.setQueryData<PostDetailType>(detailKey(feedId), (old) =>
+        old
+          ? { ...old, data: { ...old.data, likes: Math.max(0, (old.data.likes ?? 0) + (nextIsLike ? 1 : -1)) } }
+          : old
+      );
+
+      return { prevIsLike, prevDetail };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.prevIsLike !== undefined) {
+        queryClient.setQueryData(likeKey(feedId), context.prevIsLike);
+      }
+      if (context?.prevDetail) {
+        queryClient.setQueryData(detailKey(feedId), context.prevDetail);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: likeKey(feedId) });
+      queryClient.invalidateQueries({ queryKey: detailKey(feedId) });
+    },
+  });
+};


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #741 

### 좋아요 API 연동

- 상세 페이지의 좋아요 버튼을 백엔드 API(`GET/POST/DELETE /api/feeds/:id/likes`)와 연동했습니다.
- react-query `useMutation`의 `onMutate`/`onError`/`onSettled`로 Optimistic Update를 구현해, 네트워크 응답 전에 UI가 즉시 반응하고 실패 시 이전 상태로 롤백되도록 했습니다.
- 좋아요 상태(`likeKey`)와 상세 데이터(`detailKey`) 캐시를 함께 갱신해, 카운트와 토글 상태가 어긋나지 않도록 했습니다.

### 비회원 좋아요 처리

- 비로그인 상태에서 좋아요 클릭 시 토스트 대신 로그인 팝업(Dialog)을 띄우도록 변경했습니다.
- `AuthSignInForm`에 `hideBackButton`/`onSuccess` props를 추가해, 기존 로그인 페이지 동작은 유지하면서 모달 컨텍스트에서 재사용할 수 있게 했습니다. 로그인 성공 시 페이지 이동 없이 팝업만 닫힙니다.

# 📋 작업 내용

- `api/services/likes.ts`: 좋아요 조회/등록/취소 API 함수 추가
- `hooks/queries/useLike.ts`: `useLikeStatus`, `useToggleLike` 훅 추가 (Optimistic Update 포함)
- `LikeButton.tsx`: API 연동, 좋아요 상태별 스타일(채워진 하트/카운트), 비회원 로그인 팝업 처리
- `AuthSignInForm.tsx`: 모달 재사용을 위한 `hideBackButton`, `onSuccess` props 추가
- `PostContent.tsx`: `LikeButton`에 `post` 전달
- `constants/endpoints.ts`: `BLOG.LIKE` 엔드포인트 추가

# 📷 스크린 샷(선택 사항)

<img width="1886" height="908" alt="image" src="https://github.com/user-attachments/assets/4ba7889a-3898-4c06-b4d0-ccc1a79430c2" />
<img width="1905" height="902" alt="image" src="https://github.com/user-attachments/assets/02818b15-5439-4171-b0ab-51b884fa6a9b" />
<img width="904" height="872" alt="image" src="https://github.com/user-attachments/assets/8e5b0b81-3010-40ea-b6e3-747254664e03" />
