### PR TITLE
✅ test: feed-crawler 누락 테스트 보강 및 커버리지 향상

### DIFF
--- a/feed-crawler/test/config/constant/parser-fixtures.ts
+++ b/feed-crawler/test/config/constant/parser-fixtures.ts
@@ -58,6 +58,37 @@ export const ATOM_10_SAMPLE = `<?xml version="1.0" encoding="UTF-8"?>
   </entry>
 </feed>`;
 
+// RSS 2.0 단일 item 데이터 (item이 배열이 아닌 단일 객체로 파싱되는 케이스)
+export const RSS_20_SINGLE_ITEM = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>단일 글 블로그</title>
+    <link>https://rssfeed.com</link>
+    <item>
+      <title>유일한 글</title>
+      <description>유일한 글 내용입니다.</description>
+      <link>https://rssfeed.com/only</link>
+      <pubDate>${FIXED_DATE_UTC}</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+// Atom 1.0 단일 entry 데이터 (entry가 배열이 아닌 단일 객체로 파싱되는 케이스)
+export const ATOM_10_SINGLE_ENTRY = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>단일 글 Atom 피드</title>
+  <link href="https://atomfeed.com"/>
+  <id>https://atomfeed.com</id>
+  <updated>${FIXED_DATE_ISO}</updated>
+  <entry>
+    <title>유일한 Atom 글</title>
+    <link rel="alternate" href="https://atomfeed.com/only"/>
+    <id>https://atomfeed.com/only</id>
+    <published>${FIXED_DATE_ISO}</published>
+    <summary>유일한 글 요약</summary>
+  </entry>
+</feed>`;
+
 // 잘못된 형식의 XML 데이터
 export const INVALID_XML = `<?xml version="1.0"?>
 <invalid>

--- a/feed-crawler/test/e2e/ai-summary-requeue.e2e-spec.ts
+++ b/feed-crawler/test/e2e/ai-summary-requeue.e2e-spec.ts
@@ -1,0 +1,78 @@
+import { setupTestContainer } from '@test/setup/testContext.setup';
+import { ResultSetHeader } from 'mysql2';
+
+import { redisConstant } from '@common/redis/redis.constant';
+
+import { FeedCrawler } from '../../src/feed-crawler';
+
+describe('AI 요약 재요청 e2e-test', () => {
+  const testContext = setupTestContainer();
+  let feedCrawler: FeedCrawler;
+  let rssId: number;
+  let feedId: number;
+  const feedPath = 'https://requeue-test.com/post1';
+
+  beforeAll(async () => {
+    feedCrawler = testContext.feedCrawler;
+
+    const rssData = (await testContext.dbConnection.executeQuery(
+      `INSERT INTO rss_accept (name, user_name, email, rss_url, blog_platform) VALUES (?, ?, ?, ?, ?)`,
+      [
+        'requeue blog',
+        'tester',
+        'test@test.com',
+        'https://requeue-test.com/rss',
+        'etc',
+      ],
+    )) as any as ResultSetHeader;
+    rssId = rssData.insertId;
+
+    const feedData = (await testContext.dbConnection.executeQuery(
+      `INSERT INTO feed (created_at, title, path, thumbnail, blog_id) VALUES (?, ?, ?, ?, ?)`,
+      [new Date(), 'requeue title', feedPath, 'thumb', rssId],
+    )) as any as ResultSetHeader;
+    feedId = feedData.insertId;
+  });
+
+  it('RSS에서 매칭되는 게시글을 찾으면 AI 큐에 다시 적재된다.', async () => {
+    // given - RSS 파싱 결과가 DB의 feed.path와 동일한 link를 갖도록 모킹
+    jest
+      .spyOn(testContext.feedParserManager, 'fetchAndParseAll')
+      .mockResolvedValue([
+        {
+          id: null,
+          blogId: rssId,
+          blogName: 'requeue blog',
+          blogPlatform: 'etc',
+          title: 'requeue title',
+          link: feedPath,
+          pubDate: new Date().toISOString().slice(0, 19).replace('T', ' '),
+          imageUrl: 'thumb',
+          content: 'requeue content',
+          summary: '요약 생성 중...',
+          deathCount: 0,
+        },
+      ]);
+
+    // when
+    await feedCrawler.requeueFeedForAiSummary(feedId);
+
+    // then - 실제 feed/rss repository를 거쳐 Redis AI 큐에 적재됨
+    const aiQueue = await testContext.redisConnection.executePipeline(
+      (pipeline) => {
+        pipeline.lrange(redisConstant.FEED_AI_QUEUE, 0, -1);
+      },
+    );
+    const queued = (aiQueue[0][1] as string[]).map(
+      (item) => JSON.parse(item) as { id: number },
+    );
+
+    expect(queued.some((item) => item.id === feedId)).toBe(true);
+  });
+
+  it('존재하지 않는 feedId면 PermanentError를 던진다.', async () => {
+    await expect(feedCrawler.requeueFeedForAiSummary(999999)).rejects.toThrow(
+      '피드를 찾을 수 없습니다: 999999',
+    );
+  });
+});

--- a/feed-crawler/test/unit/ai-summary-retry-event-worker.spec.ts
+++ b/feed-crawler/test/unit/ai-summary-retry-event-worker.spec.ts
@@ -1,0 +1,152 @@
+import 'reflect-metadata';
+
+import { AiSummaryRetryMessage } from '@common/ai/ai.type';
+import logger from '@common/logger/logger';
+import { RedisConnection } from '@common/redis/redis-access';
+import { redisConstant } from '@common/redis/redis.constant';
+
+import { AiSummaryRetryEventWorker } from '@event_worker/workers/ai-summary-retry-event-worker';
+
+import { FeedCrawler } from '../../src/feed-crawler';
+
+describe('AiSummaryRetryEventWorker', () => {
+  let worker: AiSummaryRetryEventWorker;
+  let mockRedisConnection: jest.Mocked<RedisConnection>;
+  let mockFeedCrawler: jest.Mocked<FeedCrawler>;
+  let rpopMock: jest.Mock;
+  let delMock: jest.Mock;
+  let requeueMock: jest.Mock;
+
+  const retryMessage: AiSummaryRetryMessage = { feedId: 7, deathCount: 0 };
+
+  beforeEach(() => {
+    rpopMock = jest.fn();
+    delMock = jest.fn();
+    requeueMock = jest.fn();
+
+    mockRedisConnection = {
+      rpop: rpopMock,
+      del: delMock,
+      rpush: jest.fn(),
+    } as any;
+
+    mockFeedCrawler = {
+      requeueFeedForAiSummary: requeueMock,
+    } as any;
+
+    worker = new AiSummaryRetryEventWorker(
+      mockRedisConnection,
+      mockFeedCrawler,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('processQueue', () => {
+    it('큐가 비어있으면 처리하지 않아야 한다', async () => {
+      // Given
+      rpopMock.mockResolvedValue(null);
+
+      // When
+      await worker['processQueue']();
+
+      // Then
+      expect(requeueMock).not.toHaveBeenCalled();
+    });
+
+    it('메시지가 있으면 파싱하여 processItem을 호출해야 한다', async () => {
+      // Given
+      rpopMock.mockResolvedValue(JSON.stringify(retryMessage));
+      const processItemSpy = jest
+        .spyOn(worker as any, 'processItem')
+        .mockResolvedValue(undefined);
+
+      // When
+      await worker['processQueue']();
+
+      // Then
+      expect(rpopMock).toHaveBeenCalledWith(redisConstant.FEED_AI_RETRY_QUEUE);
+      expect(processItemSpy).toHaveBeenCalledWith(retryMessage);
+    });
+  });
+
+  describe('processItem', () => {
+    it('feedCrawler.requeueFeedForAiSummary를 호출해야 한다', async () => {
+      // Given
+      requeueMock.mockResolvedValue(undefined);
+
+      // When
+      await worker['processItem'](retryMessage);
+
+      // Then
+      expect(requeueMock).toHaveBeenCalledWith(retryMessage.feedId);
+    });
+
+    it('에러 발생 시 handleFailure를 호출해야 한다', async () => {
+      // Given
+      const error = new Error('재요청 실패');
+      requeueMock.mockRejectedValue(error);
+      const handleFailureSpy = jest
+        .spyOn(worker as any, 'handleFailure')
+        .mockResolvedValue(undefined);
+
+      // When
+      await worker['processItem'](retryMessage);
+
+      // Then
+      expect(handleFailureSpy).toHaveBeenCalledWith(retryMessage, error);
+    });
+  });
+
+  describe('onPermanentFailure', () => {
+    it('영구 실패 시 재요청 락을 해제해야 한다', async () => {
+      // Given
+      delMock.mockResolvedValue(undefined);
+
+      // When
+      await worker['onPermanentFailure'](retryMessage);
+
+      // Then
+      expect(delMock).toHaveBeenCalledWith(
+        `${redisConstant.FEED_AI_RETRY_LOCK}:${retryMessage.feedId}`,
+      );
+    });
+
+    it('락 해제가 실패해도 예외를 던지지 않고 로깅해야 한다', async () => {
+      // Given
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation();
+      delMock.mockRejectedValue(new Error('redis down'));
+
+      // When & Then
+      await expect(
+        worker['onPermanentFailure'](retryMessage),
+      ).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('AI 재요청 락 해제 실패'),
+      );
+    });
+  });
+
+  describe('queue key accessors', () => {
+    it('getQueueKey와 getRetryQueueKey는 AI 재시도 큐를 반환해야 한다', () => {
+      expect(worker['getQueueKey']()).toBe(redisConstant.FEED_AI_RETRY_QUEUE);
+      expect(worker['getRetryQueueKey']()).toBe(
+        redisConstant.FEED_AI_RETRY_QUEUE,
+      );
+    });
+
+    it('getItemLabel은 feedId를 포함해야 한다', () => {
+      expect(worker['getItemLabel'](retryMessage)).toBe(
+        `feedId ${retryMessage.feedId}`,
+      );
+    });
+
+    it('parseQueueMessage는 JSON을 파싱해야 한다', () => {
+      expect(worker['parseQueueMessage'](JSON.stringify(retryMessage))).toEqual(
+        retryMessage,
+      );
+    });
+  });
+});

--- a/feed-crawler/test/unit/claude-event-worker.spec.ts
+++ b/feed-crawler/test/unit/claude-event-worker.spec.ts
@@ -11,8 +11,8 @@ import { redisConstant } from '@common/redis/redis.constant';
 import { ClaudeEventWorker } from '@event_worker/workers/claude-event-worker';
 
 import { FeedRepository } from '@repository/feed.repository';
-import { TagRepository } from '@repository/tag.repository';
 import { TagMapRepository } from '@repository/tag-map.repository';
+import { TagRepository } from '@repository/tag.repository';
 
 describe('ClaudeEventWorker', () => {
   let claudeEventWorker: ClaudeEventWorker;
@@ -406,6 +406,90 @@ describe('ClaudeEventWorker', () => {
         JSON.stringify({ ...feedWithDeathCount2, deathCount: 3 }),
       ]);
       expect(updateNullSummaryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getQueueKey', () => {
+    it('AI 큐 키를 반환해야 한다', () => {
+      expect(claudeEventWorker['getQueueKey']()).toBe(
+        redisConstant.FEED_AI_QUEUE,
+      );
+    });
+  });
+
+  describe('loadFeeds 파이프라인', () => {
+    it('AI_RATE_LIMIT_COUNT만큼 rpop을 파이프라인에 등록해야 한다', async () => {
+      // Given
+      process.env.AI_RATE_LIMIT_COUNT = '3';
+      const pipelineRpop = jest.fn();
+      executePipelineMock.mockImplementation((cb: (pipeline: any) => void) => {
+        cb({ rpop: pipelineRpop });
+        return Promise.resolve([]);
+      });
+
+      // When
+      await claudeEventWorker['loadFeeds']();
+
+      // Then
+      expect(pipelineRpop).toHaveBeenCalledTimes(3);
+      expect(pipelineRpop).toHaveBeenCalledWith(redisConstant.FEED_AI_QUEUE);
+    });
+  });
+
+  describe('requestAI 실패 처리', () => {
+    it('Anthropic API 호출이 실패하면 에러를 전파해야 한다', async () => {
+      // Given
+      messagesCreateMock.mockRejectedValue(new Error('API down'));
+
+      // When & Then
+      await expect(
+        claudeEventWorker['requestAI'](mockFeedAIQueueItem),
+      ).rejects.toThrow('API down');
+    });
+
+    it('응답에 JSON이 없으면 RetryableError를 던져야 한다', async () => {
+      // Given
+      messagesCreateMock.mockResolvedValue({
+        content: [{ text: 'JSON이 아닌 응답' }],
+      } as any);
+
+      // When & Then
+      await expect(
+        claudeEventWorker['requestAI'](mockFeedAIQueueItem),
+      ).rejects.toThrow(RetryableError);
+    });
+  });
+
+  describe('saveAIResult 실패 처리', () => {
+    it('Redis hset이 실패하면 에러를 전파해야 한다', async () => {
+      // Given
+      const feedWithAIResult = {
+        ...mockFeedAIQueueItem,
+        summary: mockClaudeResponse.summary,
+        tagList: Object.keys(mockClaudeResponse.tags),
+      };
+      hsetMock.mockRejectedValue(new Error('redis down'));
+
+      // When & Then
+      await expect(
+        claudeEventWorker['saveAIResult'](feedWithAIResult),
+      ).rejects.toThrow('redis down');
+      expect(updateSummaryMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('pushToRetryQueue 실패 처리', () => {
+    it('재시도 큐 재투입이 실패하면 에러를 전파해야 한다', async () => {
+      // Given
+      rpushMock.mockRejectedValue(new Error('redis down'));
+
+      // When & Then
+      await expect(
+        claudeEventWorker['pushToRetryQueue'](mockFeedAIQueueItem),
+      ).rejects.toThrow('redis down');
+      expect(rpushMock).toHaveBeenCalledWith(redisConstant.FEED_AI_QUEUE, [
+        JSON.stringify(mockFeedAIQueueItem),
+      ]);
     });
   });
 

--- a/feed-crawler/test/unit/discord-notifier.spec.ts
+++ b/feed-crawler/test/unit/discord-notifier.spec.ts
@@ -1,0 +1,166 @@
+import 'reflect-metadata';
+
+import axios from 'axios';
+
+import logger from '@common/logger/logger';
+import { DiscordNotifier } from '@common/notification/discord.notifier';
+import { NOTIFICATION_EVENT } from '@common/notification/notification-event.constant';
+
+const flushAsync = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('DiscordNotifier', () => {
+  const WEBHOOK_URL = 'https://discord.com/api/webhooks/test';
+  let mockAxiosPost: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env.FEED_CRAWLER_DISCORD_WEBHOOK_URL = WEBHOOK_URL;
+    mockAxiosPost = jest.spyOn(axios, 'post').mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.FEED_CRAWLER_DISCORD_WEBHOOK_URL;
+  });
+
+  describe('constructor', () => {
+    it('webhook URL이 설정되지 않으면 에러를 던져야 한다', () => {
+      // Given
+      delete process.env.FEED_CRAWLER_DISCORD_WEBHOOK_URL;
+
+      // When & Then
+      expect(() => new DiscordNotifier()).toThrow(
+        'DISCORD Webhook url이 설정되지 않았습니다.',
+      );
+    });
+
+    it('webhook URL이 설정되면 정상적으로 생성되어야 한다', () => {
+      expect(() => new DiscordNotifier()).not.toThrow();
+    });
+  });
+
+  describe('publish', () => {
+    it('start() 이전에는 이벤트를 발행해도 아무 일도 일어나지 않아야 한다', async () => {
+      // Given - start() 호출 전에는 리스너가 등록되지 않음
+      const notifier = new DiscordNotifier();
+
+      // When
+      notifier.publish(NOTIFICATION_EVENT.FEED_CRAWLING_SCHEDULED, {
+        error: new Error('boom'),
+        blogUrl: 'https://blog.com/rss',
+        errorSource: '[Scheduled FeedCrawling]',
+      });
+      await flushAsync();
+
+      // Then
+      expect(mockAxiosPost).not.toHaveBeenCalled();
+    });
+
+    it('scheduled 크롤링 이벤트를 Discord webhook으로 전송해야 한다', async () => {
+      // Given
+      const notifier = new DiscordNotifier();
+      notifier.start();
+
+      // When
+      notifier.publish(NOTIFICATION_EVENT.FEED_CRAWLING_SCHEDULED, {
+        error: new Error('scheduled 에러'),
+        blogUrl: 'https://blog.com/rss',
+        errorSource: '[Scheduled FeedCrawling]',
+      });
+      await flushAsync();
+
+      // Then
+      expect(mockAxiosPost).toHaveBeenCalledWith(
+        WEBHOOK_URL,
+        expect.objectContaining({
+          content: expect.stringContaining('scheduled 에러'),
+        }),
+      );
+    });
+
+    it('full 크롤링 이벤트를 Discord webhook으로 전송해야 한다', async () => {
+      // Given
+      const notifier = new DiscordNotifier();
+      notifier.start();
+
+      // When
+      notifier.publish(NOTIFICATION_EVENT.FEED_CRAWLING_FULL, {
+        error: new Error('full 에러'),
+        blogUrl: 'https://blog.com/rss',
+        errorSource: '[Full FeedCrawling]',
+      });
+      await flushAsync();
+
+      // Then
+      expect(mockAxiosPost).toHaveBeenCalledWith(
+        WEBHOOK_URL,
+        expect.objectContaining({
+          content: expect.stringContaining('full feed crawling'),
+        }),
+      );
+    });
+
+    it('AI 요약 이벤트를 Discord webhook으로 전송해야 한다', async () => {
+      // Given
+      const notifier = new DiscordNotifier();
+      notifier.start();
+
+      // When
+      notifier.publish(NOTIFICATION_EVENT.AI_SUMMARY, {
+        error: new Error('ai 에러'),
+        feedId: 42,
+        errorSource: '[AI Summary]',
+      });
+      await flushAsync();
+
+      // Then
+      expect(mockAxiosPost).toHaveBeenCalledWith(
+        WEBHOOK_URL,
+        expect.objectContaining({
+          content: expect.stringContaining('42번 Feed AI 요약'),
+        }),
+      );
+    });
+
+    it('webhook 전송이 실패해도 예외를 던지지 않고 에러를 로깅해야 한다', async () => {
+      // Given
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation();
+      mockAxiosPost.mockRejectedValue(new Error('network down'));
+      const notifier = new DiscordNotifier();
+      notifier.start();
+
+      // When
+      notifier.publish(NOTIFICATION_EVENT.AI_SUMMARY, {
+        error: new Error('ai 에러'),
+        feedId: 1,
+        errorSource: '[AI Summary]',
+      });
+      await flushAsync();
+
+      // Then
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Discord 알림 전송 실패:',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('start', () => {
+    it('여러 번 호출해도 리스너가 중복 등록되지 않아야 한다 (멱등성)', async () => {
+      // Given
+      const notifier = new DiscordNotifier();
+      notifier.start();
+      notifier.start();
+
+      // When
+      notifier.publish(NOTIFICATION_EVENT.AI_SUMMARY, {
+        error: new Error('ai 에러'),
+        feedId: 1,
+        errorSource: '[AI Summary]',
+      });
+      await flushAsync();
+
+      // Then - 중복 등록되었다면 2번 호출됨
+      expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/feed-crawler/test/unit/feed-crawler.spec.ts
+++ b/feed-crawler/test/unit/feed-crawler.spec.ts
@@ -1,5 +1,8 @@
 import 'reflect-metadata';
 
+import axios from 'axios';
+
+import { PermanentError, RetryableError } from '@common/errors';
 import { FeedDetail, RssObj } from '@common/feed/feed.type';
 import { FeedParserManager } from '@common/parser/feed-parser-manager';
 
@@ -18,6 +21,8 @@ describe('FeedCrawler', () => {
   let saveAiQueueMock: jest.Mock;
   let setRecentFeedListMock: jest.Mock;
   let selectAllRssMock: jest.Mock;
+  let selectFeedByIdMock: jest.Mock;
+  let selectRssByIdMock: jest.Mock;
   let fetchAndParseMock: jest.Mock;
   let fetchAndParseAllMock: jest.Mock;
 
@@ -73,6 +78,8 @@ describe('FeedCrawler', () => {
     saveAiQueueMock = jest.fn();
     setRecentFeedListMock = jest.fn();
     selectAllRssMock = jest.fn();
+    selectFeedByIdMock = jest.fn();
+    selectRssByIdMock = jest.fn();
     fetchAndParseMock = jest.fn();
     fetchAndParseAllMock = jest.fn();
 
@@ -83,11 +90,12 @@ describe('FeedCrawler', () => {
       setRecentFeedList: setRecentFeedListMock,
       updateSummary: jest.fn(),
       updateNullSummary: jest.fn(),
+      selectFeedById: selectFeedByIdMock,
     } as any;
 
     mockRssRepository = {
       selectAllRss: selectAllRssMock,
-      selectRssById: jest.fn(),
+      selectRssById: selectRssByIdMock,
     } as any;
 
     mockFeedParserManager = {
@@ -255,6 +263,117 @@ describe('FeedCrawler', () => {
       // Then
       expect(fetchAndParseMock).not.toHaveBeenCalled();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('requeueFeedForAiSummary', () => {
+    const mockFeed = { id: 10, blogId: 1, path: 'https://test1.tistory.com/1' };
+    let axiosGetSpy: jest.SpyInstance;
+
+    afterEach(() => {
+      axiosGetSpy?.mockRestore();
+    });
+
+    it('RSS에서 매칭되는 게시글을 찾으면 AI 큐에 다시 넣어야 한다', async () => {
+      // Given
+      selectFeedByIdMock.mockResolvedValue(mockFeed);
+      selectRssByIdMock.mockResolvedValue(mockRssObjects[0]);
+      fetchAndParseAllMock.mockResolvedValue([
+        { ...mockFeedDetails[0], link: mockFeed.path },
+      ]);
+
+      // When
+      await feedCrawler.requeueFeedForAiSummary(mockFeed.id);
+
+      // Then
+      expect(selectFeedByIdMock).toHaveBeenCalledWith(mockFeed.id);
+      expect(selectRssByIdMock).toHaveBeenCalledWith(mockFeed.blogId);
+      expect(saveAiQueueMock).toHaveBeenCalledWith([
+        expect.objectContaining({ id: mockFeed.id, deathCount: 0 }),
+      ]);
+    });
+
+    it('피드를 찾을 수 없으면 PermanentError를 던져야 한다', async () => {
+      // Given
+      selectFeedByIdMock.mockResolvedValue(null);
+
+      // When & Then
+      await expect(
+        feedCrawler.requeueFeedForAiSummary(mockFeed.id),
+      ).rejects.toThrow(PermanentError);
+      expect(saveAiQueueMock).not.toHaveBeenCalled();
+    });
+
+    it('RSS를 찾을 수 없으면 PermanentError를 던져야 한다', async () => {
+      // Given
+      selectFeedByIdMock.mockResolvedValue(mockFeed);
+      selectRssByIdMock.mockResolvedValue(null);
+
+      // When & Then
+      await expect(
+        feedCrawler.requeueFeedForAiSummary(mockFeed.id),
+      ).rejects.toThrow(PermanentError);
+      expect(saveAiQueueMock).not.toHaveBeenCalled();
+    });
+
+    describe('RSS에 매칭되는 게시글이 없을 때', () => {
+      beforeEach(() => {
+        selectFeedByIdMock.mockResolvedValue(mockFeed);
+        selectRssByIdMock.mockResolvedValue(mockRssObjects[0]);
+        // 다른 link만 반환하여 매칭 실패 유도
+        fetchAndParseAllMock.mockResolvedValue([
+          { ...mockFeedDetails[0], link: 'https://other.com/different' },
+        ]);
+      });
+
+      it('원본 HTTP 200이면 PermanentError를 던져야 한다 (오래된 게시글)', async () => {
+        // Given
+        axiosGetSpy = jest
+          .spyOn(axios, 'get')
+          .mockResolvedValue({ status: 200 });
+
+        // When & Then
+        await expect(
+          feedCrawler.requeueFeedForAiSummary(mockFeed.id),
+        ).rejects.toThrow(PermanentError);
+        expect(saveAiQueueMock).not.toHaveBeenCalled();
+      });
+
+      it('원본 HTTP 404이면 PermanentError를 던져야 한다 (삭제된 게시글)', async () => {
+        // Given
+        axiosGetSpy = jest
+          .spyOn(axios, 'get')
+          .mockResolvedValue({ status: 404 });
+
+        // When & Then
+        await expect(
+          feedCrawler.requeueFeedForAiSummary(mockFeed.id),
+        ).rejects.toThrow(PermanentError);
+      });
+
+      it('원본 HTTP 500이면 RetryableError를 던져야 한다 (일시적 서버 오류)', async () => {
+        // Given
+        axiosGetSpy = jest
+          .spyOn(axios, 'get')
+          .mockResolvedValue({ status: 500 });
+
+        // When & Then
+        await expect(
+          feedCrawler.requeueFeedForAiSummary(mockFeed.id),
+        ).rejects.toThrow(RetryableError);
+      });
+
+      it('원본 요청이 네트워크 에러로 실패하면 RetryableError를 던져야 한다', async () => {
+        // Given
+        axiosGetSpy = jest
+          .spyOn(axios, 'get')
+          .mockRejectedValue(new Error('ECONNREFUSED'));
+
+        // When & Then
+        await expect(
+          feedCrawler.requeueFeedForAiSummary(mockFeed.id),
+        ).rejects.toThrow(RetryableError);
+      });
     });
   });
 });

--- a/feed-crawler/test/unit/feed-parser-manager.spec.ts
+++ b/feed-crawler/test/unit/feed-parser-manager.spec.ts
@@ -20,6 +20,12 @@ describe('FeedParserManager', () => {
   let rss20ParseFeedMock: jest.Mock;
   let atom10CanParseMock: jest.Mock;
   let atom10ParseFeedMock: jest.Mock;
+  let rss20ParseAllFeedsMock: jest.Mock;
+  let atom10ParseAllFeedsMock: jest.Mock;
+  let metricsTotalIncMock: jest.Mock;
+  let metricsSuccessIncMock: jest.Mock;
+  let metricsFailureIncMock: jest.Mock;
+  let notifierPublishMock: jest.Mock;
 
   const mockRssObj: RssObj = {
     id: 1,
@@ -52,27 +58,34 @@ describe('FeedParserManager', () => {
     atom10CanParseMock = jest.fn();
     atom10ParseFeedMock = jest.fn();
 
+    rss20ParseAllFeedsMock = jest.fn();
+    atom10ParseAllFeedsMock = jest.fn();
+
     mockRss20Parser = {
       canParse: rss20CanParseMock,
       parseFeed: rss20ParseFeedMock,
-      parseAllFeeds: jest.fn(),
+      parseAllFeeds: rss20ParseAllFeedsMock,
     } as any;
 
     mockAtom10Parser = {
       canParse: atom10CanParseMock,
       parseFeed: atom10ParseFeedMock,
-      parseAllFeeds: jest.fn(),
+      parseAllFeeds: atom10ParseAllFeedsMock,
     } as any;
 
+    notifierPublishMock = jest.fn();
     mockNotifier = {
       start: jest.fn(),
-      publish: jest.fn(),
+      publish: notifierPublishMock,
     };
 
+    metricsTotalIncMock = jest.fn();
+    metricsSuccessIncMock = jest.fn();
+    metricsFailureIncMock = jest.fn();
     mockFeedMetrics = {
-      total: { inc: jest.fn() },
-      success: { inc: jest.fn() },
-      failure: { inc: jest.fn() },
+      total: { inc: metricsTotalIncMock },
+      success: { inc: metricsSuccessIncMock },
+      failure: { inc: metricsFailureIncMock },
       fullCrawlQueueDepth: { set: jest.fn() },
       fullCrawlPermanentFailure: { inc: jest.fn() },
       start: jest.fn(),
@@ -206,6 +219,102 @@ describe('FeedParserManager', () => {
         mockRssObj,
         startTime,
       );
+
+      // Then
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchAndParseAll', () => {
+    it('RSS 2.0 전체 피드를 성공적으로 파싱해야 한다', async () => {
+      // Given
+      const rssXmlData = '<?xml version="1.0"?><rss version="2.0">...</rss>';
+      mockAxiosGet.mockResolvedValueOnce({
+        data: rssXmlData,
+        status: HttpStatusCode.Ok,
+      });
+      rss20CanParseMock.mockReturnValue(true);
+      atom10CanParseMock.mockReturnValue(false);
+      rss20ParseAllFeedsMock.mockResolvedValue(mockFeedDetails);
+
+      // When
+      const result = await feedParserManager.fetchAndParseAll(mockRssObj);
+
+      // Then
+      expect(rss20ParseAllFeedsMock).toHaveBeenCalledWith(
+        mockRssObj,
+        rssXmlData,
+      );
+      expect(result).toEqual(mockFeedDetails);
+      expect(metricsTotalIncMock).toHaveBeenCalledWith({ type: 'full' });
+      expect(metricsSuccessIncMock).toHaveBeenCalledWith({ type: 'full' });
+    });
+
+    it('Atom 1.0 전체 피드를 성공적으로 파싱해야 한다', async () => {
+      // Given
+      const atomXmlData =
+        '<?xml version="1.0"?><feed xmlns="http://www.w3.org/2005/Atom">...</feed>';
+      mockAxiosGet.mockResolvedValueOnce({
+        data: atomXmlData,
+        status: HttpStatusCode.Ok,
+      });
+      rss20CanParseMock.mockReturnValue(false);
+      atom10CanParseMock.mockReturnValue(true);
+      atom10ParseAllFeedsMock.mockResolvedValue(mockFeedDetails);
+
+      // When
+      const result = await feedParserManager.fetchAndParseAll(mockRssObj);
+
+      // Then
+      expect(atom10ParseAllFeedsMock).toHaveBeenCalledWith(
+        mockRssObj,
+        atomXmlData,
+      );
+      expect(result).toEqual(mockFeedDetails);
+    });
+
+    it('HTTP 요청이 실패하면 빈 배열을 반환하고 알림을 발행해야 한다', async () => {
+      // Given
+      mockAxiosGet.mockRejectedValueOnce(new Error('Network error'));
+
+      // When
+      const result = await feedParserManager.fetchAndParseAll(mockRssObj);
+
+      // Then
+      expect(result).toEqual([]);
+      expect(metricsFailureIncMock).toHaveBeenCalledWith({ type: 'full' });
+      expect(notifierPublishMock).toHaveBeenCalled();
+    });
+
+    it('지원하지 않는 피드 형식이면 빈 배열을 반환해야 한다', async () => {
+      // Given
+      mockAxiosGet.mockResolvedValueOnce({
+        data: '<?xml version="1.0"?><invalid>...</invalid>',
+        status: HttpStatusCode.Ok,
+      });
+      rss20CanParseMock.mockReturnValue(false);
+      atom10CanParseMock.mockReturnValue(false);
+
+      // When
+      const result = await feedParserManager.fetchAndParseAll(mockRssObj);
+
+      // Then
+      expect(result).toEqual([]);
+      expect(metricsFailureIncMock).toHaveBeenCalledWith({ type: 'full' });
+    });
+
+    it('파서에서 에러가 발생하면 빈 배열을 반환해야 한다', async () => {
+      // Given
+      const rssXmlData = '<?xml version="1.0"?><rss version="2.0">...</rss>';
+      mockAxiosGet.mockResolvedValueOnce({
+        data: rssXmlData,
+        status: HttpStatusCode.Ok,
+      });
+      rss20CanParseMock.mockReturnValue(true);
+      rss20ParseAllFeedsMock.mockRejectedValueOnce(new Error('Parser error'));
+
+      // When
+      const result = await feedParserManager.fetchAndParseAll(mockRssObj);
 
       // Then
       expect(result).toEqual([]);

--- a/feed-crawler/test/unit/full-feed-crawl-event-worker.spec.ts
+++ b/feed-crawler/test/unit/full-feed-crawl-event-worker.spec.ts
@@ -1,0 +1,188 @@
+import 'reflect-metadata';
+
+import { FullFeedCrawlMessage, RssObj } from '@common/feed/feed.type';
+import { FeedMetrics } from '@common/metrics/feed-metrics';
+import { RedisConnection } from '@common/redis/redis-access';
+import { redisConstant } from '@common/redis/redis.constant';
+
+import { FullFeedCrawlEventWorker } from '@event_worker/workers/full-feed-crawl-event-worker';
+
+import { RssRepository } from '@repository/rss.repository';
+
+import { FeedCrawler } from '../../src/feed-crawler';
+
+describe('FullFeedCrawlEventWorker', () => {
+  let worker: FullFeedCrawlEventWorker;
+  let mockRedisConnection: jest.Mocked<RedisConnection>;
+  let mockRssRepository: jest.Mocked<RssRepository>;
+  let mockFeedCrawler: jest.Mocked<FeedCrawler>;
+  let mockFeedMetrics: jest.Mocked<FeedMetrics>;
+  let llenMock: jest.Mock;
+  let rpopMock: jest.Mock;
+  let selectRssByIdMock: jest.Mock;
+  let startFullCrawlMock: jest.Mock;
+  let queueDepthSetMock: jest.Mock;
+  let permanentFailureIncMock: jest.Mock;
+
+  const crawlMessage: FullFeedCrawlMessage = {
+    rssId: 3,
+    timestamp: Date.now(),
+    deathCount: 0,
+  };
+
+  const rssObj: RssObj = {
+    id: 3,
+    blogName: '테스트 블로그',
+    blogPlatform: 'tistory',
+    rssUrl: 'https://test.tistory.com/rss',
+  };
+
+  beforeEach(() => {
+    llenMock = jest.fn().mockResolvedValue(0);
+    rpopMock = jest.fn();
+    selectRssByIdMock = jest.fn();
+    startFullCrawlMock = jest.fn();
+
+    mockRedisConnection = {
+      llen: llenMock,
+      rpop: rpopMock,
+      rpush: jest.fn(),
+    } as any;
+
+    mockRssRepository = {
+      selectRssById: selectRssByIdMock,
+    } as any;
+
+    mockFeedCrawler = {
+      startFullCrawl: startFullCrawlMock,
+    } as any;
+
+    queueDepthSetMock = jest.fn();
+    permanentFailureIncMock = jest.fn();
+    mockFeedMetrics = {
+      fullCrawlQueueDepth: { set: queueDepthSetMock },
+      fullCrawlPermanentFailure: { inc: permanentFailureIncMock },
+    } as any;
+
+    worker = new FullFeedCrawlEventWorker(
+      mockRedisConnection,
+      mockRssRepository,
+      mockFeedCrawler,
+      mockFeedMetrics,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('processQueue', () => {
+    it('큐 깊이를 메트릭에 기록해야 한다', async () => {
+      // Given
+      llenMock.mockResolvedValue(5);
+      rpopMock.mockResolvedValue(null);
+
+      // When
+      await worker['processQueue']();
+
+      // Then
+      expect(queueDepthSetMock).toHaveBeenCalledWith(5);
+    });
+
+    it('큐가 비어있으면 처리하지 않아야 한다', async () => {
+      // Given
+      rpopMock.mockResolvedValue(null);
+      const processItemSpy = jest.spyOn(worker as any, 'processItem');
+
+      // When
+      await worker['processQueue']();
+
+      // Then
+      expect(processItemSpy).not.toHaveBeenCalled();
+    });
+
+    it('메시지가 있으면 파싱하여 processItem을 호출해야 한다', async () => {
+      // Given
+      rpopMock.mockResolvedValue(JSON.stringify(crawlMessage));
+      const processItemSpy = jest
+        .spyOn(worker as any, 'processItem')
+        .mockResolvedValue(undefined);
+
+      // When
+      await worker['processQueue']();
+
+      // Then
+      expect(rpopMock).toHaveBeenCalledWith(
+        redisConstant.FULL_FEED_CRAWL_QUEUE,
+      );
+      expect(processItemSpy).toHaveBeenCalledWith(crawlMessage);
+    });
+  });
+
+  describe('processItem', () => {
+    it('RSS를 찾을 수 없으면 크롤링하지 않아야 한다', async () => {
+      // Given
+      selectRssByIdMock.mockResolvedValue(null);
+
+      // When
+      await worker['processItem'](crawlMessage);
+
+      // Then
+      expect(startFullCrawlMock).not.toHaveBeenCalled();
+    });
+
+    it('RSS를 찾으면 전체 크롤링을 수행해야 한다', async () => {
+      // Given
+      selectRssByIdMock.mockResolvedValue(rssObj);
+      startFullCrawlMock.mockResolvedValue([]);
+
+      // When
+      await worker['processItem'](crawlMessage);
+
+      // Then
+      expect(selectRssByIdMock).toHaveBeenCalledWith(crawlMessage.rssId);
+      expect(startFullCrawlMock).toHaveBeenCalledWith(rssObj);
+    });
+
+    it('크롤링 중 에러 발생 시 handleFailure를 호출해야 한다', async () => {
+      // Given
+      const error = new Error('크롤링 실패');
+      selectRssByIdMock.mockResolvedValue(rssObj);
+      startFullCrawlMock.mockRejectedValue(error);
+      const handleFailureSpy = jest
+        .spyOn(worker as any, 'handleFailure')
+        .mockResolvedValue(undefined);
+
+      // When
+      await worker['processItem'](crawlMessage);
+
+      // Then
+      expect(handleFailureSpy).toHaveBeenCalledWith(crawlMessage, error);
+    });
+  });
+
+  describe('onPermanentFailure', () => {
+    it('영구 실패 메트릭을 증가시켜야 한다', async () => {
+      // When
+      await worker['onPermanentFailure']();
+
+      // Then
+      expect(permanentFailureIncMock).toHaveBeenCalled();
+    });
+  });
+
+  describe('queue key accessors', () => {
+    it('getQueueKey와 getRetryQueueKey는 전체 크롤링 큐를 반환해야 한다', () => {
+      expect(worker['getQueueKey']()).toBe(redisConstant.FULL_FEED_CRAWL_QUEUE);
+      expect(worker['getRetryQueueKey']()).toBe(
+        redisConstant.FULL_FEED_CRAWL_QUEUE,
+      );
+    });
+
+    it('getItemLabel은 rssId를 포함해야 한다', () => {
+      expect(worker['getItemLabel'](crawlMessage)).toBe(
+        `RSS ID ${crawlMessage.rssId}`,
+      );
+    });
+  });
+});

--- a/feed-crawler/test/unit/parser.spec.ts
+++ b/feed-crawler/test/unit/parser.spec.ts
@@ -2,10 +2,12 @@ import 'reflect-metadata';
 
 import {
   ATOM_10_SAMPLE,
+  ATOM_10_SINGLE_ENTRY,
   FIXED_DATE,
   INVALID_XML,
   MOCK_RSS_OBJ,
   RSS_20_SAMPLE,
+  RSS_20_SINGLE_ITEM,
 } from '@test/config/constant/parser-fixtures';
 import axios, { HttpStatusCode } from 'axios';
 
@@ -209,6 +211,16 @@ describe('Parser 모듈 테스트', () => {
         expect(rawFeeds[0].link).toBe('https://rssfeed.com/post1');
         expect(rawFeeds[1].link).toBe('https://rssfeed.com/post2');
       });
+
+      it('item이 단일 객체일 때도 배열로 변환해야 한다', () => {
+        const rawFeeds = rss20Parser['extractRawFeeds'](RSS_20_SINGLE_ITEM);
+
+        expect(rawFeeds).toHaveLength(1);
+        expect(rawFeeds[0]).toMatchObject({
+          title: '유일한 글',
+          link: 'https://rssfeed.com/only',
+        });
+      });
     });
   });
 
@@ -249,6 +261,16 @@ describe('Parser 모듈 테스트', () => {
         expect(rawFeeds[0].link).toBe('https://atomfeed.com/entry1');
         expect(rawFeeds[1].link).toBe('https://atomfeed.com/entry2');
       });
+
+      it('entry가 단일 객체일 때도 배열로 변환해야 한다', () => {
+        const rawFeeds = atom10Parser['extractRawFeeds'](ATOM_10_SINGLE_ENTRY);
+
+        expect(rawFeeds).toHaveLength(1);
+        expect(rawFeeds[0]).toMatchObject({
+          title: '유일한 Atom 글',
+          link: 'https://atomfeed.com/only',
+        });
+      });
     });
 
     describe('extractLink', () => {
@@ -270,6 +292,56 @@ describe('Parser 모듈 테스트', () => {
         ];
         const result = atom10Parser['extractLink'](linkData);
         expect(result).toBe('https://example.com/alternate');
+      });
+    });
+  });
+
+  describe('BaseFeedParser', () => {
+    describe('parseAllFeeds (전체 크롤링)', () => {
+      it('시간 필터 없이 모든 피드를 변환해야 한다', async () => {
+        // Given - RSS_20_SAMPLE은 고정 날짜의 2개 피드를 포함
+        // When
+        const result = await rss20Parser.parseAllFeeds(
+          MOCK_RSS_OBJ,
+          RSS_20_SAMPLE,
+        );
+
+        // Then - parseFeed와 달리 시간 필터가 없으므로 모든 피드 반환
+        expect(result).toHaveLength(2);
+        expect(result[0]).toMatchObject({
+          blogId: MOCK_RSS_OBJ.id,
+          title: '첫 번째 글제목',
+          summary: expect.any(String),
+          deathCount: 0,
+        });
+      });
+    });
+
+    describe('convertToFeedDetails 실패 처리', () => {
+      it('일부 피드 변환이 실패하면 성공한 피드만 반환하고 알림을 발행해야 한다', async () => {
+        // Given - 첫 번째 피드의 썸네일 조회를 실패시켜 변환 실패 유도
+        jest
+          .spyOn(parserUtil, 'getThumbnailUrl')
+          .mockRejectedValueOnce(new Error('썸네일 GET 요청 실패'))
+          .mockResolvedValue('https://example.com/image.jpg');
+        const publishSpy = jest.spyOn(notifier, 'publish');
+
+        // When
+        const result = await rss20Parser.parseAllFeeds(
+          MOCK_RSS_OBJ,
+          RSS_20_SAMPLE,
+        );
+
+        // Then - 2개 중 1개만 성공
+        expect(result).toHaveLength(1);
+        expect(publishSpy).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            error: expect.any(Error),
+            blogUrl: MOCK_RSS_OBJ.rssUrl,
+            errorSource: '[Full FeedCrawling]',
+          }),
+        );
       });
     });
   });


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #651

### feed-crawler 테스트 공백 보강

- **작업 이유:** 신규 기능(`requeueFeedForAiSummary`, full-feed-crawl/ai-summary-retry worker)과 `discord.notifier`가 테스트 없이 머지되어 커버리지 리포트에 아예 잡히지 않았음. 회귀 안전망 부재.
- **고민한 점:** 단위/E2E를 목적에 맞게 분리. 순수 로직(parser, worker 분기, 에러 분류)은 단위로, 실 DB/Redis 통합 경로(`selectFeedById`→`selectRssById`→`saveAiQueue`)는 E2E로 검증. 기존 패턴(GIVEN/WHEN/THEN, 한국어 it 설명, URL 기반 axios 모킹) 그대로 따름.

### infra 파일 커버리지 한계 확인

- **작업 이유:** "커버리지 최대화" 목표 검증 중 repository/redis-access/metrics가 E2E 실행에도 0% 크레딧되는 현상 발견.
- **고민한 점:** unit-only와 combined 수치가 동일 → E2E가 실행해도 계측이 안 됨. 모듈 중복 로드(계측 인스턴스 ≠ 실행 인스턴스)가 원인이며 E2E `instanceof` 단언 실패와 동일 근원. 테스트로 해결 불가, jest 계측 설정 영역이라 본 PR 범위에서 제외. E2E 에러 단언은 클래스 대신 메시지 매칭으로 우회.

# 📋 작업 내용

### 신규 단위 테스트
- `discord-notifier.spec.ts` — 생성자 검증, 3개 이벤트 webhook 전송, 전송 실패 swallow, `start` 멱등성
- `ai-summary-retry-event-worker.spec.ts` — processQueue / processItem / onPermanentFailure(락 해제) 전 경로
- `full-feed-crawl-event-worker.spec.ts` — 큐 깊이 메트릭, RSS 미존재 skip, 크롤링 실패 handleFailure, 영구 실패 메트릭

### 기존 단위 테스트 확장
- `feed-crawler.spec.ts` — `requeueFeedForAiSummary` (원본 HTTP 200/404/500/네트워크 에러 → Permanent/Retryable 분기)
- `feed-parser-manager.spec.ts` — `fetchAndParseAll` (성공 / HTTP 실패 / 미지원 포맷 / 파서 에러)
- `parser.spec.ts` — base-parser `parseAllFeeds` + 변환 실패 알림 경로, RSS/Atom 단일 item 분기
- `claude-event-worker.spec.ts` — requestAI 실패·비-JSON 응답, saveAIResult·pushToRetryQueue 에러 전파

### 신규 E2E
- `ai-summary-requeue.e2e-spec.ts` — 실 MySQL/Redis를 통한 AI 요약 재요청 end-to-end

### 커버리지 (단위)

| 파일 | Before | After |
|---|---|---|
| feed-crawler.ts | 64% | 98.5% |
| feed-parser-manager.ts | 68% | 100% |
| base-feed-parser.ts | 71% | 100% |
| claude-event-worker.ts | 89% | 100% |
| discord.notifier.ts | (미측정) | 95% |
| ai-summary-retry / full-feed-crawl worker | (미측정) | 100% |

전체 단위 커버리지 61% → 74.7%, 통합 137 테스트 통과.