### PR TITLE
✨ feat: 관리자 채팅 제거 기능 및 채팅 저장 구조 List → Sorted Set 전환

### DIFF
--- a/client/src/api/services/admin/chat.ts
+++ b/client/src/api/services/admin/chat.ts
@@ -1,0 +1,20 @@
+import { ADMIN } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+import { AdminChatRoom, ChatType } from "@/types/chat";
+
+type ApiResponse<T> = { message: string; data: T };
+
+export const adminChat = {
+  getRooms: async (): Promise<AdminChatRoom[]> => {
+    const response = await axiosInstance.get<ApiResponse<AdminChatRoom[]>>(ADMIN.CHAT.ROOMS);
+    return response.data.data;
+  },
+  getMessages: async (roomId: string): Promise<ChatType[]> => {
+    const response = await axiosInstance.get<ApiResponse<ChatType[]>>(ADMIN.CHAT.MESSAGES(roomId));
+    return response.data.data;
+  },
+  remove: async (roomId: string, messageId: string): Promise<void> => {
+    await axiosInstance.delete(ADMIN.CHAT.DELETE(roomId, messageId));
+  },
+};

--- a/client/src/components/admin/chat/AdminChatTab.tsx
+++ b/client/src/components/admin/chat/AdminChatTab.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Trash2, Users } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+import { formatTime } from "@/utils/time";
+
+import { adminChat } from "@/api/services/admin/chat";
+import { AdminChatRoom } from "@/types/chat";
+
+export default function AdminChatTab() {
+  const queryClient = useQueryClient();
+  const [selectedRoom, setSelectedRoom] = useState<AdminChatRoom | null>(null);
+
+  const { data: rooms = [], isLoading: isRoomsLoading } = useQuery({
+    queryKey: ["admin-chat-rooms"],
+    queryFn: adminChat.getRooms,
+    refetchInterval: 10000,
+  });
+
+  const {
+    data: messages = [],
+    isLoading: isMessagesLoading,
+    refetch: refetchMessages,
+  } = useQuery({
+    queryKey: ["admin-chat-messages", selectedRoom?.roomId],
+    queryFn: () => adminChat.getMessages(selectedRoom!.roomId),
+    enabled: !!selectedRoom,
+    refetchInterval: 5000,
+  });
+
+  const { mutate: removeChat } = useMutation({
+    mutationFn: ({ roomId, messageId }: { roomId: string; messageId: string }) =>
+      adminChat.remove(roomId, messageId),
+    onSuccess: () => {
+      refetchMessages();
+      queryClient.invalidateQueries({ queryKey: ["admin-chat-rooms"] });
+    },
+  });
+
+  const handleDelete = (messageId?: string) => {
+    if (!selectedRoom || !messageId) return;
+    if (!window.confirm("이 채팅을 삭제하시겠습니까?")) return;
+    removeChat({ roomId: selectedRoom.roomId, messageId });
+  };
+
+  return (
+    <section className="flex flex-col gap-4 lg:flex-row min-h-[400px]">
+      <div className="lg:w-1/3 flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">채팅방</h2>
+        {isRoomsLoading ? (
+          <div>Loading...</div>
+        ) : (
+          rooms.map((room) => (
+            <Card
+              key={room.roomId}
+              onClick={() => setSelectedRoom(room)}
+              className={`p-4 cursor-pointer transition-colors ${
+                selectedRoom?.roomId === room.roomId ? "border-primary bg-accent" : "hover:bg-accent/50"
+              }`}
+            >
+              <div className="flex items-center justify-between">
+                <span className="font-medium">{room.roomName}</span>
+                <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                  <Users className="h-4 w-4" />
+                  {room.userCount}
+                </span>
+              </div>
+              <Badge variant="secondary" className="mt-2">
+                메시지 {room.messageCount}
+              </Badge>
+            </Card>
+          ))
+        )}
+      </div>
+
+      <div className="lg:w-2/3 flex flex-col gap-2">
+        {!selectedRoom ? (
+          <div className="flex h-full items-center justify-center text-muted-foreground">
+            채팅방을 선택해주세요.
+          </div>
+        ) : isMessagesLoading ? (
+          <div>Loading...</div>
+        ) : messages.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-muted-foreground">
+            메시지가 없습니다.
+          </div>
+        ) : (
+          messages.map((msg, index) => (
+            <Card
+              key={msg.messageId ?? `legacy-${index}`}
+              className="p-3 flex items-start justify-between gap-3"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="font-medium">{msg.userName}</span>
+                  <span className="text-xs text-muted-foreground">{formatTime(msg.timestamp)}</span>
+                </div>
+                <p className="mt-1 break-words whitespace-pre-wrap text-sm">{msg.message}</p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="text-red-600 hover:text-red-600 shrink-0 disabled:opacity-30"
+                onClick={() => handleDelete(msg.messageId)}
+                disabled={!msg.messageId || msg.deleted}
+                title={
+                  msg.deleted
+                    ? "이미 삭제된 메시지입니다."
+                    : msg.messageId
+                      ? "채팅 삭제"
+                      : "이전 버전 메시지라 삭제할 수 없습니다."
+                }
+                aria-label="채팅 삭제"
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </Card>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/admin/layout/AdminHeader.tsx
+++ b/client/src/components/admin/layout/AdminHeader.tsx
@@ -19,7 +19,7 @@ export const AdminHeader = ({
   name,
 }: {
   setLogin: () => void;
-  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE" | "POST") => void;
+  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT") => void;
   name?: string;
 }) => {
   const handleLogout = () => {

--- a/client/src/components/admin/layout/AdminNavigationMenu.tsx
+++ b/client/src/components/admin/layout/AdminNavigationMenu.tsx
@@ -5,6 +5,7 @@ export const TAB_TYPES = {
   RSS: "RSS",
   MEMBER: "MEMBER",
   POST: "POST",
+  CHAT: "CHAT",
 } as const;
 
 type TabType = (typeof TAB_TYPES)[keyof typeof TAB_TYPES];
@@ -26,6 +27,11 @@ export const AdminNavigationMenu = ({ handleTap }: { handleTap: (tabType: TabTyp
         <NavigationMenuItem>
           <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("POST")}>
             게시글 관리
+          </Button>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("CHAT")}>
+            채팅 관리
           </Button>
         </NavigationMenuItem>
       </NavigationMenuList>

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -13,6 +13,11 @@ export const ADMIN = {
   WITHDRAW_REQUEST: "/api/admins/me/deletion-requests",
   WITHDRAW_CONFIRM: (token: string) => `/api/admins/deletion-requests/${token}`,
   DELETE_COMMENT: (commentId: number) => `/api/admins/comments/${commentId}`,
+  CHAT: {
+    ROOMS: "/api/admins/chats",
+    MESSAGES: (roomId: string) => `/api/admins/chats/${roomId}`,
+    DELETE: (roomId: string, messageId: string) => `/api/admins/chats/${roomId}/${messageId}`,
+  },
   GET: {
     RSS: "/api/rss",
     ACCEPT: "/api/rss/history/accept",

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -8,6 +8,7 @@ import AdminMyPage from "@/components/admin/layout/AdminMyPage";
 import { AdminTabs } from "@/components/admin/layout/AdminTabs";
 import AdminLogin from "@/components/admin/login/AdminLoginModal";
 import AdminPostTab from "@/components/admin/post/AdminPostTab";
+import AdminChatTab from "@/components/admin/chat/AdminChatTab";
 import { RssRequestSearchBar } from "@/components/admin/rss/RssSearchBar";
 
 import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
@@ -15,7 +16,7 @@ import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
 export default function Admin() {
   const [isLogin, setIsLogin] = useState<boolean>(false);
   const { status, isLoading, data } = useAdminCheck();
-  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE" | "POST">("RSS");
+  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT">("RSS");
 
   useEffect(() => {
     setIsLogin(status === "success");
@@ -35,6 +36,9 @@ export default function Admin() {
     }
     if (tap === "POST") {
       return <AdminPostTab />;
+    }
+    if (tap === "CHAT") {
+      return <AdminChatTab />;
     }
     return <AdminMember />;
   };

--- a/client/src/store/useChatStore.ts
+++ b/client/src/store/useChatStore.ts
@@ -57,6 +57,16 @@ export const useChatStore = create<State & Action>((set, get) => {
       });
     });
 
+    socket.on("messageDeleted", (data) => {
+      set((state) => ({
+        chatHistory: state.chatHistory.map((msg) =>
+          msg.messageId === data.messageId
+            ? { ...msg, message: data.message, userName: data.userName }
+            : msg
+        ),
+      }));
+    });
+
     socket.on('assignUserId', ({ userId }: { userId: string }) => {
       localStorage.setItem('userID', userId);
     });

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -7,10 +7,18 @@ export type ChatType = {
   messageId?: string;
   isSend?: boolean;
   isFailed?: boolean;
+  deleted?: boolean;
 };
 
 export type SendChatType = {
   message: string;
   userId: string;
   messageId: string;
+};
+
+export type AdminChatRoom = {
+  roomId: string;
+  roomName: string;
+  messageCount: number;
+  userCount: number;
 };

--- a/server/src/chat/api-docs/adminChat.api-docs.ts
+++ b/server/src/chat/api-docs/adminChat.api-docs.ts
@@ -1,0 +1,46 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import { AdminChatMessageDto, AdminChatRoomDto } from '@chat/dto/response/adminChat.dto';
+
+import {
+  ApiDataResponse,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiGetChatRooms() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '관리자 채팅방 목록 조회 API' }),
+    ApiDataResponse(AdminChatRoomDto, true, '채팅방 목록 조회 성공'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}
+
+export function ApiGetChatMessages() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '관리자 채팅방 메시지 조회 API' }),
+    ApiParam({ name: 'roomId', description: '채팅방 ID', example: 'anonymous1' }),
+    ApiDataResponse(AdminChatMessageDto, true, '채팅 메시지 조회 성공'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}
+
+export function ApiDeleteChatByAdmin() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '관리자 채팅 삭제 API' }),
+    ApiParam({ name: 'roomId', description: '채팅방 ID', example: 'anonymous1' }),
+    ApiParam({
+      name: 'messageId',
+      description: '삭제할 메시지 ID',
+      example: '550e8400-e29b-41d4-a716-446655440000',
+    }),
+    ApiMessageResponse('채팅이 성공적으로 삭제되었습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않는 채팅입니다.'),
+  );
+}

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -123,6 +123,7 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
     );
 
     const redisPayload: RedisMessagePayload = {
+      messageId: payload.messageId,
       userId: payload.userId,
       userName,
       message: payload.message,
@@ -130,14 +131,17 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
       room: roomId,
     };
 
-    const broadcastPayload: BroadcastPayload = {
-      ...redisPayload,
-      messageId: payload.messageId,
-    };
-
     this.anonymousRoomManager.trackMessageSent(roomId);
 
     await this.chatService.saveMessageToRedis(redisPayload);
-    this.server.to(roomId).emit('message', broadcastPayload);
+    this.server.to(roomId).emit('message', redisPayload);
+  }
+
+  getRoomClientCount(roomId: string): number {
+    return this.anonymousRoomManager.getRoomClientCount(this.server, roomId);
+  }
+
+  broadcastDeletedMessage(roomId: string, payload: BroadcastPayload) {
+    this.server.to(roomId).emit('messageDeleted', payload);
   }
 }

--- a/server/src/chat/constant/constant.ts
+++ b/server/src/chat/constant/constant.ts
@@ -2,3 +2,7 @@ export const MAX_ANONYMOUS_ROOMS = 3;
 export const MAX_ROOM_CLIENTS = 50;
 export const CLIENT_KEY_PREFIX = 'socket_client:';
 export const CHAT_HISTORY_LIMIT = 20;
+
+/** 관리자에 의해 삭제된 채팅의 tombstone 표기 */
+export const ADMIN_DELETED_MESSAGE = '관리자에 의해 삭제된 채팅입니다.';
+export const ADMIN_DELETED_USERNAME = '(알 수 없음)';

--- a/server/src/chat/constant/type.ts
+++ b/server/src/chat/constant/type.ts
@@ -1,18 +1,16 @@
 type ISOstring = string;
 
-/** Redis에 저장되는 메시지 타입 (messageId 없음) */
 export type RedisMessagePayload = {
+  messageId: string;
   userId: string;
   userName: string;
   message: string;
   timestamp: ISOstring;
   room: string;
+  deleted?: boolean;
 };
 
-/** 소켓 broadcast 타입 (messageId 포함 ＊ 클라이언트 측 메세지 전달 여부 ACK) */
-export type BroadcastPayload = RedisMessagePayload & {
-  messageId: string;
-};
+export type BroadcastPayload = RedisMessagePayload;
 
 export type AssignRoomPayload = {
   roomId: string;

--- a/server/src/chat/controller/adminChat.controller.ts
+++ b/server/src/chat/controller/adminChat.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  NotFoundException,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import {
+  ApiDeleteChatByAdmin,
+  ApiGetChatMessages,
+  ApiGetChatRooms,
+} from '@chat/api-docs/adminChat.api-docs';
+import { ChatGateway } from '@chat/chat.gateway';
+import {
+  AdminChatMessageParamDto,
+  AdminChatRoomParamDto,
+} from '@chat/dto/request/adminChatParam.dto';
+import { AnonymousRoomManager } from '@chat/room/anonymous-room.manager';
+import { ChatService } from '@chat/service/chat.service';
+
+import { AdminAuthGuard } from '@common/guard/session.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+@ApiTags('Admin')
+@Controller('admins/chats')
+@UseGuards(AdminAuthGuard)
+export class AdminChatController {
+  constructor(
+    private readonly chatService: ChatService,
+    private readonly chatGateway: ChatGateway,
+    private readonly roomManager: AnonymousRoomManager,
+  ) {}
+
+  @ApiGetChatRooms()
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getRooms() {
+    const rooms = await Promise.all(
+      this.roomManager.getAllRoomIds().map(async (roomId) => ({
+        roomId,
+        roomName: this.roomManager.getRoomName(roomId),
+        messageCount: await this.chatService.getMessageCount(roomId),
+        userCount: this.chatGateway.getRoomClientCount(roomId),
+      })),
+    );
+    return ApiResponse.responseWithData('채팅방 목록 조회를 성공했습니다.', rooms);
+  }
+
+  @ApiGetChatMessages()
+  @Get(':roomId')
+  @HttpCode(HttpStatus.OK)
+  async getMessages(@Param() paramDto: AdminChatRoomParamDto) {
+    const messages = await this.chatService.getChatHistory(paramDto.roomId);
+    return ApiResponse.responseWithData('채팅 메시지 조회를 성공했습니다.', messages);
+  }
+
+  @ApiDeleteChatByAdmin()
+  @Delete(':roomId/:messageId')
+  @HttpCode(HttpStatus.OK)
+  async deleteChat(@Param() paramDto: AdminChatMessageParamDto) {
+    const deleted = await this.chatService.deleteMessageByAdmin(
+      paramDto.roomId,
+      paramDto.messageId,
+    );
+    if (!deleted) {
+      throw new NotFoundException('존재하지 않는 채팅입니다.');
+    }
+    this.chatGateway.broadcastDeletedMessage(paramDto.roomId, deleted);
+    return ApiResponse.responseWithNoContent('채팅이 성공적으로 삭제되었습니다.');
+  }
+}

--- a/server/src/chat/dto/request/adminChatParam.dto.ts
+++ b/server/src/chat/dto/request/adminChatParam.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsUUID, Matches } from 'class-validator';
+
+export class AdminChatRoomParamDto {
+  @ApiProperty({
+    example: 'anonymous1',
+    description: '채팅방 ID',
+  })
+  @Matches(/^anonymous[1-9][0-9]*$/, {
+    message: '존재하지 않는 채팅방입니다.',
+  })
+  roomId: string;
+}
+
+export class AdminChatMessageParamDto extends AdminChatRoomParamDto {
+  @ApiProperty({
+    example: '550e8400-e29b-41d4-a716-446655440000',
+    description: '삭제할 메시지 ID',
+  })
+  @IsUUID(4, {
+    message: '메세지 아이디가 없거나 UUIDv4 버전이 아닙니다.',
+  })
+  messageId: string;
+}

--- a/server/src/chat/dto/response/adminChat.dto.ts
+++ b/server/src/chat/dto/response/adminChat.dto.ts
@@ -1,0 +1,35 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AdminChatRoomDto {
+  @ApiProperty({ example: 'anonymous1', description: '채팅방 ID' })
+  roomId: string;
+
+  @ApiProperty({ example: '익명 채팅방 1', description: '채팅방 이름' })
+  roomName: string;
+
+  @ApiProperty({ example: 12, description: '저장된 메시지 수' })
+  messageCount: number;
+
+  @ApiProperty({ example: 3, description: '현재 접속자 수' })
+  userCount: number;
+}
+
+export class AdminChatMessageDto {
+  @ApiProperty({ example: '550e8400-e29b-41d4-a716-446655440000' })
+  messageId: string;
+
+  @ApiProperty({ example: '5f...', description: '작성자 ID' })
+  userId: string;
+
+  @ApiProperty({ example: '행복한 다람쥐', description: '작성자 닉네임' })
+  userName: string;
+
+  @ApiProperty({ example: '안녕하세요', description: '메시지 내용' })
+  message: string;
+
+  @ApiProperty({ example: '2026-06-23T12:00:00.000Z' })
+  timestamp: string;
+
+  @ApiProperty({ example: 'anonymous1' })
+  room: string;
+}

--- a/server/src/chat/module/chat.module.ts
+++ b/server/src/chat/module/chat.module.ts
@@ -1,10 +1,12 @@
 import { Module } from '@nestjs/common';
 
 import { ChatGateway } from '@chat/chat.gateway';
+import { AdminChatController } from '@chat/controller/adminChat.controller';
 import { AnonymousRoomManager } from '@chat/room/anonymous-room.manager';
 import { ChatService } from '@chat/service/chat.service';
 
 @Module({
+  controllers: [AdminChatController],
   providers: [ChatGateway, ChatService, AnonymousRoomManager],
 })
 export class ChatModule {}

--- a/server/src/chat/service/chat.service.ts
+++ b/server/src/chat/service/chat.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 
-import { CHAT_HISTORY_LIMIT } from '@chat/constant/constant';
+import {
+  ADMIN_DELETED_MESSAGE,
+  ADMIN_DELETED_USERNAME,
+  CHAT_HISTORY_LIMIT,
+} from '@chat/constant/constant';
 import { RedisMessagePayload } from '@chat/constant/type';
 
 import { REDIS_KEYS } from '@common/redis/redis.constant';
@@ -10,23 +14,51 @@ import { RedisService } from '@common/redis/redis.service';
 export class ChatService {
   constructor(private readonly redisService: RedisService) {}
 
-  async getChatHistory(roomId: string) {
-    return (await this.getRecentChatMessages(roomId))
-      .map((msg) => JSON.parse(msg) as RedisMessagePayload)
-      .reverse();
-  }
-
-  private async getRecentChatMessages(roomId: string) {
-    return await this.redisService.lrange(
+  async getChatHistory(roomId: string): Promise<RedisMessagePayload[]> {
+    const members = await this.redisService.zrange(
       REDIS_KEYS.CHAT_HISTORY_KEY(roomId),
       0,
-      CHAT_HISTORY_LIMIT - 1,
+      -1,
     );
+    return members.map((m) => JSON.parse(m) as RedisMessagePayload);
+  }
+
+  async getMessageCount(roomId: string): Promise<number> {
+    return this.redisService.zcard(REDIS_KEYS.CHAT_HISTORY_KEY(roomId));
   }
 
   async saveMessageToRedis(message: RedisMessagePayload) {
     const key = REDIS_KEYS.CHAT_HISTORY_KEY(message.room);
-    await this.redisService.lpush(key, JSON.stringify(message));
-    await this.redisService.ltrim(key, 0, CHAT_HISTORY_LIMIT - 1);
+    const score = new Date(message.timestamp).getTime();
+    await this.redisService.zadd(key, score, JSON.stringify(message));
+    await this.redisService.zremrangebyrank(key, 0, -(CHAT_HISTORY_LIMIT + 1));
+  }
+
+  async deleteMessageByAdmin(
+    roomId: string,
+    messageId: string,
+  ): Promise<RedisMessagePayload | null> {
+    const key = REDIS_KEYS.CHAT_HISTORY_KEY(roomId);
+    const entries = await this.redisService.zrange(key, 0, -1, 'WITHSCORES');
+
+    for (let i = 0; i < entries.length; i += 2) {
+      const member = entries[i];
+      const score = Number(entries[i + 1]);
+      const obj = JSON.parse(member) as RedisMessagePayload;
+
+      if (obj.messageId === messageId && !obj.deleted) {
+        const tombstone: RedisMessagePayload = {
+          ...obj,
+          message: ADMIN_DELETED_MESSAGE,
+          userName: ADMIN_DELETED_USERNAME,
+          deleted: true,
+        };
+        await this.redisService.zrem(key, member);
+        await this.redisService.zadd(key, score, JSON.stringify(tombstone));
+        return tombstone;
+      }
+    }
+
+    return null;
   }
 }

--- a/server/src/common/redis/redis.service.ts
+++ b/server/src/common/redis/redis.service.ts
@@ -63,6 +63,30 @@ export class RedisService {
     return this.redisClient.zrevrange(key, start, stop);
   }
 
+  async zrange(
+    key: string,
+    start: number,
+    stop: number,
+    withScores?: 'WITHSCORES',
+  ): Promise<string[]> {
+    if (withScores) {
+      return this.redisClient.zrange(key, start, stop, 'WITHSCORES');
+    }
+    return this.redisClient.zrange(key, start, stop);
+  }
+
+  async zcard(key: string): Promise<number> {
+    return this.redisClient.zcard(key);
+  }
+
+  async zremrangebyrank(
+    key: string,
+    start: number,
+    stop: number,
+  ): Promise<number> {
+    return this.redisClient.zremrangebyrank(key, start, stop);
+  }
+
   async executePipeline(commands: (pipeline: ChainableCommander) => void) {
     const pipeline = this.redisClient.pipeline();
     commands(pipeline);

--- a/server/test/chat/dto/adminChatParam.dto.spec.ts
+++ b/server/test/chat/dto/adminChatParam.dto.spec.ts
@@ -1,0 +1,82 @@
+import { validate } from 'class-validator';
+
+import {
+  AdminChatMessageParamDto,
+  AdminChatRoomParamDto,
+} from '@chat/dto/request/adminChatParam.dto';
+
+describe(`${AdminChatRoomParamDto.name} Test`, () => {
+  let dto: AdminChatRoomParamDto;
+
+  beforeEach(() => {
+    dto = new AdminChatRoomParamDto();
+    dto.roomId = 'anonymous1';
+  });
+
+  it('유효한 roomId면 통과한다', async () => {
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  it('두 자리 이상 번호도 통과한다', async () => {
+    dto.roomId = 'anonymous12';
+
+    const errors = await validate(dto);
+
+    expect(errors.length).toBe(0);
+  });
+
+  describe('roomId', () => {
+    it.each(['anonymous', 'anonymous0', 'anonymous01', 'room1', ''])(
+      '형식이 맞지 않으면 실패한다: %s',
+      async (roomId) => {
+        dto.roomId = roomId;
+
+        const errors = await validate(dto);
+
+        expect(errors.length).toBeGreaterThan(0);
+        expect(errors[0].property).toBe('roomId');
+        expect(errors[0].constraints).toHaveProperty('matches');
+      },
+    );
+  });
+});
+
+describe(`${AdminChatMessageParamDto.name} Test`, () => {
+  let dto: AdminChatMessageParamDto;
+
+  beforeEach(() => {
+    dto = new AdminChatMessageParamDto();
+    dto.roomId = 'anonymous1';
+    dto.messageId = '550e8400-e29b-41d4-a716-446655440000';
+  });
+
+  it('모든 값이 유효하면 통과한다', async () => {
+    const errors = await validate(dto);
+    expect(errors.length).toBe(0);
+  });
+
+  describe('roomId', () => {
+    it('형식이 맞지 않으면 실패한다', async () => {
+      dto.roomId = 'anonymous0';
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('roomId');
+      expect(errors[0].constraints).toHaveProperty('matches');
+    });
+  });
+
+  describe('messageId', () => {
+    it('UUIDv4 형식이 아니면 실패한다', async () => {
+      dto.messageId = 'invalid-id';
+
+      const errors = await validate(dto);
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].property).toBe('messageId');
+      expect(errors[0].constraints).toHaveProperty('isUuid');
+    });
+  });
+});

--- a/server/test/chat/e2e/adminChat.e2e-spec.ts
+++ b/server/test/chat/e2e/adminChat.e2e-spec.ts
@@ -1,0 +1,222 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+import * as uuid from 'uuid';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import {
+  ADMIN_DELETED_MESSAGE,
+  ADMIN_DELETED_USERNAME,
+} from '@chat/constant/constant';
+import { RedisMessagePayload } from '@chat/constant/type';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const ROOM = 'anonymous1';
+const ROOMS_URL = '/api/admins/chats';
+const MESSAGES_URL = (roomId: string) => `/api/admins/chats/${roomId}`;
+const DELETE_URL = (roomId: string, messageId: string) =>
+  `/api/admins/chats/${roomId}/${messageId}`;
+
+describe('Admin Chat (/api/admins/chats) E2E Test', () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+
+  const sessionKey = 'admin-chat-session-key';
+  const redisAuthKey = (data: string) =>
+    `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+
+  const createPayload = (
+    overwrites: Partial<RedisMessagePayload> = {},
+  ): RedisMessagePayload => ({
+    messageId: uuid.v4(),
+    userId: uuid.v4(),
+    userName: 'tester',
+    message: 'hello',
+    timestamp: new Date().toISOString(),
+    room: ROOM,
+    ...overwrites,
+  });
+
+  const seedMessage = async (payload: RedisMessagePayload) => {
+    await redisService.zadd(
+      REDIS_KEYS.CHAT_HISTORY_KEY(payload.room),
+      new Date(payload.timestamp).getTime(),
+      JSON.stringify(payload),
+    );
+  };
+
+  beforeAll(async () => {
+    await testApp.listen(0);
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+  });
+
+  beforeEach(async () => {
+    const admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(redisAuthKey(sessionKey), admin.email);
+  });
+
+  describe('GET /api/admins/chats', () => {
+    it('[401] 관리자 세션이 없으면 실패한다.', async () => {
+      const response = await agent.get(ROOMS_URL);
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('[200] 모든 채팅방 목록과 메시지 수를 반환한다.', async () => {
+      // given
+      await seedMessage(createPayload());
+      await seedMessage(createPayload());
+
+      // when
+      const response = await agent
+        .get(ROOMS_URL)
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      // then
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.data).toHaveLength(3);
+      const room1 = response.body.data.find(
+        (r: { roomId: string }) => r.roomId === ROOM,
+      );
+      expect(room1).toMatchObject({
+        roomId: ROOM,
+        roomName: '익명 채팅방 1',
+        messageCount: 2,
+        userCount: 0,
+      });
+    });
+  });
+
+  describe('GET /api/admins/chats/:roomId', () => {
+    it('[401] 관리자 세션이 없으면 실패한다.', async () => {
+      const response = await agent.get(MESSAGES_URL(ROOM));
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('[400] roomId 형식이 올바르지 않으면 실패한다.', async () => {
+      const response = await agent
+        .get(MESSAGES_URL('anonymous0'))
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('[200] 해당 채팅방의 메시지를 시간순으로 반환한다.', async () => {
+      // given
+      const older = createPayload({
+        message: 'older',
+        timestamp: '2025-01-01T00:00:00.000Z',
+      });
+      const newer = createPayload({
+        message: 'newer',
+        timestamp: '2025-01-01T00:00:01.000Z',
+      });
+      await seedMessage(newer);
+      await seedMessage(older);
+
+      // when
+      const response = await agent
+        .get(MESSAGES_URL(ROOM))
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      // then
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.data.map((m: RedisMessagePayload) => m.message)).toStrictEqual([
+        'older',
+        'newer',
+      ]);
+    });
+
+    it('[200] 메시지가 없으면 빈 배열을 반환한다.', async () => {
+      const response = await agent
+        .get(MESSAGES_URL(ROOM))
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(response.body.data).toStrictEqual([]);
+    });
+  });
+
+  describe('DELETE /api/admins/chats/:roomId/:messageId', () => {
+    it('[401] 관리자 세션이 없으면 실패한다.', async () => {
+      const payload = createPayload();
+      await seedMessage(payload);
+
+      const response = await agent.delete(
+        DELETE_URL(ROOM, payload.messageId),
+      );
+
+      expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    });
+
+    it('[400] messageId가 UUIDv4가 아니면 실패한다.', async () => {
+      const response = await agent
+        .delete(DELETE_URL(ROOM, 'invalid-id'))
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    });
+
+    it('[404] 존재하지 않는 메시지면 실패한다.', async () => {
+      const response = await agent
+        .delete(DELETE_URL(ROOM, uuid.v4()))
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    });
+
+    it('[200] 메시지를 tombstone으로 치환한다.', async () => {
+      // given
+      const payload = createPayload({ message: 'secret' });
+      await seedMessage(payload);
+
+      // when
+      const response = await agent
+        .delete(DELETE_URL(ROOM, payload.messageId))
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      // then
+      expect(response.status).toBe(HttpStatus.OK);
+
+      // Redis then - 같은 messageId가 tombstone으로 남는다
+      const members = await redisService.zrange(
+        REDIS_KEYS.CHAT_HISTORY_KEY(ROOM),
+        0,
+        -1,
+      );
+      expect(members).toHaveLength(1);
+      const saved = JSON.parse(members[0]) as RedisMessagePayload;
+      expect(saved.messageId).toBe(payload.messageId);
+      expect(saved.deleted).toBe(true);
+      expect(saved.message).toBe(ADMIN_DELETED_MESSAGE);
+      expect(saved.userName).toBe(ADMIN_DELETED_USERNAME);
+    });
+
+    it('[404] 이미 삭제된 메시지는 다시 삭제할 수 없다.', async () => {
+      // given
+      const payload = createPayload({ deleted: true });
+      await seedMessage(payload);
+
+      // when
+      const response = await agent
+        .delete(DELETE_URL(ROOM, payload.messageId))
+        .set('Cookie', `sessionId=${sessionKey}`);
+
+      // then
+      expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    });
+  });
+});

--- a/server/test/chat/e2e/chat.e2e-spec.ts
+++ b/server/test/chat/e2e/chat.e2e-spec.ts
@@ -74,10 +74,13 @@ describe('Socket.IO Anonymous Chat E2E Test', () => {
     // given
     const mockChatHistory = ChatFixture.createChatHistory(2);
 
-    await redisService.lpush(
-      REDIS_KEYS.CHAT_HISTORY_KEY('anonymous1'),
-      ...mockChatHistory.map((chat) => JSON.stringify(chat)).reverse(),
-    );
+    for (let i = 0; i < mockChatHistory.length; i++) {
+      await redisService.zadd(
+        REDIS_KEYS.CHAT_HISTORY_KEY('anonymous1'),
+        i + 1,
+        JSON.stringify(mockChatHistory[i]),
+      );
+    }
 
     clientSocket = io(serverUrl, {
       forceNew: true,
@@ -101,7 +104,7 @@ describe('Socket.IO Anonymous Chat E2E Test', () => {
     });
 
     // Socket.IO then
-    expect(data).toStrictEqual(mockChatHistory.reverse());
+    expect(data).toStrictEqual(mockChatHistory);
   });
 
   it('[Connect] 클라이언트가 연결될 경우 현재 접속중인 유저 수 정보를 받는다.', async () => {
@@ -346,7 +349,7 @@ describe('Socket.IO Anonymous Chat E2E Test', () => {
     });
 
     // Socket.IO then
-    const history = await redisService.lrange(
+    const history = await redisService.zrange(
       REDIS_KEYS.CHAT_HISTORY_KEY('anonymous1'),
       0,
       -1,
@@ -360,10 +363,13 @@ describe('Socket.IO Anonymous Chat E2E Test', () => {
   it('[Message] CHAT_HISTORY_LIMIT 초과 메시지 저장 시 오래된 메시지가 제거된다.', async () => {
     // given: Redis에 CHAT_HISTORY_LIMIT개의 메시지 미리 적재
     const existingMessages = ChatFixture.createChatHistory(CHAT_HISTORY_LIMIT);
-    await redisService.lpush(
-      REDIS_KEYS.CHAT_HISTORY_KEY('anonymous1'),
-      ...existingMessages.map((m) => JSON.stringify(m)).reverse(),
-    );
+    for (let i = 0; i < existingMessages.length; i++) {
+      await redisService.zadd(
+        REDIS_KEYS.CHAT_HISTORY_KEY('anonymous1'),
+        i + 1,
+        JSON.stringify(existingMessages[i]),
+      );
+    }
 
     const chat = ChatFixture.createChat();
     clientSocket = io(serverUrl, {
@@ -381,7 +387,7 @@ describe('Socket.IO Anonymous Chat E2E Test', () => {
     });
 
     // Socket.IO then
-    const history = await redisService.lrange(
+    const history = await redisService.zrange(
       REDIS_KEYS.CHAT_HISTORY_KEY('anonymous1'),
       0,
       -1,

--- a/server/test/chat/unit/chat.service.unit.spec.ts
+++ b/server/test/chat/unit/chat.service.unit.spec.ts
@@ -1,4 +1,8 @@
-import { CHAT_HISTORY_LIMIT } from '@chat/constant/constant';
+import {
+  ADMIN_DELETED_MESSAGE,
+  ADMIN_DELETED_USERNAME,
+  CHAT_HISTORY_LIMIT,
+} from '@chat/constant/constant';
 import { RedisMessagePayload } from '@chat/constant/type';
 import { ChatService } from '@chat/service/chat.service';
 
@@ -8,14 +12,19 @@ import { RedisService } from '@common/redis/redis.service';
 describe(`${ChatService.name} Unit Test`, () => {
   let chatService: ChatService;
   let redisService: jest.Mocked<
-    Pick<RedisService, 'lrange' | 'lpush' | 'ltrim'>
+    Pick<
+      RedisService,
+      'zrange' | 'zadd' | 'zrem' | 'zcard' | 'zremrangebyrank'
+    >
   >;
 
   const ROOM = 'room-1';
+  const KEY = REDIS_KEYS.CHAT_HISTORY_KEY(ROOM);
 
   const createMessage = (
     overwrites: Partial<RedisMessagePayload> = {},
   ): RedisMessagePayload => ({
+    messageId: 'message-1',
     userId: 'user-1',
     userName: 'tester',
     message: 'hello',
@@ -25,18 +34,24 @@ describe(`${ChatService.name} Unit Test`, () => {
   });
 
   beforeEach(() => {
-    redisService = { lrange: jest.fn(), lpush: jest.fn(), ltrim: jest.fn() };
+    redisService = {
+      zrange: jest.fn(),
+      zadd: jest.fn(),
+      zrem: jest.fn(),
+      zcard: jest.fn(),
+      zremrangebyrank: jest.fn(),
+    };
     chatService = new ChatService(redisService as unknown as RedisService);
   });
 
   describe('getChatHistory', () => {
-    it('최근 메시지를 파싱한 뒤 역순으로 반환한다.', async () => {
+    it('ZSET을 시간순(오름차순)으로 파싱하여 반환한다.', async () => {
       // given
       const messages = [
-        createMessage({ message: 'newest' }),
         createMessage({ message: 'oldest' }),
+        createMessage({ message: 'newest' }),
       ];
-      redisService.lrange.mockResolvedValue(
+      redisService.zrange.mockResolvedValue(
         messages.map((m) => JSON.stringify(m)),
       );
 
@@ -44,17 +59,13 @@ describe(`${ChatService.name} Unit Test`, () => {
       const result = await chatService.getChatHistory(ROOM);
 
       // then
-      expect(redisService.lrange).toHaveBeenCalledWith(
-        REDIS_KEYS.CHAT_HISTORY_KEY(ROOM),
-        0,
-        CHAT_HISTORY_LIMIT - 1,
-      );
+      expect(redisService.zrange).toHaveBeenCalledWith(KEY, 0, -1);
       expect(result.map((m) => m.message)).toStrictEqual(['oldest', 'newest']);
     });
 
     it('저장된 메시지가 없으면 빈 배열을 반환한다.', async () => {
       // given
-      redisService.lrange.mockResolvedValue([]);
+      redisService.zrange.mockResolvedValue([]);
 
       // when
       const result = await chatService.getChatHistory(ROOM);
@@ -65,24 +76,102 @@ describe(`${ChatService.name} Unit Test`, () => {
   });
 
   describe('saveMessageToRedis', () => {
-    it('메시지를 lpush하고 히스토리 길이를 ltrim으로 제한한다.', async () => {
+    it('timestamp를 score로 zadd하고 최신 N개만 남기도록 trim한다.', async () => {
       // given
       const message = createMessage();
-      const key = REDIS_KEYS.CHAT_HISTORY_KEY(ROOM);
+      const score = new Date(message.timestamp).getTime();
 
       // when
       await chatService.saveMessageToRedis(message);
 
       // then
-      expect(redisService.lpush).toHaveBeenCalledWith(
-        key,
+      expect(redisService.zadd).toHaveBeenCalledWith(
+        KEY,
+        score,
         JSON.stringify(message),
       );
-      expect(redisService.ltrim).toHaveBeenCalledWith(
-        key,
+      expect(redisService.zremrangebyrank).toHaveBeenCalledWith(
+        KEY,
         0,
-        CHAT_HISTORY_LIMIT - 1,
+        -(CHAT_HISTORY_LIMIT + 1),
       );
+    });
+  });
+
+  describe('deleteMessageByAdmin', () => {
+    it('대상 member를 ZREM 후 같은 score로 tombstone을 ZADD하고 반환한다.', async () => {
+      // given
+      const target = createMessage({ messageId: 'message-2', message: 'bye' });
+      const other = createMessage({ messageId: 'message-1' });
+      const targetScore = new Date(target.timestamp).getTime();
+      redisService.zrange.mockResolvedValue([
+        JSON.stringify(other),
+        String(new Date(other.timestamp).getTime()),
+        JSON.stringify(target),
+        String(targetScore),
+      ]);
+
+      // when
+      const result = await chatService.deleteMessageByAdmin(ROOM, 'message-2');
+
+      // then
+      const tombstone = {
+        ...target,
+        message: ADMIN_DELETED_MESSAGE,
+        userName: ADMIN_DELETED_USERNAME,
+        deleted: true,
+      };
+      expect(redisService.zrem).toHaveBeenCalledWith(
+        KEY,
+        JSON.stringify(target),
+      );
+      expect(redisService.zadd).toHaveBeenCalledWith(
+        KEY,
+        targetScore,
+        JSON.stringify(tombstone),
+      );
+      expect(result).toStrictEqual(tombstone);
+    });
+
+    it('이미 삭제된 메시지는 건너뛰고 null을 반환한다.', async () => {
+      // given
+      const deleted = createMessage({ deleted: true });
+      redisService.zrange.mockResolvedValue([
+        JSON.stringify(deleted),
+        String(new Date(deleted.timestamp).getTime()),
+      ]);
+
+      // when
+      const result = await chatService.deleteMessageByAdmin(ROOM, 'message-1');
+
+      // then
+      expect(redisService.zrem).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it('대상 메시지가 없으면 null을 반환한다.', async () => {
+      // given
+      redisService.zrange.mockResolvedValue([]);
+
+      // when
+      const result = await chatService.deleteMessageByAdmin(ROOM, 'missing');
+
+      // then
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getMessageCount', () => {
+    it('해당 채팅방의 메시지 수를 zcard로 반환한다.', async () => {
+      // given
+      redisService.zcard.mockResolvedValue(7);
+
+      // when
+      const result = await chatService.getMessageCount(ROOM);
+
+      // then
+      expect(redisService.zcard).toHaveBeenCalledWith(KEY);
+      expect(result).toBe(7);
     });
   });
 });


### PR DESCRIPTION
# 🔨 테스크

> [!CAUTION]
> 본 PR을 포함한 배포 시, 기존 Chat History는 제거되어야합니다. List -> Set 방식으로의 전환이라 데이터 타입이 다릅니다.

### Issue

- close #761 

### 채팅 저장 구조를 List → Sorted Set(ZSet)으로 전환한 이유

관리자가 특정 채팅을 제거하는 기능을 추가하려다 보니, 기존 **List 기반 저장 구조의 한계**가 드러났습니다.

**문제 — List에서 특정 메시지 삭제는 동시성에 취약합니다.**

기존 채팅은 `LPUSH` + `LTRIM`으로 최근 N개만 유지하는 List였습니다. List에서 특정 메시지(`messageId`)를 찾아 삭제/치환하려면 다음 순서가 필요합니다.

1. `LRANGE`로 전체를 읽어 대상 메시지의 **index**를 찾는다.
2. 해당 index에 `LSET`으로 tombstone을 덮어쓴다.

하지만 1번과 2번 사이에 다른 사용자가 메시지를 보내면 `LPUSH`로 인해 **모든 index가 밀려버립니다**. 즉 1번에서 찾은 index가 2번 시점에는 이미 다른 메시지를 가리키게 되어 **엉뚱한 메시지를 덮어쓰는 race condition**이 발생합니다.

**기존 방식이라면 → Lua Script로 lock을 잡아야 합니다.**

이 race를 막으려면 `LRANGE`(탐색)와 `LSET`(치환)을 **하나의 원자적 연산**으로 묶어야 하고, Redis에서는 이를 위해 Lua Script가 필요합니다. 그러나 Lua Script는

- 애플리케이션 로직이 Redis 내부 스크립트로 분산되어 **추적·디버깅·테스트가 어렵고**
- 타입 안정성이 없으며
- 유지보수 비용이 지속적으로 누적됩니다.

5년 viability 관점에서 "특정 메시지 하나 삭제"를 위해 Lua Script라는 운영 부채를 떠안는 것은 부적절하다고 판단했습니다.

**해결 — Sorted Set으로 전환하면 Lua Script 없이 안전합니다.**

Sorted Set은 `timestamp`를 score로, 직렬화된 메시지 JSON을 member로 저장합니다.

- **저장**: `ZADD`(score=timestamp) + `ZREMRANGEBYRANK`로 최근 N개 유지 → 기존 List 동작과 동일
- **조회**: `ZRANGE`로 score(시간) 순 정렬 보장
- **삭제(tombstone)**: `ZREM`으로 **member 값 자체**를 제거 → 같은 score로 tombstone을 `ZADD`

핵심은 **삭제가 index가 아니라 member 값 기반**이라는 점입니다. 동시에 다른 메시지가 들어와도 index가 밀리는 문제가 없으므로, 각 명령이 개별 원자성만으로 충분하며 **Lua Script로 lock을 잡을 필요가 사라집니다.** 정렬 또한 score(timestamp)로 보장되므로 List의 삽입 순서 의존성도 제거됩니다.

### 삭제는 Hard Delete가 아닌 Tombstone 방식

메시지를 완전히 제거하면 클라이언트 채팅 흐름에 공백/순서 혼란이 생기므로, 내용과 작성자명을 치환하는 tombstone(`deleted: true`)으로 처리했습니다. 삭제 시 `messageDeleted` 이벤트를 broadcast하여 접속 중인 클라이언트에 실시간 반영합니다.

# 📋 작업 내용

**Backend**
- 채팅 저장 구조 List → Sorted Set 전환 (`ZADD`/`ZRANGE`/`ZREM`/`ZCARD`/`ZREMRANGEBYRANK`)
- `RedisMessagePayload`에 `messageId`, `deleted` 필드 추가 (`BroadcastPayload`와 통합)
- 관리자 채팅 API 추가: 채팅방 목록 조회 / 채팅 메시지 조회 / 채팅 삭제 (`AdminChatController`, `AdminAuthGuard` 적용)
- 채팅 삭제 시 tombstone 처리 및 `messageDeleted` 소켓 broadcast
- 요청/응답 DTO 및 Swagger 문서 추가
- 단위/E2E 테스트 추가

**Frontend**
- 관리자 페이지 채팅 관리 탭(`AdminChatTab`) 구현 — 채팅방 목록, 메시지 목록, 삭제
- `messageDeleted` 소켓 수신 처리로 tombstone 실시간 반영
- 이전 버전(messageId 없는) 메시지는 삭제 버튼 비활성화 처리

# 📷 스크린 샷(선택 사항)

<img width="1269" height="883" alt="image" src="https://github.com/user-attachments/assets/dc488ebe-4d07-4761-8ccf-98100a54c2f6" />
<img width="561" height="894" alt="image" src="https://github.com/user-attachments/assets/69d3d945-7811-4a74-a4cd-0f5d09a28379" />
