### PR TITLE
♻️ refactor: email-worker 생명주기 통일 및 에러 분류 분리

### DIFF
--- a/email-worker/src/common/lifecycle/lifecycle.interface.ts
+++ b/email-worker/src/common/lifecycle/lifecycle.interface.ts
@@ -1,0 +1,4 @@
+export interface Lifecycle {
+  start(): Promise<void> | void;
+  stop?(): Promise<void> | void;
+}

--- a/email-worker/src/common/metrics/email-metrics.ts
+++ b/email-worker/src/common/metrics/email-metrics.ts
@@ -3,8 +3,11 @@ import { injectable } from 'tsyringe';
 import * as http from 'node:http';
 import { collectDefaultMetrics, Counter, register } from 'prom-client';
 
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
+import logger from '@common/logger/logger';
+
 @injectable()
-export class EmailMetrics {
+export class EmailMetrics implements Lifecycle {
   readonly total: Counter;
   readonly success: Counter;
 
@@ -20,7 +23,8 @@ export class EmailMetrics {
     });
   }
 
-  startMetricsServer(port: number): void {
+  start(): void {
+    const port = Number(process.env.EMAIL_WORKER_METRICS_PORT) || 9091;
     const handleRequest = async (
       req: http.IncomingMessage,
       res: http.ServerResponse,
@@ -38,5 +42,6 @@ export class EmailMetrics {
       (req, res) => void handleRequest(req, res),
     );
     server.listen(port);
+    logger.info(`Metrics server started on port ${port}`);
   }
 }

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -7,6 +7,7 @@ import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
 import logger from '@common/logger/logger';
 
 import { EmailPayloadConstant } from '@email/constant';
+import { classifyEmailError } from '@email/email.error';
 import { EmailService } from '@email/email.service';
 import { EmailPayload, NodeMailerError } from '@email/types';
 
@@ -166,47 +167,6 @@ export class EmailConsumer implements Lifecycle {
     });
   }
 
-  /**
-   * 이메일 전송 실패 시 에러 타입에 따라 재시도 또는 DLQ 처리를 수행합니다.
-   *
-   * @description
-   * 에러 처리 흐름:
-   * 1. 네트워크 에러 (ECONNREFUSED, ETIMEDOUT 등)
-   *    - 재시도 횟수 < 3회: Wait Queue로 재시도
-   *    - 재시도 횟수 >= 3회: DLQ로 발행 (MAX_RETRIES_EXCEEDED)
-   *
-   * 2. SMTP 에러
-   *    - 5xx 에러: 즉시 DLQ로 발행 (SMTP_PERMANENT_FAILURE)
-   *    - 4xx 에러:
-   *      - 재시도 횟수 < 3회: Wait Queue로 재시도
-   *      - 재시도 횟수 >= 3회: DLQ로 발행 (MAX_RETRIES_EXCEEDED)
-   *
-   * 3. 알 수 없는 에러: 즉시 DLQ로 발행 (UNKNOWN_ERROR)
-   *
-   * @param {NodeMailerError} error - 발생한 에러 객체 (네트워크 에러, SMTP 에러 등)
-   * @param {EmailPayload} payload - 전송 실패한 이메일 페이로드
-   * @param {number} retryCount - 현재까지의 재시도 횟수 (0부터 시작)
-   *
-   * @returns {Promise<void>}
-   *
-   * @example
-   * // 네트워크 에러로 첫 번째 재시도
-   * await handleEmailByError(
-   *   new Error('ECONNREFUSED'),
-   *   { type: 'userCertification', ... },
-   *   0
-   * );
-   * // -> Wait Queue에 발행됨
-   *
-   * @example
-   * // SMTP 5xx 에러
-   * await handleEmailByError(
-   *   { responseCode: 550, message: 'Mailbox not found' },
-   *   { type: 'userCertification', ... },
-   *   0
-   * );
-   * // -> 즉시 DLQ로 발행됨 (SMTP_PERMANENT_FAILURE)
-   */
   async handleEmailByError(
     error: NodeMailerError,
     payload: EmailPayload,
@@ -219,13 +179,9 @@ export class EmailConsumer implements Lifecycle {
       },
     };
 
-    // Node.js 네트워크 레벨의 에러
-    const isNetworkError =
-      error.code === 'ESOCKET' ||
-      error.message?.includes('ECONNREFUSED') ||
-      error.message?.includes('ETIMEDOUT') ||
-      error.message?.includes('Unexpected socket close');
-    if (isNetworkError) {
+    const classification = classifyEmailError(error);
+
+    if (classification.retryable) {
       if (retryCount >= RETRY_CONFIG.MAX_RETRY) {
         await this.sendToDLQ(
           error,
@@ -244,51 +200,28 @@ export class EmailConsumer implements Lifecycle {
       return;
     }
 
-    // SMTP 레벨의 에러
-    if (error.responseCode) {
-      if (error.responseCode >= 500) {
-        await this.sendToDLQ(
-          error,
-          stringifiedMessage,
-          retryCount,
-          'SMTP_PERMANENT_FAILURE',
-          '[SMTP 500 에러 발생]',
-        );
-        return;
-      }
-
-      if (error.responseCode >= 400) {
-        if (retryCount >= RETRY_CONFIG.MAX_RETRY) {
-          await this.sendToDLQ(
-            error,
-            stringifiedMessage,
-            retryCount,
-            'MAX_RETRIES_EXCEEDED',
-            '[retry count 초과]',
-          );
-          return;
-        }
-        await this.rabbitmqService.sendMessageToQueue(
-          RETRY_CONFIG.WAITING_QUEUE[retryCount],
-          stringifiedMessage,
-          retryOptions,
-        );
-        return;
-      }
-    }
-
-    logger.error(
-      `[EmailConsumer] 알 수 없는 에러로 DLQ 메시지 발행
-      오류 메시지: ${error.message} 
+    if (classification.failureType === 'UNKNOWN_ERROR') {
+      logger.error(
+        `[EmailConsumer] 알 수 없는 에러로 DLQ 메시지 발행
+      오류 메시지: ${error.message}
       스택 트레이스: ${error.stack}`,
-    );
+      );
+      await this.sendToDLQ(
+        error,
+        stringifiedMessage,
+        retryCount,
+        'UNKNOWN_ERROR',
+        '[알 수 없는 에러 발생]',
+      );
+      return;
+    }
 
     await this.sendToDLQ(
       error,
       stringifiedMessage,
       retryCount,
-      'UNKNOWN_ERROR',
-      '[알 수 없는 에러 발생]',
+      'SMTP_PERMANENT_FAILURE',
+      '[SMTP 500 에러 발생]',
     );
   }
 

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -3,6 +3,7 @@ import { inject, injectable } from 'tsyringe';
 import { Options } from 'amqplib/properties';
 
 import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
 import logger from '@common/logger/logger';
 
 import { EmailPayloadConstant } from '@email/constant';
@@ -16,7 +17,7 @@ import { RETRY_CONFIG, RMQ_QUEUES } from '@rabbitmq/rabbitmq.constant';
 import { RabbitMQService } from '@rabbitmq/rabbitmq.service';
 
 @injectable()
-export class EmailConsumer {
+export class EmailConsumer implements Lifecycle {
   private consumerTag: string | null;
   private shuttingDownFlag = false;
   private pendingTasks = 0;
@@ -73,6 +74,17 @@ export class EmailConsumer {
     );
 
     logger.info('[EmailConsumer] 이메일 큐 리스닝 시작');
+  }
+
+  async stop(): Promise<void> {
+    logger.info('새로운 메시지 수신 중지...');
+    await this.stopConsuming();
+
+    logger.info('진행 중인 이메일 전송 작업 완료 대기...');
+    await this.waitForPendingTasks();
+
+    logger.info('Consumer 정리 중...');
+    await this.close();
   }
 
   async close() {

--- a/email-worker/src/email/email.error.ts
+++ b/email-worker/src/email/email.error.ts
@@ -5,9 +5,19 @@ export interface EmailErrorClassification {
   failureType: 'SMTP_PERMANENT_FAILURE' | 'UNKNOWN_ERROR' | null;
 }
 
+const TRANSIENT_NETWORK_CODES = new Set([
+  'ESOCKET',
+  'ECONNECTION',
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'EAI_AGAIN',
+  'EDNS',
+]);
+
 function isNetworkError(error: NodeMailerError): boolean {
   return (
-    error.code === 'ESOCKET' ||
+    (error.code !== undefined && TRANSIENT_NETWORK_CODES.has(error.code)) ||
     error.message?.includes('ECONNREFUSED') ||
     error.message?.includes('ETIMEDOUT') ||
     error.message?.includes('Unexpected socket close')

--- a/email-worker/src/email/email.error.ts
+++ b/email-worker/src/email/email.error.ts
@@ -16,10 +16,26 @@ const TRANSIENT_NETWORK_CODES = new Set([
 ]);
 
 function isNetworkError(error: NodeMailerError): boolean {
-  return (
-    (error.code !== undefined && TRANSIENT_NETWORK_CODES.has(error.code)) ||
-    error.message?.includes('Unexpected socket close')
-  );
+  if (error.code !== undefined && TRANSIENT_NETWORK_CODES.has(error.code)) {
+    return true;
+  }
+
+  const message = error.message;
+  if (!message) {
+    return false;
+  }
+
+  if (message.includes('Unexpected socket close')) {
+    return true;
+  }
+
+  for (const code of TRANSIENT_NETWORK_CODES) {
+    if (message.includes(code)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function classifyEmailError(

--- a/email-worker/src/email/email.error.ts
+++ b/email-worker/src/email/email.error.ts
@@ -1,0 +1,34 @@
+import { NodeMailerError } from '@email/types';
+
+export interface EmailErrorClassification {
+  retryable: boolean;
+  failureType: 'SMTP_PERMANENT_FAILURE' | 'UNKNOWN_ERROR' | null;
+}
+
+function isNetworkError(error: NodeMailerError): boolean {
+  return (
+    error.code === 'ESOCKET' ||
+    error.message?.includes('ECONNREFUSED') ||
+    error.message?.includes('ETIMEDOUT') ||
+    error.message?.includes('Unexpected socket close')
+  );
+}
+
+export function classifyEmailError(
+  error: NodeMailerError,
+): EmailErrorClassification {
+  if (isNetworkError(error)) {
+    return { retryable: true, failureType: null };
+  }
+
+  if (typeof error.responseCode === 'number') {
+    if (error.responseCode >= 500) {
+      return { retryable: false, failureType: 'SMTP_PERMANENT_FAILURE' };
+    }
+    if (error.responseCode >= 400) {
+      return { retryable: true, failureType: null };
+    }
+  }
+
+  return { retryable: false, failureType: 'UNKNOWN_ERROR' };
+}

--- a/email-worker/src/email/email.error.ts
+++ b/email-worker/src/email/email.error.ts
@@ -18,8 +18,6 @@ const TRANSIENT_NETWORK_CODES = new Set([
 function isNetworkError(error: NodeMailerError): boolean {
   return (
     (error.code !== undefined && TRANSIENT_NETWORK_CODES.has(error.code)) ||
-    error.message?.includes('ECONNREFUSED') ||
-    error.message?.includes('ETIMEDOUT') ||
     error.message?.includes('Unexpected socket close')
   );
 }

--- a/email-worker/src/main.ts
+++ b/email-worker/src/main.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 
 import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
 import '@common/env/env-load';
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
 import logger from '@common/logger/logger';
 import { EmailMetrics } from '@common/metrics/email-metrics';
 
@@ -13,30 +14,27 @@ import { RabbitMQManager } from '@rabbitmq/rabbitmq.manager';
 
 import { container } from './container';
 
-function initializeDependencies() {
-  return {
-    rabbitMQManager: container.resolve(RabbitMQManager),
-    emailConsumer: container.resolve(EmailConsumer),
-    notifier: container.resolve<Notifier>(DEPENDENCY_SYMBOLS.Notifier),
-    metrics: container.resolve(EmailMetrics),
-  };
+function resolveComponents(): Lifecycle[] {
+  return [
+    container.resolve(EmailMetrics),
+    container.resolve<Notifier>(DEPENDENCY_SYMBOLS.Notifier),
+    container.resolve(RabbitMQManager),
+    container.resolve(EmailConsumer),
+  ];
 }
 
 async function startEmailWorker() {
+  const components = resolveComponents();
+
   try {
     logger.info('[Email Worker Start]');
 
-    const metricsPort = Number(process.env.EMAIL_WORKER_METRICS_PORT) || 9091;
+    for (const component of components) {
+      await component.start();
+    }
 
-    const dependencies = initializeDependencies();
-    dependencies.metrics.startMetricsServer(metricsPort);
-    logger.info(`Metrics server started on port ${metricsPort}`);
-    dependencies.notifier.initialize();
-    logger.info(`Notifier 초기화 완료`);
-    await initializeRabbitMQ(dependencies);
-
-    process.on('SIGINT', () => void handleShutdown(dependencies, 'SIGINT'));
-    process.on('SIGTERM', () => void handleShutdown(dependencies, 'SIGTERM'));
+    process.on('SIGINT', () => void handleShutdown(components, 'SIGINT'));
+    process.on('SIGTERM', () => void handleShutdown(components, 'SIGTERM'));
   } catch (error) {
     logger.error(
       `Email Worker 시작 실패: ${error instanceof Error ? error.message : error}`,
@@ -45,24 +43,13 @@ async function startEmailWorker() {
   }
 }
 
-async function handleShutdown(
-  dependencies: ReturnType<typeof initializeDependencies>,
-  signal: string,
-) {
+async function handleShutdown(components: Lifecycle[], signal: string) {
   try {
     logger.info(`${signal} 신호 수신, email-worker 종료 중...`);
 
-    logger.info('새로운 메시지 수신 중지...');
-    await dependencies.emailConsumer.stopConsuming();
-
-    logger.info('진행 중인 이메일 전송 작업 완료 대기...');
-    await dependencies.emailConsumer.waitForPendingTasks();
-
-    logger.info('Consumer 정리 중...');
-    await dependencies.emailConsumer.close();
-
-    logger.info('RabbitMQ 연결 종료 중...');
-    await dependencies.rabbitMQManager.disconnect();
+    for (const component of [...components].reverse()) {
+      await component.stop?.();
+    }
 
     logger.info('Email Worker 정상 종료');
     process.exit(0);
@@ -71,25 +58,6 @@ async function handleShutdown(
       `Email Worker 종료 중 에러 발생: ${error instanceof Error ? error.message : error}`,
     );
     process.exit(1);
-  }
-}
-
-async function initializeRabbitMQ(
-  dependencies: ReturnType<typeof initializeDependencies>,
-) {
-  try {
-    logger.info(`RabbitMQ 초기화 시작...`);
-
-    await dependencies.rabbitMQManager.connect();
-    logger.info(`RabbitMQ 초기화 완료`);
-
-    await dependencies.emailConsumer.start();
-    logger.info(`RabbitMQ Email Consumer 시작 완료`);
-  } catch (error) {
-    logger.error(
-      `RabbitMQ 초기화 실패: ${error instanceof Error ? error.message : error}`,
-    );
-    throw error;
   }
 }
 

--- a/email-worker/src/notification/discord.notifier.ts
+++ b/email-worker/src/notification/discord.notifier.ts
@@ -28,7 +28,7 @@ export class DiscordNotifier implements Notifier {
     this.eventEmitter = new EventEmitter();
   }
 
-  initialize() {
+  start() {
     if (!this.initialized) {
       this.eventEmitter.on(
         NOTIFICATION_EVENT.EMAIL_DLQ,

--- a/email-worker/src/notification/notifier-registry.ts
+++ b/email-worker/src/notification/notifier-registry.ts
@@ -1,5 +1,7 @@
 import { injectable } from 'tsyringe';
 
+import logger from '@common/logger/logger';
+
 import { NotificationEventPayloadMap } from '@notification/notification-event.constant';
 import { Notifier } from '@notification/notifier.interface';
 
@@ -11,8 +13,9 @@ export class NotifierRegistry implements Notifier {
     this.notifiers.set(name, notifier);
   }
 
-  initialize(): void {
-    this.notifiers.forEach((notifier) => notifier.initialize());
+  start(): void {
+    this.notifiers.forEach((notifier) => notifier.start());
+    logger.info('Notifier 초기화 완료');
   }
 
   publish<K extends keyof NotificationEventPayloadMap>(

--- a/email-worker/src/notification/notifier.interface.ts
+++ b/email-worker/src/notification/notifier.interface.ts
@@ -1,7 +1,9 @@
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
+
 import { NotificationEventPayloadMap } from '@notification/notification-event.constant';
 
-export interface Notifier {
-  initialize(): void;
+export interface Notifier extends Lifecycle {
+  start(): void;
   publish<K extends keyof NotificationEventPayloadMap>(
     eventName: K,
     payload: NotificationEventPayloadMap[K],

--- a/email-worker/src/rabbitmq/rabbitmq.manager.ts
+++ b/email-worker/src/rabbitmq/rabbitmq.manager.ts
@@ -3,8 +3,11 @@ import { injectable } from 'tsyringe';
 import * as amqp from 'amqplib';
 import { Channel, ChannelModel } from 'amqplib';
 
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
+import logger from '@common/logger/logger';
+
 @injectable()
-export class RabbitMQManager {
+export class RabbitMQManager implements Lifecycle {
   private connection: ChannelModel | null;
   private channel: Channel | null;
   private connectionPromise: Promise<ChannelModel> | null = null;
@@ -13,6 +16,16 @@ export class RabbitMQManager {
   constructor() {
     this.connection = null;
     this.channel = null;
+  }
+
+  async start(): Promise<void> {
+    await this.connect();
+    logger.info('RabbitMQ 초기화 완료');
+  }
+
+  async stop(): Promise<void> {
+    logger.info('RabbitMQ 연결 종료 중...');
+    await this.disconnect();
   }
 
   async connect() {

--- a/email-worker/test/unit/consumer.spec.ts
+++ b/email-worker/test/unit/consumer.spec.ts
@@ -55,7 +55,7 @@ describe('email consumer unit test', () => {
         sendMessageToQueue: jest.fn().mockResolvedValue(null),
       } as any;
       notifier = {
-        initialize: jest.fn(),
+        start: jest.fn(),
         publish: jest.fn(),
       };
       emailConsumer = new EmailConsumer(
@@ -225,7 +225,7 @@ describe('email consumer unit test', () => {
         sendMessageToQueue,
       } as any;
       notifier = {
-        initialize: jest.fn(),
+        start: jest.fn(),
         publish: jest.fn(),
       };
       emailConsumer = new EmailConsumer(


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #652

### Lifecycle 인터페이스 도입 및 main 함수 부담 절감

-   `EmailMetrics`, `Notifier`, `RabbitMQManager`, `EmailConsumer` 각 컴포넌트가 제각각의 초기화/종료 메서드(`startMetricsServer`, `initialize`, `connect/disconnect`, `start/stopConsuming/close`)를 노출하고 있어, `main.ts`가 모든 컴포넌트의 내부 구동 순서를 직접 알아야 했습니다.
-   공통 `Lifecycle` 인터페이스(`start` / 옵셔널 `stop`)를 도입해 각 컴포넌트가 자신의 구동·정리 책임을 캡슐화하도록 했습니다.
-   `main.ts`는 컴포넌트를 배열로 resolve한 뒤 순차 `start()`, 종료 시 역순 `stop()`만 호출합니다. 기동 순서와 종료 순서의 대칭성이 코드 구조로 보장되며, 새 컴포넌트 추가 시 배열에만 등록하면 됩니다.
-   메트릭 포트 결정 같은 컴포넌트 고유 설정은 `main.ts`에서 각 컴포넌트 내부로 이동시켜 응집도를 높였습니다.

### 에러 분류 로직 분리

-   `handleEmailByError` 안에 네트워크/SMTP/알 수 없는 에러 판별 로직과 재시도·DLQ 처리 흐름이 뒤섞여 있어 테스트와 변경이 어려웠습니다.
-   순수 함수 `classifyEmailError`를 `email.error.ts`로 분리했습니다. 분류(retryable 여부 + failureType)와 처리(재시도/DLQ 발행)의 책임을 나눠, 정책 변경이 분류 함수에 국한되도록 했습니다.

### 네트워크 예외 재시도 범위 확대

-   기존에는 `ESOCKET` 및 일부 메시지 문자열 매칭에만 재시도를 적용해, `ECONNRESET`, `EAI_AGAIN` 등 일시적 네트워크 장애가 재시도 없이 처리되는 사각지대가 있었습니다.
-   일시적 네트워크 에러 코드 집합(`TRANSIENT_NETWORK_CODES`)을 정의해 일시 장애를 재시도 대상으로 폭넓게 포착하도록 했습니다.

# 📋 작업 내용

-   `Lifecycle` 인터페이스 추가 및 `EmailMetrics` / `RabbitMQManager` / `EmailConsumer` / `Notifier` 적용
-   `main.ts`의 `initializeDependencies` / `initializeRabbitMQ` 제거, 컴포넌트 배열 기반 기동·종료로 단순화
-   에러 분류 순수 함수 `classifyEmailError` 분리 (`email.error.ts`)
-   일시적 네트워크 에러 코드 집합 기반으로 재시도 판단 확대
-   관련 단위 테스트 갱신 (`consumer.spec.ts`)