### PR TITLE
🐛 fix: 메인 페이지 콘솔 에러 제거 (401 / forwardRef)

### DIFF
--- a/client/src/components/about/Section.tsx
+++ b/client/src/components/about/Section.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, forwardRef } from "react";
+import { HTMLAttributes } from "react";
 
 import { useInView } from "@/hooks/common/useInView.ts";
 
@@ -8,7 +8,7 @@ interface SectionProps extends HTMLAttributes<HTMLElement> {
   children: React.ReactNode;
 }
 
-export const Section = forwardRef<HTMLElement, SectionProps>(({ children, className, ...props }) => {
+export const Section = ({ children, className, ...props }: SectionProps) => {
   const { ref, isInView } = useInView<HTMLElement>({ once: true });
 
   return (
@@ -24,6 +24,4 @@ export const Section = forwardRef<HTMLElement, SectionProps>(({ children, classN
       {children}
     </section>
   );
-});
-
-Section.displayName = "Section";
+};

--- a/client/src/store/useAuthStore.ts
+++ b/client/src/store/useAuthStore.ts
@@ -3,6 +3,8 @@ import { create } from "zustand";
 import { decodeToken } from "@/utils/jwt";
 import { refreshAccessToken, logout as logoutApi } from "@/api/services/user";
 
+const AUTH_HINT_KEY = "denamu_auth_hint";
+
 export type UserInfo = {
   id: number | null;
   email: string | null;
@@ -39,6 +41,7 @@ export const useAuthStore = create<AuthState>((set) => ({
   setUserFromToken: (token) => {
     const decoded = decodeToken(token);
     if (decoded) {
+      localStorage.setItem(AUTH_HINT_KEY, "1");
       set({
         accessToken: token,
         userInfo: {
@@ -58,6 +61,7 @@ export const useAuthStore = create<AuthState>((set) => ({
     } catch (e){
       console.warn("logout API 실패: ", e);
     } finally {
+      localStorage.removeItem(AUTH_HINT_KEY);
       set({
         accessToken: null,
         role: "guest",
@@ -71,6 +75,13 @@ export const useAuthStore = create<AuthState>((set) => ({
     }
   },
   initialize: async () => {
+    const isOAuthCallback = window.location.pathname === "/oauth-success";
+    const hasAuthHint = localStorage.getItem(AUTH_HINT_KEY) === "1";
+    if (!hasAuthHint && !isOAuthCallback) {
+      set({ isInitialized: true });
+      return;
+    }
+
     try {
       const res = await refreshAccessToken();
       const accessToken = res.data?.accessToken;
@@ -78,10 +89,12 @@ export const useAuthStore = create<AuthState>((set) => ({
       if (accessToken) {
         const decoded = decodeToken(accessToken);
         if (!decoded) {
+          localStorage.removeItem(AUTH_HINT_KEY);
           set({ isInitialized: true });
           return;
         }
 
+        localStorage.setItem(AUTH_HINT_KEY, "1");
         set({
           accessToken,
           userInfo: {
@@ -95,8 +108,10 @@ export const useAuthStore = create<AuthState>((set) => ({
         });
         return;
       }
+      localStorage.removeItem(AUTH_HINT_KEY);
       set({ isInitialized: true });
     } catch {
+      localStorage.removeItem(AUTH_HINT_KEY);
       set({
         role: "guest",
         userInfo: {


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연결된 이슈 없음 (메인 페이지 콘솔 에러 대응)

### 비로그인 새로고침 시 발생하는 401 제거

- **현상**: 비로그인 상태로 메인 페이지 새로고침 시 `POST /api/users/tokens 401 (Unauthorized)`가 콘솔에 노출.
- **원인**: 앱 초기화(`initialize`)가 인증 여부와 무관하게 무조건 refresh 요청을 전송. 비로그인 사용자는 refresh 쿠키가 없어 서버가 401 반환(REST 정상 동작), 빨간 401은 브라우저 네이티브 네트워크 로그라 `try/catch`로 억제 불가.
- **본질적 문제**: 콘솔 노이즈가 아니라 **익명 사용자 매 페이지 로드마다 불필요한 refresh 왕복 요청**.
- **해결**: localStorage 인증 이력 힌트(`denamu_auth_hint`)를 도입. 인증 이력이 없고 OAuth 콜백 경로도 아니면 refresh 요청 자체를 생략.
  - refresh_token은 HttpOnly라 클라가 쿠키 존재를 직접 확인 불가 → 힌트 플래그를 세션 존재의 클라측 신호로 사용.
  - OAuth 로그인은 access token을 본문으로 받지 않고 서버가 쿠키만 심고 `/oauth-success`로 리다이렉트한 뒤 refresh로 토큰을 획득. 첫 OAuth 사용자는 힌트가 아직 없으므로, `/oauth-success` 경로일 때는 게이트를 통과시켜 OAuth 흐름을 보존.
  - 인증 성공 시 플래그 set, 모든 비인증 결론(logout / init catch / no-token / decode 실패)에서 플래그 clear.
- **결과**: 익명 → 요청 0건·401 0건 / 유효 세션 → 무음 로그인 / 만료 세션 → 1회 401 후 무음. 서버 401 시맨틱·기존 e2e(`auth-jwt.spec.ts`) 영향 없음.

### forwardRef 경고 제거

- **현상**: `Warning: forwardRef render functions accept exactly two parameters: props and ref. Did you forget to use the ref parameter?`
- **원인**: `about/Section.tsx`가 `forwardRef`로 감싸졌으나 render 함수에 `ref` 파라미터가 없음. 컴포넌트는 자체 `useInView` ref를 사용하고, 호출처(`HeroSection` 등) 어디서도 ref를 넘기지 않아 forwardRef가 무의미.
- **해결**: forwardRef 래퍼와 불필요해진 `displayName` 제거 → 일반 함수 컴포넌트로 전환.

# 📋 작업 내용

- `useAuthStore.initialize`: 인증 이력/ OAuth 콜백 게이트 추가, 불필요한 익명 refresh 요청 제거
- `useAuthStore`: 인증 성공/실패 경로에 `denamu_auth_hint` 플래그 set/clear 일원화
- `about/Section.tsx`: 무의미한 `forwardRef` 래퍼 제거
- typecheck / lint 통과

# 📷 스크린 샷(선택 사항)

<img width="789" height="78" alt="image" src="https://github.com/user-attachments/assets/742b7418-2e87-4504-ba67-d4537bab2f9a" />
