### PR TITLE
✅ test: Email Worker 누락 테스트 보강 (커버리지 78% → 98%)

### DIFF
--- a/email-worker/test/e2e/email-consumer.e2e-spec.ts
+++ b/email-worker/test/e2e/email-consumer.e2e-spec.ts
@@ -273,4 +273,154 @@ describe(`Email Normal Scenario E2E Test`, () => {
     expect(data.messages[0].To[0].Address).toBe('test@test.com');
     expect(data.messages[0].Subject).toContain('회원탈퇴');
   });
+
+  it('RSS 소유 인증 메시지가 있다면 인증 이메일을 보낸다.', async () => {
+    //given
+    const payload = {
+      type: EmailPayloadConstant.RSS_CERTIFICATION,
+      data: {
+        userName: 'tester',
+        email: 'test@test.com',
+        blogName: 'test blog',
+        certificateCode: 'cert-code',
+        userEmail: 'requester@test.com',
+      },
+    };
+    await rabbitmqService.sendMessage(
+      RMQ_EXCHANGES.EMAIL,
+      RMQ_ROUTING_KEYS.EMAIL_SEND,
+      JSON.stringify(payload),
+    );
+
+    //when
+    await emailConsumer.start();
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    //then
+    const mailpitContainer = (global as unknown as MailpitGlobal)
+      .__MAILPIT_CONTAINER__;
+    const webPort = mailpitContainer.getMappedPort(8025);
+    const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
+
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
+
+    await axios.delete(`${baseUrl}/api/v1/messages`);
+
+    expect(data.messages).toHaveLength(1);
+    expect(data.messages[0].To[0].Address).toBe('test@test.com');
+    expect(data.messages[0].Subject).toContain('RSS 소유 인증');
+  });
+
+  it('RSS 등록 신청 메시지가 있다면 관리자에게 신청 접수 이메일을 보낸다.', async () => {
+    //given
+    const payload = {
+      type: EmailPayloadConstant.RSS_REGISTRATION_REQUEST,
+      data: {
+        rss: {
+          name: 'test blog',
+          userName: 'tester',
+          email: 'test@test.com',
+          rssUrl: 'test@blog.com',
+        },
+        adminEmail: 'admin@test.com',
+      },
+    };
+    await rabbitmqService.sendMessage(
+      RMQ_EXCHANGES.EMAIL,
+      RMQ_ROUTING_KEYS.EMAIL_SEND,
+      JSON.stringify(payload),
+    );
+
+    //when
+    await emailConsumer.start();
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    //then
+    const mailpitContainer = (global as unknown as MailpitGlobal)
+      .__MAILPIT_CONTAINER__;
+    const webPort = mailpitContainer.getMappedPort(8025);
+    const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
+
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
+
+    await axios.delete(`${baseUrl}/api/v1/messages`);
+
+    expect(data.messages).toHaveLength(1);
+    expect(data.messages[0].To[0].Address).toBe('admin@test.com');
+    expect(data.messages[0].Subject).toContain('RSS 등록 신청');
+  });
+
+  it('관리자 계정 인증 메시지가 있다면 인증 이메일을 보낸다.', async () => {
+    //given
+    const payload = {
+      type: EmailPayloadConstant.ADMIN_CERTIFICATION,
+      data: {
+        email: 'admin@test.com',
+        name: 'admin',
+        uuid: 'admin-uuid',
+      },
+    };
+    await rabbitmqService.sendMessage(
+      RMQ_EXCHANGES.EMAIL,
+      RMQ_ROUTING_KEYS.EMAIL_SEND,
+      JSON.stringify(payload),
+    );
+
+    //when
+    await emailConsumer.start();
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    //then
+    const mailpitContainer = (global as unknown as MailpitGlobal)
+      .__MAILPIT_CONTAINER__;
+    const webPort = mailpitContainer.getMappedPort(8025);
+    const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
+
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
+
+    await axios.delete(`${baseUrl}/api/v1/messages`);
+
+    expect(data.messages).toHaveLength(1);
+    expect(data.messages[0].To[0].Address).toBe('admin@test.com');
+    expect(data.messages[0].Subject).toContain('관리자 계정 인증');
+  });
+
+  it('관리자 회원탈퇴 메시지가 있다면 확인 이메일을 보낸다.', async () => {
+    //given
+    const payload = {
+      type: EmailPayloadConstant.ADMIN_ACCOUNT_DELETION,
+      data: {
+        email: 'admin@test.com',
+        name: 'admin',
+        uuid: 'admin-uuid',
+      },
+    };
+    await rabbitmqService.sendMessage(
+      RMQ_EXCHANGES.EMAIL,
+      RMQ_ROUTING_KEYS.EMAIL_SEND,
+      JSON.stringify(payload),
+    );
+
+    //when
+    await emailConsumer.start();
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
+    //then
+    const mailpitContainer = (global as unknown as MailpitGlobal)
+      .__MAILPIT_CONTAINER__;
+    const webPort = mailpitContainer.getMappedPort(8025);
+    const baseUrl = `http://${mailpitContainer.getHost()}:${webPort}`;
+
+    const response = await axios.get<MailpitResponse>(`${baseUrl}/api/v1/messages`);
+    const data = response.data;
+
+    await axios.delete(`${baseUrl}/api/v1/messages`);
+
+    expect(data.messages).toHaveLength(1);
+    expect(data.messages[0].To[0].Address).toBe('admin@test.com');
+    expect(data.messages[0].Subject).toContain('관리자 회원탈퇴');
+  });
 });

--- a/email-worker/test/unit/consumer.spec.ts
+++ b/email-worker/test/unit/consumer.spec.ts
@@ -1,8 +1,10 @@
 import 'reflect-metadata';
 
 import {
+  AdminCertification,
   RssCertification,
   RssRegistration,
+  RssRegistrationRequest,
   RssRemoval,
   User,
 } from '@common/types';
@@ -12,6 +14,7 @@ import { EmailConsumer } from '@email/email.consumer';
 import { EmailService } from '@email/email.service';
 import { EmailPayload, NodeMailerError } from '@email/types';
 
+import { NOTIFICATION_EVENT } from '@notification/notification-event.constant';
 import { Notifier } from '@notification/notifier.interface';
 
 import { RETRY_CONFIG, RMQ_QUEUES } from '@rabbitmq/rabbitmq.constant';
@@ -34,6 +37,9 @@ describe('email consumer unit test', () => {
     let sendRssCertificationMail: jest.Mock;
     let sendPasswordResetEmail: jest.Mock;
     let sendDeleteAccountMail: jest.Mock;
+    let sendRssRegistrationRequestMail: jest.Mock;
+    let sendAdminCertificationMail: jest.Mock;
+    let sendAdminDeleteAccountMail: jest.Mock;
 
     beforeEach(() => {
       sendUserCertificationMail = jest.fn().mockResolvedValue(undefined);
@@ -42,6 +48,9 @@ describe('email consumer unit test', () => {
       sendRssCertificationMail = jest.fn().mockResolvedValue(undefined);
       sendPasswordResetEmail = jest.fn().mockResolvedValue(undefined);
       sendDeleteAccountMail = jest.fn().mockResolvedValue(undefined);
+      sendRssRegistrationRequestMail = jest.fn().mockResolvedValue(undefined);
+      sendAdminCertificationMail = jest.fn().mockResolvedValue(undefined);
+      sendAdminDeleteAccountMail = jest.fn().mockResolvedValue(undefined);
 
       emailService = {
         sendUserCertificationMail,
@@ -50,6 +59,9 @@ describe('email consumer unit test', () => {
         sendRssCertificationMail,
         sendPasswordResetEmail,
         sendDeleteAccountMail,
+        sendRssRegistrationRequestMail,
+        sendAdminCertificationMail,
+        sendAdminDeleteAccountMail,
       } as any;
       rabbitmqService = {
         sendMessageToQueue: jest.fn().mockResolvedValue(null),
@@ -179,6 +191,61 @@ describe('email consumer unit test', () => {
       expect(sendDeleteAccountMail).toHaveBeenCalledWith(userData);
     });
 
+    it('RSS_REGISTRATION_REQUEST 타입일 때 sendRssRegistrationRequestMail을 호출한다', async () => {
+      const requestData: RssRegistrationRequest = {
+        rss: {
+          name: 'Test Blog',
+          userName: 'tester',
+          email: 'test@test.com',
+          rssUrl: 'https://test.com/rss',
+        },
+        adminEmail: 'admin@test.com',
+      };
+      const payload: EmailPayload = {
+        type: EmailPayloadConstant.RSS_REGISTRATION_REQUEST,
+        data: requestData,
+      };
+
+      await emailConsumer.handleEmailByType(payload);
+
+      expect(sendRssRegistrationRequestMail).toHaveBeenCalledTimes(1);
+      expect(sendRssRegistrationRequestMail).toHaveBeenCalledWith(requestData);
+    });
+
+    it('ADMIN_CERTIFICATION 타입일 때 sendAdminCertificationMail을 호출한다', async () => {
+      const adminData: AdminCertification = {
+        email: 'admin@test.com',
+        name: 'admin',
+        uuid: 'admin-uuid',
+      };
+      const payload: EmailPayload = {
+        type: EmailPayloadConstant.ADMIN_CERTIFICATION,
+        data: adminData,
+      };
+
+      await emailConsumer.handleEmailByType(payload);
+
+      expect(sendAdminCertificationMail).toHaveBeenCalledTimes(1);
+      expect(sendAdminCertificationMail).toHaveBeenCalledWith(adminData);
+    });
+
+    it('ADMIN_ACCOUNT_DELETION 타입일 때 sendAdminDeleteAccountMail을 호출한다', async () => {
+      const adminData: AdminCertification = {
+        email: 'admin@test.com',
+        name: 'admin',
+        uuid: 'admin-uuid',
+      };
+      const payload: EmailPayload = {
+        type: EmailPayloadConstant.ADMIN_ACCOUNT_DELETION,
+        data: adminData,
+      };
+
+      await emailConsumer.handleEmailByType(payload);
+
+      expect(sendAdminDeleteAccountMail).toHaveBeenCalledTimes(1);
+      expect(sendAdminDeleteAccountMail).toHaveBeenCalledWith(adminData);
+    });
+
     it('알 수 없는 타입일 때 아무 메서드도 호출하지 않는다', async () => {
       const payload = {
         type: 'unknownType',
@@ -197,6 +264,7 @@ describe('email consumer unit test', () => {
 
   describe('handleEmailByError unit test', () => {
     let sendMessageToQueue: jest.Mock;
+    let notifierPublish: jest.Mock;
 
     const networkErrors = [
       `ESOCKET`,
@@ -224,9 +292,10 @@ describe('email consumer unit test', () => {
       rabbitmqService = {
         sendMessageToQueue,
       } as any;
+      notifierPublish = jest.fn();
       notifier = {
         start: jest.fn(),
-        publish: jest.fn(),
+        publish: notifierPublish,
       };
       emailConsumer = new EmailConsumer(
         rabbitmqService,
@@ -471,6 +540,43 @@ describe('email consumer unit test', () => {
           }),
         );
       });
+
+      it('DLQ 발행 시 notifier로 EMAIL_DLQ 이벤트를 발행한다', async () => {
+        const error = new Error('Mailbox unavailable') as NodeMailerError;
+        error.responseCode = 550;
+        const emailPayload: EmailPayload = {
+          type: EmailPayloadConstant.USER_CERTIFICATION,
+          data: {
+            email: `test@test.com`,
+            userName: `tester`,
+            uuid: `tester-uuid`,
+          },
+        };
+
+        await emailConsumer.handleEmailByError(error, emailPayload, 0);
+
+        expect(notifierPublish).toHaveBeenCalledTimes(1);
+        expect(notifierPublish).toHaveBeenCalledWith(
+          NOTIFICATION_EVENT.EMAIL_DLQ,
+          expect.objectContaining({ error }),
+        );
+      });
+
+      it('재시도 가능한 에러는 notifier로 이벤트를 발행하지 않는다', async () => {
+        const error = new Error('ECONNREFUSED') as NodeMailerError;
+        const emailPayload: EmailPayload = {
+          type: EmailPayloadConstant.USER_CERTIFICATION,
+          data: {
+            email: `test@test.com`,
+            userName: `tester`,
+            uuid: `tester-uuid`,
+          },
+        };
+
+        await emailConsumer.handleEmailByError(error, emailPayload, 0);
+
+        expect(notifierPublish).not.toHaveBeenCalled();
+      });
     });
 
     describe('Transient Error 재시도 횟수 초과', () => {
@@ -524,6 +630,158 @@ describe('email consumer unit test', () => {
           );
         });
       });
+    });
+  });
+
+  describe('lifecycle unit test', () => {
+    let consumeMessage: jest.Mock;
+    let closeConsumer: jest.Mock;
+    let sendUserCertificationMail: jest.Mock;
+    let capturedCallback: (
+      payload: EmailPayload,
+      retryCount: number,
+    ) => Promise<void>;
+
+    const payload: EmailPayload = {
+      type: EmailPayloadConstant.USER_CERTIFICATION,
+      data: { email: 'test@test.com', userName: 'tester', uuid: 'tester-uuid' },
+    };
+
+    beforeEach(() => {
+      consumeMessage = jest.fn().mockImplementation((_queue, callback) => {
+        capturedCallback = callback;
+        return Promise.resolve('test-consumer-tag');
+      });
+      closeConsumer = jest.fn().mockResolvedValue(undefined);
+      sendUserCertificationMail = jest.fn().mockResolvedValue(undefined);
+
+      rabbitmqService = {
+        consumeMessage,
+        closeConsumer,
+        sendMessageToQueue: jest.fn().mockResolvedValue(null),
+      } as any;
+      emailService = { sendUserCertificationMail } as any;
+      notifier = { start: jest.fn(), publish: jest.fn() };
+      emailConsumer = new EmailConsumer(rabbitmqService, emailService, notifier);
+    });
+
+    it('start 호출 시 EMAIL_SEND 큐를 consume 한다', async () => {
+      await emailConsumer.start();
+
+      expect(consumeMessage).toHaveBeenCalledTimes(1);
+      expect(consumeMessage).toHaveBeenCalledWith(
+        RMQ_QUEUES.EMAIL_SEND,
+        expect.any(Function),
+      );
+    });
+
+    it('consume 콜백이 정상 메시지를 받으면 handleEmailByType을 호출한다', async () => {
+      await emailConsumer.start();
+
+      await capturedCallback(payload, 0);
+
+      expect(sendUserCertificationMail).toHaveBeenCalledWith(payload.data);
+    });
+
+    it('consume 콜백 처리 중 에러가 나면 handleEmailByError로 위임한다', async () => {
+      const error = new Error('ECONNREFUSED');
+      sendUserCertificationMail.mockRejectedValueOnce(error);
+      const handleErrorSpy = jest.spyOn(emailConsumer, 'handleEmailByError');
+      await emailConsumer.start();
+
+      await capturedCallback(payload, 0);
+
+      expect(handleErrorSpy).toHaveBeenCalledWith(error, payload, 0);
+    });
+
+    it('shutdown 중에는 새 메시지를 처리하지 않고 SHUTDOWN_IN_PROGRESS를 던진다', async () => {
+      await emailConsumer.start();
+      await emailConsumer.stopConsuming();
+
+      await expect(capturedCallback(payload, 0)).rejects.toThrow(
+        'SHUTDOWN_IN_PROGRESS',
+      );
+      expect(sendUserCertificationMail).not.toHaveBeenCalled();
+    });
+
+    it('stopConsuming은 consumerTag로 consumer를 취소한다', async () => {
+      await emailConsumer.start();
+
+      await emailConsumer.stopConsuming();
+
+      expect(closeConsumer).toHaveBeenCalledWith('test-consumer-tag');
+    });
+
+    it('대기 중인 작업이 없으면 waitForPendingTasks는 즉시 반환한다', async () => {
+      await expect(emailConsumer.waitForPendingTasks()).resolves.toBeUndefined();
+    });
+
+    it('stop은 진행 중인 작업이 모두 끝날 때까지 대기한 후 종료한다', async () => {
+      // waitForPendingTasks의 10초 타임아웃 타이머 누수를 막기 위해 fake timer 사용
+      jest.useFakeTimers();
+      try {
+        const flushMicrotasks = async () => {
+          for (let i = 0; i < 5; i++) await Promise.resolve();
+        };
+        let resolveSend: () => void;
+        sendUserCertificationMail.mockReturnValueOnce(
+          new Promise<void>((resolve) => {
+            resolveSend = resolve;
+          }),
+        );
+        await emailConsumer.start();
+
+        // 작업 시작 (아직 완료되지 않음 → pendingTasks=1)
+        const taskPromise = capturedCallback(payload, 0);
+        await flushMicrotasks();
+
+        // stop 시작 → consumer 취소 후 작업 완료 대기 상태
+        let stopped = false;
+        const stopPromise = emailConsumer.stop().then(() => {
+          stopped = true;
+        });
+        await flushMicrotasks();
+        expect(stopped).toBe(false);
+
+        // 작업 완료 → drain 후 stop 완료
+        resolveSend();
+        await taskPromise;
+        await flushMicrotasks();
+        await stopPromise;
+
+        expect(stopped).toBe(true);
+        expect(closeConsumer).toHaveBeenCalled();
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it('대기 시간이 초과되면 강제로 종료된다', async () => {
+      jest.useFakeTimers();
+      try {
+        sendUserCertificationMail.mockReturnValueOnce(new Promise(() => {}));
+        await emailConsumer.start();
+
+        void capturedCallback(payload, 0);
+        await Promise.resolve();
+
+        const waitPromise = emailConsumer.waitForPendingTasks();
+        jest.advanceTimersByTime(10000);
+
+        await expect(waitPromise).resolves.toBeUndefined();
+      } finally {
+        jest.clearAllTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it('close는 shutdown 중이 아니고 consumerTag가 있으면 consume을 중지한다', async () => {
+      await emailConsumer.start();
+
+      await emailConsumer.close();
+
+      expect(closeConsumer).toHaveBeenCalledWith('test-consumer-tag');
     });
   });
 });

--- a/email-worker/test/unit/discordNotifier.spec.ts
+++ b/email-worker/test/unit/discordNotifier.spec.ts
@@ -1,0 +1,126 @@
+import 'reflect-metadata';
+
+import axios from 'axios';
+
+import { NOTIFICATION_EVENT } from '@notification/notification-event.constant';
+import { DiscordNotifier } from '@notification/discord.notifier';
+
+jest.mock('axios');
+
+const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('DiscordNotifier unit test', () => {
+  const mockWebhookUrl = 'http://discord.test/webhook';
+  let originalWebhookUrl: string | undefined;
+  let mockPost: jest.Mock;
+
+  beforeEach(() => {
+    originalWebhookUrl = process.env.EMAIL_WORKER_DISCORD_WEBHOOK_URL;
+    process.env.EMAIL_WORKER_DISCORD_WEBHOOK_URL = mockWebhookUrl;
+
+    mockPost = jest.fn().mockResolvedValue({ status: 204 });
+    (axios.post as jest.Mock) = mockPost;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    if (originalWebhookUrl !== undefined) {
+      process.env.EMAIL_WORKER_DISCORD_WEBHOOK_URL = originalWebhookUrl;
+    } else {
+      delete process.env.EMAIL_WORKER_DISCORD_WEBHOOK_URL;
+    }
+  });
+
+  describe('생성자 unit test', () => {
+    it('Webhook URL이 없으면 에러를 던진다', () => {
+      delete process.env.EMAIL_WORKER_DISCORD_WEBHOOK_URL;
+
+      expect(() => new DiscordNotifier()).toThrow(
+        'DISCORD Webhook url이 설정되지 않았습니다.',
+      );
+    });
+  });
+
+  describe('publish unit test', () => {
+    it('start 후 EMAIL_DLQ 이벤트를 publish하면 Discord webhook으로 알림을 전송한다', async () => {
+      const notifier = new DiscordNotifier();
+      notifier.start();
+
+      const payload = {
+        error: new Error('SMTP 550'),
+        dlqMessage: '[SMTP 500 에러 발생]',
+      };
+      notifier.publish(NOTIFICATION_EVENT.EMAIL_DLQ, payload);
+
+      await flushAsync();
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+      const [url, body] = mockPost.mock.calls[0] as [string, { content: string }];
+      expect(url).toBe(mockWebhookUrl);
+      expect(body.content).toContain(payload.dlqMessage);
+      expect(body.content).toContain('SMTP 550');
+    });
+
+    it('start를 호출하지 않으면 publish해도 알림을 전송하지 않는다', async () => {
+      const notifier = new DiscordNotifier();
+
+      notifier.publish(NOTIFICATION_EVENT.EMAIL_DLQ, {
+        error: new Error('boom'),
+        dlqMessage: '[테스트]',
+      });
+
+      await flushAsync();
+
+      expect(mockPost).not.toHaveBeenCalled();
+    });
+
+    it('start를 여러 번 호출해도 리스너는 한 번만 등록된다', async () => {
+      const notifier = new DiscordNotifier();
+      notifier.start();
+      notifier.start();
+
+      notifier.publish(NOTIFICATION_EVENT.EMAIL_DLQ, {
+        error: new Error('boom'),
+        dlqMessage: '[테스트]',
+      });
+
+      await flushAsync();
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('webhook 전송이 실패해도 예외를 전파하지 않는다', async () => {
+      mockPost.mockRejectedValueOnce(new Error('network down'));
+      const notifier = new DiscordNotifier();
+      notifier.start();
+
+      expect(() =>
+        notifier.publish(NOTIFICATION_EVENT.EMAIL_DLQ, {
+          error: new Error('boom'),
+          dlqMessage: '[테스트]',
+        }),
+      ).not.toThrow();
+
+      await flushAsync();
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+
+    it('Error 인스턴스가 아닌 값으로 실패해도 예외를 전파하지 않는다', async () => {
+      mockPost.mockRejectedValueOnce('non-error failure');
+      const notifier = new DiscordNotifier();
+      notifier.start();
+
+      expect(() =>
+        notifier.publish(NOTIFICATION_EVENT.EMAIL_DLQ, {
+          error: new Error('boom'),
+          dlqMessage: '[테스트]',
+        }),
+      ).not.toThrow();
+
+      await flushAsync();
+
+      expect(mockPost).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/email-worker/test/unit/emailError.spec.ts
+++ b/email-worker/test/unit/emailError.spec.ts
@@ -1,0 +1,105 @@
+import 'reflect-metadata';
+
+import { classifyEmailError } from '@email/email.error';
+import { NodeMailerError } from '@email/types';
+
+function makeError(
+  message: string,
+  extra: Partial<NodeMailerError> = {},
+): NodeMailerError {
+  const error = new Error(message) as NodeMailerError;
+  Object.assign(error, extra);
+  return error;
+}
+
+describe('classifyEmailError unit test', () => {
+  describe('네트워크 에러 → retryable', () => {
+    const transientCodes = [
+      'ESOCKET',
+      'ECONNECTION',
+      'ECONNRESET',
+      'ECONNREFUSED',
+      'ETIMEDOUT',
+      'EAI_AGAIN',
+      'EDNS',
+    ];
+
+    transientCodes.forEach((code) => {
+      it(`error.code가 ${code}이면 retryable=true, failureType=null`, () => {
+        const error = makeError('network failure', { code });
+
+        expect(classifyEmailError(error)).toEqual({
+          retryable: true,
+          failureType: null,
+        });
+      });
+    });
+
+    it('메시지에 "Unexpected socket close"가 포함되면 retryable=true', () => {
+      const error = makeError('Unexpected socket close');
+
+      expect(classifyEmailError(error)).toEqual({
+        retryable: true,
+        failureType: null,
+      });
+    });
+
+    it('code는 없지만 메시지에 네트워크 코드 문자열이 포함되면 retryable=true', () => {
+      const error = makeError('connect ETIMEDOUT 1.2.3.4:587');
+
+      expect(classifyEmailError(error)).toEqual({
+        retryable: true,
+        failureType: null,
+      });
+    });
+
+    it('message가 비어있고 code도 없으면 네트워크 에러로 판단하지 않는다', () => {
+      const error = makeError('');
+
+      expect(classifyEmailError(error)).toEqual({
+        retryable: false,
+        failureType: 'UNKNOWN_ERROR',
+      });
+    });
+  });
+
+  describe('SMTP responseCode 기반 분류', () => {
+    it('responseCode >= 500이면 SMTP_PERMANENT_FAILURE, retryable=false', () => {
+      const error = makeError('Mailbox unavailable', { responseCode: 550 });
+
+      expect(classifyEmailError(error)).toEqual({
+        retryable: false,
+        failureType: 'SMTP_PERMANENT_FAILURE',
+      });
+    });
+
+    it('responseCode가 400~499이면 retryable=true, failureType=null', () => {
+      const error = makeError('Mailbox busy', { responseCode: 450 });
+
+      expect(classifyEmailError(error)).toEqual({
+        retryable: true,
+        failureType: null,
+      });
+    });
+
+    it('responseCode가 400 미만이면 UNKNOWN_ERROR로 분류한다', () => {
+      const error = makeError('Unexpected response', { responseCode: 250 });
+
+      expect(classifyEmailError(error)).toEqual({
+        retryable: false,
+        failureType: 'UNKNOWN_ERROR',
+      });
+    });
+  });
+
+  describe('분류 불가 에러', () => {
+    it('code도 responseCode도 없으면 UNKNOWN_ERROR', () => {
+      const error = makeError('Something went wrong');
+
+      expect(classifyEmailError(error)).toEqual({
+        retryable: false,
+        failureType: 'UNKNOWN_ERROR',
+      });
+    });
+  });
+});

--- a/email-worker/test/unit/emailMetrics.spec.ts
+++ b/email-worker/test/unit/emailMetrics.spec.ts
@@ -1,0 +1,117 @@
+import 'reflect-metadata';
+
+import * as http from 'node:http';
+import { register } from 'prom-client';
+
+import { EmailMetrics } from '@common/metrics/email-metrics';
+
+jest.mock('node:http', () => ({
+  ...jest.requireActual('node:http'),
+  createServer: jest.fn(),
+}));
+
+const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('EmailMetrics unit test', () => {
+  let originalMetricsPort: string | undefined;
+  let listenMock: jest.Mock;
+  let closeMock: jest.Mock;
+  let requestListener: http.RequestListener;
+
+  beforeEach(() => {
+    // prom-client는 전역 register를 사용하므로 재생성 시 중복 등록 에러 방지
+    register.clear();
+
+    originalMetricsPort = process.env.EMAIL_WORKER_METRICS_PORT;
+
+    listenMock = jest.fn();
+    closeMock = jest.fn();
+    jest.mocked(http.createServer).mockImplementation((...args: unknown[]) => {
+      requestListener = args[0] as http.RequestListener;
+      return { listen: listenMock, close: closeMock } as unknown as http.Server;
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    register.clear();
+    if (originalMetricsPort !== undefined) {
+      process.env.EMAIL_WORKER_METRICS_PORT = originalMetricsPort;
+    } else {
+      delete process.env.EMAIL_WORKER_METRICS_PORT;
+    }
+  });
+
+  describe('생성자 unit test', () => {
+    it('total, success 카운터를 생성한다', () => {
+      const metrics = new EmailMetrics();
+
+      expect(metrics.total).toBeDefined();
+      expect(metrics.success).toBeDefined();
+    });
+
+    it('카운터 inc 호출이 정상 동작한다', () => {
+      const metrics = new EmailMetrics();
+
+      expect(() => {
+        metrics.total.inc();
+        metrics.success.inc();
+      }).not.toThrow();
+    });
+  });
+
+  describe('start unit test', () => {
+    it('기본 포트(9091)로 메트릭 서버를 리슨한다', () => {
+      delete process.env.EMAIL_WORKER_METRICS_PORT;
+      const metrics = new EmailMetrics();
+
+      metrics.start();
+
+      expect(listenMock).toHaveBeenCalledWith(9091);
+    });
+
+    it('EMAIL_WORKER_METRICS_PORT 환경 변수가 있으면 해당 포트로 리슨한다', () => {
+      process.env.EMAIL_WORKER_METRICS_PORT = '12345';
+      const metrics = new EmailMetrics();
+
+      metrics.start();
+
+      expect(listenMock).toHaveBeenCalledWith(12345);
+    });
+
+    it('/metrics 요청 시 prometheus 메트릭을 응답한다', async () => {
+      const metrics = new EmailMetrics();
+      metrics.start();
+
+      const setHeader = jest.fn();
+      const end = jest.fn();
+      const req = { url: '/metrics' } as http.IncomingMessage;
+      const res = { setHeader, end } as unknown as http.ServerResponse;
+
+      requestListener(req, res);
+      await flushAsync();
+
+      expect(setHeader).toHaveBeenCalledWith(
+        'Content-Type',
+        register.contentType,
+      );
+      expect(end).toHaveBeenCalledTimes(1);
+      expect(typeof (end.mock.calls[0] as [string])[0]).toBe('string');
+    });
+
+    it('/metrics 외 경로 요청 시 404를 응답한다', async () => {
+      const metrics = new EmailMetrics();
+      metrics.start();
+
+      const end = jest.fn();
+      const req = { url: '/health' } as http.IncomingMessage;
+      const res = { statusCode: 200, end } as unknown as http.ServerResponse;
+
+      requestListener(req, res);
+      await flushAsync();
+
+      expect(res.statusCode).toBe(404);
+      expect(end).toHaveBeenCalledWith('Not Found');
+    });
+  });
+});

--- a/email-worker/test/unit/emailService.spec.ts
+++ b/email-worker/test/unit/emailService.spec.ts
@@ -4,8 +4,10 @@ import * as nodemailer from 'nodemailer';
 
 import { EmailMetrics } from '@common/metrics/email-metrics';
 import {
+  AdminCertification,
   RssCertification,
   RssRegistration,
+  RssRegistrationRequest,
   RssRemoval,
   User,
 } from '@common/types';
@@ -88,6 +90,24 @@ describe('EmailService unit test', () => {
         },
       });
     });
+
+    it('SMTP_HOST, SMTP_PORT 환경 변수가 있으면 해당 값으로 transporter를 생성한다', () => {
+      process.env.SMTP_HOST = 'smtp.custom.com';
+      process.env.SMTP_PORT = '2525';
+      (nodemailer.createTransport as jest.Mock).mockClear();
+
+      new EmailService(mockEmailMetrics);
+
+      expect(nodemailer.createTransport).toHaveBeenCalledWith({
+        host: 'smtp.custom.com',
+        port: 2525,
+        secure: false,
+        auth: {
+          user: mockEmailUser,
+          pass: mockEmailPassword,
+        },
+      });
+    });
   });
 
   describe('sendUserCertificationMail unit test', () => {
@@ -128,6 +148,19 @@ describe('EmailService unit test', () => {
       await expect(
         emailService.sendUserCertificationMail(user),
       ).rejects.toThrow('SMTP connection failed');
+    });
+
+    it('Error 인스턴스가 아닌 값으로 실패해도 그대로 전파한다', async () => {
+      const user: User = {
+        email: 'user@test.com',
+        userName: 'testUser',
+        uuid: 'test-uuid',
+      };
+      mockSendMail.mockRejectedValue('non-error failure');
+
+      await expect(emailService.sendUserCertificationMail(user)).rejects.toBe(
+        'non-error failure',
+      );
     });
   });
 
@@ -299,6 +332,89 @@ describe('EmailService unit test', () => {
       expect(callArgs.html).toContain(
         `${PRODUCT_DOMAIN}/users/deletion-requests/confirm?token=${user.uuid}`,
       );
+    });
+  });
+
+  describe('sendAdminCertificationMail unit test', () => {
+    it('관리자 계정 인증 메일을 올바르게 전송한다', async () => {
+      const admin: AdminCertification = {
+        email: 'admin@test.com',
+        name: 'adminUser',
+        uuid: 'admin-uuid',
+      };
+
+      await emailService.sendAdminCertificationMail(admin);
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: admin.email,
+          subject: '[🎋 Denamu] 관리자 계정 인증 메일',
+        }),
+      );
+
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(admin.name);
+      expect(callArgs.html).toContain(
+        `${PRODUCT_DOMAIN}/admins/email-verifications?token=${admin.uuid}`,
+      );
+    });
+  });
+
+  describe('sendAdminDeleteAccountMail unit test', () => {
+    it('관리자 회원탈퇴 확인 메일을 올바르게 전송한다', async () => {
+      const admin: AdminCertification = {
+        email: 'admin@test.com',
+        name: 'adminUser',
+        uuid: 'admin-uuid',
+      };
+
+      await emailService.sendAdminDeleteAccountMail(admin);
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: admin.email,
+          subject: '[🎋 Denamu] 관리자 회원탈퇴 확인 메일',
+        }),
+      );
+
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(admin.name);
+      expect(callArgs.html).toContain(
+        `${PRODUCT_DOMAIN}/admins/deletion-requests/confirm?token=${admin.uuid}`,
+      );
+    });
+  });
+
+  describe('sendRssRegistrationRequestMail unit test', () => {
+    it('RSS 등록 신청 접수 메일을 관리자에게 올바르게 전송한다', async () => {
+      const request: RssRegistrationRequest = {
+        rss: {
+          name: 'Test Blog',
+          userName: 'tester',
+          email: 'tester@test.com',
+          rssUrl: 'https://test.com/rss',
+        },
+        adminEmail: 'admin@test.com',
+      };
+
+      await emailService.sendRssRegistrationRequestMail(request);
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: request.adminEmail,
+          subject: '[🎋 Denamu] 새로운 RSS 등록 신청이 접수되었습니다.',
+        }),
+      );
+
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(request.rss.name);
+      expect(callArgs.html).toContain(request.rss.rssUrl);
     });
   });
 });

--- a/email-worker/test/unit/notifierRegistry.spec.ts
+++ b/email-worker/test/unit/notifierRegistry.spec.ts
@@ -1,0 +1,79 @@
+import 'reflect-metadata';
+
+import { NOTIFICATION_EVENT } from '@notification/notification-event.constant';
+import { NotifierRegistry } from '@notification/notifier-registry';
+import { Notifier } from '@notification/notifier.interface';
+
+describe('NotifierRegistry unit test', () => {
+  let registry: NotifierRegistry;
+  let notifierA: Notifier;
+  let notifierB: Notifier;
+  let startA: jest.Mock;
+  let startB: jest.Mock;
+  let publishA: jest.Mock;
+  let publishB: jest.Mock;
+
+  beforeEach(() => {
+    registry = new NotifierRegistry();
+    startA = jest.fn();
+    startB = jest.fn();
+    publishA = jest.fn();
+    publishB = jest.fn();
+    notifierA = { start: startA, publish: publishA };
+    notifierB = { start: startB, publish: publishB };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('start unit test', () => {
+    it('등록된 모든 notifier의 start를 호출한다', () => {
+      registry.register('A', notifierA);
+      registry.register('B', notifierB);
+
+      registry.start();
+
+      expect(startA).toHaveBeenCalledTimes(1);
+      expect(startB).toHaveBeenCalledTimes(1);
+    });
+
+    it('등록된 notifier가 없어도 에러 없이 동작한다', () => {
+      expect(() => registry.start()).not.toThrow();
+    });
+  });
+
+  describe('publish unit test', () => {
+    it('등록된 모든 notifier에 이벤트를 전달한다', () => {
+      registry.register('A', notifierA);
+      registry.register('B', notifierB);
+      const payload = {
+        error: new Error('boom'),
+        dlqMessage: '[테스트]',
+      };
+
+      registry.publish(NOTIFICATION_EVENT.EMAIL_DLQ, payload);
+
+      expect(publishA).toHaveBeenCalledWith(
+        NOTIFICATION_EVENT.EMAIL_DLQ,
+        payload,
+      );
+      expect(publishB).toHaveBeenCalledWith(
+        NOTIFICATION_EVENT.EMAIL_DLQ,
+        payload,
+      );
+    });
+  });
+
+  describe('register unit test', () => {
+    it('같은 이름으로 재등록하면 마지막 notifier로 덮어쓴다', () => {
+      registry.register('A', notifierA);
+      registry.register('A', notifierB);
+
+      registry.start();
+
+      expect(startA).not.toHaveBeenCalled();
+      expect(startB).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #652 

### 단위 테스트 추가/보강

- 미작성 모듈 단위 테스트 신규 작성: `email-metrics`, `discord.notifier`, `notifier-registry`, `email.error`(classify 직접 검증)
- 기존 `consumer`/`emailService` 스펙 확장: ADMIN/RSS_REGISTRATION_REQUEST 타입, graceful shutdown(drain/timeout), SMTP 커스텀 env, non-Error 전파 분기
- 테스트 전용 변경 (프로덕션 소스 무수정). drain 테스트는 `waitForPendingTasks`의 10초 타이머 누수 회피 위해 fake timer 사용

### E2E 시나리오 보강

- 정상 발송 누락 케이스 추가: `RSS_CERTIFICATION`, `RSS_REGISTRATION_REQUEST`, `ADMIN_CERTIFICATION`, `ADMIN_ACCOUNT_DELETION`
- 기존 testcontainers(RabbitMQ + Mailpit) 패턴 그대로 준수

# 📋 작업 내용

CI 측정 기준(`npm run test:coverage` = unit + e2e 통합) 커버리지 비교:

| 구분 | Stmts | Branch | Funcs | Lines |
|---|---|---|---|---|
| 기존 | 78.83 | 71.59 | 71.79 | 78.65 |
| 변경 | **97.3** | **92.04** | **96.42** | **98** |

파일별 주요 상승:

| 파일 | 이전 → 현재 (line) |
|---|---|
| email-metrics.ts | 40% → 100% |
| discord.notifier.ts | 54% → 100% |
| notifier-registry.ts | 미측정 → 100% |
| email.consumer.ts | 74% → 100% |
| email.service.ts | 80% → 100% |
| email.error.ts | 95% → 100% |

- 통합 테스트 결과: **9 suites / 126 tests 전부 통과**
- GIVEN/WHEN/THEN, `jest.Mocked`, env 복원 등 기존 테스트 컨벤션 준수

### 남은 갭 (본 PR 범위 밖, 사전 존재)

- `rabbitmq.manager.ts` `start()`/connect 재사용 분기 (amqp 모킹 필요)
- `logger.ts`, `rabbitmq.service.ts` 일부 non-Error catch 분기