### PR TITLE
♻️ refactor: 태그 상수를 tag 레포지토리 조회로 전환

### DIFF
--- a/feed-crawler/src/common/ai/ai.constant.ts
+++ b/feed-crawler/src/common/ai/ai.constant.ts
@@ -1,29 +1,4 @@
-export const ALLOWED_TAGS = [
-  '회고',
-  'Frontend',
-  'Backend',
-  'DB',
-  'Network',
-  'OS',
-  'Algorithm',
-  'Infra',
-  'TypeScript',
-  'JavaScript',
-  'Java',
-  'React',
-  'Vue.JS',
-  'Nest.JS',
-  'Express.JS',
-  'Spring',
-  'MySQL',
-  'SQLite',
-  'PostgreSQL',
-  'MongoDB',
-  'Redis',
-  'Docker',
-];
-
-export const PROMPT_CONTENT = `[System]
+export const buildPromptContent = (allowedTags: string[]) => `[System]
 You need to assign tags and provide a summary of the content.
 The input format is XML.
 Remove the XML tags and analyze the content.
@@ -67,5 +42,5 @@ The response should look exactly like this, without any surrounding characters:
 Strictly follow this rule.
 
 Tag List:
-${ALLOWED_TAGS.map((tag) => `- ${tag}`).join('\n')}
+${allowedTags.map((tag) => `- ${tag}`).join('\n')}
 `;

--- a/feed-crawler/src/container.ts
+++ b/feed-crawler/src/container.ts
@@ -22,6 +22,7 @@ import { FullFeedCrawlEventWorker } from '@event_worker/workers/full-feed-crawl-
 
 import { FeedRepository } from '@repository/feed.repository';
 import { RssRepository } from '@repository/rss.repository';
+import { TagRepository } from '@repository/tag.repository';
 import { TagMapRepository } from '@repository/tag-map.repository';
 
 import { FeedCrawler } from './feed-crawler';
@@ -37,6 +38,7 @@ container.registerSingleton(RedisMetrics);
 container.registerSingleton(RedisConnection);
 container.registerSingleton(RssRepository);
 container.registerSingleton(FeedRepository);
+container.registerSingleton(TagRepository);
 container.registerSingleton(TagMapRepository);
 container.registerSingleton(ClaudeEventWorker);
 container.registerSingleton(ParserUtil);

--- a/feed-crawler/src/event_worker/workers/claude-event-worker.ts
+++ b/feed-crawler/src/event_worker/workers/claude-event-worker.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from 'tsyringe';
 
 import Anthropic from '@anthropic-ai/sdk';
 
-import { PROMPT_CONTENT } from '@common/ai/ai.constant';
+import { buildPromptContent } from '@common/ai/ai.constant';
 import { ClaudeResponse, FeedAIQueueItem } from '@common/ai/ai.type';
 import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
 import { RetryableError } from '@common/errors';
@@ -17,15 +17,19 @@ import { redisConstant } from '@common/redis/redis.constant';
 import { AbstractQueueWorker } from '@event_worker/abstract-queue-worker';
 
 import { FeedRepository } from '@repository/feed.repository';
+import { TagRepository } from '@repository/tag.repository';
 import { TagMapRepository } from '@repository/tag-map.repository';
 
 @injectable()
 export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
   private readonly client: Anthropic;
+  private promptContent: string | null = null;
 
   constructor(
     @inject(TagMapRepository)
     private readonly tagMapRepository: TagMapRepository,
+    @inject(TagRepository)
+    private readonly tagRepository: TagRepository,
     @inject(FeedRepository)
     private readonly feedRepository: FeedRepository,
     @inject(RedisConnection)
@@ -110,6 +114,14 @@ export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
     }
   }
 
+  private async getPromptContent(): Promise<string> {
+    if (this.promptContent === null) {
+      const allowedTags = await this.tagRepository.findAllNames();
+      this.promptContent = buildPromptContent(allowedTags);
+    }
+    return this.promptContent;
+  }
+
   private async requestAI(feed: FeedAIQueueItem) {
     logger.info(`${this.nameTag} AI 요청: ${JSON.stringify(feed)}`);
     this.aiMetrics.total.inc();
@@ -117,7 +129,7 @@ export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
     try {
       const params: Anthropic.MessageCreateParams = {
         max_tokens: 8192,
-        system: PROMPT_CONTENT,
+        system: await this.getPromptContent(),
         messages: [{ role: 'user', content: feed.content }],
         model: 'claude-haiku-4-5',
       };

--- a/feed-crawler/src/repository/tag.repository.ts
+++ b/feed-crawler/src/repository/tag.repository.ts
@@ -1,0 +1,29 @@
+import { inject, injectable } from 'tsyringe';
+
+import { DatabaseConnection } from '@common/database/database-connection';
+import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
+import { DbMetrics } from '@common/metrics/db-metrics';
+
+@injectable()
+export class TagRepository {
+  constructor(
+    @inject(DEPENDENCY_SYMBOLS.DatabaseConnection)
+    private readonly dbConnection: DatabaseConnection,
+    @inject(DbMetrics)
+    private readonly dbMetrics: DbMetrics,
+  ) {}
+
+  public async findAllNames(): Promise<string[]> {
+    this.dbMetrics.total.inc({ operation: 'find_all_tags' });
+    try {
+      const rows = await this.dbConnection.executeQueryStrict<{ name: string }>(
+        'SELECT name FROM tag',
+      );
+      this.dbMetrics.success.inc({ operation: 'find_all_tags' });
+      return rows.map((row) => row.name);
+    } catch (error) {
+      this.dbMetrics.failure.inc({ operation: 'find_all_tags' });
+      throw error;
+    }
+  }
+}

--- a/feed-crawler/test/unit/claude-event-worker.spec.ts
+++ b/feed-crawler/test/unit/claude-event-worker.spec.ts
@@ -11,11 +11,13 @@ import { redisConstant } from '@common/redis/redis.constant';
 import { ClaudeEventWorker } from '@event_worker/workers/claude-event-worker';
 
 import { FeedRepository } from '@repository/feed.repository';
+import { TagRepository } from '@repository/tag.repository';
 import { TagMapRepository } from '@repository/tag-map.repository';
 
 describe('ClaudeEventWorker', () => {
   let claudeEventWorker: ClaudeEventWorker;
   let mockTagMapRepository: jest.Mocked<TagMapRepository>;
+  let mockTagRepository: jest.Mocked<TagRepository>;
   let mockFeedRepository: jest.Mocked<FeedRepository>;
   let mockRedisConnection: jest.Mocked<RedisConnection>;
   let mockAnthropicClient: any;
@@ -62,6 +64,10 @@ describe('ClaudeEventWorker', () => {
       insertTags: insertTagsMock,
     } as any;
 
+    mockTagRepository = {
+      findAllNames: jest.fn().mockResolvedValue(['JavaScript', 'React']),
+    } as any;
+
     mockFeedRepository = {
       updateSummary: updateSummaryMock,
       updateNullSummary: updateNullSummaryMock,
@@ -102,6 +108,7 @@ describe('ClaudeEventWorker', () => {
 
     claudeEventWorker = new ClaudeEventWorker(
       mockTagMapRepository,
+      mockTagRepository,
       mockFeedRepository,
       mockRedisConnection,
       mockNotifier,


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #651

### 태그 목록 동적화

- AI 태깅 프롬프트의 `ALLOWED_TAGS` 하드코딩 상수를 제거하고 `tag` 테이블에서 조회하도록 전환했습니다.
- 태그가 추가/변경될 때마다 코드를 수정·배포해야 했던 문제를 DB 단일 출처로 일원화했습니다.
- `PROMPT_CONTENT` 상수를 `buildPromptContent(allowedTags)` 팩토리 함수로 변경하여 런타임 태그 목록을 주입받도록 했습니다.

### 프롬프트 캐싱

- `findAllNames()` 결과로 만든 프롬프트를 워커 인스턴스에 메모이즈하여, 피드마다 DB를 재조회하지 않도록 했습니다.

# 📋 작업 내용

- `TagRepository` 신규 추가 (`SELECT name FROM tag`, DbMetrics 계측 포함)
- `container.ts`에 `TagRepository` 싱글톤 등록
- `ClaudeEventWorker`에 `TagRepository` 주입 및 `getPromptContent()` 캐싱 로직 추가
- `ai.constant.ts`: `ALLOWED_TAGS` 제거, `PROMPT_CONTENT` → `buildPromptContent` 전환
- 관련 유닛 테스트 보강