### PR TITLE
✨ feat: AI 요약 없는 게시글 조회 및 요약 신청 기능

### DIFF
--- a/client/src/__tests__/components/common/Card/PostCard.test.tsx
+++ b/client/src/__tests__/components/common/Card/PostCard.test.tsx
@@ -66,6 +66,7 @@ describe("PostCard", () => {
       blogPlatform: "etc",
       tag: ["JavaScript", "React"],
       likes: 0,
+      comments: 0,
     };
 
     render(<MemoryRouter><PostCard post={minimalPost} /></MemoryRouter>);

--- a/client/src/__tests__/mocks/data/posts.ts
+++ b/client/src/__tests__/mocks/data/posts.ts
@@ -9,6 +9,7 @@ export const createMockPost = (override = {}) => ({
   authorImageUrl: "author-image.jpg",
   tag: ["React", "Testing"],
   likes: 50,
+  comments: 0,
   blogPlatform: "etc",
   summary: "# test",
   ...override,

--- a/client/src/api/mocks/data/posts.ts
+++ b/client/src/api/mocks/data/posts.ts
@@ -12,6 +12,7 @@ export const generateMockPost = (id: number): FeedList => ({
   thumbnail: `https://picsum.photos/640/480?random=${id}`,
   blogPlatform: "etc",
   likes: 0,
+  comments: 0,
   tag: [],
 });
 

--- a/client/src/api/services/admin/feed.ts
+++ b/client/src/api/services/admin/feed.ts
@@ -1,0 +1,14 @@
+import { BLOG } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+import { NoSummaryFeed, NoSummaryFeedsApiResponse } from "@/types/post";
+
+export const adminFeed = {
+  getNoSummaryFeeds: async (): Promise<NoSummaryFeed[]> => {
+    const response = await axiosInstance.get<NoSummaryFeedsApiResponse>(BLOG.NO_SUMMARY);
+    return response.data.data;
+  },
+  requestAiSummary: async (feedId: number): Promise<void> => {
+    await axiosInstance.post(BLOG.AI_SUMMARY(feedId));
+  },
+};

--- a/client/src/components/admin/post/AdminPostDetail.tsx
+++ b/client/src/components/admin/post/AdminPostDetail.tsx
@@ -1,12 +1,17 @@
 import { useRef } from "react";
 
-import { X } from "lucide-react";
+import { AxiosError } from "axios";
+import { Heart, MessageSquare, Sparkles, X } from "lucide-react";
 import Markdown from "react-markdown";
 
 import PostComment from "@/components/common/Card/detail/PostComment";
 import { PostHeader } from "@/components/common/Card/detail/PostHeader";
+import { Button } from "@/components/ui/button";
 
+import { useCustomToast } from "@/hooks/common/useCustomToast";
 import { usePostDetail } from "@/hooks/queries/usePostDetail";
+import { NO_SUMMARY_FEEDS_KEY, useRequestAiSummary } from "@/hooks/queries/useAiSummaryRequest";
+import { useQueryClient } from "@tanstack/react-query";
 
 interface AdminPostDetailProps {
   feedId: number;
@@ -16,6 +21,9 @@ interface AdminPostDetailProps {
 export default function AdminPostDetail({ feedId, onClose }: AdminPostDetailProps) {
   const modalRef = useRef<HTMLDivElement>(null);
   const { data } = usePostDetail(feedId);
+  const { toast } = useCustomToast();
+  const queryClient = useQueryClient();
+  const { mutate: requestSummary, isPending } = useRequestAiSummary();
 
   const handleClickOutside = (event: React.MouseEvent<HTMLDivElement>) => {
     if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
@@ -27,23 +35,52 @@ export default function AdminPostDetail({ feedId, onClose }: AdminPostDetailProp
   const post = data.data;
   const markdownString = (post.summary ?? "").replace(/\\n/g, "\n").replace(/\\r/g, "\r");
 
+  const handleRetry = () => {
+    if (isPending) return;
+    requestSummary(post.id, {
+      onSuccess: () => {
+        toast({ title: "AI 요약 재요청 접수", description: "요약 재생성이 접수되었습니다." });
+        queryClient.invalidateQueries({ queryKey: NO_SUMMARY_FEEDS_KEY });
+      },
+      onError: (error) => {
+        const message =
+          (error as AxiosError<{ message?: string }>).response?.data?.message ?? "다시 시도해주세요.";
+        toast({ title: "AI 요약 재요청 실패", description: message });
+      },
+    });
+  };
+
   return (
     <div
       className="fixed inset-0 bg-black/50 flex justify-center items-start z-[999] overflow-y-auto py-10"
       onClick={handleClickOutside}
     >
       <div ref={modalRef} className="bg-white rounded-md w-[90%] max-w-4xl h-auto relative">
-        <div className="w-full border-b flex justify-end">
-          <button onClick={onClose} className="rounded my-5 mx-5" aria-label="Close modal">
+        <div className="w-full border-b flex justify-between items-center px-5 py-4">
+          <Button size="sm" onClick={handleRetry} disabled={isPending} className="gap-1">
+            <Sparkles size={14} />
+            {isPending ? "재요청 중..." : "AI 요약 재시도"}
+          </Button>
+          <button onClick={onClose} className="rounded" aria-label="Close modal">
             <X size={15} />
           </button>
         </div>
         <div className="mt-5 flex flex-col gap-5 px-10 pb-10">
           <PostHeader data={post} />
+          <div className="flex gap-4 text-sm text-gray-500">
+            <span className="flex items-center gap-1">
+              <Heart size={16} /> 공감 {post.likes}
+            </span>
+            <span className="flex items-center gap-1">
+              <MessageSquare size={16} /> 댓글 {post.comments}
+            </span>
+          </div>
           <div className="prose max-w-full border-b pb-5">
             <Markdown>{markdownString}</Markdown>
-            {post.summary && (
+            {post.summary ? (
               <p className="text-gray-400">💡 인공지능이 요약한 내용입니다. 오류가 포함될 수 있으니 참고 바랍니다.</p>
+            ) : (
+              <p className="text-gray-400">아직 AI 요약이 없습니다. 상단의 “AI 요약 재시도” 버튼으로 재생성할 수 있습니다.</p>
             )}
           </div>
           <PostComment feedId={post.id} isAdmin />

--- a/client/src/components/admin/post/AdminPostTab.tsx
+++ b/client/src/components/admin/post/AdminPostTab.tsx
@@ -1,19 +1,31 @@
 import { useEffect, useRef, useState } from "react";
 
+import { AlertTriangle, CheckSquare, Heart, MessageSquare, Square } from "lucide-react";
+
 import AdminPostDetail from "@/components/admin/post/AdminPostDetail";
 import { PostCardContent } from "@/components/common/Card/PostCardContent";
 import { PostCardImage } from "@/components/common/Card/PostCardImage";
 import { PostGridSkeleton } from "@/components/common/Card/PostCardSkeleton";
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
+import { useCustomToast } from "@/hooks/common/useCustomToast";
+import { NO_SUMMARY_FEEDS_KEY, useBatchRequestAiSummary, useNoSummaryFeeds } from "@/hooks/queries/useAiSummaryRequest";
 import { useInfiniteScrollQuery } from "@/hooks/queries/useInfiniteScrollQuery";
 
 import { posts } from "@/api/services/posts";
 import { FeedList } from "@/types/post";
+import { useQueryClient } from "@tanstack/react-query";
 
 export default function AdminPostTab() {
   const observerTarget = useRef<HTMLDivElement>(null);
   const [selectedFeedId, setSelectedFeedId] = useState<number | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+
+  const queryClient = useQueryClient();
+  const { toast } = useCustomToast();
+  const { data: noSummaryFeeds = [], isLoading: isNoSummaryLoading } = useNoSummaryFeeds();
+  const { mutate: batchRequest, isPending } = useBatchRequestAiSummary();
 
   const { items, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useInfiniteScrollQuery<FeedList>({
     queryKey: "admin-latest-posts",
@@ -34,36 +46,140 @@ export default function AdminPostTab() {
     return () => observer.disconnect();
   }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
-  return (
-    <section className="flex flex-col min-h-[300px]">
-      {isLoading ? (
-        <PostGridSkeleton count={8} />
-      ) : (
-        <>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 min-h-[300px]">
-            {items.map((post) => (
-              <Card
-                key={post.id}
-                onClick={() => setSelectedFeedId(post.id)}
-                className="h-[270px] group shadow-md hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 border-none rounded-xl cursor-pointer"
-              >
-                <PostCardImage thumbnail={post.thumbnail} alt={post.title} isNew={post.isNew} />
-                <PostCardContent post={post} />
-              </Card>
-            ))}
-          </div>
-          {isFetchingNextPage && (
-            <div className="mt-8">
-              <PostGridSkeleton count={4} />
-            </div>
-          )}
-          <div ref={observerTarget} className="h-10" />
-        </>
-      )}
+  const toggleSelect = (feedId: number) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(feedId)) {
+        next.delete(feedId);
+      } else {
+        next.add(feedId);
+      }
+      return next;
+    });
+  };
 
-      {selectedFeedId !== null && (
-        <AdminPostDetail feedId={selectedFeedId} onClose={() => setSelectedFeedId(null)} />
-      )}
+  const selectAll = () => setSelectedIds(new Set(noSummaryFeeds.map((feed) => feed.id)));
+  const clearSelection = () => setSelectedIds(new Set());
+
+  const handleBatchRequest = () => {
+    if (selectedIds.size === 0 || isPending) return;
+    batchRequest(Array.from(selectedIds), {
+      onSuccess: ({ success, failed }) => {
+        toast({
+          title: "AI 요약 재요청 접수",
+          description: failed === 0 ? `${success}개 접수되었습니다.` : `성공 ${success}개 · 실패 ${failed}개`,
+        });
+        clearSelection();
+        queryClient.invalidateQueries({ queryKey: NO_SUMMARY_FEEDS_KEY });
+      },
+    });
+  };
+
+  return (
+    <section className="flex flex-col gap-8 min-h-[300px]">
+      {/* 상단: AI 요약 없는 게시글 - 선택 후 일괄 재요청 */}
+      <div className="flex flex-col gap-3 rounded-xl border border-amber-300 bg-amber-50/60 p-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h2 className="flex items-center gap-2 text-lg font-bold text-amber-700">
+            <AlertTriangle size={20} />
+            AI 요약 없는 게시글 <span className="text-amber-600">{noSummaryFeeds.length}</span>
+          </h2>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={selectAll} disabled={isPending || noSummaryFeeds.length === 0}>
+              전체 선택 ({selectedIds.size})
+            </Button>
+            <Button size="sm" onClick={handleBatchRequest} disabled={selectedIds.size === 0 || isPending}>
+              {isPending ? "재요청 중..." : `AI 요약 재요청 (${selectedIds.size})`}
+            </Button>
+          </div>
+        </div>
+
+        {isNoSummaryLoading ? (
+          <p className="text-sm text-gray-400 py-6 text-center">불러오는 중...</p>
+        ) : noSummaryFeeds.length === 0 ? (
+          <p className="text-sm text-gray-400 py-6 text-center">AI 요약이 없는 게시글이 없습니다.</p>
+        ) : (
+          <div className="max-h-[320px] overflow-y-auto pr-1">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {noSummaryFeeds.map((feed) => {
+                const isSelected = selectedIds.has(feed.id);
+                return (
+                  <div
+                    key={feed.id}
+                    onClick={() => setSelectedFeedId(feed.id)}
+                    className={`flex items-start gap-3 p-3 rounded-lg border-l-4 border cursor-pointer transition-colors bg-white hover:bg-amber-50 ${
+                      isSelected
+                        ? "ring-2 ring-amber-500 border-amber-500 border-l-amber-500"
+                        : "border-amber-200 border-l-amber-400"
+                    }`}
+                  >
+                    <button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        toggleSelect(feed.id);
+                      }}
+                      aria-label={isSelected ? "선택 해제" : "선택"}
+                      className="shrink-0 mt-0.5"
+                    >
+                      {isSelected ? (
+                        <CheckSquare size={20} className="text-amber-600" />
+                      ) : (
+                        <Square size={20} className="text-gray-400" />
+                      )}
+                    </button>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                          요약 없음
+                        </span>
+                      </div>
+                      <p className="font-medium text-sm line-clamp-2 mt-1">{feed.title}</p>
+                      <div className="flex gap-3 text-xs text-gray-500 mt-1.5">
+                        <span className="flex items-center gap-1">
+                          <Heart size={12} /> {feed.likes}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <MessageSquare size={12} /> {feed.comments}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col">
+        <h2 className="text-lg font-bold mb-3">전체 게시글</h2>
+        {isLoading ? (
+          <PostGridSkeleton count={8} />
+        ) : (
+          <>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 min-h-[300px]">
+              {items.map((post) => (
+                <Card
+                  key={post.id}
+                  onClick={() => setSelectedFeedId(post.id)}
+                  className="h-[270px] group shadow-md hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 border-none rounded-xl cursor-pointer"
+                >
+                  <PostCardImage thumbnail={post.thumbnail} alt={post.title} isNew={post.isNew} />
+                  <PostCardContent post={post} />
+                </Card>
+              ))}
+            </div>
+            {isFetchingNextPage && (
+              <div className="mt-8">
+                <PostGridSkeleton count={4} />
+              </div>
+            )}
+            <div ref={observerTarget} className="h-10" />
+          </>
+        )}
+      </div>
+
+      {selectedFeedId !== null && <AdminPostDetail feedId={selectedFeedId} onClose={() => setSelectedFeedId(null)} />}
     </section>
   );
 }

--- a/client/src/constants/dummyData.ts
+++ b/client/src/constants/dummyData.ts
@@ -147,6 +147,7 @@ export const POST_MODAL_DATA: FeedDetailType = {
     thumbnail: "https://velog.velcdn.com/images/seok3765/post/ae79f20a-b64c-4b6d-b246-6e501f9c868a/image.png",
     viewCount: 999999,
     likes: 0,
+    comments: 0,
     summary:
       "# React의 이벤트 시스템 심층 분석\nReact의 합성 이벤트(Synthetic Event) 시스템에 대한 상세한 기술 문서입니다. 이 글에서는 React가 어떻게 브라우저 간의 이벤트 처리 차이를 해결하고, 성능을 최적화하는지 다룹니다.\n\n주요 내용:\n- 브라우저 호환성을 위한 합성 이벤트 시스템 구현 원리\n- 이벤트 위임을 통한 성능 최적화 방식\n- React 17에서 달라진 이벤트 처리 메커니즘\n- 실제 코드 예제와 함께 보는 이벤트 핸들링 패턴\n\n특히 마우스 휠 이벤트나 클릭 이벤트 처리에서 브라우저별 차이를 어떻게 극복하는지, 그리고 1000개의 리스트 아이템을 어떻게 효율적으로 처리하는지 등 실무에서 마주치는 구체적인 사례들을 통해 React의 이벤트 시스템을 깊이 있게 이해할 수 있습니다.",
     tag: ["JavaScript", "React", "Frontend"],

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -29,6 +29,8 @@ export const BLOG = {
   RECENT: "/api/feed/recent",
   Trend: "/api/feeds/trend/sse",
   LIKE: (id: number) => `/api/feeds/${id}/likes`,
+  AI_SUMMARY: (id: number) => `/api/feeds/${id}/ai-summary-requests`,
+  NO_SUMMARY: "/api/feeds/no-summary",
   COMMENT: {
     LIST: (feedId: number) => `/api/feeds/${feedId}/comments`,
     ITEM: (feedId: number, commentId: number) => `/api/feeds/${feedId}/comments/${commentId}`,

--- a/client/src/hooks/queries/useAiSummaryRequest.ts
+++ b/client/src/hooks/queries/useAiSummaryRequest.ts
@@ -1,0 +1,31 @@
+import { adminFeed } from "@/api/services/admin/feed";
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+export interface BatchAiSummaryResult {
+  success: number;
+  failed: number;
+}
+
+export const NO_SUMMARY_FEEDS_KEY = ["admin-no-summary-feeds"];
+
+export const useNoSummaryFeeds = () =>
+  useQuery({
+    queryKey: NO_SUMMARY_FEEDS_KEY,
+    queryFn: adminFeed.getNoSummaryFeeds,
+  });
+
+export const useRequestAiSummary = () =>
+  useMutation({
+    mutationFn: (feedId: number) => adminFeed.requestAiSummary(feedId),
+  });
+
+export const useBatchRequestAiSummary = () =>
+  useMutation<BatchAiSummaryResult, Error, number[]>({
+    mutationFn: async (feedIds: number[]) => {
+      const results = await Promise.allSettled(feedIds.map((feedId) => adminFeed.requestAiSummary(feedId)));
+      return {
+        success: results.filter((result) => result.status === "fulfilled").length,
+        failed: results.filter((result) => result.status === "rejected").length,
+      };
+    },
+  });

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -11,6 +11,7 @@ export interface FeedBase {
   authorImageUrl?: string;
   tag: string[];
   likes: number;
+  comments: number;
   blogPlatform: string;
   isNew?: boolean;
 }
@@ -46,6 +47,15 @@ export interface FeedCommentType {
     profileImage: string | null;
   };
 }
+
+export interface NoSummaryFeed {
+  id: number;
+  title: string;
+  likes: number;
+  comments: number;
+}
+
+export type NoSummaryFeedsApiResponse = ApiData<NoSummaryFeed[]>;
 
 export interface RecentFeedsApiResponse {
   message: string;

--- a/server/src/feed/api-docs/readNoSummaryFeedList.api-docs.ts
+++ b/server/src/feed/api-docs/readNoSummaryFeedList.api-docs.ts
@@ -1,0 +1,17 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+import { ApiDataResponse, ApiUnauthorizedDoc } from '@common/swagger/swagger.helper';
+import { ReadNoSummaryFeedResponseDto } from '@feed/dto/response/readNoSummaryFeed.dto';
+
+export function ApiReadNoSummaryFeedList() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'AI 요약이 없는 게시글 목록 조회 API (관리자 전용)',
+      description:
+        'AI 요약이 비어있는(생성 실패 또는 미생성) 공개 게시글 전체 목록을 반환합니다. AI 요약 재요청 대상 선택에 사용합니다.',
+    }),
+    ApiDataResponse(ReadNoSummaryFeedResponseDto, true, 'AI 요약 없는 게시글 목록 조회 성공'),
+    ApiUnauthorizedDoc('관리자 인증이 되지 않은 경우'),
+  );
+}

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -26,6 +26,7 @@ import { ApiResponse } from '@common/response/common.response';
 import { ApiDeleteCheckFeed } from '@feed/api-docs/deleteCheckFeed.api-docs';
 import { ApiGetFeedDetail } from '@feed/api-docs/getFeedDetail.api-docs';
 import { ApiReadFeedPagination } from '@feed/api-docs/readFeedPagination.api-docs';
+import { ApiReadNoSummaryFeedList } from '@feed/api-docs/readNoSummaryFeedList.api-docs';
 import { ApiReadRecentFeedList } from '@feed/api-docs/readRecentFeedList.api-docs';
 import { ApiReadTrendFeedList } from '@feed/api-docs/readTrendFeedList.api-docs';
 import { ApiRequestAiSummary } from '@feed/api-docs/requestAiSummary.api-docs';
@@ -114,6 +115,17 @@ export class FeedController {
     );
     return ApiResponse.responseWithNoContent(
       '요청이 성공적으로 처리되었습니다.',
+    );
+  }
+
+  @ApiReadNoSummaryFeedList()
+  @UseGuards(AdminAuthGuard)
+  @Get('/no-summary')
+  @HttpCode(HttpStatus.OK)
+  async readFeedsWithoutSummary() {
+    return ApiResponse.responseWithData(
+      'AI 요약 없는 게시글 목록 조회 완료',
+      await this.feedService.readFeedsWithoutSummary(),
     );
   }
 

--- a/server/src/feed/dto/response/readNoSummaryFeed.dto.ts
+++ b/server/src/feed/dto/response/readNoSummaryFeed.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Feed } from '@feed/entity/feed.entity';
+
+export class ReadNoSummaryFeedResponseDto {
+  @ApiProperty({ example: 1, description: '게시글 ID' })
+  id: number;
+
+  @ApiProperty({ example: 'example title', description: '게시글 제목' })
+  title: string;
+
+  @ApiProperty({ example: 0, description: '좋아요 수' })
+  likes: number;
+
+  @ApiProperty({ example: 0, description: '댓글 수' })
+  comments: number;
+
+  constructor(partial: Partial<ReadNoSummaryFeedResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(feed: Feed) {
+    return new ReadNoSummaryFeedResponseDto({
+      id: feed.id,
+      title: feed.title,
+      likes: feed.likeCount,
+      comments: feed.commentCount,
+    });
+  }
+
+  static toResponseDtoArray(feeds: Feed[]) {
+    return feeds.map((feed) => this.toResponseDto(feed));
+  }
+}

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -130,6 +130,15 @@ export class FeedRepository extends Repository<Feed> {
     return count > 0;
   }
 
+  async findFeedsWithoutSummary() {
+    return this.createQueryBuilder('feed')
+      .select(['feed.id', 'feed.title', 'feed.likeCount', 'feed.commentCount'])
+      .where('feed.is_public = 1')
+      .andWhere("(feed.summary IS NULL OR feed.summary = '')")
+      .orderBy('feed.id', 'DESC')
+      .getMany();
+  }
+
   async findAllStatisticsOrderByViewCount(limit: number) {
     return this.find({
       select: ['id', 'title', 'viewCount'],

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -17,6 +17,7 @@ import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
 import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
 import { SearchFeedRequestDto } from '@feed/dto/request/searchFeed.dto';
 import { GetFeedDetailResponseDto } from '@feed/dto/response/getFeedDetail';
+import { ReadNoSummaryFeedResponseDto } from '@feed/dto/response/readNoSummaryFeed.dto';
 import {
   FeedPaginationResult,
   FeedResult,
@@ -66,6 +67,11 @@ export class FeedService {
     }
 
     return feed;
+  }
+
+  async readFeedsWithoutSummary() {
+    const feeds = await this.feedRepository.findFeedsWithoutSummary();
+    return ReadNoSummaryFeedResponseDto.toResponseDtoArray(feeds);
   }
 
   async requestAiSummary(feedId: number) {

--- a/server/test/feed/e2e/read-no-summary.e2e-spec.ts
+++ b/server/test/feed/e2e/read-no-summary.e2e-spec.ts
@@ -1,0 +1,103 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/feeds/no-summary';
+const AI_SUMMARY_IN_PROGRESS_MESSAGE = '아직 AI가 요약을 진행중인 게시글 이에요! 💭';
+
+describe(`GET ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let feedRepository: FeedRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let adminRepository: AdminRepository;
+  let rssAccept: RssAccept;
+
+  const sessionKey = 'no-summary-session-key';
+  const adminSessionKey = (sid: string) =>
+    `${REDIS_KEYS.ADMIN_AUTH_KEY}:${sid}`;
+  const withCookie = () => `sessionId=${sessionKey}`;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    feedRepository = testApp.get(FeedRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    adminRepository = testApp.get(AdminRepository);
+  });
+
+  beforeEach(async () => {
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    const admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(adminSessionKey(sessionKey), admin.email);
+  });
+
+  const createFeed = (summary: string | null) =>
+    feedRepository.save(FeedFixture.createFeedFixture(rssAccept, { summary }));
+
+  it('[401] 관리자 인증 쿠키가 없으면 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(URL);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[200] summary가 NULL/빈문자열(영구 실패)인 게시글만 최신순으로 반환한다.', async () => {
+    // given
+    const withReal: Feed = await createFeed('실제 요약 내용');
+    const withInProgress: Feed = await createFeed(
+      AI_SUMMARY_IN_PROGRESS_MESSAGE,
+    );
+    const withNull: Feed = await createFeed(null);
+    const withEmpty: Feed = await createFeed('');
+
+    // Http when
+    const response = await agent.get(URL).set('Cookie', withCookie());
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data } = response.body;
+    const result = data as Array<{
+      id: number;
+      title: string;
+      likes: number;
+      comments: number;
+    }>;
+
+    const ids = result.map((feed) => feed.id);
+    // 영구 실패(NULL/빈문자열)만 포함, 최신순(id DESC)
+    expect(ids).toEqual([withEmpty.id, withNull.id]);
+    // 실제 요약, AI 대기중(placeholder)은 제외
+    expect(ids).not.toContain(withReal.id);
+    expect(ids).not.toContain(withInProgress.id);
+
+    expect(result[0]).toStrictEqual({
+      id: withEmpty.id,
+      title: withEmpty.title,
+      likes: withEmpty.likeCount,
+      comments: withEmpty.commentCount,
+    });
+  });
+});

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -9,6 +9,7 @@ import { RedisService } from '@common/redis/redis.service';
 import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
 import { SearchFeedRequestDto } from '@feed/dto/request/searchFeed.dto';
 import { GetFeedDetailResponseDto } from '@feed/dto/response/getFeedDetail';
+import { ReadNoSummaryFeedResponseDto } from '@feed/dto/response/readNoSummaryFeed.dto';
 import {
   FeedRepository,
   FeedViewRepository,
@@ -23,7 +24,12 @@ describe(`${FeedService.name} Unit Test`, () => {
   let feedRepository: jest.Mocked<
     Pick<
       FeedRepository,
-      'findOneBy' | 'searchFeedList' | 'update' | 'delete' | 'isOwnedByUser'
+      | 'findOneBy'
+      | 'searchFeedList'
+      | 'update'
+      | 'delete'
+      | 'isOwnedByUser'
+      | 'findFeedsWithoutSummary'
     >
   >;
   let feedViewRepository: jest.Mocked<
@@ -53,6 +59,7 @@ describe(`${FeedService.name} Unit Test`, () => {
       update: jest.fn(),
       delete: jest.fn(),
       isOwnedByUser: jest.fn(),
+      findFeedsWithoutSummary: jest.fn(),
     };
     feedViewRepository = {
       findOneBy: jest.fn(),
@@ -169,6 +176,37 @@ describe(`${FeedService.name} Unit Test`, () => {
         ConflictException,
       );
       expect(redisService.rpush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('readFeedsWithoutSummary', () => {
+    it('레포지토리 조회 결과를 응답 DTO 배열로 변환해 반환한다.', async () => {
+      // given
+      const feeds = [
+        { id: 2, title: 'b', likeCount: 5, commentCount: 1 },
+        { id: 1, title: 'a', likeCount: 0, commentCount: 0 },
+      ] as any[];
+      feedRepository.findFeedsWithoutSummary.mockResolvedValue(feeds);
+
+      // when
+      const result = await feedService.readFeedsWithoutSummary();
+
+      // then
+      expect(feedRepository.findFeedsWithoutSummary).toHaveBeenCalledTimes(1);
+      expect(result).toStrictEqual(
+        ReadNoSummaryFeedResponseDto.toResponseDtoArray(feeds),
+      );
+    });
+
+    it('조회 결과가 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      feedRepository.findFeedsWithoutSummary.mockResolvedValue([]);
+
+      // when
+      const result = await feedService.readFeedsWithoutSummary();
+
+      // then
+      expect(result).toStrictEqual([]);
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-  close #759 

### AI 요약 없는 게시글 조회 API

-   크롤링 시 AI 요약 생성이 실패하거나 누락된 게시글이 존재해, 관리자가 이를 재확인/재처리할 수 있는 경로가 없었습니다.
-   `summary IS NULL OR summary = ''` 조건 + `is_public = 1`로 공개 게시글 중 요약 누락 건만 조회하도록 했습니다.
-   목록 응답은 관리자 화면에 필요한 최소 필드(`id`, `title`, `likes`, `comments`)만 노출해 페이로드를 줄였습니다.

### AI 요약 신청 (관리자)

-   기존 단건 요약 신청 API(`POST /api/feeds/:feedId/ai-summary-requests`)를 관리자 화면과 연동했습니다.
-   여러 건을 한 번에 신청할 수 있도록 `Promise.allSettled` 기반 배치 신청 훅을 추가해, 일부 실패해도 성공/실패 건수를 집계하도록 했습니다.
-   detail 팝업에도 단건 신청 버튼을 추가했습니다.

# 📋 작업 내용

**Server**
-   `GET /api/feeds/no-summary` (AdminAuthGuard) 요약 누락 공개 게시글 목록 조회 API 추가
-   `FeedRepository.findFeedsWithoutSummary`, `FeedService.readFeedsWithoutSummary`, `ReadNoSummaryFeedResponseDto`, Swagger api-docs 추가
-   E2E / 단위 테스트 추가

**Client**
-   `adminFeed` 서비스(`getNoSummaryFeeds`, `requestAiSummary`) 및 엔드포인트 추가
-   `useNoSummaryFeeds`, `useRequestAiSummary`, `useBatchRequestAiSummary` 훅 추가
-   `AdminPostTab`에 AI 요약 신청 영역, `AdminPostDetail`에 신청 버튼 추가

# 📷 스크린 샷(선택 사항)

<img width="1363" height="890" alt="image" src="https://github.com/user-attachments/assets/4ea997a6-482f-4631-8b2e-051316d103e8" />
<img width="899" height="434" alt="image" src="https://github.com/user-attachments/assets/99eb7ee4-11b2-4534-834f-21bbffcebc7c" />
