### PR TITLE
✨ feat: 관리자 댓글 삭제 및 관리자 메인 페이지 탭 추가

### DIFF
--- a/client/src/api/services/admin/comment.ts
+++ b/client/src/api/services/admin/comment.ts
@@ -1,0 +1,9 @@
+import { ADMIN } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+
+export const adminComment = {
+  remove: async (commentId: number): Promise<void> => {
+    await axiosInstance.delete(ADMIN.DELETE_COMMENT(commentId));
+  },
+};

--- a/client/src/components/admin/layout/AdminHeader.tsx
+++ b/client/src/components/admin/layout/AdminHeader.tsx
@@ -19,7 +19,7 @@ export const AdminHeader = ({
   name,
 }: {
   setLogin: () => void;
-  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE") => void;
+  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE" | "POST") => void;
   name?: string;
 }) => {
   const handleLogout = () => {

--- a/client/src/components/admin/layout/AdminNavigationMenu.tsx
+++ b/client/src/components/admin/layout/AdminNavigationMenu.tsx
@@ -4,6 +4,7 @@ import { NavigationMenu, NavigationMenuItem, NavigationMenuList } from "@/compon
 export const TAB_TYPES = {
   RSS: "RSS",
   MEMBER: "MEMBER",
+  POST: "POST",
 } as const;
 
 type TabType = (typeof TAB_TYPES)[keyof typeof TAB_TYPES];
@@ -20,6 +21,11 @@ export const AdminNavigationMenu = ({ handleTap }: { handleTap: (tabType: TabTyp
         <NavigationMenuItem>
           <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("MEMBER")}>
             회원 관리
+          </Button>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("POST")}>
+            게시글 관리
           </Button>
         </NavigationMenuItem>
       </NavigationMenuList>

--- a/client/src/components/admin/post/AdminPostDetail.tsx
+++ b/client/src/components/admin/post/AdminPostDetail.tsx
@@ -1,0 +1,54 @@
+import { useRef } from "react";
+
+import { X } from "lucide-react";
+import Markdown from "react-markdown";
+
+import PostComment from "@/components/common/Card/detail/PostComment";
+import { PostHeader } from "@/components/common/Card/detail/PostHeader";
+
+import { usePostDetail } from "@/hooks/queries/usePostDetail";
+
+interface AdminPostDetailProps {
+  feedId: number;
+  onClose: () => void;
+}
+
+export default function AdminPostDetail({ feedId, onClose }: AdminPostDetailProps) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const { data } = usePostDetail(feedId);
+
+  const handleClickOutside = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
+      onClose();
+    }
+  };
+
+  if (!data) return null;
+  const post = data.data;
+  const markdownString = (post.summary ?? "").replace(/\\n/g, "\n").replace(/\\r/g, "\r");
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex justify-center items-start z-[999] overflow-y-auto py-10"
+      onClick={handleClickOutside}
+    >
+      <div ref={modalRef} className="bg-white rounded-md w-[90%] max-w-4xl h-auto relative">
+        <div className="w-full border-b flex justify-end">
+          <button onClick={onClose} className="rounded my-5 mx-5" aria-label="Close modal">
+            <X size={15} />
+          </button>
+        </div>
+        <div className="mt-5 flex flex-col gap-5 px-10 pb-10">
+          <PostHeader data={post} />
+          <div className="prose max-w-full border-b pb-5">
+            <Markdown>{markdownString}</Markdown>
+            {post.summary && (
+              <p className="text-gray-400">💡 인공지능이 요약한 내용입니다. 오류가 포함될 수 있으니 참고 바랍니다.</p>
+            )}
+          </div>
+          <PostComment feedId={post.id} isAdmin />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/admin/post/AdminPostTab.tsx
+++ b/client/src/components/admin/post/AdminPostTab.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from "react";
+
+import AdminPostDetail from "@/components/admin/post/AdminPostDetail";
+import { PostCardContent } from "@/components/common/Card/PostCardContent";
+import { PostCardImage } from "@/components/common/Card/PostCardImage";
+import { PostGridSkeleton } from "@/components/common/Card/PostCardSkeleton";
+import { Card } from "@/components/ui/card";
+
+import { useInfiniteScrollQuery } from "@/hooks/queries/useInfiniteScrollQuery";
+
+import { posts } from "@/api/services/posts";
+import { FeedList } from "@/types/post";
+
+export default function AdminPostTab() {
+  const observerTarget = useRef<HTMLDivElement>(null);
+  const [selectedFeedId, setSelectedFeedId] = useState<number | null>(null);
+
+  const { items, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useInfiniteScrollQuery<FeedList>({
+    queryKey: "admin-latest-posts",
+    fetchFn: posts.latest,
+    tags: [],
+  });
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.3, rootMargin: "100px" }
+    );
+    if (observerTarget.current) observer.observe(observerTarget.current);
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  return (
+    <section className="flex flex-col min-h-[300px]">
+      {isLoading ? (
+        <PostGridSkeleton count={8} />
+      ) : (
+        <>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 min-h-[300px]">
+            {items.map((post) => (
+              <Card
+                key={post.id}
+                onClick={() => setSelectedFeedId(post.id)}
+                className="h-[270px] group shadow-md hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 border-none rounded-xl cursor-pointer"
+              >
+                <PostCardImage thumbnail={post.thumbnail} alt={post.title} isNew={post.isNew} />
+                <PostCardContent post={post} />
+              </Card>
+            ))}
+          </div>
+          {isFetchingNextPage && (
+            <div className="mt-8">
+              <PostGridSkeleton count={4} />
+            </div>
+          )}
+          <div ref={observerTarget} className="h-10" />
+        </>
+      )}
+
+      {selectedFeedId !== null && (
+        <AdminPostDetail feedId={selectedFeedId} onClose={() => setSelectedFeedId(null)} />
+      )}
+    </section>
+  );
+}

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -6,7 +6,13 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 
 import { useNavigateToProfile } from "@/hooks/common/useNavigateToProfile";
-import { useComments, useCreateComment, useUpdateComment, useDeleteComment } from "@/hooks/queries/useComments";
+import {
+  useComments,
+  useCreateComment,
+  useUpdateComment,
+  useDeleteComment,
+  useAdminDeleteComment,
+} from "@/hooks/queries/useComments";
 import { useUserProfile } from "@/hooks/queries/useProfile";
 
 import { timeAgo } from "@/utils/timeago";
@@ -17,12 +23,14 @@ import { FeedCommentType } from "@/types/post";
 interface PostCommentProps {
   feedId: number;
   isFeedOwner?: boolean;
+  isAdmin?: boolean;
 }
 
 interface CommentItemProps {
   comment: FeedCommentType;
   canEdit: boolean;
   canDelete: boolean;
+  canReply?: boolean;
   isReply?: boolean;
   modifyId: number | null;
   handleModify: (id: number | null) => void;
@@ -33,7 +41,7 @@ interface CommentItemProps {
 
 const INITIAL_VISIBLE = 3;
 
-export default function PostComment({ feedId, isFeedOwner = false }: PostCommentProps) {
+export default function PostComment({ feedId, isFeedOwner = false, isAdmin = false }: PostCommentProps) {
   const { id: userId, userName } = useAuthStore((state) => state.userInfo);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
@@ -41,7 +49,9 @@ export default function PostComment({ feedId, isFeedOwner = false }: PostComment
   const { data: myProfile } = useUserProfile(userId ?? 0);
   const { mutate: createComment, isPending: isCreating } = useCreateComment(feedId);
   const { mutate: updateComment } = useUpdateComment(feedId);
-  const { mutate: deleteComment } = useDeleteComment(feedId);
+  const { mutate: deleteCommentUser } = useDeleteComment(feedId);
+  const { mutate: deleteCommentAdmin } = useAdminDeleteComment(feedId);
+  const deleteComment = isAdmin ? deleteCommentAdmin : deleteCommentUser;
 
   const [content, setContent] = useState("");
   const [modifyId, setModifyId] = useState<number | null>(null);
@@ -91,9 +101,10 @@ export default function PostComment({ feedId, isFeedOwner = false }: PostComment
     updateComment({ commentId, newComment: trimmed }, { onSuccess: () => setModifyId(null) });
   };
 
-  const canEditComment = (comment: FeedCommentType) => !comment.isDeleted && comment.user.id === userId;
+  const canEditComment = (comment: FeedCommentType) =>
+    !isAdmin && !comment.isDeleted && comment.user.id === userId;
   const canDeleteComment = (comment: FeedCommentType) =>
-    !comment.isDeleted && (comment.user.id === userId || isFeedOwner);
+    !comment.isDeleted && (isAdmin || comment.user.id === userId || isFeedOwner);
 
   const repliesByParent = comments.reduce<Record<number, FeedCommentType[]>>((acc, comment) => {
     if (comment.parentId !== null) {
@@ -113,31 +124,33 @@ export default function PostComment({ feedId, isFeedOwner = false }: PostComment
   return (
     <div className="w-full space-y-6">
       {/* 댓글 입력 영역 */}
-      <div className="bg-gray-50 rounded-lg shadow-sm border border-gray-200 overflow-hidden">
-        <div className="p-4">
-          <div className="flex items-start gap-3">
-            <Avatar className="w-10 h-10">
-              <AvatarImage src={myProfile?.profileImage ?? undefined} alt={userName ?? "사용자 프로필"} />
-              <AvatarFallback>{(myProfile?.userName ?? userName ?? "?").substring(0, 2)}</AvatarFallback>
-            </Avatar>
-            <textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              placeholder="댓글을 입력하세요..."
-              className="flex-1 bg-transparent p-2 rounded-md h-20 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent resize-none"
-            ></textarea>
+      {!isAdmin && (
+        <div className="bg-gray-50 rounded-lg shadow-sm border border-gray-200 overflow-hidden">
+          <div className="p-4">
+            <div className="flex items-start gap-3">
+              <Avatar className="w-10 h-10">
+                <AvatarImage src={myProfile?.profileImage ?? undefined} alt={userName ?? "사용자 프로필"} />
+                <AvatarFallback>{(myProfile?.userName ?? userName ?? "?").substring(0, 2)}</AvatarFallback>
+              </Avatar>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="댓글을 입력하세요..."
+                className="flex-1 bg-transparent p-2 rounded-md h-20 focus:outline-none focus:ring-2 focus:ring-gray-300 focus:border-transparent resize-none"
+              ></textarea>
+            </div>
+          </div>
+          <div className="flex justify-end px-4 pb-4">
+            <button
+              onClick={handleSubmit}
+              disabled={isCreating}
+              className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-full transition-colors disabled:opacity-60"
+            >
+              등록
+            </button>
           </div>
         </div>
-        <div className="flex justify-end px-4 pb-4">
-          <button
-            onClick={handleSubmit}
-            disabled={isCreating}
-            className="bg-primary hover:bg-primary/90 text-white font-medium py-2 px-4 rounded-full transition-colors disabled:opacity-60"
-          >
-            등록
-          </button>
-        </div>
-      </div>
+      )}
 
       {/* 댓글 목록 헤더 */}
       <div className="flex items-center border-b border-gray-200 pb-2">
@@ -154,6 +167,7 @@ export default function PostComment({ feedId, isFeedOwner = false }: PostComment
               comment={root}
               canEdit={canEditComment(root)}
               canDelete={canDeleteComment(root)}
+              canReply={!isAdmin}
               modifyId={modifyId}
               handleModify={handleModify}
               onUpdate={handleUpdate}
@@ -170,6 +184,7 @@ export default function PostComment({ feedId, isFeedOwner = false }: PostComment
                       comment={reply}
                       canEdit={canEditComment(reply)}
                       canDelete={canDeleteComment(reply)}
+                      canReply={!isAdmin}
                       isReply
                       modifyId={modifyId}
                       handleModify={handleModify}
@@ -243,6 +258,7 @@ const CommentItem = ({
   comment,
   canEdit,
   canDelete,
+  canReply = true,
   isReply = false,
   modifyId,
   handleModify,
@@ -314,7 +330,7 @@ const CommentItem = ({
             </div>
           </div>
         )}
-        {!isEditing && !comment.isDeleted && (
+        {canReply && !isEditing && !comment.isDeleted && (
           <button
             onClick={() => onReply(comment.id, isReply ? comment.user.userName : undefined)}
             className="mt-1 text-xs text-gray-400 hover:text-gray-600"

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -12,6 +12,7 @@ export const ADMIN = {
   DELETE_CHILD: (id: number) => `/api/admins/children/${id}`,
   WITHDRAW_REQUEST: "/api/admins/me/deletion-requests",
   WITHDRAW_CONFIRM: (token: string) => `/api/admins/deletion-requests/${token}`,
+  DELETE_COMMENT: (commentId: number) => `/api/admins/comments/${commentId}`,
   GET: {
     RSS: "/api/rss",
     ACCEPT: "/api/rss/history/accept",

--- a/client/src/hooks/queries/useComments.ts
+++ b/client/src/hooks/queries/useComments.ts
@@ -1,3 +1,4 @@
+import { adminComment } from "@/api/services/admin/comment";
 import { comments } from "@/api/services/comments";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -32,6 +33,14 @@ export const useDeleteComment = (feedId: number) => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (commentId: number) => comments.remove(feedId, commentId),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: commentsKey(feedId) }),
+  });
+};
+
+export const useAdminDeleteComment = (feedId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (commentId: number) => adminComment.remove(commentId),
     onSettled: () => queryClient.invalidateQueries({ queryKey: commentsKey(feedId) }),
   });
 };

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -7,6 +7,7 @@ import AdminMember from "@/components/admin/layout/AdminMember";
 import AdminMyPage from "@/components/admin/layout/AdminMyPage";
 import { AdminTabs } from "@/components/admin/layout/AdminTabs";
 import AdminLogin from "@/components/admin/login/AdminLoginModal";
+import AdminPostTab from "@/components/admin/post/AdminPostTab";
 import { RssRequestSearchBar } from "@/components/admin/rss/RssSearchBar";
 
 import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
@@ -14,7 +15,7 @@ import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
 export default function Admin() {
   const [isLogin, setIsLogin] = useState<boolean>(false);
   const { status, isLoading, data } = useAdminCheck();
-  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE">("RSS");
+  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE" | "POST">("RSS");
 
   useEffect(() => {
     setIsLogin(status === "success");
@@ -31,6 +32,9 @@ export default function Admin() {
     }
     if (tap === "MYPAGE") {
       return <AdminMyPage onBack={() => setTap("RSS")} />;
+    }
+    if (tap === "POST") {
+      return <AdminPostTab />;
     }
     return <AdminMember />;
   };

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -135,6 +135,7 @@ CREATE TABLE `comment` (
   `id` int NOT NULL AUTO_INCREMENT,
   `comment` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci NOT NULL,
   `is_deleted` tinyint NOT NULL DEFAULT '0',
+  `is_admin_deleted` tinyint NOT NULL DEFAULT '0',
   `date` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `feed_id` int NOT NULL,
   `user_id` int NOT NULL,

--- a/server/src/comment/api-docs/deleteCommentByAdmin.api-docs.ts
+++ b/server/src/comment/api-docs/deleteCommentByAdmin.api-docs.ts
@@ -1,0 +1,19 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiDeleteCommentByAdmin() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '관리자 댓글 삭제 API' }),
+    ApiParam({ name: 'commentId', description: '삭제할 댓글 ID', example: 1 }),
+    ApiMessageResponse('댓글이 성공적으로 삭제되었습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않는 댓글입니다.'),
+  );
+}

--- a/server/src/comment/controller/adminComment.controller.ts
+++ b/server/src/comment/controller/adminComment.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Delete, HttpCode, HttpStatus, Param, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { ApiDeleteCommentByAdmin } from '@comment/api-docs/deleteCommentByAdmin.api-docs';
+import { CommentParamRequestDto } from '@comment/dto/request/commentParam.dto';
+import { CommentService } from '@comment/service/comment.service';
+
+import { AdminAuthGuard } from '@common/guard/session.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+@ApiTags('Admin')
+@Controller('admins/comments')
+export class AdminCommentController {
+  constructor(private readonly commentService: CommentService) {}
+
+  @ApiDeleteCommentByAdmin()
+  @Delete(':commentId')
+  @UseGuards(AdminAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async deleteComment(@Param() paramDto: CommentParamRequestDto) {
+    await this.commentService.deleteByAdmin(paramDto.commentId);
+    return ApiResponse.responseWithNoContent('댓글 삭제를 성공했습니다.');
+  }
+}

--- a/server/src/comment/dto/response/getComment.dto.ts
+++ b/server/src/comment/dto/response/getComment.dto.ts
@@ -57,7 +57,11 @@ export class GetCommentResponseDto {
       id: comment.id,
       parentId: comment.parentId ?? null,
       isDeleted: comment.isDeleted,
-      comment: comment.isDeleted ? '삭제된 댓글입니다.' : comment.comment,
+      comment: comment.isAdminDeleted
+        ? '관리자에 의해 제거된 댓글입니다.'
+        : comment.isDeleted
+          ? '삭제된 댓글입니다.'
+          : comment.comment,
       date: comment.date,
       user: comment.isDeleted
         ? { id: 0, userName: '(알 수 없음)', profileImage: null }

--- a/server/src/comment/entity/comment.entity.ts
+++ b/server/src/comment/entity/comment.entity.ts
@@ -32,6 +32,14 @@ export class Comment extends BaseEntity {
   })
   isDeleted: boolean;
 
+  @Column({
+    name: 'is_admin_deleted',
+    type: 'boolean',
+    nullable: false,
+    default: false,
+  })
+  isAdminDeleted: boolean;
+
   @CreateDateColumn({
     name: 'date',
     nullable: false,

--- a/server/src/comment/module/comment.module.ts
+++ b/server/src/comment/module/comment.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 
+import { AdminCommentController } from '@comment/controller/adminComment.controller';
 import { CommentController } from '@comment/controller/comment.controller';
 import { UserCommentController } from '@comment/controller/userComment.controller';
 import { CommentRepository } from '@comment/repository/comment.repository';
@@ -11,7 +12,7 @@ import { UserModule } from '@user/module/user.module';
 
 @Module({
   imports: [FeedModule, UserModule],
-  controllers: [CommentController, UserCommentController],
+  controllers: [CommentController, UserCommentController, AdminCommentController],
   providers: [CommentRepository, CommentService],
   exports: [],
 })

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -175,6 +175,20 @@ export class CommentService {
     });
   }
 
+  async deleteByAdmin(commentId: number) {
+    const comment = await this.commentRepository.findOne({
+      where: { id: commentId },
+    });
+
+    if (!comment) {
+      throw new NotFoundException('존재하지 않는 댓글입니다.');
+    }
+
+    comment.isDeleted = true;
+    comment.isAdminDeleted = true;
+    await this.commentRepository.save(comment);
+  }
+
   async update(
     userInformation: Payload,
     commentId: number,

--- a/server/src/common/database/migration/1781300000000-AddCommentAdminDeleted.ts
+++ b/server/src/common/database/migration/1781300000000-AddCommentAdminDeleted.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddCommentAdminDeleted1781300000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE comment
+        ADD COLUMN is_admin_deleted tinyint NOT NULL DEFAULT '0';
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE comment
+        DROP COLUMN is_admin_deleted;
+    `);
+  }
+}

--- a/server/test/comment/e2e/deleteCommentByAdmin.e2e-spec.ts
+++ b/server/test/comment/e2e/deleteCommentByAdmin.e2e-spec.ts
@@ -1,0 +1,120 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { Comment } from '@comment/entity/comment.entity';
+import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { CommentFixture } from '@test/config/common/fixture/comment.fixture';
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = (commentId: number | string) => `/api/admins/comments/${commentId}`;
+
+describe(`DELETE /api/admins/comments/:commentId E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let commentRepository: CommentRepository;
+  let userRepository: UserRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+
+  const sessionKey = 'admin-comment-delete-session-key';
+  const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+
+  let feed: Feed;
+  let user: User;
+  let comment: Comment;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+    commentRepository = testApp.get(CommentRepository);
+    userRepository = testApp.get(UserRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  beforeEach(async () => {
+    const admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(redisKeyMake(sessionKey), admin.email);
+
+    const rssAccept: RssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    [user, feed] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      feedRepository.save(
+        FeedFixture.createFeedFixture(rssAccept, { commentCount: 1 }),
+      ),
+    ]);
+    comment = await commentRepository.save(
+      CommentFixture.createCommentFixture(feed, user),
+    );
+  });
+
+  it('[401] 관리자 세션 쿠키가 없으면 삭제를 실패한다.', async () => {
+    // Http when
+    const response = await agent.delete(URL(comment.id));
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+
+    // DB then
+    const found = await commentRepository.findOneBy({ id: comment.id });
+    expect(found.isDeleted).toBe(false);
+    expect(found.isAdminDeleted).toBe(false);
+  });
+
+  it('[404] 존재하지 않는 댓글 삭제를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .delete(URL(999999))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[200] 어떤 유저의 댓글이든 soft delete + 관리자 삭제 플래그를 세우고 commentCount는 유지한다.', async () => {
+    // Http when
+    const response = await agent
+      .delete(URL(comment.id))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB then - 댓글은 남아 있고 플래그만 세워짐
+    const found = await commentRepository.findOneBy({ id: comment.id });
+    expect(found).not.toBeNull();
+    expect(found.isDeleted).toBe(true);
+    expect(found.isAdminDeleted).toBe(true);
+
+    // DB then - commentCount는 변동 없음
+    const foundFeed = await feedRepository.findOneBy({ id: feed.id });
+    expect(foundFeed.commentCount).toBe(1);
+  });
+});

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -393,6 +393,99 @@ describe(`${CommentService.name} Unit Test`, () => {
     });
   });
 
+  describe('deleteByAdmin', () => {
+    it('존재하지 않는 댓글이면 NotFoundException을 던진다.', async () => {
+      // given
+      commentRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(commentService.deleteByAdmin(5)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(commentRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('권한·답글·commentCount 분기 없이 isDeleted와 isAdminDeleted를 true로 저장한다.', async () => {
+      // given
+      const comment = {
+        id: 5,
+        isDeleted: false,
+        isAdminDeleted: false,
+      } as any;
+      commentRepository.findOne.mockResolvedValue(comment);
+
+      // when
+      await commentService.deleteByAdmin(5);
+
+      // then
+      expect(commentRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 5 },
+      });
+      expect(comment.isDeleted).toBe(true);
+      expect(comment.isAdminDeleted).toBe(true);
+      expect(commentRepository.save).toHaveBeenCalledWith(comment);
+      expect(commentRepository.count).not.toHaveBeenCalled();
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GetCommentResponseDto placeholder', () => {
+    const baseComment = {
+      id: 5,
+      parentId: null,
+      date: new Date('2025-01-01'),
+      comment: '원본 내용',
+      user: { id: 1, userName: 'tester', profileImage: null },
+    };
+
+    it('관리자가 삭제한 댓글은 "관리자에 의해 제거된 댓글입니다." placeholder로 변환한다.', () => {
+      // given
+      const comment = {
+        ...baseComment,
+        isDeleted: true,
+        isAdminDeleted: true,
+      } as any;
+
+      // when
+      const dto = GetCommentResponseDto.toResponseDto(comment);
+
+      // then
+      expect(dto.comment).toBe('관리자에 의해 제거된 댓글입니다.');
+      expect(dto.isDeleted).toBe(true);
+      expect(dto.user).toEqual({ id: 0, userName: '(알 수 없음)', profileImage: null });
+    });
+
+    it('일반 soft delete 댓글은 "삭제된 댓글입니다." placeholder로 변환한다.', () => {
+      // given
+      const comment = {
+        ...baseComment,
+        isDeleted: true,
+        isAdminDeleted: false,
+      } as any;
+
+      // when
+      const dto = GetCommentResponseDto.toResponseDto(comment);
+
+      // then
+      expect(dto.comment).toBe('삭제된 댓글입니다.');
+    });
+
+    it('삭제되지 않은 댓글은 원본 내용을 그대로 노출한다.', () => {
+      // given
+      const comment = {
+        ...baseComment,
+        isDeleted: false,
+        isAdminDeleted: false,
+      } as any;
+
+      // when
+      const dto = GetCommentResponseDto.toResponseDto(comment);
+
+      // then
+      expect(dto.comment).toBe('원본 내용');
+    });
+  });
+
   describe('update', () => {
     it('본인 댓글의 내용을 수정하고 저장한다.', async () => {
       // given


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   관련 이슈 없음 (관리자 운영 편의 기능 자체 추가)

### 관리자 권한 댓글 삭제

-   서비스 운영 중 부적절한 댓글을 관리자가 직접 제거할 수 있어야 함. 기존 댓글 삭제는 작성자/피드 소유자만 가능했기 때문에 관리자 전용 삭제 경로가 필요했음.
-   데이터 보존 관점에서 hard delete 대신 soft delete 채택. 일반 사용자 삭제(`is_deleted`)와 관리자 삭제를 구분하기 위해 `is_admin_deleted` 컬럼을 신설해, 추후 운영 통계/감사 시 삭제 주체를 식별할 수 있도록 설계함.
-   관리자 전용 엔드포인트(`DELETE /admins/comments/:commentId`)는 `AdminAuthGuard`로 보호해 일반 사용자 경로와 권한 경계를 분리함.

### 관리자 페이지 메인 페이지 탭

-   관리자가 별도 화면 전환 없이 발행된 최신 게시글과 그 댓글을 점검할 수 있도록 관리자 페이지에 메인 페이지(게시글) 탭을 추가함.
-   기존 `PostComment` 컴포넌트를 재사용하되 `isAdmin` 플래그를 추가해, 관리자 모드에서는 댓글 입력/수정/답글 UI를 숨기고 삭제만 가능하도록 분기 처리함. 컴포넌트 중복 생성을 피하고 단일 책임을 유지하기 위함.

# 📋 작업 내용

**Backend**

-   `Comment` 엔티티에 `is_admin_deleted` 컬럼 추가 및 마이그레이션 작성 (`AddCommentAdminDeleted`)
-   `CommentService.deleteByAdmin` 구현 (존재하지 않는 댓글 `NotFoundException`, soft delete 처리)
-   `AdminCommentController` 신설 — `DELETE /admins/comments/:commentId` (`AdminAuthGuard` 적용)
-   Swagger api-docs 및 단위/E2E 테스트 작성

**Frontend**

-   관리자 페이지에 게시글 탭(`AdminPostTab`)·상세(`AdminPostDetail`) 추가, 무한 스크롤 적용
-   `PostComment`에 `isAdmin` 분기 추가 (입력/수정/답글 숨김, 관리자 삭제 허용)
-   `useAdminDeleteComment` 훅 및 admin comment API 서비스 추가

# 📷 스크린 샷(선택 사항)

<img width="1401" height="909" alt="image" src="https://github.com/user-attachments/assets/29cb723c-2f0b-4491-81d1-3ba26bcd7483" />

<img width="1361" height="904" alt="image" src="https://github.com/user-attachments/assets/742ee689-bf45-4542-a9ae-a9a2c497799a" />
