### PR TITLE
✨ feat: 관리자 게시글 관리 페이지 검색 기능 추가

### DIFF
--- a/client/src/__tests__/components/common/search/SearchResults/SearchResultItem.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/SearchResultItem.test.tsx
@@ -22,6 +22,13 @@ describe("SearchResultItem", () => {
     title: "테스트 제목입니다",
     blogName: "테스트 블로그",
     path: "/test-path",
+    author: "테스트 블로그",
+    blogPlatform: "etc",
+    thumbnail: "",
+    viewCount: 0,
+    tag: [],
+    likes: 0,
+    comments: 0,
   };
 
   it("검색 결과의 제목과 블로그명이 렌더링되어야 한다", () => {

--- a/client/src/__tests__/components/common/search/SearchResults/SearchResultList.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/SearchResultList.test.tsx
@@ -80,9 +80,10 @@ describe("SearchResultList", () => {
   });
 
   it("검색 결과가 있을 때는 결과 목록과 페이지네이션을 표시해야 한다", () => {
+    const cardFields = { author: "", blogPlatform: "etc", thumbnail: "", viewCount: 0, tag: [], likes: 0, comments: 0 };
     const mockResults = [
-      { id: 1, title: "제목1", blogName: "블로그1", path: "/1", createdAt: "2024-01-01" },
-      { id: 2, title: "제목2", blogName: "블로그2", path: "/2", createdAt: "2024-01-01" },
+      { id: 1, title: "제목1", blogName: "블로그1", path: "/1", createdAt: "2024-01-01", ...cardFields },
+      { id: 2, title: "제목2", blogName: "블로그2", path: "/2", createdAt: "2024-01-01", ...cardFields },
     ];
 
     vi.mocked(useSearchStore).mockReturnValue({

--- a/client/src/api/searchMockApi.ts
+++ b/client/src/api/searchMockApi.ts
@@ -5,7 +5,7 @@ import { SearchResult } from "@/types/search";
 
 const mock = new MockAdapter(axios);
 
-const mockData: SearchResult[] = [
+const baseMockData = [
   {
     id: 1,
     blogName: "토스",
@@ -77,6 +77,17 @@ const mockData: SearchResult[] = [
     createdAt: "2024-11-05 13:42:30",
   },
 ];
+
+const mockData: SearchResult[] = baseMockData.map((item) => ({
+  ...item,
+  author: item.blogName,
+  blogPlatform: "etc",
+  thumbnail: "",
+  viewCount: 0,
+  tag: [],
+  likes: 0,
+  comments: 0,
+}));
 
 mock.onGet("/api/search").reply((config) => {
   const { find, type, limit = 4, page = 1 } = config.params;

--- a/client/src/components/admin/post/AdminPostTab.tsx
+++ b/client/src/components/admin/post/AdminPostTab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { AlertTriangle, CheckSquare, Heart, MessageSquare, Square } from "lucide-react";
+import { AlertTriangle, CheckSquare, Heart, MessageSquare, Search, Square } from "lucide-react";
 
 import AdminPostDetail from "@/components/admin/post/AdminPostDetail";
 import { PostCardContent } from "@/components/common/Card/PostCardContent";
@@ -8,24 +8,60 @@ import { PostCardImage } from "@/components/common/Card/PostCardImage";
 import { PostGridSkeleton } from "@/components/common/Card/PostCardSkeleton";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast";
 import { NO_SUMMARY_FEEDS_KEY, useBatchRequestAiSummary, useNoSummaryFeeds } from "@/hooks/queries/useAiSummaryRequest";
 import { useInfiniteScrollQuery } from "@/hooks/queries/useInfiniteScrollQuery";
+import { useSearch } from "@/hooks/queries/useSearch";
 
 import { posts } from "@/api/services/posts";
 import { FeedList } from "@/types/post";
+import { SearchResult } from "@/types/search";
 import { useQueryClient } from "@tanstack/react-query";
+
+const SEARCH_PAGE_SIZE = 12;
+
+const toFeedCard = (result: SearchResult): FeedList => ({
+  id: result.id,
+  title: result.title,
+  path: result.path,
+  createdAt: result.createdAt,
+  author: result.author,
+  blogPlatform: result.blogPlatform,
+  thumbnail: result.thumbnail,
+  viewCount: result.viewCount,
+  tag: result.tag,
+  likes: result.likes,
+  comments: result.comments,
+});
 
 export default function AdminPostTab() {
   const observerTarget = useRef<HTMLDivElement>(null);
   const [selectedFeedId, setSelectedFeedId] = useState<number | null>(null);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
+  const [noSummaryQuery, setNoSummaryQuery] = useState("");
+  const [postQuery, setPostQuery] = useState("");
 
   const queryClient = useQueryClient();
   const { toast } = useCustomToast();
   const { data: noSummaryFeeds = [], isLoading: isNoSummaryLoading } = useNoSummaryFeeds();
   const { mutate: batchRequest, isPending } = useBatchRequestAiSummary();
+
+  const trimmedPostQuery = postQuery.trim();
+  const isSearching = trimmedPostQuery.length > 0;
+  const { data: searchData, isLoading: isSearchLoading } = useSearch({
+    query: trimmedPostQuery,
+    filter: "title",
+    page: 1,
+    pageSize: SEARCH_PAGE_SIZE,
+  });
+  const searchResults = searchData?.data.result ?? [];
+  const searchTotalCount = searchData?.data.totalCount ?? 0;
+
+  const filteredNoSummaryFeeds = noSummaryFeeds.filter((feed) =>
+    feed.title.toLowerCase().includes(noSummaryQuery.trim().toLowerCase())
+  );
 
   const { items, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useInfiniteScrollQuery<FeedList>({
     queryKey: "admin-latest-posts",
@@ -58,7 +94,7 @@ export default function AdminPostTab() {
     });
   };
 
-  const selectAll = () => setSelectedIds(new Set(noSummaryFeeds.map((feed) => feed.id)));
+  const selectAll = () => setSelectedIds(new Set(filteredNoSummaryFeeds.map((feed) => feed.id)));
   const clearSelection = () => setSelectedIds(new Set());
 
   const handleBatchRequest = () => {
@@ -94,14 +130,26 @@ export default function AdminPostTab() {
           </div>
         </div>
 
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-amber-400" />
+          <Input
+            placeholder="제목으로 검색"
+            className="pl-10 bg-white"
+            value={noSummaryQuery}
+            onChange={(event) => setNoSummaryQuery(event.target.value)}
+          />
+        </div>
+
         {isNoSummaryLoading ? (
           <p className="text-sm text-gray-400 py-6 text-center">불러오는 중...</p>
         ) : noSummaryFeeds.length === 0 ? (
           <p className="text-sm text-gray-400 py-6 text-center">AI 요약이 없는 게시글이 없습니다.</p>
+        ) : filteredNoSummaryFeeds.length === 0 ? (
+          <p className="text-sm text-gray-400 py-6 text-center">검색 결과가 없습니다.</p>
         ) : (
           <div className="max-h-[320px] overflow-y-auto pr-1">
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-              {noSummaryFeeds.map((feed) => {
+              {filteredNoSummaryFeeds.map((feed) => {
                 const isSelected = selectedIds.has(feed.id);
                 return (
                   <div
@@ -152,8 +200,41 @@ export default function AdminPostTab() {
       </div>
 
       <div className="flex flex-col">
-        <h2 className="text-lg font-bold mb-3">전체 게시글</h2>
-        {isLoading ? (
+        <h2 className="text-lg font-bold mb-3">
+          {isSearching ? `검색 결과 (${searchTotalCount})` : "전체 게시글"}
+        </h2>
+        <div className="relative mb-6">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="제목으로 게시글 검색"
+            className="pl-10"
+            value={postQuery}
+            onChange={(event) => setPostQuery(event.target.value)}
+          />
+        </div>
+
+        {isSearching ? (
+          isSearchLoading ? (
+            <PostGridSkeleton count={8} />
+          ) : searchResults.length === 0 ? (
+            <p className="text-sm text-gray-400 py-12 text-center">검색 결과가 없습니다.</p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 min-h-[300px]">
+              {searchResults.map((result) => {
+                const post = toFeedCard(result);
+                return (
+                  <Card
+                    key={post.id}
+                    className="h-[270px] group shadow-md hover:shadow-xl transition-all duration-300 border-none rounded-xl"
+                  >
+                    <PostCardImage thumbnail={post.thumbnail} alt={post.title} />
+                    <PostCardContent post={post} />
+                  </Card>
+                );
+              })}
+            </div>
+          )
+        ) : isLoading ? (
           <PostGridSkeleton count={8} />
         ) : (
           <>

--- a/client/src/components/admin/post/AdminPostTab.tsx
+++ b/client/src/components/admin/post/AdminPostTab.tsx
@@ -133,7 +133,7 @@ export default function AdminPostTab() {
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-amber-400" />
           <Input
-            placeholder="제목으로 검색"
+            placeholder="제목으로 게시글 검색"
             className="pl-10 bg-white"
             value={noSummaryQuery}
             onChange={(event) => setNoSummaryQuery(event.target.value)}
@@ -200,9 +200,7 @@ export default function AdminPostTab() {
       </div>
 
       <div className="flex flex-col">
-        <h2 className="text-lg font-bold mb-3">
-          {isSearching ? `검색 결과 (${searchTotalCount})` : "전체 게시글"}
-        </h2>
+        <h2 className="text-lg font-bold mb-3">{isSearching ? `검색 결과 (${searchTotalCount})` : "전체 게시글"}</h2>
         <div className="relative mb-6">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
           <Input

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -6,6 +6,13 @@ export interface SearchResult {
   blogName: string;
   path: string;
   createdAt: string;
+  author: string;
+  blogPlatform: string;
+  thumbnail: string;
+  viewCount: number;
+  tag: string[];
+  likes: number;
+  comments: number;
 }
 
 export interface SearchData {

--- a/server/src/feed/dto/response/searchFeed.dto.ts
+++ b/server/src/feed/dto/response/searchFeed.dto.ts
@@ -18,6 +18,21 @@ export class SearchFeedResult {
   @ApiProperty({ example: '2025-01-01T01:00:00.000Z', description: '게시글 작성 일자' })
   createdAt: Date;
 
+  @ApiProperty({ example: 'example author', description: '작성자' })
+  author: string;
+
+  @ApiProperty({ example: 'example platform', description: '블로그 플랫폼' })
+  blogPlatform: string;
+
+  @ApiProperty({ example: 'https://example.com/thumbnail', description: '썸네일 URL' })
+  thumbnail: string;
+
+  @ApiProperty({ example: 0, description: '조회수' })
+  viewCount: number;
+
+  @ApiProperty({ example: [], description: '태그 목록' })
+  tag: string[];
+
   @ApiProperty({ example: 0, description: '좋아요 수' })
   likes: number;
 
@@ -35,6 +50,11 @@ export class SearchFeedResult {
       title: feed.title,
       path: feed.path,
       createdAt: feed.createdAt,
+      author: feed.blog.name,
+      blogPlatform: feed.blog.blogPlatform,
+      thumbnail: feed.thumbnail,
+      viewCount: feed.viewCount,
+      tag: [],
       likes: feed.likeCount,
       comments: feed.commentCount,
     });

--- a/server/test/feed/e2e/search.e2e-spec.ts
+++ b/server/test/feed/e2e/search.e2e-spec.ts
@@ -68,6 +68,11 @@ describe(`GET ${URL}?type={}&find={} E2E Test`, () => {
           comments: feed.commentCount,
           path: feed.path,
           createdAt: feed.createdAt.toISOString(),
+          author: feed.blog.name,
+          blogPlatform: feed.blog.blogPlatform,
+          thumbnail: feed.thumbnail,
+          viewCount: feed.viewCount,
+          tag: [],
         };
       }),
       totalPages: 2,


### PR DESCRIPTION
# 🔨 테스크

### Issue
- close #772 

### 관리자 게시글 관리 페이지 검색

- 운영 중 특정 게시글을 빠르게 찾을 수 있는 수단이 없어, 관리자 게시글 관리 페이지에 검색 기능을 추가했습니다.
- **AI 요약 없는 게시글** 영역은 이미 로드된 목록을 클라이언트에서 제목 기준으로 필터링합니다. 별도 네트워크 요청 없이 즉시 반응하도록 했습니다.
  - 전체 선택(selectAll)이 필터링된 목록만 대상으로 동작하도록 수정하여, 검색 상태와 선택 동작이 일관되게 맞춰지도록 했습니다.
- **전체 게시글** 영역은 기존 검색 API(`useSearch`, `filter: title`)를 재사용해 서버 검색 결과를 카드 그리드로 렌더링합니다.

### 검색 결과 Response DTO 변경

- 검색 결과를 게시글 카드(`PostCardContent`)로 그대로 렌더링하려면 카드가 요구하는 필드가 응답에 포함되어야 합니다.
- 이를 위해 `SearchFeedResult`에 `author`, `blogPlatform`, `thumbnail`, `viewCount`, `tag` 필드를 추가했습니다.
  - `tag`는 현재 검색 응답에서 제공하지 않아 빈 배열로 채웁니다. (추후 태그 연동 시 확장 여지)
- FE `SearchResult` 타입과 mock 데이터도 동일 필드를 갖도록 맞췄습니다.

# 📋 작업 내용

- 관리자 게시글 관리 페이지에 검색 input 2개 추가 (AI 요약 없는 게시글 / 전체 게시글)
- 전체 게시글 검색은 기존 search API 재사용, 검색 결과를 카드 그리드로 렌더링
- 검색 결과 카드 렌더링에 필요한 필드 추가 (`SearchFeedResult` DTO, FE `SearchResult` 타입)
- 관련 테스트(검색 e2e, 컴포넌트 테스트, mock api) 필드 보강

# 📷 스크린 샷(선택 사항)

<img width="1350" height="908" alt="image" src="https://github.com/user-attachments/assets/9894421c-f764-4965-925f-3ea4895c0713" />
