### PR TITLE
🐛 fix: feed thumbnail 컬럼 길이 제한 제거 (varchar → text)

### DIFF
--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -86,7 +86,7 @@ CREATE TABLE `feed` (
   `title` varchar(255) NOT NULL,
   `view_count` int NOT NULL DEFAULT '0',
   `path` varchar(512) NOT NULL,
-  `thumbnail` varchar(255) DEFAULT NULL,
+  `thumbnail` text,
   `blog_id` int NOT NULL,
   `summary` text,
   `like_count` int NOT NULL DEFAULT '0',

--- a/server/src/common/database/migration/1781100000000-AlterFeedThumbnailToText.ts
+++ b/server/src/common/database/migration/1781100000000-AlterFeedThumbnailToText.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterFeedThumbnailToText1781100000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `feed` MODIFY `thumbnail` text NULL;',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `feed` MODIFY `thumbnail` varchar(255) NULL;',
+    );
+  }
+}

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -45,7 +45,7 @@ export class Feed extends BaseEntity {
   path: string;
 
   @Column({
-    length: 255,
+    type: 'text',
     nullable: true,
   })
   thumbnail: string;


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   N/A

### thumbnail 길이 초과 문제

-   일부 블로그의 thumbnail URL이 `varchar(255)`를 초과하여 저장 시 잘리거나 실패하는 문제가 있었습니다.
-   컬럼 타입을 `text`로 변경하여 길이 제한을 제거했습니다.
-   엔티티(`feed.entity.ts`), 신규 환경용 `init.sql`, 기존 환경용 마이그레이션을 함께 반영하여 스키마 정합성을 유지했습니다.

# 📋 작업 내용

-   `feed.entity.ts`: `thumbnail` 컬럼을 `length: 255` → `type: 'text'`로 변경
-   `init.sql`: `thumbnail varchar(255)` → `text`
-   마이그레이션 추가 `AlterFeedThumbnailToText`: 기존 DB의 `thumbnail` 컬럼을 `text`로 `MODIFY` (down 시 `varchar(255)` 복구)

# 📷 스크린 샷(선택 사항)

```
2026-05-17 21:30:01 [error]: [MySQL] 쿼리 

            INSERT INTO feed (blog_id, created_at, title, path, thumbnail, summary)

            VALUES (?, ?, ?, ?, ?, ?)

         실행 중 오류 발생

          오류 메시지: Data too long for column 'thumbnail' at row 1

          스택 트레이스: Error: Data too long for column 'thumbnail' at row 1

    at PromisePoolConnection.query (/app/node_modules/mysql2/promise.js:94:22)

    at MySQLConnection.executeQueryStrict (/app/dist/src/common/mysql-access.js:78:45)

    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)

    at async /app/dist/src/repository/feed.repository.js:36:32

    at async Promise.all (index 0)

    at async FeedRepository.insertFeeds (/app/dist/src/repository/feed.repository.js:54:32)

    at async FeedCrawler.start (/app/dist/src/feed-crawler.js:46:30)

node:internal/process/promises:394

    triggerUncaughtException(err, true /* fromPromise */);

    ^

Error: Data too long for column 'thumbnail' at row 1

    at PromisePoolConnection.query (/app/node_modules/mysql2/promise.js:94:22)

    at MySQLConnection.executeQueryStrict (/app/dist/src/common/mysql-access.js:78:45)

    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)

    at async /app/dist/src/repository/feed.repository.js:36:32

    at async Promise.all (index 0)

    at async FeedRepository.insertFeeds (/app/dist/src/repository/feed.repository.js:54:32)

    at async FeedCrawler.start (/app/dist/src/feed-crawler.js:46:30) {

  code: 'ER_DATA_TOO_LONG',

  errno: 1406,

  sql: '\n' +

    '            INSERT INTO feed (blog_id, created_at, title, path, thumbnail, summary)\n' +

    "            VALUES (8, '2026-05-17 12:03:50', '[모닥랩] 5주 동안 AI 스터디를 하면서 느꼈던 것들 &mdash; &ldquo;AI를 잘 쓰는 방법&rdquo;보다 더 중요했던 것', 'https://jacky0831.tistory.com/140', 'https://img1.daumcdn.net/thumb/R800x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdna%2F79xN5%2FdJMcaiDlUAt%2FAAAAAAAAAAAAAAAAAAAAADh5UZnwD70Tk74sC0BOVOPYq06nWkvE64O1YTOm70tm%2Fimg.png%3Fcredential%3DyqXZFxpELC7KVnFOS48ylbz2pIh7yKj8%26expires%3D1780239599%26allow_ip%3D%26allow_referer%3D%26signature%3DfiFeNzCpOy09CQ2ma%252FJF64i23jY%253D', '아직 AI가 요약을 진행중인 게시글 이에요! 💭')\n" +

    '        ',

  sqlState: '22001',

  sqlMessage: "Data too long for column 'thumbnail' at row 1"

}


```