### PR TITLE
✨ feat: RSS 게시글 공개 제어 및 소유 RSS 게시글 조회

### DIFF
--- a/client/src/api/services/profile.ts
+++ b/client/src/api/services/profile.ts
@@ -1,17 +1,20 @@
 import { FILE, PROFILE, USER } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
+
 import { ApiData, ApiMessage } from "@/types/api";
+
 import {
   CertifiedRss,
-  ChangePasswordPayload,
   CommentItem,
   CursorPage,
   LikedItem,
   ProfileActivity,
   UpdateProfilePayload,
   UploadResult,
+  RssFeedItem,
   UserProfile,
+  ChangePasswordPayload
 } from "@/types/profile";
 
 export const getProfile = async (userId: number): Promise<UserProfile> => {
@@ -33,6 +36,18 @@ export const getActivityYears = async (userId: number): Promise<number[]> => {
 
 export const getCertifiedRss = async (userId: number): Promise<CertifiedRss[]> => {
   const response = await axiosInstance.get<ApiData<CertifiedRss[]>>(PROFILE.RSS(userId));
+  return response.data.data;
+};
+
+export const getRssFeeds = async (
+  userId: number,
+  rssId: number,
+  lastId?: number,
+  limit = 10
+): Promise<CursorPage<RssFeedItem>> => {
+  const response = await axiosInstance.get<ApiData<CursorPage<RssFeedItem>>>(PROFILE.RSS_FEEDS(userId, rssId), {
+    params: { lastId, limit },
+  });
   return response.data.data;
 };
 

--- a/client/src/api/services/rss.ts
+++ b/client/src/api/services/rss.ts
@@ -2,7 +2,12 @@ import { BLOG } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
 import { ApiData, ApiMessage } from "@/types/api";
-import { CreateRssCertificationResult, RssCertificationPreview } from "@/types/profile";
+import {
+  CreateRssCertificationResult,
+  CursorPage,
+  OwnedRssFeedItem,
+  RssCertificationPreview,
+} from "@/types/profile";
 import { RegisterRss, RegisterResponse } from "@/types/rss";
 
 export const registerRss = async (data: RegisterRss): Promise<RegisterResponse> => {
@@ -39,6 +44,26 @@ export const updateRssCertification = async (
 
 export const deleteRssCertification = async (id: number): Promise<ApiMessage> => {
   const response = await axiosInstance.delete<ApiMessage>(BLOG.RSS.CERTIFICATION_BY_ID(id));
+  return response.data;
+};
+
+export const getOwnedRssFeeds = async (
+  rssId: number,
+  lastId?: number,
+  limit = 10
+): Promise<CursorPage<OwnedRssFeedItem>> => {
+  const response = await axiosInstance.get<ApiData<CursorPage<OwnedRssFeedItem>>>(BLOG.RSS.OWNED_FEEDS(rssId), {
+    params: { lastId, limit },
+  });
+  return response.data.data;
+};
+
+export const setFeedVisibility = async (
+  rssId: number,
+  feedId: number,
+  isPublic: boolean
+): Promise<ApiMessage> => {
+  const response = await axiosInstance.patch<ApiMessage>(BLOG.RSS.FEED_VISIBILITY(rssId, feedId), { isPublic });
   return response.data;
 };
 

--- a/client/src/components/profile/CertifiedRssList.tsx
+++ b/client/src/components/profile/CertifiedRssList.tsx
@@ -1,15 +1,14 @@
-import { Rss } from "lucide-react";
-
-import { Badge } from "@/components/ui/badge.tsx";
+import { CertifiedRssCard } from "@/components/profile/rss/CertifiedRssCard.tsx";
 import { Card, CardContent } from "@/components/ui/card.tsx";
 
 import { CertifiedRss } from "@/types/profile.ts";
 
 interface CertifiedRssListProps {
+  userId: number;
   rssList: CertifiedRss[];
 }
 
-export const CertifiedRssList = ({ rssList }: CertifiedRssListProps) => {
+export const CertifiedRssList = ({ userId, rssList }: CertifiedRssListProps) => {
   return (
     <Card className="mb-8">
       <CardContent className="p-6">
@@ -19,25 +18,7 @@ export const CertifiedRssList = ({ rssList }: CertifiedRssListProps) => {
         ) : (
           <ul className="space-y-3">
             {rssList.map((rss) => (
-              <li key={rss.id} className="flex items-center justify-between p-3 border border-gray-100 rounded-lg">
-                <div className="flex items-center min-w-0 space-x-3">
-                  <Rss className="flex-shrink-0 w-5 h-5 text-blue-500" />
-                  <div className="min-w-0">
-                    <p className="font-medium truncate">{rss.name}</p>
-                    <a
-                      href={rss.rssUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm text-gray-500 truncate hover:underline"
-                    >
-                      {rss.rssUrl}
-                    </a>
-                  </div>
-                </div>
-                <Badge variant="secondary" className="flex-shrink-0 ml-3">
-                  {rss.blogPlatform}
-                </Badge>
-              </li>
+              <CertifiedRssCard key={rss.id} userId={userId} rss={rss} />
             ))}
           </ul>
         )}

--- a/client/src/components/profile/MyPage.tsx
+++ b/client/src/components/profile/MyPage.tsx
@@ -58,7 +58,7 @@ export const MyPage = ({ userId, name, email }: MyPageProps) => {
         </CardContent>
       </Card>
 
-      <CertifiedRssList rssList={rssList ?? []} />
+      <CertifiedRssList userId={userId} rssList={rssList ?? []} />
 
       <LikedList userId={userId} />
       <CommentList userId={userId} />

--- a/client/src/components/profile/rss/CertifiedRssCard.tsx
+++ b/client/src/components/profile/rss/CertifiedRssCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { ChevronDown } from "lucide-react";
+import { ChevronDown, FileText } from "lucide-react";
 
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 import { RssFeedRow } from "@/components/profile/rss/RssFeedRow.tsx";
@@ -42,6 +42,10 @@ export const CertifiedRssCard = ({ userId, rss }: CertifiedRssCardProps) => {
             >
               {rss.rssUrl}
             </a>
+            <p className="flex items-center gap-1 text-sm text-gray-400">
+              <FileText className="w-3.5 h-3.5" />
+              게시글 {rss.feedCount}개
+            </p>
           </div>
         </div>
         <div className="flex items-center flex-shrink-0 gap-2 ml-3">

--- a/client/src/components/profile/rss/CertifiedRssCard.tsx
+++ b/client/src/components/profile/rss/CertifiedRssCard.tsx
@@ -1,68 +1,51 @@
 import { useState } from "react";
 
-import { ChevronDown, Pencil, Trash2 } from "lucide-react";
+import { ChevronDown } from "lucide-react";
 
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 import { RssFeedRow } from "@/components/profile/rss/RssFeedRow.tsx";
 import { Badge } from "@/components/ui/badge.tsx";
 import { Button } from "@/components/ui/button.tsx";
 
-import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
-import { useOwnedRssFeeds, useSetFeedVisibility } from "@/hooks/queries/useRssCertification.ts";
+import { useRssFeeds } from "@/hooks/queries/useProfile.ts";
 
 import { CertifiedRss } from "@/types/profile.ts";
 
-interface OwnedRssCardProps {
+interface CertifiedRssCardProps {
+  userId: number;
   rss: CertifiedRss;
-  onEdit: (rss: CertifiedRss) => void;
-  onDelete: (rss: CertifiedRss) => void;
 }
 
-export const OwnedRssCard = ({ rss, onEdit, onDelete }: OwnedRssCardProps) => {
-  const { toast } = useCustomToast();
+export const CertifiedRssCard = ({ userId, rss }: CertifiedRssCardProps) => {
   const [expanded, setExpanded] = useState(false);
 
-  const { data, isLoading, isError, hasNextPage, fetchNextPage, isFetchingNextPage } = useOwnedRssFeeds(
+  const { data, isLoading, isError, hasNextPage, fetchNextPage, isFetchingNextPage } = useRssFeeds(
+    userId,
     rss.id,
     expanded
   );
-  const visibilityMutation = useSetFeedVisibility(rss.id);
 
   const feeds = data?.pages.flatMap((page) => page.result) ?? [];
 
-  const handleToggle = (feedId: number, next: boolean) => {
-    visibilityMutation.mutate(
-      { feedId, isPublic: next },
-      {
-        onError: () => toast({ title: "변경 실패", description: "다시 시도해주세요." }),
-      }
-    );
-  };
-
   return (
     <li className="border border-gray-100 rounded-lg">
-      <div className="flex items-center justify-between p-4">
+      <div className="flex items-center justify-between p-3">
         <div className="flex items-center min-w-0 space-x-3">
           <PlatformIcon platform={rss.blogPlatform} className="flex-shrink-0 w-10 h-10" />
           <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <p className="font-medium truncate">{rss.name}</p>
-              <Badge variant="secondary" className="flex-shrink-0">
-                {rss.blogPlatform}
-              </Badge>
-            </div>
-            <p className="text-sm text-gray-500 truncate">{rss.userName}</p>
+            <p className="font-medium truncate">{rss.name}</p>
             <a
               href={rss.rssUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm text-gray-400 truncate hover:underline"
+              className="text-sm text-gray-500 truncate hover:underline"
             >
               {rss.rssUrl}
             </a>
           </div>
         </div>
-        <div className="flex flex-shrink-0 gap-1 ml-3">
+        <div className="flex items-center flex-shrink-0 gap-2 ml-3">
+          <Badge variant="secondary">{rss.blogPlatform}</Badge>
           <Button
             variant="ghost"
             size="icon"
@@ -72,27 +55,15 @@ export const OwnedRssCard = ({ rss, onEdit, onDelete }: OwnedRssCardProps) => {
           >
             <ChevronDown className={`w-4 h-4 transition-transform ${expanded ? "rotate-180" : ""}`} />
           </Button>
-          <Button variant="ghost" size="icon" onClick={() => onEdit(rss)} aria-label="RSS 정보 수정">
-            <Pencil className="w-4 h-4" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => onDelete(rss)}
-            aria-label="RSS 소유 해제"
-            className="text-red-500 hover:text-red-600"
-          >
-            <Trash2 className="w-4 h-4" />
-          </Button>
         </div>
       </div>
 
       {expanded && (
-        <div className="px-4 py-3 border-t border-gray-100">
+        <div className="px-3 py-3 border-t border-gray-100">
           {isLoading && <p className="text-sm text-gray-400">게시글을 불러오는 중...</p>}
           {isError && <p className="text-sm text-red-500">게시글을 불러오지 못했습니다.</p>}
           {!isLoading && !isError && feeds.length === 0 && (
-            <p className="text-sm text-gray-400">등록된 게시글이 없습니다.</p>
+            <p className="text-sm text-gray-400">게시글이 없습니다.</p>
           )}
 
           <ul className="space-y-2">
@@ -104,9 +75,6 @@ export const OwnedRssCard = ({ rss, onEdit, onDelete }: OwnedRssCardProps) => {
                 createdAt={feed.createdAt}
                 commentCount={feed.commentCount}
                 likeCount={feed.likeCount}
-                isPublic={feed.isPublic}
-                onToggleVisibility={(next) => handleToggle(feed.id, next)}
-                toggleDisabled={visibilityMutation.isPending}
               />
             ))}
           </ul>

--- a/client/src/components/profile/rss/OwnedRssCard.tsx
+++ b/client/src/components/profile/rss/OwnedRssCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { ChevronDown, Pencil, Trash2 } from "lucide-react";
+import { ChevronDown, FileText, Pencil, Trash2 } from "lucide-react";
 
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 import { RssFeedRow } from "@/components/profile/rss/RssFeedRow.tsx";
@@ -60,6 +60,10 @@ export const OwnedRssCard = ({ rss, onEdit, onDelete }: OwnedRssCardProps) => {
             >
               {rss.rssUrl}
             </a>
+            <p className="flex items-center gap-1 text-sm text-gray-400">
+              <FileText className="w-3.5 h-3.5" />
+              공개 중인 게시글 {rss.feedCount}개
+            </p>
           </div>
         </div>
         <div className="flex flex-shrink-0 gap-1 ml-3">

--- a/client/src/components/profile/rss/RssFeedRow.tsx
+++ b/client/src/components/profile/rss/RssFeedRow.tsx
@@ -1,0 +1,70 @@
+import { Link } from "react-router-dom";
+
+import { Eye, EyeOff, Heart, MessageSquare } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge.tsx";
+import { Button } from "@/components/ui/button.tsx";
+
+interface RssFeedRowProps {
+  id: number;
+  title: string;
+  createdAt: string;
+  commentCount: number;
+  likeCount: number;
+  isPublic?: boolean;
+  onToggleVisibility?: (next: boolean) => void;
+  toggleDisabled?: boolean;
+}
+
+export const RssFeedRow = ({
+  id,
+  title,
+  createdAt,
+  commentCount,
+  likeCount,
+  isPublic = true,
+  onToggleVisibility,
+  toggleDisabled = false,
+}: RssFeedRowProps) => {
+  return (
+    <li className="flex items-center justify-between gap-3 text-sm">
+      <div className="flex items-center min-w-0 gap-2">
+        {isPublic ? (
+          <Link to={`/${id}`} className="text-gray-800 truncate hover:underline">
+            {title}
+          </Link>
+        ) : (
+          <span className="text-gray-400 truncate">{title}</span>
+        )}
+        {!isPublic && (
+          <Badge variant="secondary" className="flex-shrink-0">
+            비공개
+          </Badge>
+        )}
+      </div>
+      <div className="flex items-center flex-shrink-0 gap-3 text-gray-400">
+        <span>{new Date(createdAt).toLocaleDateString("ko-KR")}</span>
+        <span className="flex items-center gap-1">
+          <MessageSquare className="w-3.5 h-3.5" />
+          {commentCount}
+        </span>
+        <span className="flex items-center gap-1">
+          <Heart className="w-3.5 h-3.5" />
+          {likeCount}
+        </span>
+        {onToggleVisibility && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="w-7 h-7"
+            onClick={() => onToggleVisibility(!isPublic)}
+            disabled={toggleDisabled}
+            aria-label={isPublic ? "비공개로 전환" : "공개로 전환"}
+          >
+            {isPublic ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4 text-red-500" />}
+          </Button>
+        )}
+      </div>
+    </li>
+  );
+};

--- a/client/src/components/profile/rss/RssFeedRow.tsx
+++ b/client/src/components/profile/rss/RssFeedRow.tsx
@@ -1,8 +1,7 @@
 import { Link } from "react-router-dom";
 
-import { Eye, EyeOff, Heart, MessageSquare } from "lucide-react";
+import { Eye, EyeOff, Heart, Lock, MessageSquare } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge.tsx";
 import { Button } from "@/components/ui/button.tsx";
 
 interface RssFeedRowProps {
@@ -28,18 +27,16 @@ export const RssFeedRow = ({
 }: RssFeedRowProps) => {
   return (
     <li className="flex items-center justify-between gap-3 text-sm">
-      <div className="flex items-center min-w-0 gap-2">
+      <div className="flex items-center min-w-0 gap-1.5">
+        {!isPublic && (
+          <Lock className="flex-shrink-0 w-3.5 h-3.5 text-gray-400" aria-label="비공개" />
+        )}
         {isPublic ? (
           <Link to={`/${id}`} className="text-gray-800 truncate hover:underline">
             {title}
           </Link>
         ) : (
           <span className="text-gray-400 truncate">{title}</span>
-        )}
-        {!isPublic && (
-          <Badge variant="secondary" className="flex-shrink-0">
-            비공개
-          </Badge>
         )}
       </div>
       <div className="flex items-center flex-shrink-0 gap-3 text-gray-400">

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -38,6 +38,9 @@ export const BLOG = {
     CERTIFICATION_PREVIEW: "/api/rss/certifications/preview",
     CERTIFICATION_VERIFY: "/api/rss/certifications/verify",
     CERTIFICATION_BY_ID: (id: number) => `/api/rss/certifications/${id}`,
+    OWNED_FEEDS: (id: number) => `/api/rss/certifications/${id}/feeds`,
+    FEED_VISIBILITY: (id: number, feedId: number) =>
+      `/api/rss/certifications/${id}/feeds/${feedId}/visibility`,
     REMOVE_CONFIRM: (code: string) => `/api/rss/remove/${code}`,
   },
 };
@@ -77,6 +80,7 @@ export const PROFILE = {
   PROFILE: (id: number) => `/api/users/${id}/profile`,
   UPDATE: "/api/users/profile",
   RSS: (id: number) => `/api/users/${id}/rss`,
+  RSS_FEEDS: (id: number, rssId: number) => `/api/users/${id}/rss/${rssId}/feeds`,
   LIKES: (id: number) => `/api/users/${id}/likes`,
   COMMENTS: (id: number) => `/api/users/${id}/comments`,
   ACTIVITIES: (id: number) => `/api/activities/${id}`,

--- a/client/src/hooks/queries/useProfile.ts
+++ b/client/src/hooks/queries/useProfile.ts
@@ -3,6 +3,7 @@ import {
   getActivityYears,
   getCertifiedRss,
   getProfile,
+  getRssFeeds,
   getUserComments,
   getUserLikes,
 } from "@/api/services/profile";
@@ -34,6 +35,15 @@ export const useCertifiedRss = (userId: number) =>
     queryKey: ["certifiedRss", userId],
     queryFn: () => getCertifiedRss(userId),
     enabled: !!userId,
+  });
+
+export const useRssFeeds = (userId: number, rssId: number, enabled: boolean) =>
+  useInfiniteQuery({
+    queryKey: ["rssFeeds", userId, rssId],
+    queryFn: ({ pageParam }) => getRssFeeds(userId, rssId, pageParam),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.lastId : undefined),
+    enabled: enabled && !!userId && !!rssId,
   });
 
 export const useUserLikes = (userId: number) =>

--- a/client/src/hooks/queries/useRssCertification.ts
+++ b/client/src/hooks/queries/useRssCertification.ts
@@ -3,13 +3,15 @@ import { AxiosError } from "axios";
 import {
   createRssCertification,
   deleteRssCertification,
+  getOwnedRssFeeds,
   previewRssCertification,
+  setFeedVisibility,
   updateRssCertification,
   verifyRssCertification,
 } from "@/api/services/rss";
 import { ApiMessage } from "@/types/api";
 import { CreateRssCertificationResult, RssCertificationPreview } from "@/types/profile";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 type ApiError = AxiosError<{ message?: string }>;
 
@@ -55,5 +57,22 @@ export const useDeleteRssCertification = (userId: number) => {
   return useMutation<ApiMessage, ApiError, number>({
     mutationFn: deleteRssCertification,
     onSuccess: () => invalidate(),
+  });
+};
+
+export const useOwnedRssFeeds = (rssId: number, enabled: boolean) =>
+  useInfiniteQuery({
+    queryKey: ["ownedRssFeeds", rssId],
+    queryFn: ({ pageParam }) => getOwnedRssFeeds(rssId, pageParam),
+    initialPageParam: undefined as number | undefined,
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.lastId : undefined),
+    enabled: enabled && !!rssId,
+  });
+
+export const useSetFeedVisibility = (rssId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<ApiMessage, ApiError, { feedId: number; isPublic: boolean }>({
+    mutationFn: ({ feedId, isPublic }) => setFeedVisibility(rssId, feedId, isPublic),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["ownedRssFeeds", rssId] }),
   });
 };

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -44,7 +44,7 @@ export interface FeedCommentType {
   };
 }
 
-export interface UpdatePostsApiResponse {
+export interface RecentFeedsApiResponse {
   message: string;
   data: FeedList[];
 }

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -99,6 +99,19 @@ export interface CommentItem {
   feed: FeedRef;
 }
 
+export interface RssFeedItem {
+  id: number;
+  title: string;
+  path: string;
+  createdAt: string;
+  commentCount: number;
+  likeCount: number;
+}
+
+export interface OwnedRssFeedItem extends RssFeedItem {
+  isPublic: boolean;
+}
+
 export interface CursorPage<T> {
   result: T[];
   lastId: number;

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -64,6 +64,7 @@ export interface CertifiedRss {
   userName: string;
   rssUrl: string;
   blogPlatform: string;
+  feedCount: number;
 }
 
 export interface RssCertificationPreview {

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -90,6 +90,7 @@ CREATE TABLE `feed` (
   `blog_id` int NOT NULL,
   `summary` text,
   `like_count` int NOT NULL DEFAULT '0',
+  `is_public` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   UNIQUE KEY `IDX_cbdceca2d71f784a8bb160268e` (`path`),
   KEY `IDX_fda780ffdcc013b739cdc6f31d` (`created_at`),

--- a/server/src/comment/repository/comment.repository.ts
+++ b/server/src/comment/repository/comment.repository.ts
@@ -24,7 +24,8 @@ export class CommentRepository extends Repository<Comment> {
       .innerJoin('comment.feed', 'feed')
       .select(['comment.id', 'comment.comment', 'comment.date'])
       .addSelect(['feed.id', 'feed.title', 'feed.path'])
-      .where('comment.user_id = :userId', { userId });
+      .where('comment.user_id = :userId', { userId })
+      .andWhere('feed.is_public = 1');
 
     if (lastId) {
       query.andWhere('comment.id < :lastId', { lastId });

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -54,7 +54,7 @@ export class CommentService {
   }
 
   async get(commentDto: GetCommentRequestDto) {
-    await this.feedService.getFeed(commentDto.feedId);
+    await this.feedService.getPublicFeed(commentDto.feedId);
 
     const comments = await this.commentRepository.getCommentInformation(
       commentDto.feedId,
@@ -87,7 +87,7 @@ export class CommentService {
     commentDto: CreateCommentRequestDto,
   ) {
     await this.dataSource.transaction(async (manager) => {
-      const feed = await this.feedService.getFeed(feedId);
+      const feed = await this.feedService.getPublicFeed(feedId);
       feed.commentCount++;
       await manager.save(feed);
       await manager.save(Comment, {

--- a/server/src/common/database/migration/1781100000000-AddFeedIsPublic.ts
+++ b/server/src/common/database/migration/1781100000000-AddFeedIsPublic.ts
@@ -1,0 +1,66 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddFeedIsPublic1781100000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE feed ADD COLUMN is_public tinyint NOT NULL DEFAULT 1;`,
+    );
+
+    await queryRunner.query(
+      `CREATE OR REPLACE VIEW feed_view AS
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY f.created_at) AS order_id,
+        f.id AS id,
+        f.title AS title,
+        f.path AS path,
+        f.created_at AS created_at,
+        f.thumbnail AS thumbnail,
+        f.view_count AS view_count,
+        f.summary AS summary,
+        f.like_count AS like_count,
+        f.comment_count AS comment_count,
+        r.name AS blog_name,
+        r.blog_platform AS blog_platform,
+        (
+          SELECT JSON_ARRAYAGG(t.name)
+          FROM tag_map tm
+          INNER JOIN tag t ON t.id = tm.tag_id
+          WHERE tm.feed_id = f.id
+        ) AS tag
+      FROM feed f
+      INNER JOIN rss_accept r ON r.id = f.blog_id
+      WHERE f.is_public = 1
+      GROUP BY f.id;`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE OR REPLACE VIEW feed_view AS
+      SELECT
+        ROW_NUMBER() OVER (ORDER BY f.created_at) AS order_id,
+        f.id AS id,
+        f.title AS title,
+        f.path AS path,
+        f.created_at AS created_at,
+        f.thumbnail AS thumbnail,
+        f.view_count AS view_count,
+        f.summary AS summary,
+        f.like_count AS like_count,
+        f.comment_count AS comment_count,
+        r.name AS blog_name,
+        r.blog_platform AS blog_platform,
+        (
+          SELECT JSON_ARRAYAGG(t.name)
+          FROM tag_map tm
+          INNER JOIN tag t ON t.id = tm.tag_id
+          WHERE tm.feed_id = f.id
+        ) AS tag
+      FROM feed f
+      INNER JOIN rss_accept r ON r.id = f.blog_id
+      GROUP BY f.id;`,
+    );
+
+    await queryRunner.query(`ALTER TABLE feed DROP COLUMN is_public;`);
+  }
+}

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -70,6 +70,13 @@ export class Feed extends BaseEntity {
   })
   commentCount: number;
 
+  @Column({
+    name: 'is_public',
+    nullable: false,
+    default: true,
+  })
+  isPublic: boolean;
+
   @ManyToOne(() => RssAccept, (rssAccept) => rssAccept.feeds, {
     nullable: false,
     onUpdate: 'CASCADE',
@@ -117,6 +124,7 @@ export class Feed extends BaseEntity {
       )
       .from(Feed, 'f')
       .innerJoin(RssAccept, 'r', 'r.id = f.blog_id')
+      .where('f.is_public = 1')
       .groupBy('f.id'),
   name: 'feed_view',
 })

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -85,7 +85,32 @@ export class FeedRepository extends Repository<Feed> {
       .getMany();
   }
 
-  async setVisibilityForBlog(feedId: number, blogId: number, isPublic: boolean) {
+  async countPublicFeedsByBlogIds(
+    blogIds: number[],
+  ): Promise<Map<number, number>> {
+    if (!blogIds.length) return new Map();
+
+    const rows = await this.createQueryBuilder('feed')
+      .select('feed.blog_id', 'blogId')
+      .addSelect('COUNT(*)', 'count')
+      .where('feed.blog_id IN (:...blogIds)', { blogIds })
+      .andWhere('feed.is_public = 1')
+      .groupBy('feed.blog_id')
+      .getRawMany();
+
+    return new Map(
+      rows.map((row: { blogId: number; count: number }) => [
+        Number(row.blogId),
+        Number(row.count),
+      ]),
+    );
+  }
+
+  async setVisibilityForBlog(
+    feedId: number,
+    blogId: number,
+    isPublic: boolean,
+  ) {
     const result = await this.createQueryBuilder()
       .update(Feed)
       .set({ isPublic })

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -66,6 +66,7 @@ export class FeedRepository extends Repository<Feed> {
         'feed.path',
         'feed.createdAt',
         'feed.commentCount',
+        'feed.likeCount',
         'feed.isPublic',
       ])
       .where('feed.blog_id = :blogId', { blogId });

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -22,6 +22,7 @@ export class FeedRepository extends Repository<Feed> {
       .innerJoinAndSelect('feed.blog', 'rss_accept')
       .addSelect(this.getMatchAgainstExpression(type, 'find'), 'relevance')
       .where(this.getWhereCondition(type), { find })
+      .andWhere('feed.is_public = 1')
       .orderBy('relevance', 'DESC')
       .addOrderBy('feed.createdAt', 'DESC')
       .skip(offset)
@@ -52,9 +53,53 @@ export class FeedRepository extends Repository<Feed> {
     }
   }
 
+  async getFeedsByBlog(
+    blogId: number,
+    lastId: number,
+    limit: number,
+    onlyPublic: boolean,
+  ) {
+    const query = this.createQueryBuilder('feed')
+      .select([
+        'feed.id',
+        'feed.title',
+        'feed.path',
+        'feed.createdAt',
+        'feed.commentCount',
+        'feed.isPublic',
+      ])
+      .where('feed.blog_id = :blogId', { blogId });
+
+    if (onlyPublic) {
+      query.andWhere('feed.is_public = 1');
+    }
+
+    if (lastId) {
+      query.andWhere('feed.id < :lastId', { lastId });
+    }
+
+    return await query
+      .orderBy('feed.id', 'DESC')
+      .take(limit + 1)
+      .getMany();
+  }
+
+  async setVisibilityForBlog(feedId: number, blogId: number, isPublic: boolean) {
+    const result = await this.createQueryBuilder()
+      .update(Feed)
+      .set({ isPublic })
+      .where('id = :feedId AND blog_id = :blogId', { feedId, blogId })
+      .execute();
+
+    return result.affected ?? 0;
+  }
+
   async findAllStatisticsOrderByViewCount(limit: number) {
     return this.find({
       select: ['id', 'title', 'viewCount'],
+      where: {
+        isPublic: true,
+      },
       order: {
         viewCount: 'DESC',
       },

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -59,6 +59,15 @@ export class FeedService {
     return feed;
   }
 
+  async getPublicFeed(feedId: number) {
+    const feed = await this.getFeed(feedId);
+    if (!feed.isPublic) {
+      throw new NotFoundException('존재하지 않는 게시글입니다.');
+    }
+
+    return feed;
+  }
+
   async requestAiSummary(feedId: number) {
     await this.getFeed(feedId);
 

--- a/server/src/like/repository/like.repository.ts
+++ b/server/src/like/repository/like.repository.ts
@@ -15,7 +15,8 @@ export class LikeRepository extends Repository<Like> {
       .innerJoin('like.feed', 'feed')
       .select(['like.id', 'like.likeDate'])
       .addSelect(['feed.id', 'feed.title', 'feed.path'])
-      .where('like.user_id = :userId', { userId });
+      .where('like.user_id = :userId', { userId })
+      .andWhere('feed.is_public = 1');
 
     if (lastId) {
       query.andWhere('like.id < :lastId', { lastId });

--- a/server/src/like/service/like.service.ts
+++ b/server/src/like/service/like.service.ts
@@ -48,7 +48,7 @@ export class LikeService {
     userInformation: Payload | null,
     feedLikeGetDto: ManageLikeRequestDto,
   ) {
-    await this.feedService.getFeed(feedLikeGetDto.feedId);
+    await this.feedService.getPublicFeed(feedLikeGetDto.feedId);
     let isLike = false;
 
     if (userInformation) {
@@ -67,7 +67,7 @@ export class LikeService {
     feedLikeCreateDto: ManageLikeRequestDto,
   ) {
     await this.dataSource.transaction(async (manager) => {
-      const feed = await this.feedService.getFeed(feedLikeCreateDto.feedId);
+      const feed = await this.feedService.getPublicFeed(feedLikeCreateDto.feedId);
       const existing = await this.likeRepository.findOneBy({
         user: { id: userInformation.id },
         feed,

--- a/server/src/rss/api-docs/getOwnedRssFeeds.api-docs.ts
+++ b/server/src/rss/api-docs/getOwnedRssFeeds.api-docs.ts
@@ -1,0 +1,32 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+  ApiForbiddenDoc,
+  ApiNotFoundDoc,
+} from '@common/swagger/swagger.helper';
+
+import { GetOwnedRssFeedsResponseDto } from '@rss/dto/response/getOwnedRssFeeds.dto';
+
+export function ApiGetOwnedRssFeeds() {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: '소유 RSS의 게시글 관리 목록 조회 API',
+      description:
+        '본인이 인증한 RSS의 게시글을 공개/비공개 상태와 함께 커서 기반으로 조회합니다. 비공개 게시글도 포함됩니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      type: Number,
+      description: '게시글을 조회할 RSS(rss_accept) ID',
+      example: 1,
+    }),
+    ApiDataResponse(GetOwnedRssFeedsResponseDto),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiForbiddenDoc('본인이 인증한 RSS가 아닙니다.'),
+    ApiNotFoundDoc('RSS를 찾을 수 없습니다.'),
+  );
+}

--- a/server/src/rss/api-docs/setFeedVisibility.api-docs.ts
+++ b/server/src/rss/api-docs/setFeedVisibility.api-docs.ts
@@ -1,0 +1,36 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiForbiddenDoc,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiSetFeedVisibility() {
+  return applyDecorators(
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: '소유 RSS 게시글 공개/비공개 전환 API',
+      description:
+        '본인이 인증한 RSS에 속한 게시글의 공개 여부를 변경합니다. 비공개 처리 시 denamu의 공개 화면(홈/검색/트렌딩/상세)에서 제외됩니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      type: Number,
+      description: '게시글이 속한 RSS(rss_accept) ID',
+      example: 1,
+    }),
+    ApiParam({
+      name: 'feedId',
+      type: Number,
+      description: '공개/비공개를 변경할 게시글 ID',
+      example: 1,
+    }),
+    ApiMessageResponse('게시글 공개 상태 변경 완료'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiForbiddenDoc('본인이 인증한 RSS가 아닙니다.'),
+    ApiNotFoundDoc('RSS 또는 게시글을 찾을 수 없습니다.'),
+  );
+}

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -24,6 +24,8 @@ import { ApiCreateRssCertification } from '@rss/api-docs/createRssCertification.
 import { ApiDeleteCertificateRss } from '@rss/api-docs/deleteCertificateRss.api-docs';
 import { ApiDeleteRss } from '@rss/api-docs/deleteRss.api-docs';
 import { ApiDeleteRssCertification } from '@rss/api-docs/deleteRssCertification.api-docs';
+import { ApiGetOwnedRssFeeds } from '@rss/api-docs/getOwnedRssFeeds.api-docs';
+import { ApiSetFeedVisibility } from '@rss/api-docs/setFeedVisibility.api-docs';
 import { ApiPreviewRssCertification } from '@rss/api-docs/previewRssCertification.api-docs';
 import { ApiReadAllRss } from '@rss/api-docs/readAllRss.api-docs';
 import { ApiReadRssAcceptHistory } from '@rss/api-docs/readRssAcceptHistory.api-docs';
@@ -34,6 +36,10 @@ import { ApiVerifyRssCertification } from '@rss/api-docs/verifyRssCertification.
 import { CreateRssCertificationRequestDto } from '@rss/dto/request/createRssCertification.dto';
 import { DeleteCertificateRssRequestDto } from '@rss/dto/request/deleteCertificateRss.dto';
 import { DeleteRssCertificationParamRequestDto } from '@rss/dto/request/deleteRssCertificationParam.dto';
+import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dto';
+import { GetOwnedRssFeedsParamRequestDto } from '@rss/dto/request/getOwnedRssFeedsParam.dto';
+import { SetFeedVisibilityRequestDto } from '@rss/dto/request/setFeedVisibility.dto';
+import { SetFeedVisibilityParamRequestDto } from '@rss/dto/request/setFeedVisibilityParam.dto';
 import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { PreviewRssCertificationRequestDto } from '@rss/dto/request/previewRssCertification.dto';
@@ -207,5 +213,38 @@ export class RssController {
       deleteRssCertificationDto.id,
     );
     return ApiResponse.responseWithNoContent('RSS 소유 인증을 해제했습니다.');
+  }
+
+  @ApiGetOwnedRssFeeds()
+  @UseGuards(JwtGuard)
+  @Get('certifications/:id/feeds')
+  @HttpCode(HttpStatus.OK)
+  async getOwnedRssFeeds(
+    @CurrentUser() user: Payload,
+    @Param() paramDto: GetOwnedRssFeedsParamRequestDto,
+    @Query() queryDto: GetOwnedRssFeedsRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '소유 RSS 게시글 목록 조회를 처리했습니다.',
+      await this.rssService.getOwnedRssFeeds(user, paramDto.id, queryDto),
+    );
+  }
+
+  @ApiSetFeedVisibility()
+  @UseGuards(JwtGuard)
+  @Patch('certifications/:id/feeds/:feedId/visibility')
+  @HttpCode(HttpStatus.OK)
+  async setFeedVisibility(
+    @CurrentUser() user: Payload,
+    @Param() paramDto: SetFeedVisibilityParamRequestDto,
+    @Body() bodyDto: SetFeedVisibilityRequestDto,
+  ) {
+    await this.rssService.setFeedVisibility(
+      user,
+      paramDto.id,
+      paramDto.feedId,
+      bodyDto.isPublic,
+    );
+    return ApiResponse.responseWithNoContent('게시글 공개 상태를 변경했습니다.');
   }
 }

--- a/server/src/rss/dto/request/getOwnedRssFeeds.dto.ts
+++ b/server/src/rss/dto/request/getOwnedRssFeeds.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class GetOwnedRssFeedsRequestDto {
+  @ApiPropertyOptional({
+    example: 1,
+    description: '마지막으로 조회한 게시글 ID (커서)',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'lastId 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  lastId?: number;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: '받아올 최대 게시글 개수',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'limit 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  limit?: number = 10;
+
+  constructor(partial: Partial<GetOwnedRssFeedsRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/request/getOwnedRssFeedsParam.dto.ts
+++ b/server/src/rss/dto/request/getOwnedRssFeedsParam.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class GetOwnedRssFeedsParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '게시글을 조회할 RSS(rss_accept) ID',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: 'RSS ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  constructor(partial: Partial<GetOwnedRssFeedsParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/request/setFeedVisibility.dto.ts
+++ b/server/src/rss/dto/request/setFeedVisibility.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsBoolean } from 'class-validator';
+
+export class SetFeedVisibilityRequestDto {
+  @ApiProperty({
+    example: false,
+    description: '공개 여부 (true: 공개, false: 비공개)',
+  })
+  @IsBoolean({
+    message: 'isPublic 값은 boolean이어야 합니다.',
+  })
+  isPublic: boolean;
+
+  constructor(partial: Partial<SetFeedVisibilityRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/request/setFeedVisibilityParam.dto.ts
+++ b/server/src/rss/dto/request/setFeedVisibilityParam.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class SetFeedVisibilityParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '게시글이 속한 RSS(rss_accept) ID',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: 'RSS ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  @ApiProperty({
+    example: 1,
+    description: '공개/비공개를 변경할 게시글 ID',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: '게시글 ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  feedId: number;
+
+  constructor(partial: Partial<SetFeedVisibilityParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/response/getOwnedRssFeeds.dto.ts
+++ b/server/src/rss/dto/response/getOwnedRssFeeds.dto.ts
@@ -1,0 +1,89 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Feed } from '@feed/entity/feed.entity';
+
+export class OwnedRssFeedResult {
+  @ApiProperty({
+    example: 1,
+    description: '게시글 ID',
+  })
+  id: number;
+
+  @ApiProperty({
+    example: 'example title',
+    description: '게시글 제목',
+  })
+  title: string;
+
+  @ApiProperty({
+    example: 'https://example.com/feed',
+    description: '게시글 원본 URL',
+  })
+  path: string;
+
+  @ApiProperty({
+    example: '2025-01-01T00:00:00.000Z',
+    description: '게시글 작성일',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: 0,
+    description: '게시글 댓글 수',
+  })
+  commentCount: number;
+
+  @ApiProperty({
+    example: true,
+    description: '공개 여부 (true: 공개, false: 비공개)',
+  })
+  isPublic: boolean;
+
+  private constructor(partial: Partial<OwnedRssFeedResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(feed: Feed) {
+    return new OwnedRssFeedResult({
+      id: feed.id,
+      title: feed.title,
+      path: feed.path,
+      createdAt: feed.createdAt,
+      commentCount: feed.commentCount,
+      isPublic: feed.isPublic,
+    });
+  }
+
+  static toResultDtoArray(feeds: Feed[]) {
+    return feeds.map((feed) => this.toResultDto(feed));
+  }
+}
+
+export class GetOwnedRssFeedsResponseDto {
+  @ApiProperty({ type: [OwnedRssFeedResult], description: 'RSS의 게시글 목록' })
+  result: OwnedRssFeedResult[];
+
+  @ApiProperty({
+    example: 1,
+    description: '마지막으로 조회한 게시글 ID (다음 요청의 커서)',
+  })
+  lastId: number;
+
+  @ApiProperty({
+    example: true,
+    description: '다음 페이지 존재 여부',
+  })
+  hasMore: boolean;
+
+  constructor(partial: Partial<GetOwnedRssFeedsResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(feeds: Feed[], lastId: number, hasMore: boolean) {
+    return new GetOwnedRssFeedsResponseDto({
+      result: OwnedRssFeedResult.toResultDtoArray(feeds),
+      lastId,
+      hasMore,
+    });
+  }
+}

--- a/server/src/rss/dto/response/getOwnedRssFeeds.dto.ts
+++ b/server/src/rss/dto/response/getOwnedRssFeeds.dto.ts
@@ -34,6 +34,12 @@ export class OwnedRssFeedResult {
   commentCount: number;
 
   @ApiProperty({
+    example: 0,
+    description: '게시글 좋아요 수',
+  })
+  likeCount: number;
+
+  @ApiProperty({
     example: true,
     description: '공개 여부 (true: 공개, false: 비공개)',
   })
@@ -50,6 +56,7 @@ export class OwnedRssFeedResult {
       path: feed.path,
       createdAt: feed.createdAt,
       commentCount: feed.commentCount,
+      likeCount: feed.likeCount,
       isPublic: feed.isPublic,
     });
   }

--- a/server/src/rss/module/rss.module.ts
+++ b/server/src/rss/module/rss.module.ts
@@ -5,6 +5,8 @@ import { NotifierModule } from '@common/notification/notifier.module';
 
 import { AdminModule } from '@admin/module/admin.module';
 
+import { FeedRepository } from '@feed/repository/feed.repository';
+
 import { RssController } from '@rss/controller/rss.controller';
 import {
   RssAcceptRepository,
@@ -21,6 +23,7 @@ import { RssService } from '@rss/service/rss.service';
     RssRepository,
     RssAcceptRepository,
     RssRejectRepository,
+    FeedRepository,
   ],
   exports: [RssAcceptRepository],
 })

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -24,7 +24,9 @@ import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
+import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dto';
 import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
+import { GetOwnedRssFeedsResponseDto } from '@rss/dto/response/getOwnedRssFeeds.dto';
 import { PreviewRssCertificationResponseDto } from '@rss/dto/response/previewRssCertification.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
 import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
@@ -35,6 +37,8 @@ import {
   RssRejectRepository,
   RssRepository,
 } from '@rss/repository/rss.repository';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
 
 type FullFeedCrawlMessage = {
   rssId: number;
@@ -48,6 +52,7 @@ export class RssService {
     private readonly rssRepository: RssRepository,
     private readonly rssAcceptRepository: RssAcceptRepository,
     private readonly rssRejectRepository: RssRejectRepository,
+    private readonly feedRepository: FeedRepository,
     private readonly emailProducer: EmailProducer,
     private readonly dataSource: DataSource,
     private readonly redisService: RedisService,
@@ -436,5 +441,61 @@ export class RssService {
     }
 
     await this.rssAcceptRepository.update({ id: rssAcceptId }, { userId: null });
+  }
+
+  private async assertRssOwnership(rssAcceptId: number, userId: number) {
+    const rssAccept = await this.rssAcceptRepository.findOne({
+      where: { id: rssAcceptId },
+    });
+
+    if (!rssAccept) {
+      throw new NotFoundException('RSS를 찾을 수 없습니다.');
+    }
+
+    if (rssAccept.userId !== userId) {
+      throw new ForbiddenException('본인이 인증한 RSS가 아닙니다.');
+    }
+
+    return rssAccept;
+  }
+
+  async getOwnedRssFeeds(
+    user: Payload,
+    rssAcceptId: number,
+    feedDto: GetOwnedRssFeedsRequestDto,
+  ) {
+    await this.assertRssOwnership(rssAcceptId, user.id);
+
+    const feeds = await this.feedRepository.getFeedsByBlog(
+      rssAcceptId,
+      feedDto.lastId,
+      feedDto.limit,
+      false,
+    );
+
+    const hasMore = feeds.length > feedDto.limit;
+    if (hasMore) feeds.pop();
+    const lastId = feeds.length ? feeds[feeds.length - 1].id : 0;
+
+    return GetOwnedRssFeedsResponseDto.toResponseDto(feeds, lastId, hasMore);
+  }
+
+  async setFeedVisibility(
+    user: Payload,
+    rssAcceptId: number,
+    feedId: number,
+    isPublic: boolean,
+  ) {
+    await this.assertRssOwnership(rssAcceptId, user.id);
+
+    const affected = await this.feedRepository.setVisibilityForBlog(
+      feedId,
+      rssAcceptId,
+      isPublic,
+    );
+
+    if (!affected) {
+      throw new NotFoundException('해당 RSS의 게시글을 찾을 수 없습니다.');
+    }
   }
 }

--- a/server/src/user/api-docs/getUserRssFeeds.api-docs.ts
+++ b/server/src/user/api-docs/getUserRssFeeds.api-docs.ts
@@ -1,0 +1,33 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+} from '@common/swagger/swagger.helper';
+
+import { GetUserRssFeedsResponseDto } from '@user/dto/response/getUserRssFeeds.dto';
+
+export function ApiGetUserRssFeeds() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '특정 RSS의 게시글 목록 조회 API',
+      description:
+        '특정 RSS(rss_accept)에 등록된 게시글 목록을 작성일, 댓글 수와 함께 커서 기반으로 조회합니다.',
+    }),
+    ApiParam({
+      name: 'id',
+      type: Number,
+      description: 'RSS 소유자 사용자 ID',
+      example: 1,
+    }),
+    ApiParam({
+      name: 'rssId',
+      type: Number,
+      description: '게시글을 조회할 RSS(rss_accept) ID',
+      example: 1,
+    }),
+    ApiDataResponse(GetUserRssFeedsResponseDto),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -28,6 +28,7 @@ import { ApiConfirmDeleteAccount } from '@user/api-docs/confirmDeleteAccount.api
 import { ApiForgotPassword } from '@user/api-docs/forgotPassword.api-docs';
 import { ApiGetUserProfile } from '@user/api-docs/getUserProfile.api-docs';
 import { ApiGetUserRss } from '@user/api-docs/getUserRss.api-docs';
+import { ApiGetUserRssFeeds } from '@user/api-docs/getUserRssFeeds.api-docs';
 import { ApiLoginUser } from '@user/api-docs/loginUser.api-docs';
 import { ApiLogoutUser } from '@user/api-docs/logoutUser.api-docs';
 import { ApiRefreshToken } from '@user/api-docs/refreshToken.api-docs';
@@ -42,6 +43,8 @@ import { CheckUserNameDuplicationRequestDto } from '@user/dto/request/checkUserN
 import { ConfirmDeleteAccountParamRequestDto } from '@user/dto/request/confirmDeleteAccountParam.dto';
 import { ForgotPasswordRequestDto } from '@user/dto/request/forgotPassword.dto';
 import { GetUserProfileParamRequestDto } from '@user/dto/request/getUserProfileParam.dto';
+import { GetUserRssFeedsRequestDto } from '@user/dto/request/getUserRssFeeds.dto';
+import { GetUserRssFeedsParamRequestDto } from '@user/dto/request/getUserRssFeedsParam.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { RequestDeleteAccountRequestDto } from '@user/dto/request/requestDeleteAccount.dto';
@@ -102,6 +105,19 @@ export class UserController {
     return ApiResponse.responseWithData(
       '사용자 소유 RSS 조회가 성공적으로 처리되었습니다.',
       await this.userService.getUserRss(paramDto.id),
+    );
+  }
+
+  @ApiGetUserRssFeeds()
+  @Get('/:id/rss/:rssId/feeds')
+  @HttpCode(HttpStatus.OK)
+  async getUserRssFeeds(
+    @Param() paramDto: GetUserRssFeedsParamRequestDto,
+    @Query() queryDto: GetUserRssFeedsRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      'RSS 게시글 목록 조회가 성공적으로 처리되었습니다.',
+      await this.userService.getUserRssFeeds(paramDto.rssId, queryDto),
     );
   }
 

--- a/server/src/user/dto/request/getUserRssFeeds.dto.ts
+++ b/server/src/user/dto/request/getUserRssFeeds.dto.ts
@@ -1,0 +1,36 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class GetUserRssFeedsRequestDto {
+  @ApiPropertyOptional({
+    example: 1,
+    description: '마지막으로 조회한 게시글 ID (커서)',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'lastId 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  lastId?: number;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: '받아올 최대 게시글 개수',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'limit 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  limit?: number = 10;
+
+  constructor(partial: Partial<GetUserRssFeedsRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/request/getUserRssFeedsParam.dto.ts
+++ b/server/src/user/dto/request/getUserRssFeedsParam.dto.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class GetUserRssFeedsParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: 'RSS 소유자 사용자 ID',
+  })
+  @IsInt({
+    message: '숫자로 입력해주세요.',
+  })
+  @Min(1, { message: '사용자 ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  @ApiProperty({
+    example: 1,
+    description: '게시글을 조회할 RSS(rss_accept) ID',
+  })
+  @IsInt({
+    message: '숫자로 입력해주세요.',
+  })
+  @Min(1, { message: 'RSS ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  rssId: number;
+
+  constructor(partial: Partial<GetUserRssFeedsParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/response/getUserRss.dto.ts
+++ b/server/src/user/dto/response/getUserRss.dto.ts
@@ -33,21 +33,33 @@ export class GetUserRssResponseDto {
   })
   blogPlatform: string;
 
+  @ApiProperty({
+    example: 0,
+    description: 'RSS의 공개 게시글 수',
+  })
+  feedCount: number;
+
   constructor(partial: Partial<GetUserRssResponseDto>) {
     Object.assign(this, partial);
   }
 
-  static toResponseDto(rssAccept: RssAccept) {
+  static toResponseDto(rssAccept: RssAccept, feedCount: number) {
     return new GetUserRssResponseDto({
       id: rssAccept.id,
       name: rssAccept.name,
       userName: rssAccept.userName,
       rssUrl: rssAccept.rssUrl,
       blogPlatform: rssAccept.blogPlatform,
+      feedCount,
     });
   }
 
-  static toResponseDtoArray(rssAcceptList: RssAccept[]) {
-    return rssAcceptList.map((rssAccept) => this.toResponseDto(rssAccept));
+  static toResponseDtoArray(
+    rssAcceptList: RssAccept[],
+    feedCountMap: Map<number, number>,
+  ) {
+    return rssAcceptList.map((rssAccept) =>
+      this.toResponseDto(rssAccept, feedCountMap.get(rssAccept.id) ?? 0),
+    );
   }
 }

--- a/server/src/user/dto/response/getUserRssFeeds.dto.ts
+++ b/server/src/user/dto/response/getUserRssFeeds.dto.ts
@@ -1,0 +1,82 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Feed } from '@feed/entity/feed.entity';
+
+export class UserRssFeedResult {
+  @ApiProperty({
+    example: 1,
+    description: '게시글 ID',
+  })
+  id: number;
+
+  @ApiProperty({
+    example: 'example title',
+    description: '게시글 제목',
+  })
+  title: string;
+
+  @ApiProperty({
+    example: 'https://example.com/feed',
+    description: '게시글 URL',
+  })
+  path: string;
+
+  @ApiProperty({
+    example: '2025-01-01T00:00:00.000Z',
+    description: '게시글 작성일',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: 0,
+    description: '게시글 댓글 수',
+  })
+  commentCount: number;
+
+  private constructor(partial: Partial<UserRssFeedResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(feed: Feed) {
+    return new UserRssFeedResult({
+      id: feed.id,
+      title: feed.title,
+      path: feed.path,
+      createdAt: feed.createdAt,
+      commentCount: feed.commentCount,
+    });
+  }
+
+  static toResultDtoArray(feeds: Feed[]) {
+    return feeds.map((feed) => this.toResultDto(feed));
+  }
+}
+
+export class GetUserRssFeedsResponseDto {
+  @ApiProperty({ type: [UserRssFeedResult], description: 'RSS의 게시글 목록' })
+  result: UserRssFeedResult[];
+
+  @ApiProperty({
+    example: 1,
+    description: '마지막으로 조회한 게시글 ID (다음 요청의 커서)',
+  })
+  lastId: number;
+
+  @ApiProperty({
+    example: true,
+    description: '다음 페이지 존재 여부',
+  })
+  hasMore: boolean;
+
+  constructor(partial: Partial<GetUserRssFeedsResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(feeds: Feed[], lastId: number, hasMore: boolean) {
+    return new GetUserRssFeedsResponseDto({
+      result: UserRssFeedResult.toResultDtoArray(feeds),
+      lastId,
+      hasMore,
+    });
+  }
+}

--- a/server/src/user/dto/response/getUserRssFeeds.dto.ts
+++ b/server/src/user/dto/response/getUserRssFeeds.dto.ts
@@ -33,6 +33,12 @@ export class UserRssFeedResult {
   })
   commentCount: number;
 
+  @ApiProperty({
+    example: 0,
+    description: '게시글 좋아요 수',
+  })
+  likeCount: number;
+
   private constructor(partial: Partial<UserRssFeedResult>) {
     Object.assign(this, partial);
   }
@@ -44,6 +50,7 @@ export class UserRssFeedResult {
       path: feed.path,
       createdAt: feed.createdAt,
       commentCount: feed.commentCount,
+      likeCount: feed.likeCount,
     });
   }
 

--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 
 import { JwtAuthModule } from '@common/auth/jwt.module';
 
+import { FeedRepository } from '@feed/repository/feed.repository';
+
 import { FileModule } from '@file/module/file.module';
 
 import { RssModule } from '@rss/module/rss.module';
@@ -24,6 +26,7 @@ import { UserService } from '@user/service/user.service';
     OAuthService,
     UserRepository,
     ProviderRepository,
+    FeedRepository,
     GoogleOAuthProvider,
     GithubOAuthProvider,
     UserScheduler,

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -139,7 +139,10 @@ export class UserService {
       where: { userId },
       order: { id: 'DESC' },
     });
-    return GetUserRssResponseDto.toResponseDtoArray(rssList);
+    const feedCountMap = await this.feedRepository.countPublicFeedsByBlogIds(
+      rssList.map((rss) => rss.id),
+    );
+    return GetUserRssResponseDto.toResponseDtoArray(rssList, feedCountMap);
   }
 
   async getUserRssFeeds(rssId: number, feedDto: GetUserRssFeedsRequestDto) {

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -18,6 +18,8 @@ import { Payload } from '@common/guard/jwt.guard';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
+import { FeedRepository } from '@feed/repository/feed.repository';
+
 import { FileService } from '@file/service/file.service';
 
 import { RssAccept } from '@rss/entity/rss.entity';
@@ -33,6 +35,8 @@ import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUse
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
 import { GetUserProfileResponseDto } from '@user/dto/response/getUserProfile.dto';
 import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
+import { GetUserRssFeedsRequestDto } from '@user/dto/request/getUserRssFeeds.dto';
+import { GetUserRssFeedsResponseDto } from '@user/dto/response/getUserRssFeeds.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
@@ -46,6 +50,7 @@ export class UserService {
     private readonly configService: ConfigService,
     private readonly fileService: FileService,
     private readonly rssAcceptRepository: RssAcceptRepository,
+    private readonly feedRepository: FeedRepository,
     private readonly dataSource: DataSource,
   ) {}
 
@@ -135,6 +140,21 @@ export class UserService {
       order: { id: 'DESC' },
     });
     return GetUserRssResponseDto.toResponseDtoArray(rssList);
+  }
+
+  async getUserRssFeeds(rssId: number, feedDto: GetUserRssFeedsRequestDto) {
+    const feeds = await this.feedRepository.getFeedsByBlog(
+      rssId,
+      feedDto.lastId,
+      feedDto.limit,
+      true,
+    );
+
+    const hasMore = feeds.length > feedDto.limit;
+    if (hasMore) feeds.pop();
+    const lastId = feeds.length ? feeds[feeds.length - 1].id : 0;
+
+    return GetUserRssFeedsResponseDto.toResponseDto(feeds, lastId, hasMore);
   }
 
   async loginUser(loginDto: LoginUserRequestDto, response: Response) {

--- a/server/test/comment/e2e/create.e2e-spec.ts
+++ b/server/test/comment/e2e/create.e2e-spec.ts
@@ -98,6 +98,29 @@ describe(`POST ${BASE_URL}/:feedId/comments E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
+  it('[404] 비공개 게시글에는 댓글을 등록할 수 없다.', async () => {
+    // given
+    const privateFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: false }),
+    );
+    const requestDto = new CreateCommentRequestDto({
+      comment: COMMENT_DEFAULT_TEXT,
+    });
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${privateFeed.id}/comments`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    const savedComment = await commentRepository.findOneBy({
+      feed: { id: privateFeed.id },
+    });
+    expect(savedComment).toBeNull();
+  });
+
   it('[201] 로그인이 되어 있을 경우 댓글 등록을 성공한다.', async () => {
     // given
     const requestDto = new CreateCommentRequestDto({

--- a/server/test/comment/e2e/get.e2e-spec.ts
+++ b/server/test/comment/e2e/get.e2e-spec.ts
@@ -67,6 +67,24 @@ describe(`GET ${BASE_URL}/:feedId/comments E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
+  it('[404] 비공개 게시글의 댓글은 조회할 수 없다.', async () => {
+    // given - 비공개 게시글 + 댓글
+    const privateFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: false }),
+    );
+    await commentRepository.save(
+      CommentFixture.createCommentFixture(privateFeed, user),
+    );
+
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${privateFeed.id}/comments`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
   it('[200] 게시글이 존재할 경우 댓글 조회를 성공한다.', async () => {
     // Http when
     const response = await agent.get(`${BASE_URL}/${feed.id}/comments`);

--- a/server/test/comment/e2e/getUserComments.e2e-spec.ts
+++ b/server/test/comment/e2e/getUserComments.e2e-spec.ts
@@ -130,6 +130,26 @@ describe(`GET ${BASE_URL}/:userId/comments E2E Test`, () => {
     expect(data.hasMore).toBe(false);
   });
 
+  it('[200] 비공개 게시글에 작성한 댓글은 목록에서 제외된다.', async () => {
+    // given - 비공개 게시글에 댓글 작성
+    const privateFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: false }),
+    );
+    const privateComment = await commentRepository.save(
+      CommentFixture.createCommentFixture(privateFeed, user, { comment: 'private' }),
+    );
+
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${user.id}/comments`);
+
+    // Http then
+    const { data }: { data: GetUserCommentsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    const ids = data.result.map((item) => item.id);
+    expect(ids).not.toContain(privateComment.id);
+    expect(data.result).toHaveLength(3);
+  });
+
   it('[200] 댓글이 없는 유저는 빈 목록과 lastId=0을 반환한다.', async () => {
     // Http given
     const otherUser = await userRepository.save(

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -22,7 +22,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       'findOne' | 'getCommentInformation' | 'getCommentsByUser' | 'save'
     >
   >;
-  let feedService: jest.Mocked<Pick<FeedService, 'getFeed'>>;
+  let feedService: jest.Mocked<Pick<FeedService, 'getPublicFeed'>>;
   let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
   let manager: { save: jest.Mock; remove: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
@@ -41,7 +41,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       getCommentsByUser: jest.fn(),
       save: jest.fn(),
     };
-    feedService = { getFeed: jest.fn() };
+    feedService = { getPublicFeed: jest.fn() };
     userService = { getUser: jest.fn() };
     manager = { save: jest.fn(), remove: jest.fn() };
     dataSource = {
@@ -68,14 +68,14 @@ describe(`${CommentService.name} Unit Test`, () => {
           user: { id: 1, userName: 'tester', profileImage: null },
         },
       ] as any;
-      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+      feedService.getPublicFeed.mockResolvedValue({ id: 10, isPublic: true } as any);
       commentRepository.getCommentInformation.mockResolvedValue(comments);
 
       // when
       const result = await commentService.get(dto);
 
       // then
-      expect(feedService.getFeed).toHaveBeenCalledWith(10);
+      expect(feedService.getPublicFeed).toHaveBeenCalledWith(10);
       expect(commentRepository.getCommentInformation).toHaveBeenCalledWith(10);
       expect(result).toEqual(
         GetCommentResponseDto.toResponseDtoArray(comments),
@@ -165,8 +165,8 @@ describe(`${CommentService.name} Unit Test`, () => {
   describe('create', () => {
     it('트랜잭션 안에서 댓글 수를 증가시키고 댓글을 저장한다.', async () => {
       // given
-      const feed = { id: 10, commentCount: 2 };
-      feedService.getFeed.mockResolvedValue(feed as any);
+      const feed = { id: 10, commentCount: 2, isPublic: true };
+      feedService.getPublicFeed.mockResolvedValue(feed as any);
       const dto = { comment: '새 댓글' };
 
       // when
@@ -180,6 +180,19 @@ describe(`${CommentService.name} Unit Test`, () => {
         feed,
         user: { id: user.id },
       });
+    });
+
+    it('비공개 게시글이면 NotFoundException을 던지고 저장하지 않는다.', async () => {
+      // given - getPublicFeed가 비공개 게시글에 대해 404를 던진다.
+      feedService.getPublicFeed.mockRejectedValue(
+        new NotFoundException('존재하지 않는 게시글입니다.')
+      );
+
+      // when & then
+      await expect(commentService.create(user, 10, { comment: 'x' })).rejects.toThrow(
+        NotFoundException
+      );
+      expect(manager.save).not.toHaveBeenCalled();
     });
   });
 

--- a/server/test/feed/e2e/visibility.e2e-spec.ts
+++ b/server/test/feed/e2e/visibility.e2e-spec.ts
@@ -1,0 +1,63 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/feeds';
+
+describe(`비공개 게시글 공개 노출 제외 E2E Test (feed_view 필터)`, () => {
+  let agent: TestAgent;
+  let feedRepository: FeedRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let rssAccept: RssAccept;
+  let publicFeed: Feed;
+  let privateFeed: Feed;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    feedRepository = testApp.get(FeedRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+  });
+
+  beforeEach(async () => {
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    publicFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { title: '공개글', isPublic: true }),
+    );
+    privateFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { title: '비공개글', isPublic: false }),
+    );
+  });
+
+  it('[200] 페이지네이션에서 비공개 게시글은 제외되고 공개 게시글만 제공된다.', async () => {
+    const response = await agent.get(URL).query({ limit: 10 });
+
+    expect(response.status).toBe(HttpStatus.OK);
+    const ids = response.body.data.result.map((f: { id: number }) => f.id);
+    expect(ids).toContain(publicFeed.id);
+    expect(ids).not.toContain(privateFeed.id);
+  });
+
+  it('[404] 비공개 게시글 상세 조회는 존재하지 않는 것으로 처리된다.', async () => {
+    const response = await agent.get(`${URL}/${privateFeed.id}`);
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[200] 공개 게시글 상세 조회는 정상 제공된다.', async () => {
+    const response = await agent.get(`${URL}/${publicFeed.id}`);
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(response.body.data.id).toBe(publicFeed.id);
+  });
+});

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -85,6 +85,24 @@ describe(`${FeedService.name} Unit Test`, () => {
     });
   });
 
+  describe('getPublicFeed', () => {
+    it('존재하지 않으면 NotFoundException을 던진다.', async () => {
+      feedRepository.findOneBy.mockResolvedValue(null);
+      await expect(feedService.getPublicFeed(1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('비공개 게시글이면 NotFoundException을 던진다.', async () => {
+      feedRepository.findOneBy.mockResolvedValue({ id: 1, isPublic: false } as any);
+      await expect(feedService.getPublicFeed(1)).rejects.toThrow(NotFoundException);
+    });
+
+    it('공개 게시글이면 피드를 반환한다.', async () => {
+      const feed = { id: 1, isPublic: true } as any;
+      feedRepository.findOneBy.mockResolvedValue(feed);
+      await expect(feedService.getPublicFeed(1)).resolves.toBe(feed);
+    });
+  });
+
   describe('getFeedByView', () => {
     it('존재하지 않으면 NotFoundException을 던진다.', async () => {
       feedViewRepository.findOneBy.mockResolvedValue(null);

--- a/server/test/like/e2e/create.e2e-spec.ts
+++ b/server/test/like/e2e/create.e2e-spec.ts
@@ -92,6 +92,25 @@ describe(`POST ${BASE_URL}/:feedId/likes E2E Test`, () => {
     expect(savedLike).toBeNull();
   });
 
+  it('[404] 비공개 게시글에는 좋아요를 등록할 수 없다.', async () => {
+    // given
+    const privateFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: false }),
+    );
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${privateFeed.id}/likes`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    const savedLike = await likeRepository.findOneBy({
+      feed: { id: privateFeed.id },
+    });
+    expect(savedLike).toBeNull();
+  });
+
   it('[409] 이미 좋아요를 한 게시글일 경우 좋아요 등록을 실패한다.', async () => {
     // given
     await likeRepository.insert({ user, feed });

--- a/server/test/like/e2e/get.e2e-spec.ts
+++ b/server/test/like/e2e/get.e2e-spec.ts
@@ -63,6 +63,20 @@ describe(`GET ${BASE_URL}/:feedId/likes E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
+  it('[404] 비공개 게시글의 좋아요 정보는 조회할 수 없다.', async () => {
+    // given
+    const privateFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: false }),
+    );
+
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${privateFeed.id}/likes`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(response.body.data).toBeUndefined();
+  });
+
   it('[200] 로그인하지 않은 상황에서 게시글에 대한 좋아요 조회 요청을 받을 경우 좋아요 정보 제공을 성공한다.', async () => {
     // Http when
     const response = await agent.get(`${BASE_URL}/${feed.id}/likes`);

--- a/server/test/like/e2e/getUserLikes.e2e-spec.ts
+++ b/server/test/like/e2e/getUserLikes.e2e-spec.ts
@@ -126,6 +126,24 @@ describe(`GET ${BASE_URL}/:userId/likes E2E Test`, () => {
     expect(data.hasMore).toBe(false);
   });
 
+  it('[200] 비공개 게시글에 누른 좋아요는 목록에서 제외된다.', async () => {
+    // given - 비공개 게시글에 좋아요 추가
+    const privateFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { title: '비공개', isPublic: false }),
+    );
+    const privateLike = await likeRepository.save({ user, feed: privateFeed });
+
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${user.id}/likes`);
+
+    // Http then
+    const { data }: { data: GetUserLikesResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    const ids = data.result.map((item) => item.id);
+    expect(ids).not.toContain(privateLike.id);
+    expect(data.result).toHaveLength(3);
+  });
+
   it('[200] 좋아요가 없는 유저는 빈 목록과 lastId=0을 반환한다.', async () => {
     // Http given
     const otherUser = await userRepository.save(

--- a/server/test/like/unit/like.service.unit.spec.ts
+++ b/server/test/like/unit/like.service.unit.spec.ts
@@ -19,7 +19,7 @@ describe(`${LikeService.name} Unit Test`, () => {
   let likeRepository: jest.Mocked<
     Pick<LikeRepository, 'findOneBy' | 'getLikesByUser'>
   >;
-  let feedService: jest.Mocked<Pick<FeedService, 'getFeed'>>;
+  let feedService: jest.Mocked<Pick<FeedService, 'getFeed' | 'getPublicFeed'>>;
   let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
   let manager: { save: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
@@ -34,7 +34,7 @@ describe(`${LikeService.name} Unit Test`, () => {
 
   beforeEach(() => {
     likeRepository = { findOneBy: jest.fn(), getLikesByUser: jest.fn() };
-    feedService = { getFeed: jest.fn() };
+    feedService = { getFeed: jest.fn(), getPublicFeed: jest.fn() };
     userService = { getUser: jest.fn() };
     manager = { save: jest.fn(), delete: jest.fn() };
     dataSource = {
@@ -52,7 +52,7 @@ describe(`${LikeService.name} Unit Test`, () => {
   describe('get', () => {
     it('비로그인 사용자는 좋아요 조회 없이 false를 반환한다.', async () => {
       // given
-      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+      feedService.getPublicFeed.mockResolvedValue({ id: 10 } as any);
 
       // when
       const result = await likeService.get(null, dto);
@@ -64,7 +64,7 @@ describe(`${LikeService.name} Unit Test`, () => {
 
     it('로그인 사용자가 좋아요를 눌렀으면 true를 반환한다.', async () => {
       // given
-      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+      feedService.getPublicFeed.mockResolvedValue({ id: 10 } as any);
       likeRepository.findOneBy.mockResolvedValue({ id: 1 } as any);
 
       // when
@@ -76,7 +76,7 @@ describe(`${LikeService.name} Unit Test`, () => {
 
     it('로그인 사용자가 좋아요를 누르지 않았으면 false를 반환한다.', async () => {
       // given
-      feedService.getFeed.mockResolvedValue({ id: 10 } as any);
+      feedService.getPublicFeed.mockResolvedValue({ id: 10 } as any);
       likeRepository.findOneBy.mockResolvedValue(null);
 
       // when
@@ -90,7 +90,7 @@ describe(`${LikeService.name} Unit Test`, () => {
   describe('create', () => {
     it('이미 좋아요한 상태면 ConflictException을 던진다.', async () => {
       // given
-      feedService.getFeed.mockResolvedValue({ id: 10, likeCount: 0 } as any);
+      feedService.getPublicFeed.mockResolvedValue({ id: 10, likeCount: 0 } as any);
       likeRepository.findOneBy.mockResolvedValue({ id: 1 } as any);
 
       // when & then
@@ -103,7 +103,7 @@ describe(`${LikeService.name} Unit Test`, () => {
     it('좋아요 수를 증가시키고 좋아요를 저장한다.', async () => {
       // given
       const feed = { id: 10, likeCount: 2 };
-      feedService.getFeed.mockResolvedValue(feed as any);
+      feedService.getPublicFeed.mockResolvedValue(feed as any);
       likeRepository.findOneBy.mockResolvedValue(null);
 
       // when

--- a/server/test/rss/e2e/certification/feeds.e2e-spec.ts
+++ b/server/test/rss/e2e/certification/feeds.e2e-spec.ts
@@ -1,0 +1,136 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+describe(`소유 RSS 게시글 관리 E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let feedRepository: FeedRepository;
+  let user: User;
+  let rssAccept: RssAccept;
+  let feeds: Feed[];
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  beforeEach(async () => {
+    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+    accessToken = createAccessToken(user);
+
+    feeds = [];
+    for (let i = 0; i < 3; i++) {
+      feeds.push(
+        await feedRepository.save(
+          FeedFixture.createFeedFixture(rssAccept, {
+            title: `feed ${i + 1}`,
+            commentCount: i,
+            isPublic: i !== 1, // 두 번째 글은 비공개
+          }),
+        ),
+      );
+    }
+  });
+
+  describe(`GET /api/rss/certifications/:id/feeds`, () => {
+    const makeURL = (id: number | string) =>
+      `/api/rss/certifications/${id}/feeds`;
+
+    it('[401] 로그인하지 않으면 조회할 수 없다.', async () => {
+      const response = await agent.get(makeURL(rssAccept.id));
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('[403] 본인이 인증한 RSS가 아니면 조회할 수 없다.', async () => {
+      const other = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+      const othersRss = await rssAcceptRepository.save(
+        RssAcceptFixture.createRssAcceptFixture({ userId: other.id }),
+      );
+
+      const response = await agent
+        .get(makeURL(othersRss.id))
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(response.status).toBe(HttpStatus.FORBIDDEN);
+    });
+
+    it('[200] 비공개 게시글을 포함해 isPublic 상태와 함께 최신순으로 조회한다.', async () => {
+      const response = await agent
+        .get(makeURL(rssAccept.id))
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      expect(response.status).toBe(HttpStatus.OK);
+      const { data } = response.body;
+      expect(data.result).toHaveLength(3);
+      // id DESC → feeds[2], feeds[1](비공개), feeds[0]
+      expect(data.result.map((f: { id: number }) => f.id)).toStrictEqual([
+        feeds[2].id,
+        feeds[1].id,
+        feeds[0].id,
+      ]);
+      expect(data.result[1].isPublic).toBe(false);
+      expect(data.result[0].isPublic).toBe(true);
+    });
+  });
+
+  describe(`PATCH /api/rss/certifications/:id/feeds/:feedId/visibility`, () => {
+    const makeURL = (id: number | string, feedId: number | string) =>
+      `/api/rss/certifications/${id}/feeds/${feedId}/visibility`;
+
+    it('[401] 로그인하지 않으면 변경할 수 없다.', async () => {
+      const response = await agent
+        .patch(makeURL(rssAccept.id, feeds[0].id))
+        .send({ isPublic: false });
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('[404] 다른 RSS에 속한 게시글은 변경할 수 없다.', async () => {
+      const otherRss = await rssAcceptRepository.save(
+        RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+      );
+
+      const response = await agent
+        .patch(makeURL(otherRss.id, feeds[0].id))
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ isPublic: false });
+
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it('[200] 본인 RSS 게시글을 비공개로 전환한다.', async () => {
+      const response = await agent
+        .patch(makeURL(rssAccept.id, feeds[0].id))
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ isPublic: false });
+
+      expect(response.status).toBe(HttpStatus.OK);
+      const saved = await feedRepository.findOneBy({ id: feeds[0].id });
+      expect(saved.isPublic).toBe(false);
+    });
+  });
+});

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -10,6 +10,8 @@ import { DataSource } from 'typeorm';
 
 import { AdminRepository } from '@admin/repository/admin.repository';
 
+import { FeedRepository } from '@feed/repository/feed.repository';
+
 import { EmailProducer } from '@common/email/email.producer';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { NotifierRegistry } from '@common/notification/notifier-registry';
@@ -39,6 +41,9 @@ describe(`${RssService.name} Unit Test`, () => {
     Pick<RssAcceptRepository, 'findOne' | 'find' | 'delete' | 'update'>
   >;
   let rssRejectRepository: jest.Mocked<Pick<RssRejectRepository, 'find'>>;
+  let feedRepository: jest.Mocked<
+    Pick<FeedRepository, 'getFeedsByBlog' | 'setVisibilityForBlog'>
+  >;
   let emailProducer: jest.Mocked<
     Pick<
       EmailProducer,
@@ -72,6 +77,10 @@ describe(`${RssService.name} Unit Test`, () => {
       update: jest.fn().mockResolvedValue({ affected: 1 }),
     };
     rssRejectRepository = { find: jest.fn() };
+    feedRepository = {
+      getFeedsByBlog: jest.fn(),
+      setVisibilityForBlog: jest.fn().mockResolvedValue(1),
+    };
     emailProducer = {
       produceRssRegistration: jest.fn(),
       produceRssRegistrationRequest: jest.fn(),
@@ -96,6 +105,7 @@ describe(`${RssService.name} Unit Test`, () => {
       rssRepository as unknown as RssRepository,
       rssAcceptRepository as unknown as RssAcceptRepository,
       rssRejectRepository as unknown as RssRejectRepository,
+      feedRepository as unknown as FeedRepository,
       emailProducer as unknown as EmailProducer,
       dataSource as unknown as DataSource,
       redisService as unknown as RedisService,
@@ -588,6 +598,66 @@ describe(`${RssService.name} Unit Test`, () => {
         { id: 1 },
         { userId: null },
       );
+    });
+  });
+
+  describe('getOwnedRssFeeds', () => {
+    const user = { id: 10, email: 'me@test.com', userName: 'me', role: 'user' };
+
+    it('본인이 인증한 RSS가 아니면 ForbiddenException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({ id: 1, userId: 99 } as any);
+
+      await expect(
+        rssService.getOwnedRssFeeds(user, 1, { limit: 10 }),
+      ).rejects.toThrow(ForbiddenException);
+      expect(feedRepository.getFeedsByBlog).not.toHaveBeenCalled();
+    });
+
+    it('비공개 글 포함 전체 게시글을 커서로 조회한다(onlyPublic=false).', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({ id: 1, userId: 10 } as any);
+      feedRepository.getFeedsByBlog.mockResolvedValue([
+        { id: 3, isPublic: true },
+        { id: 2, isPublic: false },
+        { id: 1, isPublic: true },
+      ] as any);
+
+      const result = await rssService.getOwnedRssFeeds(user, 1, { lastId: 4, limit: 2 });
+
+      expect(feedRepository.getFeedsByBlog).toHaveBeenCalledWith(1, 4, 2, false);
+      expect(result.result).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.lastId).toBe(2);
+    });
+  });
+
+  describe('setFeedVisibility', () => {
+    const user = { id: 10, email: 'me@test.com', userName: 'me', role: 'user' };
+
+    it('본인이 인증한 RSS가 아니면 ForbiddenException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({ id: 1, userId: 99 } as any);
+
+      await expect(
+        rssService.setFeedVisibility(user, 1, 5, false),
+      ).rejects.toThrow(ForbiddenException);
+      expect(feedRepository.setVisibilityForBlog).not.toHaveBeenCalled();
+    });
+
+    it('게시글이 해당 RSS 소속이 아니면(affected=0) NotFoundException을 던진다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({ id: 1, userId: 10 } as any);
+      feedRepository.setVisibilityForBlog.mockResolvedValue(0);
+
+      await expect(
+        rssService.setFeedVisibility(user, 1, 5, false),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('소유/소속 검증 통과 시 공개 상태를 변경한다.', async () => {
+      rssAcceptRepository.findOne.mockResolvedValue({ id: 1, userId: 10 } as any);
+      feedRepository.setVisibilityForBlog.mockResolvedValue(1);
+
+      await rssService.setFeedVisibility(user, 1, 5, false);
+
+      expect(feedRepository.setVisibilityForBlog).toHaveBeenCalledWith(5, 1, false);
     });
   });
 

--- a/server/test/user/e2e/get-rss.e2e-spec.ts
+++ b/server/test/user/e2e/get-rss.e2e-spec.ts
@@ -3,12 +3,15 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { FeedRepository } from '@feed/repository/feed.repository';
+
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
 import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
@@ -19,12 +22,14 @@ describe(`GET /api/users/:id/rss E2E Test`, () => {
   let agent: TestAgent;
   let rssAcceptRepository: RssAcceptRepository;
   let userRepository: UserRepository;
+  let feedRepository: FeedRepository;
   let user: User;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     rssAcceptRepository = testApp.get(RssAcceptRepository);
     userRepository = testApp.get(UserRepository);
+    feedRepository = testApp.get(FeedRepository);
   });
 
   beforeEach(async () => {
@@ -63,5 +68,30 @@ describe(`GET /api/users/:id/rss E2E Test`, () => {
     expect(item.name).toBe(rssAccept.name);
     expect(item.blogPlatform).toBe(rssAccept.blogPlatform);
     expect(item).not.toHaveProperty('email');
+  });
+
+  it('[200] 각 RSS의 공개 게시글 수(feedCount)를 반환하며 비공개 게시글은 제외한다.', async () => {
+    // given (공개 2개 + 비공개 1개)
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: true }),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: true }),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: false }),
+    );
+
+    // when
+    const response = await agent.get(makeURL(user.id));
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetUserRssResponseDto[] } = response.body;
+    const [item] = data;
+    expect(item.feedCount).toBe(2);
   });
 });

--- a/server/test/user/e2e/getUserRssFeeds.e2e-spec.ts
+++ b/server/test/user/e2e/getUserRssFeeds.e2e-spec.ts
@@ -67,6 +67,7 @@ describe(`GET ${BASE_URL}/:id/rss/:rssId/feeds E2E Test`, () => {
         path: feed.path,
         createdAt: feed.createdAt.toISOString(),
         commentCount: feed.commentCount,
+        likeCount: feed.likeCount,
       })),
     );
   });

--- a/server/test/user/e2e/getUserRssFeeds.e2e-spec.ts
+++ b/server/test/user/e2e/getUserRssFeeds.e2e-spec.ts
@@ -1,0 +1,121 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { GetUserRssFeedsResponseDto } from '@user/dto/response/getUserRssFeeds.dto';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/users';
+
+describe(`GET ${BASE_URL}/:id/rss/:rssId/feeds E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+  let rssAccept: RssAccept;
+  let feeds: Feed[];
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  beforeEach(async () => {
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+
+    // id 오름차순으로 게시글 3개 저장 (commentCount 구별)
+    feeds = [];
+    for (let i = 0; i < 3; i++) {
+      feeds.push(
+        await feedRepository.save(
+          FeedFixture.createFeedFixture(rssAccept, {
+            title: `feed ${i + 1}`,
+            commentCount: i + 1,
+          }),
+        ),
+      );
+    }
+  });
+
+  it('[200] RSS의 게시글을 작성일/댓글 수와 함께 최신순(id DESC)으로 조회한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/1/rss/${rssAccept.id}/feeds`,
+    );
+
+    // Http then
+    const { data }: { data: GetUserRssFeedsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.hasMore).toBe(false);
+    expect(data.lastId).toBe(feeds[0].id);
+    expect(data.result).toStrictEqual(
+      [...feeds].reverse().map((feed) => ({
+        id: feed.id,
+        title: feed.title,
+        path: feed.path,
+        createdAt: feed.createdAt.toISOString(),
+        commentCount: feed.commentCount,
+      })),
+    );
+  });
+
+  it('[200] limit으로 페이지 크기를 제한하고 hasMore와 커서(lastId)를 반환한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/1/rss/${rssAccept.id}/feeds?limit=2`,
+    );
+
+    // Http then
+    const { data }: { data: GetUserRssFeedsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toHaveLength(2);
+    expect(data.hasMore).toBe(true);
+    expect(data.result[0].id).toBe(feeds[2].id);
+    expect(data.lastId).toBe(feeds[1].id);
+  });
+
+  it('[200] lastId 커서 이후의 게시글만 조회한다.', async () => {
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/1/rss/${rssAccept.id}/feeds?lastId=${feeds[1].id}`,
+    );
+
+    // Http then
+    const { data }: { data: GetUserRssFeedsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toHaveLength(1);
+    expect(data.result[0].id).toBe(feeds[0].id);
+    expect(data.hasMore).toBe(false);
+  });
+
+  it('[200] 게시글이 없는 RSS는 빈 목록과 lastId=0을 반환한다.', async () => {
+    // Http given
+    const emptyRss = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+
+    // Http when
+    const response = await agent.get(
+      `${BASE_URL}/1/rss/${emptyRss.id}/feeds`,
+    );
+
+    // Http then
+    const { data }: { data: GetUserRssFeedsResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toStrictEqual([]);
+    expect(data.lastId).toBe(0);
+    expect(data.hasMore).toBe(false);
+  });
+});

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -59,7 +59,9 @@ describe(`${UserService.name} Unit Test`, () => {
   let rssAcceptRepository: jest.Mocked<
     Pick<RssAcceptRepository, 'find' | 'update'>
   >;
-  let feedRepository: jest.Mocked<Pick<FeedRepository, 'getFeedsByBlog'>>;
+  let feedRepository: jest.Mocked<
+    Pick<FeedRepository, 'getFeedsByBlog' | 'countPublicFeedsByBlogIds'>
+  >;
   let manager: { remove: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
 
@@ -96,7 +98,10 @@ describe(`${UserService.name} Unit Test`, () => {
     configService = { get: jest.fn().mockReturnValue('14d') };
     fileService = { deleteByPath: jest.fn() };
     rssAcceptRepository = { find: jest.fn(), update: jest.fn() };
-    feedRepository = { getFeedsByBlog: jest.fn() };
+    feedRepository = {
+      getFeedsByBlog: jest.fn(),
+      countPublicFeedsByBlogIds: jest.fn().mockResolvedValue(new Map()),
+    };
     manager = { remove: jest.fn(), delete: jest.fn() };
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
@@ -357,10 +362,12 @@ describe(`${UserService.name} Unit Test`, () => {
   });
 
   describe('getUserRss', () => {
-    it('userId로 소유 RSS를 조회하고 응답으로 변환한다.', async () => {
+    it('userId로 소유 RSS를 조회하고 공개 게시글 수와 함께 응답으로 변환한다.', async () => {
       // given
-      const rssList = [] as RssAccept[];
+      const rssList = [{ id: 7 } as RssAccept];
+      const feedCountMap = new Map<number, number>([[7, 3]]);
       rssAcceptRepository.find.mockResolvedValue(rssList);
+      feedRepository.countPublicFeedsByBlogIds.mockResolvedValue(feedCountMap);
 
       // when
       const result = await userService.getUserRss(1);
@@ -370,9 +377,11 @@ describe(`${UserService.name} Unit Test`, () => {
         where: { userId: 1 },
         order: { id: 'DESC' },
       });
+      expect(feedRepository.countPublicFeedsByBlogIds).toHaveBeenCalledWith([7]);
       expect(result).toEqual(
-        GetUserRssResponseDto.toResponseDtoArray(rssList),
+        GetUserRssResponseDto.toResponseDtoArray(rssList, feedCountMap),
       );
+      expect(result[0].feedCount).toBe(3);
     });
   });
 

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -14,6 +14,9 @@ import { Payload } from '@common/guard/jwt.guard';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
 import { FileService } from '@file/service/file.service';
 
 import { RssAccept } from '@rss/entity/rss.entity';
@@ -56,6 +59,7 @@ describe(`${UserService.name} Unit Test`, () => {
   let rssAcceptRepository: jest.Mocked<
     Pick<RssAcceptRepository, 'find' | 'update'>
   >;
+  let feedRepository: jest.Mocked<Pick<FeedRepository, 'getFeedsByBlog'>>;
   let manager: { remove: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
 
@@ -92,6 +96,7 @@ describe(`${UserService.name} Unit Test`, () => {
     configService = { get: jest.fn().mockReturnValue('14d') };
     fileService = { deleteByPath: jest.fn() };
     rssAcceptRepository = { find: jest.fn(), update: jest.fn() };
+    feedRepository = { getFeedsByBlog: jest.fn() };
     manager = { remove: jest.fn(), delete: jest.fn() };
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
@@ -105,6 +110,7 @@ describe(`${UserService.name} Unit Test`, () => {
       configService as unknown as ConfigService,
       fileService as unknown as FileService,
       rssAcceptRepository as unknown as RssAcceptRepository,
+      feedRepository as unknown as FeedRepository,
       dataSource as unknown as DataSource,
     );
   });
@@ -367,6 +373,55 @@ describe(`${UserService.name} Unit Test`, () => {
       expect(result).toEqual(
         GetUserRssResponseDto.toResponseDtoArray(rssList),
       );
+    });
+  });
+
+  describe('getUserRssFeeds', () => {
+    const makeFeed = (id: number) =>
+      ({ id, title: `t${id}`, path: `p${id}`, createdAt: new Date(), commentCount: id }) as Feed;
+
+    it('limit보다 많이 조회되면 마지막 항목을 잘라내고 hasMore=true로 반환한다.', async () => {
+      // given (limit=2인데 3개 조회 → 다음 페이지 존재)
+      feedRepository.getFeedsByBlog.mockResolvedValue([
+        makeFeed(10),
+        makeFeed(9),
+        makeFeed(8),
+      ]);
+
+      // when
+      const result = await userService.getUserRssFeeds(5, { lastId: 11, limit: 2 });
+
+      // then
+      expect(feedRepository.getFeedsByBlog).toHaveBeenCalledWith(5, 11, 2, true);
+      expect(result.result).toHaveLength(2);
+      expect(result.hasMore).toBe(true);
+      expect(result.lastId).toBe(9);
+      expect(result.result[0].commentCount).toBe(10);
+    });
+
+    it('limit 이하로 조회되면 hasMore=false로 반환한다.', async () => {
+      // given
+      feedRepository.getFeedsByBlog.mockResolvedValue([makeFeed(3)]);
+
+      // when
+      const result = await userService.getUserRssFeeds(5, { limit: 10 });
+
+      // then
+      expect(result.hasMore).toBe(false);
+      expect(result.lastId).toBe(3);
+    });
+
+    it('조회 결과가 없으면 lastId=0, hasMore=false로 반환한다.', async () => {
+      // given
+      feedRepository.getFeedsByBlog.mockResolvedValue([]);
+
+      // when
+      const result = await userService.getUserRssFeeds(5, { limit: 10 });
+
+      // then
+      expect(result.result).toHaveLength(0);
+      expect(result.lastId).toBe(0);
+      expect(result.hasMore).toBe(false);
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #743

### 게시글 공개 범위(is_public) 도입

- `feed` 테이블에 `is_public` 컬럼 추가(마이그레이션 포함). RSS 소유자가 자신의 게시글을 비공개로 전환할 수 있도록 함.
- 데이터 정합성: 비공개 게시글은 목록 페이지네이션 / 검색 / 댓글 / 좋아요 조회에서 모두 제외. 공개 게시글만 외부에 노출되도록 조회 경로를 일괄 정리.

### 소유 RSS 게시글 조회 + 공개 상태 제어 API

- RSS 소유자용: 소유 RSS의 게시글 목록 조회(비공개 포함) + 게시글 공개/비공개 토글 API.
- 타인 프로필용: `getUserRssFeeds`로 공개 게시글만 커서 페이지네이션 조회.
- 두 경로 모두 `getFeedsByBlog` 단일 쿼리 공유. 소유 여부(`onlyPublic`)로 분기.

### RSS당 게시글 수 / 좋아요 수 노출

- 소유 RSS 목록 응답(`getUserRss`)에 공개 게시글 수(`feedCount`) 추가. N+1 회피를 위해 `blog_id IN (...)` + `GROUP BY` 단일 집계 쿼리 사용.
- 게시글 행에 좋아요 수 표시. 두 엔드포인트 모두 `likeCount`를 항상 내려주도록 통일.

# 📋 작업 내용

**Backend**
- `feed.is_public` 컬럼 + 마이그레이션 추가
- 비공개 게시글 제외: 페이지네이션 / 검색 / 댓글 / 좋아요 조회
- 소유 RSS 게시글 조회 API (`getOwnedRssFeeds`) + 공개 상태 토글 API (`setFeedVisibility`)
- 타인 RSS 게시글 조회 API (`getUserRssFeeds`) — 공개만
- `getUserRss` 응답에 공개 게시글 수(`feedCount`) 추가 (group count, N+1 회피)
- 게시글 조회 응답에 `likeCount` 추가
- 관련 unit / e2e 테스트 작성

**Frontend**
- 소유 RSS 카드(관리 탭) / 마이페이지 RSS 카드에서 게시글 목록 조회 + 펼치기
- 게시글 행: 댓글 수 / 좋아요 수 표시, 비공개는 제목 앞 Lock 아이콘 + 토글
- RSS 카드에 공개 게시글 수 노출
- 카드 아이콘 크기 통일

# 📷 스크린 샷(선택 사항)

<img width="1263" height="739" alt="image" src="https://github.com/user-attachments/assets/9a959310-7096-4c37-9cab-db69125a6c52" />
