### PR TITLE
🐛 fix: 피드 크롤러 게시글 변환 실패 격리 및 실패 알림 추가

### DIFF
--- a/feed-crawler/src/common/parser/base-feed-parser.ts
+++ b/feed-crawler/src/common/parser/base-feed-parser.ts
@@ -5,6 +5,9 @@ import {
   ONE_MINUTE,
   TIME_INTERVAL,
 } from '@common/constant';
+import logger from '@common/logger';
+import { NOTIFICATION_EVENT } from '@common/notification/notification-event.constant';
+import { Notifier } from '@common/notification/notifier.interface';
 import { ParserUtil } from '@common/parser/utils/parser-util';
 import { FeedDetail, RssObj } from '@common/types';
 
@@ -23,9 +26,11 @@ export abstract class BaseFeedParser {
     trimValues: true,
   });
   protected readonly parserUtil: ParserUtil;
+  protected readonly notifier: Notifier;
 
-  constructor(parserUtil: ParserUtil) {
+  constructor(parserUtil: ParserUtil, notifier: Notifier) {
     this.parserUtil = parserUtil;
+    this.notifier = notifier;
   }
 
   async parseFeed(
@@ -39,6 +44,8 @@ export abstract class BaseFeedParser {
     const detailedFeeds = await this.convertToFeedDetails(
       rssObj,
       timeMatchedFeeds,
+      NOTIFICATION_EVENT.FEED_CRAWLING_SCHEDULED,
+      '[Scheduled FeedCrawling]',
     );
 
     return detailedFeeds;
@@ -46,7 +53,12 @@ export abstract class BaseFeedParser {
 
   async parseAllFeeds(rssObj: RssObj, xmlData: string): Promise<FeedDetail[]> {
     const rawFeeds = this.extractRawFeeds(xmlData);
-    const detailedFeeds = await this.convertToFeedDetails(rssObj, rawFeeds);
+    const detailedFeeds = await this.convertToFeedDetails(
+      rssObj,
+      rawFeeds,
+      NOTIFICATION_EVENT.FEED_CRAWLING_FULL,
+      '[Full FeedCrawling]',
+    );
 
     return detailedFeeds;
   }
@@ -66,8 +78,12 @@ export abstract class BaseFeedParser {
   private async convertToFeedDetails(
     rssObj: RssObj,
     rawFeeds: RawFeed[],
+    event:
+      | typeof NOTIFICATION_EVENT.FEED_CRAWLING_SCHEDULED
+      | typeof NOTIFICATION_EVENT.FEED_CRAWLING_FULL,
+    errorSource: string,
   ): Promise<FeedDetail[]> {
-    return Promise.all(
+    const results = await Promise.allSettled(
       rawFeeds.map(async (feed) => {
         const imageUrl = await this.parserUtil.getThumbnailUrl(feed.link);
         const date = new Date(feed.pubDate);
@@ -95,5 +111,42 @@ export abstract class BaseFeedParser {
         };
       }),
     );
+
+    const succeeded: FeedDetail[] = [];
+    const failedReasons: unknown[] = [];
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        succeeded.push(result.value);
+      } else {
+        failedReasons.push(result.reason);
+        logger.warn(
+          `[${rssObj.blogName}] 게시글 변환 실패 (${rawFeeds[index]?.link}): ${result.reason}`,
+        );
+      }
+    });
+
+    if (failedReasons.length > 0) {
+      const groupedByReason = new Map<string, number>();
+      failedReasons.forEach((reason) => {
+        const message =
+          reason instanceof Error
+            ? reason.message
+            : (JSON.stringify(reason) ?? 'unknown');
+        groupedByReason.set(message, (groupedByReason.get(message) ?? 0) + 1);
+      });
+      const reasonDetail = [...groupedByReason.entries()]
+        .map(([message, count]) => `- ${message} (${count}건)`)
+        .join('\n');
+
+      this.notifier.publish(event, {
+        error: new Error(
+          `${rssObj.blogName}: 게시글 ${failedReasons.length}/${rawFeeds.length}개 변환 실패\n${reasonDetail}`,
+        ),
+        blogUrl: rssObj.rssUrl,
+        errorSource,
+      });
+    }
+
+    return succeeded;
   }
 }

--- a/feed-crawler/src/common/parser/formats/atom10-parser.ts
+++ b/feed-crawler/src/common/parser/formats/atom10-parser.ts
@@ -1,12 +1,17 @@
 import { inject, injectable } from 'tsyringe';
 
+import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
+import { Notifier } from '@common/notification/notifier.interface';
 import { BaseFeedParser, RawFeed } from '@common/parser/base-feed-parser';
 import { ParserUtil } from '@common/parser/utils/parser-util';
 
 @injectable()
 export class Atom10Parser extends BaseFeedParser {
-  constructor(@inject(ParserUtil) parserUtil: ParserUtil) {
-    super(parserUtil);
+  constructor(
+    @inject(ParserUtil) parserUtil: ParserUtil,
+    @inject(DEPENDENCY_SYMBOLS.Notifier) notifier: Notifier,
+  ) {
+    super(parserUtil, notifier);
   }
   canParse(xmlData: string): boolean {
     try {

--- a/feed-crawler/src/common/parser/formats/rss20-parser.ts
+++ b/feed-crawler/src/common/parser/formats/rss20-parser.ts
@@ -1,12 +1,17 @@
 import { inject, injectable } from 'tsyringe';
 
+import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
+import { Notifier } from '@common/notification/notifier.interface';
 import { BaseFeedParser, RawFeed } from '@common/parser/base-feed-parser';
 import { ParserUtil } from '@common/parser/utils/parser-util';
 
 @injectable()
 export class Rss20Parser extends BaseFeedParser {
-  constructor(@inject(ParserUtil) parserUtil: ParserUtil) {
-    super(parserUtil);
+  constructor(
+    @inject(ParserUtil) parserUtil: ParserUtil,
+    @inject(DEPENDENCY_SYMBOLS.Notifier) notifier: Notifier,
+  ) {
+    super(parserUtil, notifier);
   }
   canParse(xmlData: string): boolean {
     try {

--- a/feed-crawler/src/common/parser/utils/parser-util.ts
+++ b/feed-crawler/src/common/parser/utils/parser-util.ts
@@ -17,7 +17,7 @@ export class ParserUtil {
       validateStatus: () => true,
     });
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`${feedUrl}에 GET 요청 실패`);
+      throw new Error(`썸네일 GET 요청 실패 (HTTP ${response.status})`);
     }
 
     const htmlData = response.data;

--- a/feed-crawler/test/unit/parser-util.spec.ts
+++ b/feed-crawler/test/unit/parser-util.spec.ts
@@ -121,7 +121,7 @@ describe('ParserUtil', () => {
 
       // When & Then
       await expect(parserUtil.getThumbnailUrl(feedUrl)).rejects.toThrow(
-        `${feedUrl}에 GET 요청 실패`,
+        `썸네일 GET 요청 실패 (HTTP ${HttpStatusCode.NotFound})`,
       );
     });
 

--- a/feed-crawler/test/unit/parser.spec.ts
+++ b/feed-crawler/test/unit/parser.spec.ts
@@ -35,8 +35,9 @@ describe('Parser 모듈 테스트', () => {
 
   beforeEach(() => {
     parserUtil = new ParserUtil();
-    rss20Parser = new Rss20Parser(parserUtil);
-    atom10Parser = new Atom10Parser(parserUtil);
+    notifier = { initialize: jest.fn(), publish: jest.fn() };
+    rss20Parser = new Rss20Parser(parserUtil, notifier);
+    atom10Parser = new Atom10Parser(parserUtil, notifier);
     feedParserManager = new FeedParserManager(
       rss20Parser,
       atom10Parser,


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #651 (관련 — Feed Crawler 안정화, close 아님)

### 게시글 변환 실패 격리

-   기존 `convertToFeedDetails`가 `Promise.all`이라, 한 블로그에서 게시글 1개 변환(썸네일 fetch 등) 실패 시 **해당 블로그 게시글 전체가 유실**되는 문제.
-   `Promise.allSettled`로 전환해 성공분만 수집하도록 격리. 실패 건은 개별 로그 + **RSS당 알림 1건**으로 집계(게시글당 알림 폭탄 방지).
-   고민점: 알림을 건별로 보내면 썸네일 호스트 다운 시 스팸 → RSS 단위 1건 + **사유별 그룹핑**으로 압축.

### 실패 사유 식별성 개선

-   `getThumbnailUrl` 에러 메시지가 `${feedUrl}에 GET 요청 실패`라 **게시글마다 URL이 달라 그룹핑 키가 매번 unique** → 알림 집계가 무력화됨.
-   메시지에서 URL 제거 + **HTTP status 포함**(`썸네일 GET 요청 실패 (HTTP 404)`)으로 변경 → 404/500이 status 기준으로 묶임. URL은 개별 로그에 그대로 남김(책임 분리).

### DI

-   알림 발행 위해 `BaseFeedParser`에 `Notifier` 주입. 추상 클래스는 직접 resolve 대상이 아니라, 자식(`Rss20Parser`/`Atom10Parser`)에서 `@inject` 후 `super(parserUtil, notifier)`로 전달 — tsyringe 정석 패턴.

# 📋 작업 내용

-   `base-feed-parser.ts`: `Promise.allSettled` 격리, `Notifier` 주입, 실패 사유별 그룹핑 알림 발행
-   `rss20-parser.ts` / `atom10-parser.ts`: `Notifier` 주입 + `super` 전달
-   `parser-util.ts`: 썸네일 GET 실패 메시지에 HTTP status 포함
-   단위 테스트 갱신 (parser / parser-util, 38 passed)