### PR TITLE
✨ feat: 유저 닉네임 검색 기능 구현

### DIFF
--- a/client/src/__tests__/__mocks__/external/lucide-react.tsx
+++ b/client/src/__tests__/__mocks__/external/lucide-react.tsx
@@ -2,6 +2,7 @@ export const mockLucideIcons = {
   Image: () => <div data-testid="fallback-icon">Mock Image Icon</div>,
   FileText: () => <div data-testid="file-text-icon">Mock File Text Icon</div>,
   User: () => <div data-testid="user-icon">Mock User Icon</div>,
+  Users: () => <div data-testid="users-icon">Mock Users Icon</div>,
   PanelBottom: () => <div data-testid="panel-bottom-icon">Mock Panel Bottom Icon</div>,
   Search: () => <div data-testid="search-icon">Mock Search Icon</div>,
   X: () => <div data-testid="x-icon">Mock X Icon</div>,

--- a/client/src/__tests__/__mocks__/hooks/useSearchStore.ts
+++ b/client/src/__tests__/__mocks__/hooks/useSearchStore.ts
@@ -3,12 +3,15 @@ import { vi } from "vitest";
 export const mockSearchStore = {
   useSearchStore: () => ({
     currentFilter: "title",
+    searchMode: "feed",
     setFilter: vi.fn(),
+    setSearchMode: vi.fn(),
     setPage: vi.fn(),
     searchParam: "",
     setSearchParam: vi.fn(),
     resetPage: vi.fn(),
     resetParam: vi.fn(),
     resetFilter: vi.fn(),
+    resetMode: vi.fn(),
   }),
 };

--- a/client/src/__tests__/components/common/search/SearchModal.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchModal.test.tsx
@@ -11,9 +11,13 @@ vi.mock("@/components/search/SearchResults/SearchResultList", () => ({
 
 vi.mock("@/store/useSearchStore", () => ({
   useSearchStore: vi.fn(() => ({
+    searchMode: "feed",
+    setSearchMode: vi.fn(),
+    setPage: vi.fn(),
     resetPage: vi.fn(),
     resetParam: vi.fn(),
     resetFilter: vi.fn(),
+    resetMode: vi.fn(),
   })),
 }));
 
@@ -31,9 +35,13 @@ describe("SearchModal", () => {
     const mockResetFilter = vi.fn();
 
     vi.mocked(useSearchStore).mockReturnValue({
+      searchMode: "feed",
+      setSearchMode: vi.fn(),
+      setPage: vi.fn(),
       resetPage: mockResetPage,
       resetParam: mockResetParam,
       resetFilter: mockResetFilter,
+      resetMode: vi.fn(),
     });
 
     const { container } = render(<SearchModal onClose={mockOnClose} />);

--- a/client/src/__tests__/components/common/search/SearchResults/UserSearchResultItem.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/UserSearchResultItem.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from "vitest";
+
+import UserSearchResultItem from "@/components/search/SearchResults/UserSearchResultItem";
+
+import { UserSearchResult } from "@/types/search.ts";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("@/components/search/SearchHigilight", () => ({
+  default: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+vi.mock("@/store/useSearchStore", () => ({
+  useSearchStore: vi.fn(() => ({
+    searchParam: "김",
+  })),
+}));
+
+describe("UserSearchResultItem", () => {
+  const mockUser: UserSearchResult = {
+    id: 7,
+    userName: "김개발",
+    profileImage: null,
+  };
+
+  it("유저 닉네임이 렌더링되어야 한다", () => {
+    render(<UserSearchResultItem {...mockUser} onSelect={vi.fn()} />);
+
+    expect(screen.getByText(mockUser.userName)).toBeInTheDocument();
+  });
+
+  it("클릭하면 해당 유저 id로 onSelect가 호출되어야 한다", () => {
+    const onSelect = vi.fn();
+    render(<UserSearchResultItem {...mockUser} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onSelect).toHaveBeenCalledWith(mockUser.id);
+  });
+});

--- a/client/src/api/services/search.ts
+++ b/client/src/api/services/search.ts
@@ -1,13 +1,24 @@
 import { SEARCH } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
-import { SearchRequest, SearchResponse } from "@/types/search";
+import { SearchRequest, SearchResponse, UserSearchRequest, UserSearchResponse } from "@/types/search";
 
 export const getSearch = async (data: SearchRequest): Promise<SearchResponse> => {
   const response = await axiosInstance.get<SearchResponse>(SEARCH.GET_RESULT, {
     params: {
       find: data.query,
       type: data.filter,
+      page: data.page,
+      limit: data.pageSize,
+    },
+  });
+  return response.data;
+};
+
+export const getUserSearch = async (data: UserSearchRequest): Promise<UserSearchResponse> => {
+  const response = await axiosInstance.get<UserSearchResponse>(SEARCH.GET_USER_RESULT, {
+    params: {
+      find: data.query,
       page: data.page,
       limit: data.pageSize,
     },

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -21,7 +21,7 @@ export const ProfileHeader = ({ name, email, profileImage, introduction }: Profi
           </Avatar>
           <div className="min-w-0">
             <h1 className="text-2xl font-bold">{name}</h1>
-            <p className="mt-1 text-gray-600">{email}</p>
+            {email && <p className="mt-1 text-gray-600">{email}</p>}
             <p className="mt-4 text-gray-800 whitespace-pre-wrap">
               {introduction ? introduction : <span className="text-gray-400">자기소개가 없습니다.</span>}
             </p>

--- a/client/src/components/search/SearchModal.tsx
+++ b/client/src/components/search/SearchModal.tsx
@@ -1,16 +1,19 @@
 import FilterButton from "@/components/search/SearchFilters/FilterButton";
 import SearchInput from "@/components/search/SearchHeader/SearchInput";
+import SearchModeTabs from "@/components/search/SearchModeTabs";
 import SearchResultList from "@/components/search/SearchResults/SearchResultList";
+import UserSearchResultList from "@/components/search/SearchResults/UserSearchResultList";
 import { Command, CommandSeparator } from "@/components/ui/command";
 
 import { useSearchStore } from "@/store/useSearchStore";
 
 export default function SearchModal({ onClose }: { onClose: () => void }) {
-  const { resetPage, resetParam, resetFilter } = useSearchStore();
+  const { searchMode, resetPage, resetParam, resetFilter, resetMode } = useSearchStore();
   const handleClose = () => {
     resetPage();
     resetParam();
     resetFilter();
+    resetMode();
     onClose();
   };
   return (
@@ -21,9 +24,17 @@ export default function SearchModal({ onClose }: { onClose: () => void }) {
       <div className="bg-white rounded-lg p-6 w-full max-w-2xl mx-4" onClick={(e) => e.stopPropagation()}>
         <SearchInput onClose={handleClose} />
         <CommandSeparator />
-        <FilterButton />
+        <SearchModeTabs />
         <CommandSeparator />
-        <SearchResultList />
+        {searchMode === "feed" ? (
+          <>
+            <FilterButton />
+            <CommandSeparator />
+            <SearchResultList />
+          </>
+        ) : (
+          <UserSearchResultList onClose={handleClose} />
+        )}
       </div>
     </Command>
   );

--- a/client/src/components/search/SearchModeTabs.tsx
+++ b/client/src/components/search/SearchModeTabs.tsx
@@ -1,0 +1,47 @@
+import { FileText, Users } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+import { useSearchStore } from "@/store/useSearchStore";
+import { SearchMode } from "@/types/search";
+
+interface ModeOption {
+  label: string;
+  mode: SearchMode;
+  icon: JSX.Element;
+}
+
+const modeOptions: ModeOption[] = [
+  { label: "게시글", mode: "feed", icon: <FileText size={16} /> },
+  { label: "유저", mode: "user", icon: <Users size={16} /> },
+];
+
+export default function SearchModeTabs() {
+  const { searchMode, setSearchMode, setPage } = useSearchStore();
+
+  const handleModeClick = (mode: SearchMode) => {
+    if (mode === searchMode) return;
+    setSearchMode(mode);
+    setPage(1);
+  };
+
+  return (
+    <div className="my-3 inline-flex w-full gap-1 rounded-lg bg-gray-100 p-1">
+      {modeOptions.map(({ label, mode, icon }) => (
+        <button
+          key={mode}
+          onClick={() => handleModeClick(mode)}
+          className={cn(
+            "flex flex-1 items-center justify-center gap-2 rounded-md px-4 py-2 text-sm transition-all duration-200",
+            mode === searchMode
+              ? "bg-white font-semibold text-gray-900 shadow-sm"
+              : "text-gray-500 hover:text-gray-800"
+          )}
+        >
+          {icon}
+          <span>{label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/search/SearchResults/UserSearchResultItem.tsx
+++ b/client/src/components/search/SearchResults/UserSearchResultItem.tsx
@@ -1,0 +1,33 @@
+import SearchHighlight from "@/components/search/SearchHigilight";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { CommandItem } from "@/components/ui/command";
+
+import { useSearchStore } from "@/store/useSearchStore";
+import { UserSearchResult } from "@/types/search";
+
+interface UserSearchResultItemProps extends UserSearchResult {
+  onSelect: (userId: number) => void;
+}
+
+export default function UserSearchResultItem({ id, userName, profileImage, onSelect }: UserSearchResultItemProps) {
+  const { searchParam } = useSearchStore();
+  const initials = userName ? userName.substring(0, 2).toUpperCase() : "사용자";
+
+  return (
+    <CommandItem className="p-0">
+      <button
+        type="button"
+        onClick={() => onSelect(id)}
+        className="flex items-center gap-3 w-full px-2 py-1.5 text-left cursor-pointer"
+      >
+        <Avatar className="h-9 w-9">
+          {profileImage && <AvatarImage src={profileImage} alt={userName} />}
+          <AvatarFallback>{initials}</AvatarFallback>
+        </Avatar>
+        <p className="text-sm">
+          <SearchHighlight text={userName} highlight={searchParam} />
+        </p>
+      </button>
+    </CommandItem>
+  );
+}

--- a/client/src/components/search/SearchResults/UserSearchResultList.tsx
+++ b/client/src/components/search/SearchResults/UserSearchResultList.tsx
@@ -1,0 +1,63 @@
+import { Loader } from "lucide-react";
+
+import { CommandList, CommandEmpty, CommandGroup } from "@/components/ui/command";
+
+import { useNavigateToProfile } from "@/hooks/common/useNavigateToProfile";
+import { useUserSearch } from "@/hooks/queries/useUserSearch";
+
+import SearchPages from "../searchPages/SearchPages";
+import UserSearchResultItem from "./UserSearchResultItem";
+import { useSearchStore } from "@/store/useSearchStore";
+
+const RESULT_PER_PAGE = 5;
+const COMMANDCLASS = "flex h-[28rem] justify-center items-center";
+
+export default function UserSearchResultList({ onClose }: { onClose: () => void }) {
+  const { searchParam, page } = useSearchStore();
+  const navigateToProfile = useNavigateToProfile();
+  const { data, isLoading, error } = useUserSearch({
+    query: searchParam,
+    page,
+    pageSize: RESULT_PER_PAGE,
+  });
+
+  const totalItems = data?.data.totalCount ?? 0;
+  const totalPages = data?.data.totalPages ?? 0;
+  const results = data?.data.result || [];
+
+  const handleSelect = (userId: number) => {
+    onClose();
+    navigateToProfile(userId);
+  };
+
+  const renderContent = {
+    noQuery: <CommandEmpty className={COMMANDCLASS}>검색어를 입력해주세요</CommandEmpty>,
+    loading: (
+      <CommandEmpty className={COMMANDCLASS}>
+        <Loader />
+      </CommandEmpty>
+    ),
+    searchEmpty: <CommandEmpty className={COMMANDCLASS}>검색결과가 없습니다</CommandEmpty>,
+    error: <div className={COMMANDCLASS}>에러발생</div>,
+    default: (
+      <CommandGroup heading={`검색결과 (총 ${totalItems}건)`} className="h-[28rem] relative">
+        <CommandList>
+          {results.map((result) => (
+            <UserSearchResultItem key={result.id} {...result} onSelect={handleSelect} />
+          ))}
+        </CommandList>
+        <SearchPages totalPages={totalPages} />
+      </CommandGroup>
+    ),
+  };
+
+  const getRenderKey = () => {
+    if (isLoading || !results) return "loading";
+    if (error) return "error";
+    if (searchParam.length === 0) return "noQuery";
+    if (results.length === 0) return "searchEmpty";
+    return "default";
+  };
+
+  return renderContent[getRenderKey()];
+}

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -53,6 +53,7 @@ export const CHART = {
 
 export const SEARCH = {
   GET_RESULT: "/api/feeds/search",
+  GET_USER_RESULT: "/api/users/search",
 };
 
 export const USER = {

--- a/client/src/hooks/common/useNavigateToProfile.ts
+++ b/client/src/hooks/common/useNavigateToProfile.ts
@@ -1,0 +1,13 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const useNavigateToProfile = () => {
+  const navigate = useNavigate();
+
+  return useCallback(
+    (userId: number) => {
+      navigate(`/profile/${userId}`);
+    },
+    [navigate]
+  );
+};

--- a/client/src/hooks/queries/useUserSearch.ts
+++ b/client/src/hooks/queries/useUserSearch.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from "react";
+
+import { debounce } from "@/utils/debounce";
+
+import { getUserSearch } from "@/api/services/search";
+import { UserSearchRequest } from "@/types/search";
+import { useQuery } from "@tanstack/react-query";
+
+export const useUserSearch = ({ query, page, pageSize }: UserSearchRequest) => {
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+  useEffect(() => {
+    const handler = debounce((newQuery) => {
+      setDebouncedQuery(newQuery);
+    }, 300);
+
+    handler(query);
+
+    return () => {
+      if (handler.cancel) handler.cancel();
+    };
+  }, [query]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["getUserSearch", debouncedQuery, page, pageSize],
+    queryFn: () => getUserSearch({ query: debouncedQuery, page, pageSize }),
+    enabled: debouncedQuery.trim().length > 0,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+  return { data, isLoading, error };
+};

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -1,41 +1,60 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import Layout from "@/components/layout/Layout";
 import { MyPage } from "@/components/profile/MyPage.tsx";
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar.tsx";
-import { ProfileEditTab } from "@/components/profile/sections/ProfileEditTab.tsx";
 import { RssManagementTab } from "@/components/profile/rss/RssManagementTab.tsx";
+import { ProfileEditTab } from "@/components/profile/sections/ProfileEditTab.tsx";
 
 import { useAuthStore } from "@/store/useAuthStore.ts";
 import { ProfileTab } from "@/types/profile.ts";
 
 export default function Profile() {
   const navigate = useNavigate();
+  const { id } = useParams();
   const { isAuthenticated, isInitialized, userInfo } = useAuthStore();
   const [activeTab, setActiveTab] = useState<ProfileTab>("mypage");
 
+  const targetId = id ? Number(id) : userInfo.id;
+  const isOwner = isAuthenticated && userInfo.id !== null && userInfo.id === targetId;
+
   useEffect(() => {
-    if (isInitialized && !isAuthenticated) {
+    if (!isInitialized) return;
+    if (!id && !isAuthenticated) {
       navigate("/signin");
     }
-  }, [isInitialized, isAuthenticated, navigate]);
+  }, [isInitialized, isAuthenticated, id, navigate]);
 
-  if (!isInitialized || !isAuthenticated || userInfo.id === null) {
+  if (!isInitialized) {
     return null;
   }
+  if (!id && (!isAuthenticated || userInfo.id === null)) {
+    return null;
+  }
+  if (id && (!targetId || Number.isNaN(targetId))) {
+    return null;
+  }
+
+  const currentTab: ProfileTab = isOwner ? activeTab : "mypage";
 
   return (
     <Layout>
       <div className="flex min-h-screen">
-        <ProfileSidebar activeTab={activeTab} onTabChange={setActiveTab} isOwner={true} />
+        <ProfileSidebar activeTab={currentTab} onTabChange={setActiveTab} isOwner={isOwner} />
 
         <div className="flex-1 min-w-0 px-4 py-8 md:px-8">
-          {activeTab === "mypage" && (
-            <MyPage userId={userInfo.id} name={userInfo.userName ?? ""} email={userInfo.email ?? ""} />
+          {currentTab === "mypage" && (
+            <MyPage
+              userId={targetId as number}
+              name={isOwner ? (userInfo.userName ?? "") : ""}
+              email={isOwner ? (userInfo.email ?? "") : ""}
+            />
           )}
-          {activeTab === "rss" && <RssManagementTab userId={userInfo.id} />}
-          {activeTab === "settings" && <ProfileEditTab userId={userInfo.id} email={userInfo.email ?? ""} />}
+          {isOwner && currentTab === "rss" && <RssManagementTab userId={targetId as number} />}
+          {isOwner && currentTab === "settings" && (
+            <ProfileEditTab userId={targetId as number} email={userInfo.email ?? ""} />
+          )}
         </div>
       </div>
     </Layout>

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -143,6 +143,14 @@ export const AppRouter = ({ location, state }: RouterProps) => {
           }
         />
         <Route
+          path="/profile/:id"
+          element={
+            <Suspense fallback={<Loading />}>
+              <Profile />
+            </Suspense>
+          }
+        />
+        <Route
           path="/:id"
           element={
             <Suspense fallback={<Loading />}>

--- a/client/src/store/useSearchStore.ts
+++ b/client/src/store/useSearchStore.ts
@@ -1,17 +1,20 @@
 import { create } from "zustand";
 
-import { FilterType } from "@/types/search";
+import { FilterType, SearchMode } from "@/types/search";
 
 interface SearchState {
   currentFilter: FilterType;
+  searchMode: SearchMode;
   searchParam: string;
   page: number;
   setFilter: (filter: FilterType) => void;
+  setSearchMode: (mode: SearchMode) => void;
   setSearchParam: (param: string) => void;
   setPage: (page: number) => void;
   resetPage: () => void;
   resetParam: () => void;
   resetFilter: () => void;
+  resetMode: () => void;
 }
 interface AdminSearchType {
   searchParam: string;
@@ -19,14 +22,17 @@ interface AdminSearchType {
 }
 export const useSearchStore = create<SearchState>((set) => ({
   currentFilter: "title",
+  searchMode: "feed",
   searchParam: "",
   page: 1,
   setFilter: (currentFilter) => set({ currentFilter }),
+  setSearchMode: (searchMode) => set({ searchMode }),
   setSearchParam: (param) => set({ searchParam: param }),
   setPage: (page) => set({ page }),
   resetPage: () => set({ page: 1 }),
   resetParam: () => set({ searchParam: "" }),
   resetFilter: () => set({ currentFilter: "title" }),
+  resetMode: () => set({ searchMode: "feed" }),
 }));
 
 export const useAdminSearchStore = create<AdminSearchType>((set) => ({

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -22,3 +22,25 @@ export interface SearchRequest {
   pageSize: number;
 }
 export type FilterType = "title" | "blogName" | "all";
+
+export type SearchMode = "feed" | "user";
+
+export interface UserSearchResult {
+  id: number;
+  userName: string;
+  profileImage: string | null;
+}
+
+export interface UserSearchData {
+  totalCount: number;
+  result: UserSearchResult[];
+  totalPages: number;
+}
+
+export type UserSearchResponse = ApiData<UserSearchData>;
+
+export interface UserSearchRequest {
+  query: string;
+  page: number;
+  pageSize: number;
+}

--- a/server/src/user/api-docs/searchUser.api-docs.ts
+++ b/server/src/user/api-docs/searchUser.api-docs.ts
@@ -1,0 +1,42 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiQuery } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+} from '@common/swagger/swagger.helper';
+
+import { SearchUserResponseDto } from '@user/dto/response/searchUser.dto';
+
+export function ApiSearchUser() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '유저 닉네임 검색 API',
+      description:
+        '닉네임 부분 일치(LIKE)로 유저를 검색합니다. 결과는 id, 닉네임, 프로필 이미지를 포함합니다.',
+    }),
+    ApiQuery({
+      name: 'find',
+      required: true,
+      type: String,
+      description: '검색할 유저 닉네임',
+      example: '김개발',
+    }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      type: Number,
+      description: '페이지 번호',
+      example: 1,
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: '한 페이지에 보여줄 개수',
+      example: 5,
+    }),
+    ApiDataResponse(SearchUserResponseDto, false, '유저 검색 결과 조회 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -35,6 +35,7 @@ import { ApiRefreshToken } from '@user/api-docs/refreshToken.api-docs';
 import { ApiRegisterUser } from '@user/api-docs/registerUser.api-docs';
 import { ApiRequestDeleteAccount } from '@user/api-docs/requestDeleteAccount.api-docs';
 import { ApiResetPassword } from '@user/api-docs/resetPassword.api-docs';
+import { ApiSearchUser } from '@user/api-docs/searchUser.api-docs';
 import { ApiUpdateUser } from '@user/api-docs/updateUser.api-docs';
 import { CertificateUserRequestDto } from '@user/dto/request/certificateUser.dto';
 import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
@@ -50,6 +51,7 @@ import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { RequestDeleteAccountRequestDto } from '@user/dto/request/requestDeleteAccount.dto';
 import { ResetPasswordRequestDto } from '@user/dto/request/resetPassword.dto';
 import { ResetPasswordParamRequestDto } from '@user/dto/request/resetPasswordParam.dto';
+import { SearchUserRequestDto } from '@user/dto/request/searchUser.dto';
 import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
 import { UserService } from '@user/service/user.service';
 
@@ -85,6 +87,16 @@ export class UserController {
       await this.userService.checkUserNameDuplication(
         checkUserNameDuplicationRequestDto.userName,
       ),
+    );
+  }
+
+  @ApiSearchUser()
+  @Get('/search')
+  @HttpCode(HttpStatus.OK)
+  async searchUser(@Query() searchUserQueryDto: SearchUserRequestDto) {
+    return ApiResponse.responseWithData(
+      '유저 검색 결과 조회 완료',
+      await this.userService.searchUserList(searchUserQueryDto),
     );
   }
 

--- a/server/src/user/dto/request/searchUser.dto.ts
+++ b/server/src/user/dto/request/searchUser.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+
+export class SearchUserRequestDto {
+  @ApiProperty({
+    example: '김개발',
+    description: '검색할 유저 닉네임',
+  })
+  @IsNotEmpty({
+    message: '검색어를 입력해주세요.',
+  })
+  @IsString({
+    message: '문자열로 입력해주세요.',
+  })
+  find: string;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: '페이지 번호 입력',
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({
+    message: '페이지 번호는 정수입니다.',
+  })
+  @Min(1, { message: '페이지 번호는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    example: 5,
+    description: '받아올 유저 최대 개수',
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({
+    message: '한 페이지에 보여줄 개수는 정수입니다.',
+  })
+  @Min(1, { message: '개수 제한은 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  limit?: number = 5;
+
+  constructor(partial: Partial<SearchUserRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/response/searchUser.dto.ts
+++ b/server/src/user/dto/response/searchUser.dto.ts
@@ -1,0 +1,75 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { User } from '@user/entity/user.entity';
+
+export class SearchUserResult {
+  @ApiProperty({ example: 1, description: '유저 ID' })
+  id: number;
+
+  @ApiProperty({ example: '김개발', description: '유저 닉네임' })
+  userName: string;
+
+  @ApiProperty({
+    example: 'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+    description: '프로필 이미지 URL (미설정 시 null)',
+    nullable: true,
+  })
+  profileImage: string | null;
+
+  private constructor(partial: Partial<SearchUserResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(user: User) {
+    return new SearchUserResult({
+      id: user.id,
+      userName: user.userName,
+      profileImage: user.profileImage ?? null,
+    });
+  }
+
+  static toResultDtoArray(users: User[]) {
+    return users.map((user) => this.toResultDto(user));
+  }
+}
+
+export class SearchUserResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: '전체 유저 개수',
+  })
+  totalCount: number;
+
+  @ApiProperty({ type: [SearchUserResult], description: '검색 결과 유저' })
+  result: SearchUserResult[];
+
+  @ApiProperty({
+    example: 10,
+    description: '총 페이지 수',
+  })
+  totalPages: number;
+
+  @ApiProperty({
+    example: 5,
+    description: '한 페이지 최대 유저 개수',
+  })
+  limit: number;
+
+  constructor(partial: Partial<SearchUserResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(
+    totalCount: number,
+    users: SearchUserResult[],
+    totalPages: number,
+    limit: number,
+  ) {
+    return new SearchUserResponseDto({
+      totalCount,
+      result: users,
+      totalPages,
+      limit,
+    });
+  }
+}

--- a/server/src/user/repository/user.repository.ts
+++ b/server/src/user/repository/user.repository.ts
@@ -9,4 +9,18 @@ export class UserRepository extends Repository<User> {
   constructor(private dataSource: DataSource) {
     super(User, dataSource.createEntityManager());
   }
+
+  async searchUserList(find: string, limit: number, offset: number) {
+    const escaped = find.replace(/[\\%_]/g, (char) => `\\${char}`);
+
+    return this.createQueryBuilder('user')
+      .where('user.userName LIKE :pattern', { pattern: `%${escaped}%` })
+      .orderBy('user.userName = :find', 'DESC')
+      .addOrderBy('user.userName LIKE :prefix', 'DESC')
+      .addOrderBy('user.userName', 'ASC')
+      .setParameters({ find, prefix: `${escaped}%` })
+      .skip(offset)
+      .take(limit)
+      .getManyAndCount();
+  }
 }

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -29,11 +29,16 @@ import { REFRESH_TOKEN_TTL, SALT_ROUNDS } from '@user/constant/user.constants';
 import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
+import { SearchUserRequestDto } from '@user/dto/request/searchUser.dto';
 import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
 import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUserNameDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
 import { GetUserProfileResponseDto } from '@user/dto/response/getUserProfile.dto';
+import {
+  SearchUserResponseDto,
+  SearchUserResult,
+} from '@user/dto/response/searchUser.dto';
 import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
 import { GetUserRssFeedsRequestDto } from '@user/dto/request/getUserRssFeeds.dto';
 import { GetUserRssFeedsResponseDto } from '@user/dto/response/getUserRssFeeds.dto';
@@ -67,6 +72,27 @@ export class UserService {
   async getUserProfile(userId: number) {
     const user = await this.getUser(userId);
     return GetUserProfileResponseDto.toResponseDto(user);
+  }
+
+  async searchUserList(searchUserQueryDto: SearchUserRequestDto) {
+    const { find, page, limit } = searchUserQueryDto;
+    const offset = (page - 1) * limit;
+
+    const [searchResult, totalCount] = await this.userRepository.searchUserList(
+      find,
+      limit,
+      offset,
+    );
+
+    const users = SearchUserResult.toResultDtoArray(searchResult);
+    const totalPages = Math.ceil(totalCount / limit);
+
+    return SearchUserResponseDto.toResponseDto(
+      totalCount,
+      users,
+      totalPages,
+      limit,
+    );
   }
 
   async checkEmailDuplication(email: string) {

--- a/server/test/user/dto/searchUser.dto.spec.ts
+++ b/server/test/user/dto/searchUser.dto.spec.ts
@@ -1,0 +1,161 @@
+import { validate } from 'class-validator';
+
+import { SearchUserRequestDto } from '@user/dto/request/searchUser.dto';
+
+describe(`${SearchUserRequestDto.name} Test`, () => {
+  let dto: SearchUserRequestDto;
+
+  beforeEach(() => {
+    dto = new SearchUserRequestDto({
+      find: '김개발',
+      page: 1,
+      limit: 5,
+    });
+  });
+
+  it('검색어가 있을 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('find', () => {
+    it('검색어가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.find = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('검색어가 빈 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.find = '';
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('검색어가 문자열이 아니고 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.find = 1 as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+  });
+
+  describe('page', () => {
+    it('생략할 경우 기본값 1로 유효성 검사에 성공한다.', async () => {
+      // given
+      dto = new SearchUserRequestDto({ find: '김개발' });
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(0);
+      expect(dto.page).toBe(1);
+    });
+
+    it('페이지 번호가 정수가 아니고 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 'abcdefg' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('페이지 번호가 실수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 1.1;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('페이지 번호가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+
+  describe('limit', () => {
+    it('생략할 경우 기본값 5로 유효성 검사에 성공한다.', async () => {
+      // given
+      dto = new SearchUserRequestDto({ find: '김개발' });
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(0);
+      expect(dto.limit).toBe(5);
+    });
+
+    it('개수 제한이 정수가 아니고 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('개수 제한이 실수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 1.1;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('개수 제한이 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/user/e2e/search.e2e-spec.ts
+++ b/server/test/user/e2e/search.e2e-spec.ts
@@ -1,0 +1,155 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/users/search';
+
+describe(`GET ${URL}?find={} E2E Test`, () => {
+  let agent: TestAgent;
+  let userRepository: UserRepository;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    userRepository = testApp.get(UserRepository);
+  });
+
+  const saveUser = (userName: string, overwrites: Partial<User> = {}) =>
+    userRepository.save(
+      UserFixture.createUserFixture({ userName, ...overwrites }),
+    );
+
+  it('[200] 닉네임이 부분 일치하는 유저를 모두 반환하고 관련도 순으로 정렬한다.', async () => {
+    // given - 완전일치 > prefix(가나다) > 부분일치 순서를 검증한다.
+    const exact = await saveUser('김');
+    const prefixA = await saveUser('김가');
+    const prefixB = await saveUser('김나');
+    const contains = await saveUser('하김');
+    await saveUser('박개발'); // '김' 미포함 → 결과 제외
+
+    // when
+    const response = await agent.get(URL).query({ find: '김' });
+
+    // then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.totalCount).toBe(4);
+    expect(data.totalPages).toBe(1);
+    expect(data.limit).toBe(5);
+    expect(data.result.map((user: { id: number }) => user.id)).toStrictEqual([
+      exact.id,
+      prefixA.id,
+      prefixB.id,
+      contains.id,
+    ]);
+  });
+
+  it('[200] 검색 결과는 id, 닉네임, 프로필 이미지만 포함한다.', async () => {
+    // given
+    const user = await saveUser('프로필유저', {
+      profileImage:
+        'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+    });
+
+    // when
+    const response = await agent.get(URL).query({ find: '프로필유저' });
+
+    // then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toStrictEqual([
+      {
+        id: user.id,
+        userName: user.userName,
+        profileImage: user.profileImage,
+      },
+    ]);
+  });
+
+  it('[200] 프로필 이미지가 없으면 null로 반환한다.', async () => {
+    // given
+    const user = await saveUser('이미지없음', { profileImage: null });
+
+    // when
+    const response = await agent.get(URL).query({ find: '이미지없음' });
+
+    // then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result[0]).toStrictEqual({
+      id: user.id,
+      userName: user.userName,
+      profileImage: null,
+    });
+  });
+
+  it('[200] LIKE 와일드카드(%)가 포함된 검색어는 리터럴로 처리한다.', async () => {
+    // given
+    const literal = await saveUser('a%b');
+    await saveUser('axb'); // 이스케이프 없으면 %가 와일드카드가 되어 함께 매칭됨
+
+    // when
+    const response = await agent.get(URL).query({ find: 'a%b' });
+
+    // then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.totalCount).toBe(1);
+    expect(data.result[0].id).toBe(literal.id);
+  });
+
+  it('[200] 검색 결과가 없으면 빈 배열을 반환한다.', async () => {
+    // given
+    await saveUser('김개발');
+
+    // when
+    const response = await agent.get(URL).query({ find: '존재하지않는닉네임' });
+
+    // then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toStrictEqual({
+      totalCount: 0,
+      result: [],
+      totalPages: 0,
+      limit: 5,
+    });
+  });
+
+  it('[200] page와 limit으로 페이지네이션한다.', async () => {
+    // given - '김0' ~ '김5' 6명, 모두 '김' prefix → 가나다순 정렬.
+    const users = await Promise.all(
+      Array.from({ length: 6 }).map((_, i) => saveUser(`김${i}`)),
+    );
+
+    // when
+    const response = await agent.get(URL).query({ find: '김', page: 2, limit: 2 });
+
+    // then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.totalCount).toBe(6);
+    expect(data.totalPages).toBe(3);
+    expect(data.limit).toBe(2);
+    expect(data.result.map((user: { id: number }) => user.id)).toStrictEqual([
+      users[2].id,
+      users[3].id,
+    ]);
+  });
+
+  it('[400] 검색어(find)가 없으면 검증에 실패한다.', async () => {
+    // when
+    const response = await agent.get(URL).query({});
+
+    // then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+  });
+});

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -23,6 +23,7 @@ import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
+import { SearchUserRequestDto } from '@user/dto/request/searchUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
 import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUserNameDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
@@ -40,7 +41,10 @@ import {
 describe(`${UserService.name} Unit Test`, () => {
   let userService: UserService;
   let userRepository: jest.Mocked<
-    Pick<UserRepository, 'findOneBy' | 'findOne' | 'save' | 'remove'>
+    Pick<
+      UserRepository,
+      'findOneBy' | 'findOne' | 'save' | 'remove' | 'searchUserList'
+    >
   >;
   let redisService: jest.Mocked<
     Pick<RedisService, 'set' | 'get' | 'del' | 'setex'>
@@ -82,6 +86,7 @@ describe(`${UserService.name} Unit Test`, () => {
       findOne: jest.fn(),
       save: jest.fn(),
       remove: jest.fn(),
+      searchUserList: jest.fn(),
     };
     redisService = {
       set: jest.fn(),
@@ -130,6 +135,72 @@ describe(`${UserService.name} Unit Test`, () => {
       const user = UserFixture.createUserFixture();
       userRepository.findOneBy.mockResolvedValue(user);
       await expect(userService.getUser(1)).resolves.toBe(user);
+    });
+  });
+
+  describe('searchUserList', () => {
+    it('닉네임 검색 결과를 id·닉네임·프로필 이미지로 매핑하고 페이지 정보를 계산한다.', async () => {
+      // given
+      const users = [
+        UserFixture.createUserFixture({
+          userName: '김개발',
+          profileImage: 'https://denamu.dev/profile.png',
+        }),
+        UserFixture.createUserFixture({
+          userName: '김철수',
+          profileImage: null,
+        }),
+      ] as User[];
+      users[0].id = 1;
+      users[1].id = 2;
+      userRepository.searchUserList.mockResolvedValue([users, 2]);
+
+      // when
+      const result = await userService.searchUserList(
+        new SearchUserRequestDto({ find: '김', page: 1, limit: 5 }),
+      );
+
+      // then
+      expect(result).toEqual({
+        totalCount: 2,
+        result: [
+          { id: 1, userName: '김개발', profileImage: 'https://denamu.dev/profile.png' },
+          { id: 2, userName: '김철수', profileImage: null },
+        ],
+        totalPages: 1,
+        limit: 5,
+      });
+    });
+
+    it('page와 limit으로 offset을 계산해 레포지토리에 전달한다.', async () => {
+      // given
+      userRepository.searchUserList.mockResolvedValue([[], 0]);
+
+      // when
+      await userService.searchUserList(
+        new SearchUserRequestDto({ find: '김', page: 3, limit: 4 }),
+      );
+
+      // then
+      expect(userRepository.searchUserList).toHaveBeenCalledWith('김', 4, 8);
+    });
+
+    it('검색 결과가 없으면 빈 배열과 0건을 반환한다.', async () => {
+      // given
+      userRepository.searchUserList.mockResolvedValue([[], 0]);
+
+      // when
+      const result = await userService.searchUserList(
+        new SearchUserRequestDto({ find: '없음', page: 1, limit: 5 }),
+      );
+
+      // then
+      expect(result).toEqual({
+        totalCount: 0,
+        result: [],
+        totalPages: 0,
+        limit: 5,
+      });
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #748 

### 유저 닉네임 검색 API (BE)

- 기존 검색은 게시글 한정 → 닉네임으로 유저를 찾는 기능 추가.
- `GET /api/users/search?find=&page=&limit=` 엔드포인트 신설.
- **`LIKE '%find%'` 채택 (게시글 검색의 FULLTEXT NATURAL LANGUAGE 미사용).**
  - InnoDB `innodb_ft_min_token_size=3` + 단어 토큰 매칭 특성상 짧은 닉네임/부분 일치("김" → 김개발/김철수)가 안 잡힘 → "비슷한 이름 다 노출" 요구 충족 불가.
  - LIKE는 substring 보장 + 스키마 변경(FULLTEXT 인덱스 마이그레이션) 불필요.
  - 관련도 정렬: 완전일치 > prefix(가나다) > 부분일치.
  - LIKE 와일드카드(`%` `_` `\`) 이스케이프로 입력 오염 차단.

### 유저 검색 UI (FE)

- 검색 모달에 `게시글 / 유저` 세그먼트 탭 추가 (별도 검색 영역). 모드별 엔드포인트/응답 분리.
- 유저 결과 = 프로필 이미지 + 닉네임, 검색어 하이라이트.

### 프로필 이동 공용화 + 타인 마이페이지

- `useNavigateToProfile` 공용 훅 추출 (검색 결과 등 재사용).
- 클릭 → `/profile/:id`로 이동. `Profile` 페이지를 본인/타인 겸용으로 일반화.
- `isOwner = 로그인 && 본인 id === 대상 id` 기준으로 `RSS 관리`·`정보 수정` 탭 노출 제어. 타인은 마이페이지 섹션만.
- 이메일(PII)은 공개 프로필 응답에 미포함 — 본인만 표시.

# 📋 작업 내용

**Backend**
- `searchUser` 요청/응답 DTO, repository(`searchUserList`), service, controller, Swagger api-docs 추가.

**Frontend**
- 검색 모드 탭(`SearchModeTabs`), 유저 결과 컴포넌트(`UserSearchResultList`/`Item`), `useUserSearch` 훅, `useNavigateToProfile` 훅 추가.
- `useSearchStore`에 `searchMode` 추가, `Profile` 페이지 본인/타인 일반화, 라우터 `/profile/:id` 추가.

**Test**
- DTO 검증 (12), service unit (3), e2e 실DB (7: 부분일치·관련도 정렬·와일드카드 이스케이프·페이지네이션·검증).
- FE: 유저 결과 클릭 → 핸들러 호출 단위 테스트.

### cmdk 관련 메모

- `CommandItem`이 내부에서 자체 `onClick`을 덮어쓰는 특성 때문에 클릭 핸들러를 자식 `<button>`에 부착 (기존 게시글 item이 `<a href>`를 자식에 둔 것과 동일 패턴).

# 📷 스크린 샷(선택 사항)

<img width="1901" height="910" alt="image" src="https://github.com/user-attachments/assets/0b53520f-b64b-4219-be8e-829ddb160260" />
