### PR TITLE
♻️ refactor: Feed Crawler 라이프사이클 통합 및 Redis try-catch 정리

### DIFF
--- a/feed-crawler/src/common/database/database-connection.ts
+++ b/feed-crawler/src/common/database/database-connection.ts
@@ -1,5 +1,6 @@
-export interface DatabaseConnection {
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
+
+export interface DatabaseConnection extends Lifecycle {
   executeQuery<T>(query: string, params?: any[]): Promise<T[] | null>;
   executeQueryStrict<T>(query: string, params?: any[]): Promise<T[]>;
-  end(): Promise<void>;
 }

--- a/feed-crawler/src/common/database/mysql-access.ts
+++ b/feed-crawler/src/common/database/mysql-access.ts
@@ -82,7 +82,8 @@ export class MySQLConnection implements DatabaseConnection {
     }
   }
 
-  public async end() {
+  public async stop() {
+    logger.info('데이터 베이스 연결 종료 중...');
     await this.pool.end();
   }
 }

--- a/feed-crawler/src/common/lifecycle/lifecycle.interface.ts
+++ b/feed-crawler/src/common/lifecycle/lifecycle.interface.ts
@@ -1,0 +1,3 @@
+export interface Lifecycle {
+  stop(): Promise<void> | void;
+}

--- a/feed-crawler/src/common/lifecycle/lifecycle.interface.ts
+++ b/feed-crawler/src/common/lifecycle/lifecycle.interface.ts
@@ -1,3 +1,4 @@
 export interface Lifecycle {
-  stop(): Promise<void> | void;
+  start?(): Promise<void> | void;
+  stop?(): Promise<void> | void;
 }

--- a/feed-crawler/src/common/metrics/feed-metrics.ts
+++ b/feed-crawler/src/common/metrics/feed-metrics.ts
@@ -3,8 +3,11 @@ import { injectable } from 'tsyringe';
 import * as http from 'node:http';
 import { collectDefaultMetrics, Counter, Gauge, register } from 'prom-client';
 
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
+import logger from '@common/logger/logger';
+
 @injectable()
-export class FeedMetrics {
+export class FeedMetrics implements Lifecycle {
   readonly total: Counter;
   readonly success: Counter;
   readonly failure: Counter;
@@ -38,7 +41,8 @@ export class FeedMetrics {
     });
   }
 
-  startMetricsServer(port: number) {
+  start(): void {
+    const port = Number(process.env.FEED_CRAWLER_METRICS_PORT) || 9092;
     const handleRequest = async (
       req: http.IncomingMessage,
       res: http.ServerResponse,
@@ -56,5 +60,6 @@ export class FeedMetrics {
       (req, res) => void handleRequest(req, res),
     );
     server.listen(port);
+    logger.info(`Metrics server started on port ${port}`);
   }
 }

--- a/feed-crawler/src/common/notification/discord.notifier.ts
+++ b/feed-crawler/src/common/notification/discord.notifier.ts
@@ -29,7 +29,7 @@ export class DiscordNotifier implements Notifier {
     this.eventEmitter = new EventEmitter();
   }
 
-  initialize() {
+  start() {
     if (!this.initialized) {
       this.eventEmitter.on(
         NOTIFICATION_EVENT.FEED_CRAWLING_SCHEDULED,

--- a/feed-crawler/src/common/notification/notifier-registry.ts
+++ b/feed-crawler/src/common/notification/notifier-registry.ts
@@ -11,8 +11,8 @@ export class NotifierRegistry implements Notifier {
     this.notifiers.set(name, notifier);
   }
 
-  initialize(): void {
-    this.notifiers.forEach((notifier) => notifier.initialize());
+  start(): void {
+    this.notifiers.forEach((notifier) => notifier.start());
   }
 
   publish<K extends keyof NotificationEventPayloadMap>(

--- a/feed-crawler/src/common/notification/notifier.interface.ts
+++ b/feed-crawler/src/common/notification/notifier.interface.ts
@@ -1,7 +1,8 @@
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
 import { NotificationEventPayloadMap } from '@common/notification/notification-event.constant';
 
-export interface Notifier {
-  initialize(): void;
+export interface Notifier extends Lifecycle {
+  start(): void;
   publish<K extends keyof NotificationEventPayloadMap>(
     eventName: K,
     payload: NotificationEventPayloadMap[K],

--- a/feed-crawler/src/common/redis/redis-access.ts
+++ b/feed-crawler/src/common/redis/redis-access.ts
@@ -29,12 +29,15 @@ export class RedisConnection implements Lifecycle {
     }
   }
 
-  async rpop(key: string) {
+  private async execute<T>(
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
     try {
-      return await this.redis.rpop(key);
+      return await fn();
     } catch (error) {
       logger.error(
-        `${this.nameTag} rpop 실행 중 오류 발생:
+        `${this.nameTag} ${operation} 실행 중 오류 발생:
         메시지: ${error instanceof Error ? error.message : String(error)}
         스택 트레이스: ${error instanceof Error ? error.stack : ''}`,
       );
@@ -42,16 +45,12 @@ export class RedisConnection implements Lifecycle {
     }
   }
 
+  async rpop(key: string) {
+    return this.execute('rpop', () => this.redis.rpop(key));
+  }
+
   async rpush(key: string, elements: (string | Buffer | number)[]) {
-    try {
-      await this.redis.rpush(key, ...elements);
-    } catch (error) {
-      logger.error(
-        `${this.nameTag} rpush 실행 중 오류 발생:
-        메시지: ${error instanceof Error ? error.message : String(error)}
-        스택 트레이스: ${error instanceof Error ? error.stack : ''}`,
-      );
-    }
+    await this.execute('rpush', () => this.redis.rpush(key, ...elements));
   }
 
   async stop() {
@@ -70,37 +69,30 @@ export class RedisConnection implements Lifecycle {
   }
 
   async del(...keys: string[]): Promise<number> {
-    return this.redis.del(...keys);
+    return this.execute('del', () => this.redis.del(...keys));
   }
 
   async executePipeline(commands: (pipeline: ChainableCommander) => void) {
-    const pipeline = this.redis.pipeline();
-    try {
+    return this.execute('pipeline', () => {
+      const pipeline = this.redis.pipeline();
       commands(pipeline);
       return pipeline.exec();
-    } catch (error) {
-      logger.error(
-        `${this.nameTag} 파이프라인 실행 중 오류 발생:
-        메시지: ${error instanceof Error ? error.message : String(error)}
-        스택 트레이스: ${error instanceof Error ? error.stack : ''}`,
-      );
-      throw error;
-    }
+    });
   }
 
   async smembers(key: string): Promise<string[]> {
-    return this.redis.smembers(key);
+    return this.execute('smembers', () => this.redis.smembers(key));
   }
 
   async hset(key: string, ...fieldValues: (string | Buffer | number)[]) {
-    await this.redis.hset(key, fieldValues);
+    await this.execute('hset', () => this.redis.hset(key, fieldValues));
   }
 
   async llen(key: string): Promise<number> {
-    return this.redis.llen(key);
+    return this.execute('llen', () => this.redis.llen(key));
   }
 
   async flushall() {
-    await this.redis.flushall();
+    await this.execute('flushall', () => this.redis.flushall());
   }
 }

--- a/feed-crawler/src/common/redis/redis-access.ts
+++ b/feed-crawler/src/common/redis/redis-access.ts
@@ -3,10 +3,11 @@ import { injectable } from 'tsyringe';
 import Redis, { ChainableCommander } from 'ioredis';
 import Redis_Mock from 'ioredis-mock';
 
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
 import logger from '@common/logger/logger';
 
 @injectable()
-export class RedisConnection {
+export class RedisConnection implements Lifecycle {
   private redis: Redis;
   private nameTag: string;
 
@@ -53,7 +54,8 @@ export class RedisConnection {
     }
   }
 
-  async quit() {
+  async stop() {
+    logger.info('Redis 연결 종료 중...');
     if (this.redis) {
       try {
         await this.redis.quit();

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -63,12 +63,12 @@ function registerSchedulers(
   });
 }
 
-async function handleShutdown(shutdownTargets: Lifecycle[], signal: string) {
+async function handleShutdown(components: Lifecycle[], signal: string) {
   try {
     logger.info(`${signal} 신호 수신, feed-crawler 종료 중...`);
 
-    for (const target of shutdownTargets) {
-      await target.stop();
+    for (const component of [...components].reverse()) {
+      await component.stop?.();
     }
 
     logger.info('Feed Crawler 정상 종료');
@@ -81,24 +81,27 @@ async function handleShutdown(shutdownTargets: Lifecycle[], signal: string) {
   }
 }
 
-function startScheduler() {
+async function startScheduler() {
   try {
     logger.info('[Feed Crawler Scheduler Start]');
 
-    const metricsPort = Number(process.env.FEED_CRAWLER_METRICS_PORT) || 9092;
-
     const dependencies = initializeDependencies();
-    dependencies.metrics.startMetricsServer(metricsPort);
-    logger.info(`Metrics server started on port ${metricsPort}`);
-    dependencies.notifier.initialize();
-    registerSchedulers(dependencies);
 
-    const shutdownTargets: Lifecycle[] = [
+    const components: Lifecycle[] = [
+      dependencies.metrics,
+      dependencies.notifier,
       dependencies.dbConnection,
       dependencies.redisConnection,
     ];
-    process.on('SIGINT', () => void handleShutdown(shutdownTargets, 'SIGINT'));
-    process.on('SIGTERM', () => void handleShutdown(shutdownTargets, 'SIGTERM'));
+
+    for (const component of components) {
+      await component.start?.();
+    }
+
+    registerSchedulers(dependencies);
+
+    process.on('SIGINT', () => void handleShutdown(components, 'SIGINT'));
+    process.on('SIGTERM', () => void handleShutdown(components, 'SIGTERM'));
 
     logger.info('[Feed Crawler Scheduler Complete]');
   } catch (error) {
@@ -107,4 +110,4 @@ function startScheduler() {
   }
 }
 
-startScheduler();
+void startScheduler();

--- a/feed-crawler/src/main.ts
+++ b/feed-crawler/src/main.ts
@@ -6,6 +6,7 @@ import '@common/env-load';
 
 import { DatabaseConnection } from '@common/database/database-connection';
 import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
+import { Lifecycle } from '@common/lifecycle/lifecycle.interface';
 import logger from '@common/logger/logger';
 import { FeedMetrics } from '@common/metrics/feed-metrics';
 import { Notifier } from '@common/notification/notifier.interface';
@@ -62,18 +63,13 @@ function registerSchedulers(
   });
 }
 
-async function handleShutdown(
-  dependencies: ReturnType<typeof initializeDependencies>,
-  signal: string,
-) {
+async function handleShutdown(shutdownTargets: Lifecycle[], signal: string) {
   try {
     logger.info(`${signal} 신호 수신, feed-crawler 종료 중...`);
 
-    logger.info('데이터 베이스 연결 종료 중...');
-    await dependencies.dbConnection.end();
-
-    logger.info('Redis 연결 종료 중...');
-    await dependencies.redisConnection.quit();
+    for (const target of shutdownTargets) {
+      await target.stop();
+    }
 
     logger.info('Feed Crawler 정상 종료');
     process.exit(0);
@@ -97,8 +93,12 @@ function startScheduler() {
     dependencies.notifier.initialize();
     registerSchedulers(dependencies);
 
-    process.on('SIGINT', () => void handleShutdown(dependencies, 'SIGINT'));
-    process.on('SIGTERM', () => void handleShutdown(dependencies, 'SIGTERM'));
+    const shutdownTargets: Lifecycle[] = [
+      dependencies.dbConnection,
+      dependencies.redisConnection,
+    ];
+    process.on('SIGINT', () => void handleShutdown(shutdownTargets, 'SIGINT'));
+    process.on('SIGTERM', () => void handleShutdown(shutdownTargets, 'SIGTERM'));
 
     logger.info('[Feed Crawler Scheduler Complete]');
   } catch (error) {

--- a/feed-crawler/test/unit/claude-event-worker.spec.ts
+++ b/feed-crawler/test/unit/claude-event-worker.spec.ts
@@ -87,7 +87,7 @@ describe('ClaudeEventWorker', () => {
     };
 
     mockNotifier = {
-      initialize: jest.fn(),
+      start: jest.fn(),
       publish: jest.fn(),
     };
 

--- a/feed-crawler/test/unit/feed-parser-manager.spec.ts
+++ b/feed-crawler/test/unit/feed-parser-manager.spec.ts
@@ -65,7 +65,7 @@ describe('FeedParserManager', () => {
     } as any;
 
     mockNotifier = {
-      initialize: jest.fn(),
+      start: jest.fn(),
       publish: jest.fn(),
     };
 
@@ -75,7 +75,7 @@ describe('FeedParserManager', () => {
       failure: { inc: jest.fn() },
       fullCrawlQueueDepth: { set: jest.fn() },
       fullCrawlPermanentFailure: { inc: jest.fn() },
-      startMetricsServer: jest.fn(),
+      start: jest.fn(),
     } as any;
 
     feedParserManager = new FeedParserManager(

--- a/feed-crawler/test/unit/parser.spec.ts
+++ b/feed-crawler/test/unit/parser.spec.ts
@@ -30,12 +30,12 @@ describe('Parser 모듈 테스트', () => {
     failure: { inc: jest.fn() },
     fullCrawlQueueDepth: { set: jest.fn() },
     fullCrawlPermanentFailure: { inc: jest.fn() },
-    startMetricsServer: jest.fn(),
+    start: jest.fn(),
   } as unknown as FeedMetrics;
 
   beforeEach(() => {
     parserUtil = new ParserUtil();
-    notifier = { initialize: jest.fn(), publish: jest.fn() };
+    notifier = { start: jest.fn(), publish: jest.fn() };
     rss20Parser = new Rss20Parser(parserUtil, notifier);
     atom10Parser = new Atom10Parser(parserUtil, notifier);
     feedParserManager = new FeedParserManager(


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #651

### Lifecycle 인터페이스 도입

- 기존 `main.ts`는 각 컴포넌트의 시작/종료 메서드(`startMetricsServer`, `initialize`, `end`, `quit`)를 개별적으로 호출하고 있어, 컴포넌트가 늘어날 때마다 부팅/셧다운 로직을 직접 수정해야 했습니다.
- `Lifecycle { start?(); stop?(); }` 인터페이스를 도입해 `FeedMetrics`, `Notifier`, `DatabaseConnection`, `RedisConnection`이 동일한 계약을 따르도록 통일했습니다.
- 부팅은 `components` 배열 순서대로 `start()`, 셧다운은 역순으로 `stop()`을 호출하도록 변경해, 리소스 해제 순서(의존성 역순)를 보장하면서 컴포넌트 추가/제거 시 배열만 수정하면 되도록 했습니다.

### Redis try-catch 정리

- `RedisConnection`의 각 명령어 메서드마다 중복되던 try-catch/로깅 블록을 `execute(operation, fn)` 헬퍼로 통합했습니다.
- 에러 로그 포맷을 한 곳에서 관리하고, 일부 메서드에만 적용돼 있던 에러 핸들링을 전체 명령어로 일관되게 확장했습니다.

# 📋 작업 내용

- `Lifecycle` 인터페이스 신규 추가
- `FeedMetrics.startMetricsServer` → `start()` (메트릭 포트 결정 로직 내부로 이동)
- `DiscordNotifier`/`NotifierRegistry`의 `initialize()` → `start()`, `Notifier`가 `Lifecycle` 확장
- `DatabaseConnection`의 `end()` → `stop()`, `Lifecycle` 확장
- `RedisConnection`의 `quit()` → `stop()`, `Lifecycle` 구현, `execute()` 헬퍼로 try-catch 통합
- `main.ts` 부팅/셧다운 로직을 `Lifecycle[]` 기반으로 리팩토링
- 관련 단위 테스트 메서드명 갱신