### PR TITLE
📝 docs: client Storybook 구축

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ PRD.md
 
 # CLAUDE
 .claude/**/*.local.*
+
+# Playwright MCP
+.playwright-mcp

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -45,3 +45,7 @@ stats.html
 # Lighthouse
 lhci_reports
 .lighthouseci
+
+# Storybook
+*storybook.log
+storybook-static

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -41,6 +41,7 @@ stats.html
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+.playwright-mcp
 
 # Lighthouse
 lhci_reports

--- a/client/.storybook/main.ts
+++ b/client/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  "stories": [
+    "../src/**/*.mdx",
+    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
+  ],
+  "addons": [
+    "@chromatic-com/storybook",
+    "@storybook/addon-a11y",
+    "@storybook/addon-docs",
+    "@storybook/addon-mcp"
+  ],
+  "framework": "@storybook/react-vite"
+};
+export default config;

--- a/client/.storybook/preview.tsx
+++ b/client/.storybook/preview.tsx
@@ -1,19 +1,18 @@
-import { Component, type ReactNode } from "react";
-
-import type { Preview } from "@storybook/react-vite";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Component, useEffect, useRef, type ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { action } from "storybook/actions";
 
 import { Toaster } from "@/components/ui/toaster";
 
-import { setupMocks } from "@/api/mocks";
-import { mockApi } from "@/__storybook__/mockApi";
-
 import "../src/index.css";
+import { mockApi } from "@/__storybook__/mockApi";
+import { queryClient } from "@/__storybook__/queryClient";
+import { setupMocks } from "@/api/mocks";
+import type { Preview } from "@storybook/react-vite";
+import { QueryClientProvider } from "@tanstack/react-query";
 
 setupMocks();
 
-// Kakao SDK stub so share-related components render in isolation.
 (window as unknown as { Kakao: Record<string, unknown> }).Kakao = {
   init: () => {},
   cleanup: () => {},
@@ -21,14 +20,20 @@ setupMocks();
   Share: { sendDefault: () => {} },
 };
 
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false, refetchOnWindowFocus: false },
-  },
-});
+const logNavigate = action("NAVIGATE");
+const NavigationLogger = () => {
+  const location = useLocation();
+  const isFirst = useRef(true);
+  useEffect(() => {
+    if (isFirst.current) {
+      isFirst.current = false;
+      return;
+    }
+    logNavigate(`${location.pathname}${location.search}`);
+  }, [location]);
+  return null;
+};
 
-// Renders a deterministic DOM marker on render-phase throws so story health
-// can be asserted reliably (used by the render sweep, harmless otherwise).
 class StoryErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
   state = { error: null as Error | null };
   static getDerivedStateFromError(error: Error) {
@@ -63,16 +68,12 @@ const preview: Preview = {
     },
   },
 
-  // Reset mocked API + query cache before every story so success/error states
-  // configured by a story's own beforeEach never leak into the next.
   beforeEach: async () => {
     mockApi.reset();
     queryClient.clear();
   },
 
   decorators: [
-    // Single Router for all stories. A story sets `parameters.router` to drive
-    // the URL (query params via initialEntries) or match a path (useParams).
     (Story, context) => {
       const router = (context.parameters?.router ?? {}) as { initialEntries?: string[]; path?: string };
       const entries = router.initialEntries ?? ["/"];
@@ -80,6 +81,7 @@ const preview: Preview = {
         <StoryErrorBoundary>
           <QueryClientProvider client={queryClient}>
             <MemoryRouter initialEntries={entries}>
+              <NavigationLogger />
               {router.path ? (
                 <Routes>
                   <Route path={router.path} element={<Story />} />

--- a/client/.storybook/preview.tsx
+++ b/client/.storybook/preview.tsx
@@ -1,0 +1,99 @@
+import { Component, type ReactNode } from "react";
+
+import type { Preview } from "@storybook/react-vite";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { Toaster } from "@/components/ui/toaster";
+
+import { setupMocks } from "@/api/mocks";
+import { mockApi } from "@/__storybook__/mockApi";
+
+import "../src/index.css";
+
+setupMocks();
+
+// Kakao SDK stub so share-related components render in isolation.
+(window as unknown as { Kakao: Record<string, unknown> }).Kakao = {
+  init: () => {},
+  cleanup: () => {},
+  isInitialized: () => true,
+  Share: { sendDefault: () => {} },
+};
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, refetchOnWindowFocus: false },
+  },
+});
+
+// Renders a deterministic DOM marker on render-phase throws so story health
+// can be asserted reliably (used by the render sweep, harmless otherwise).
+class StoryErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state = { error: null as Error | null };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <div data-sb-render-error style={{ color: "#b91c1c", padding: 16, fontFamily: "monospace" }}>
+          {String(this.state.error)}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+
+    a11y: {
+      // 'todo' - show a11y violations in the test UI only
+      // 'error' - fail CI on a11y violations
+      // 'off' - skip a11y checks entirely
+      test: "todo",
+    },
+  },
+
+  // Reset mocked API + query cache before every story so success/error states
+  // configured by a story's own beforeEach never leak into the next.
+  beforeEach: async () => {
+    mockApi.reset();
+    queryClient.clear();
+  },
+
+  decorators: [
+    // Single Router for all stories. A story sets `parameters.router` to drive
+    // the URL (query params via initialEntries) or match a path (useParams).
+    (Story, context) => {
+      const router = (context.parameters?.router ?? {}) as { initialEntries?: string[]; path?: string };
+      const entries = router.initialEntries ?? ["/"];
+      return (
+        <StoryErrorBoundary>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={entries}>
+              {router.path ? (
+                <Routes>
+                  <Route path={router.path} element={<Story />} />
+                </Routes>
+              ) : (
+                <Story />
+              )}
+              <Toaster />
+            </MemoryRouter>
+          </QueryClientProvider>
+        </StoryErrorBoundary>
+      );
+    },
+  ],
+};
+
+export default preview;

--- a/client/.storybook/tsconfig.json
+++ b/client/.storybook/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.app.json",
+  "include": ["../src", "**/*.ts", "**/*.tsx"]
+}

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,13 +1,12 @@
 // For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
+import pluginReact from "eslint-plugin-react";
 import storybook from "eslint-plugin-storybook";
-
 import globals from "globals";
 import tseslint from "typescript-eslint";
-import pluginReact from "eslint-plugin-react";
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
-  { ignores: ["dist", "node_modules", "coverage"] },
+  { ignores: ["dist", "node_modules", "coverage", "storybook-static"] },
   { files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"] },
   { languageOptions: { globals: globals.browser } },
   ...tseslint.configs.recommended,
@@ -17,5 +16,5 @@ export default [
       "react/react-in-jsx-scope": "off",
     },
   },
-  ...storybook.configs["flat/recommended"]
+  ...storybook.configs["flat/recommended"],
 ];

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,3 +1,6 @@
+// For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
+import storybook from "eslint-plugin-storybook";
+
 import globals from "globals";
 import tseslint from "typescript-eslint";
 import pluginReact from "eslint-plugin-react";
@@ -14,4 +17,5 @@ export default [
       "react/react-in-jsx-scope": "off",
     },
   },
+  ...storybook.configs["flat/recommended"]
 ];

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -49,9 +49,14 @@
         "zustand": "^5.0.13"
       },
       "devDependencies": {
+        "@chromatic-com/storybook": "^5.2.1",
         "@eslint/js": "^9.39.4",
         "@lhci/cli": "^0.15.1",
         "@playwright/test": "^1.59.1",
+        "@storybook/addon-a11y": "^10.4.6",
+        "@storybook/addon-docs": "^10.4.6",
+        "@storybook/addon-mcp": "^0.6.0",
+        "@storybook/react-vite": "^10.4.6",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.2",
@@ -64,7 +69,7 @@
         "@typescript-eslint/eslint-plugin": "^8.59.2",
         "@typescript-eslint/parser": "^8.59.2",
         "@vitejs/plugin-react-swc": "^3.5.0",
-        "@vitest/coverage-v8": "^2.1.6",
+        "@vitest/coverage-v8": "^2.1.4",
         "autoprefixer": "^10.5.0",
         "axios-mock-adapter": "^2.1.0",
         "dotenv": "^16.6.1",
@@ -73,11 +78,14 @@
         "eslint-plugin-react": "^7.37.2",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "eslint-plugin-storybook": "^10.4.6",
         "globals": "^15.11.0",
         "jsdom": "^25.0.1",
+        "playwright": "^1.61.1",
         "postcss": "^8.5.14",
         "prettier": "^3.8.3",
         "rollup-plugin-visualizer": "^5.12.0",
+        "storybook": "^10.4.6",
         "tailwindcss": "^3.4.19",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.2",
@@ -133,18 +141,132 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core/node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -160,6 +282,43 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -217,6 +376,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-hoist-variables": {
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
@@ -242,6 +411,164 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports/node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms/node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
@@ -272,9 +599,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -282,23 +609,61 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -308,14 +673,14 @@
       }
     },
     "node_modules/@babel/parser/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -331,29 +696,29 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -455,6 +820,57 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@chromatic-com/storybook": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@chromatic-com/storybook/-/storybook-5.2.1.tgz",
+      "integrity": "sha512-z6I7NJk/0VngA64y5TNYaB4Hc2X8+90n4op6lBt9PvWk5TmIlFLDqdX33rlrwbNRkkYijVgA/wO04rVYXi5Mlg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@neoconfetti/react": "^1.0.0",
+        "chromatic": "16.10.0",
+        "jsonfile": "^6.1.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0",
+        "yarn": ">=1.22.18"
+      },
+      "peerDependencies": {
+        "storybook": "^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0"
+      }
+    },
+    "node_modules/@chromatic-com/storybook/node_modules/chromatic": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.10.0.tgz",
+      "integrity": "sha512-nFsztmnu7rFiGafUJgXvLUNpqmRylz92eNvzBoJNTKKQj4EQUyxznwnfpf1dTs7hXtWD8JwcH92jADydaHA1sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "bin": {
+        "chroma": "dist/bin.cjs",
+        "chromatic": "dist/bin.cjs",
+        "chromatic-cli": "dist/bin.cjs"
+      },
+      "peerDependencies": {
+        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0",
+        "@chromatic-com/vitest": "^0.*.* || ^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@chromatic-com/cypress": {
+          "optional": true
+        },
+        "@chromatic-com/playwright": {
+          "optional": true
+        },
+        "@chromatic-com/vitest": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
@@ -569,6 +985,40 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1366,6 +1816,71 @@
         "node": ">=8"
       }
     },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+      "integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1373,6 +1888,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -1656,6 +2182,50 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@neoconfetti/react": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@neoconfetti/react/-/react-1.0.0.tgz",
+      "integrity": "sha512-klcSooChXXOzIm+SE5IISIAn3bYzYfPjbX7D7HoqZL84oAfgREeSg5vSIaSFH+DaGzzvImTyWe1OyrJ67vik4A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1690,6 +2260,663 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.21.3.tgz",
+      "integrity": "sha512-eNU11A2WNizh04v3uyaJCootrHIaS0B9aHYXvAvVnPNk4xYSjMUjHnhQ6dewPN2MRYDskV85d1N0Aw0WNWhcyg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.21.3.tgz",
+      "integrity": "sha512-8Q+ZjTLvn2dIcWsrmhdrEihm7q+ag/k+mkry7Z+t0QbbHaVxXQfvH9AewyVMh/WrpEKhQ3DDgx9fYbqeCpeOEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.21.3.tgz",
+      "integrity": "sha512-wkh0qKZGHXVUDxFw3oA1TXnU2BDYY/r775oJflGeIr8uDPPoN2pk8gijQIzYRT6hoql/lg3+Tx/SaTn9e2/aGg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.21.3.tgz",
+      "integrity": "sha512-HbNc23FAQYbuyDV2vBWMez4u4mrsm5RAkniGZAWqr6lYZ3N4beeqIb776jzwRl8qL2zRhHVXpUj97X0QgogVzg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.21.3.tgz",
+      "integrity": "sha512-K6xNsTUPEUdfrn0+kbMq5nOUB5w1C5pavPQngt4TM2FpN91lP0PBe2srSpamb4d69O7h86oAi/qWX/kZNRSjkw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.21.3.tgz",
+      "integrity": "sha512-VcFmOpcpWX1zoEy8M58tR2M9YxM+Z9RuQhqAx5q0CTmrruaP7Gveejg75hzd/5sg5nk9G3aLALEa3hE2FsmmTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.21.3.tgz",
+      "integrity": "sha512-quVoxFLBy43hWaQbbDtQNRwAX5vX76mv7n64icAtQcJ3eNgVeblqmkupF/hAneNthdqSlnd1sTjb3aQSaDPaCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.21.3.tgz",
+      "integrity": "sha512-X0AqNZgcD07Q4V3RDK18/vYOj/HQT/FnmEFGYS2jTWqY7JO13ryE3TEs3eAIgUJhBnNkpEaiXqz3VK8M7qQhWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.21.3.tgz",
+      "integrity": "sha512-YkaQnaKYdbuaXvRt5Qd0GpbihzVnyfR6z1SpYfIUC6RTu4NF7lDKPjVkYb+jRI2gedVO2rVpN35Y6akG6ud4Lw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.21.3.tgz",
+      "integrity": "sha512-gB9HwhrPiFqUzDeEq+y/CgAijz1YdI6BnXz5GaH2Pa9cWdutchlkGFAiAuGb/PjVQpiK6NFKzFuztxrweoit7A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.21.3.tgz",
+      "integrity": "sha512-zjDWBlYk8QGv0H8dsPUWqkfjYIIjG2TvspGkzXL0eImbgxtZorA/klKeHyolevoT3Kvbi+1iMr9Lhrh7jf54Og==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.21.3.tgz",
+      "integrity": "sha512-4UfsQvacV388y1zpXL7C1x1FNYaV52JtuNRiuzrfQA2z1z6ElVrsidkGsrvQ5EgeSq1Pj7kaKqrgGkvFuxJ/tw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.21.3.tgz",
+      "integrity": "sha512-b5uH+HKH0MP5mNBYaK75SKsJbw52URqrx2LavYdq6wb0l3ExAG5niYRP9DWUNHdKilpaBVM2bXk9HNWrH3ew7Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.21.3.tgz",
+      "integrity": "sha512-PjYlmilBpNRh2ntXNYAK3Am5w/nPfEpnU/96iNx7CI8EzAn12J4JRiec63wHJTH31nLoCNxBg/829pN+3CfG3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.21.3.tgz",
+      "integrity": "sha512-QTBAb7JuHlZ7JUEyM8UiQi2f7m/L4swBhP2TNpYIDc9Wp/wRw1G/8sl6i13aIzQAXH7LKIm294LeOHd0lQR8zA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.21.3.tgz",
+      "integrity": "sha512-4j1DFwjwv36ec9kds0jU/ucQ5Ha4ERO/H95BxR5JFf0kqUUAJ1kwII7XhTc1vZrkdJkvLGC9Q2MbpObpum8RBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.21.3.tgz",
+      "integrity": "sha512-i8oluoel5kru/j1WNrjmQSiA3GQ7wvIYVR1IwIoZtKogAhya2iub+ZKIeSIkcJOrnzQ18Tzl/F+kL3fYOxZLvA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.0",
+        "@emnapi/runtime": "1.11.0",
+        "@napi-rs/wasm-runtime": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.0.tgz",
+      "integrity": "sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.21.3.tgz",
+      "integrity": "sha512-M/8dw8dD6aOs+NlPJax401CZB9I7Aut84isQLgALGGwke4Afvw+/7yYhZb94yXf6t2sPLhQLmSmtSV+2FhsOWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.21.3.tgz",
+      "integrity": "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@paulirish/trace_engine": {
       "version": "0.0.53",
@@ -1737,6 +2964,38 @@
       },
       "bin": {
         "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/@playwright/test/node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -3100,6 +4359,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
@@ -3541,6 +4830,281 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.4.6.tgz",
+      "integrity": "sha512-XCJy+f0DFOiCgUU9knRDlLDxVFI+AAQ3/wE/NF85zB9iDPPS2DwkSN+mas3zDgHt66zhN8Cq3/UiyCDUweV9Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.4.6"
+      }
+    },
+    "node_modules/@storybook/addon-docs": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.4.6.tgz",
+      "integrity": "sha512-aWAfP5JMiT5a3zBJizwroCRzOCqZwDTJmvsYvwMD3ilIEa/kT1vhf6Xrbk4XIPhDwbh8Hpb/Gfnka1xBYEISWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/react": "^3.0.0",
+        "@storybook/csf-plugin": "10.4.6",
+        "@storybook/icons": "^2.0.2",
+        "@storybook/react-dom-shim": "10.4.6",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-mcp": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-mcp/-/addon-mcp-0.6.0.tgz",
+      "integrity": "sha512-E79m2S7ik9wiF1AnI49fwbLQkrD03PicIZpCdeFhbbB19MF4tKFKyaQtbT3f6eaAP4EP2+COLDVLCQ7B3rGF4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/mcp": "0.7.0",
+        "@tmcp/adapter-valibot": "^0.1.5",
+        "@tmcp/transport-http": "^0.8.5",
+        "picoquery": "^2.5.0",
+        "tmcp": "^1.19.3",
+        "valibot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@storybook/addon-vitest": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0",
+        "storybook": "^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@storybook/addon-vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.4.6.tgz",
+      "integrity": "sha512-BHBtD81HiXUiDQz/CaFynLtWmm7AFUQn8VnXuHipZ8KlnUANopa4yqdVuy/Gwz8ub254uFI5NMZsW/KlgWNgNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.4.6",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.4.6",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.4.6.tgz",
+      "integrity": "sha512-NILLxDqpA/JR/AazGWpsz+4fadJwRU4uhHephGtYpVOWnQA/DkJfKT6zpcJVq8+QA8A2zKMLX3GVKsXIrxjuDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.4.6",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.0.2.tgz",
+      "integrity": "sha512-KZBCpXsshAIjczYNXR/rlxEtCUX/eAbpFNwKi8bcOomrLA4t/SyPz5RF+lVPO2oZBUE4sAkt43mfJUevQDSEEw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/mcp": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@storybook/mcp/-/mcp-0.7.0.tgz",
+      "integrity": "sha512-Pr4E61tM5e7aDzqgNOL/Ylw8CGdb+BIDGOf3vbmFfkR8ZnXjPxaV/vhTEsiXynnIpjQWCzySCxOU1icxZsgjrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tmcp/adapter-valibot": "^0.1.5",
+        "@tmcp/transport-http": "^0.8.5",
+        "tmcp": "^1.19.3",
+        "valibot": "1.2.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.4.6.tgz",
+      "integrity": "sha512-9Y7YecrVFe1/01KYjfOLxVqTg2Aq+IO6TEv6sC2U0PfD0AWCSCmQ91QqgBpN/XW4aFFWoiZNinyXMUlU8zxy2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.4.6",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.4.6.tgz",
+      "integrity": "sha512-iGNmKzrq9vgl2PDrYAnZKI+yvac3Ym+lJXXuQaqlFRS23zA5MNm4EBX+rAG7WulqchoK6NaZ0KQOs2mAgEpTMg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.4.6.tgz",
+      "integrity": "sha512-0arEQtybqGYXHbXpTot+Wv9YtG+V5Vp43QayXavPKQ20M8mpEzhyCPKd0EhqMGSC1Z1UEt0hm365WUBhI9LfKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.4.6",
+        "@storybook/react": "10.4.6",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.0",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.4.6",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/react-vite/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.15.33",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.33.tgz",
@@ -3943,6 +5507,91 @@
         }
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@tmcp/adapter-valibot/-/adapter-valibot-0.1.6.tgz",
+      "integrity": "sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@valibot/to-json-schema": "^1.3.0",
+        "valibot": "^1.1.0"
+      },
+      "peerDependencies": {
+        "tmcp": "^1.17.0",
+        "valibot": "^1.1.0"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot/node_modules/@valibot/to-json-schema": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@valibot/to-json-schema/-/to-json-schema-1.7.1.tgz",
+      "integrity": "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "valibot": "^1.4.0"
+      }
+    },
+    "node_modules/@tmcp/adapter-valibot/node_modules/valibot": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
+      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tmcp/session-manager": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@tmcp/session-manager/-/session-manager-0.2.2.tgz",
+      "integrity": "sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tmcp": "^1.16.3"
+      }
+    },
+    "node_modules/@tmcp/transport-http": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@tmcp/transport-http/-/transport-http-0.8.6.tgz",
+      "integrity": "sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tmcp/session-manager": "^0.2.2",
+        "esm-env": "^1.2.2"
+      },
+      "peerDependencies": {
+        "@tmcp/auth": "^0.3.3 || ^0.4.0",
+        "tmcp": "^1.18.0"
+      },
+      "peerDependenciesMeta": {
+        "@tmcp/auth": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -3974,12 +5623,107 @@
         }
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__core/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/babel__traverse/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -4053,6 +5797,20 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -4099,6 +5857,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -4151,6 +5916,13 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -4567,6 +6339,13 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -5318,6 +7097,22 @@
         "node": "*"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -5912,6 +7707,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -6276,6 +8078,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -6526,6 +8358,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -7100,6 +8942,20 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-storybook": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-10.4.6.tgz",
+      "integrity": "sha512-CfGSXn6zFspeYTU8R7v797MOmJFj8xc6MWf/oGuRwbKeMoSwnliR+OlXSjMZYM1D6gfmwiuH1VX58LSHdn+ZPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.48.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8",
+        "storybook": "^10.4.6"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -7183,6 +9039,13 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "10.4.0",
@@ -7898,6 +9761,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -8985,6 +10858,41 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -9481,6 +11389,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-rpc-2.0": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/json-rpc-2.0/-/json-rpc-2.0-1.7.1.tgz",
+      "integrity": "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -9494,6 +11409,32 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -11081,6 +13022,75 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.21.3",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.21.3.tgz",
+      "integrity": "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.21.3",
+        "@oxc-resolver/binding-android-arm64": "11.21.3",
+        "@oxc-resolver/binding-darwin-arm64": "11.21.3",
+        "@oxc-resolver/binding-darwin-x64": "11.21.3",
+        "@oxc-resolver/binding-freebsd-x64": "11.21.3",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.3",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.3",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.21.3",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.21.3",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.21.3",
+        "@oxc-resolver/binding-linux-x64-musl": "11.21.3",
+        "@oxc-resolver/binding-openharmony-arm64": "11.21.3",
+        "@oxc-resolver/binding-wasm32-wasi": "11.21.3",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.21.3",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.21.3"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -11357,6 +13367,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/picoquery": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/picoquery/-/picoquery-2.5.0.tgz",
+      "integrity": "sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -11376,13 +13393,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -11395,9 +13412,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -11929,6 +13946,149 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-docgen": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+      "integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__traverse": "^7.20.7",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "node_modules/react-docgen/node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/react-docgen/node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-docgen/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/react-docgen/node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
@@ -12169,6 +14329,46 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/recast": {
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/recast/node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/recast/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/recharts": {
@@ -12561,6 +14761,19 @@
       "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -13103,6 +15316,13 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/sqids": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/sqids/-/sqids-0.3.0.tgz",
+      "integrity": "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -13139,6 +15359,163 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/storybook": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.4.6.tgz",
+      "integrity": "sha512-6wkA6LxfDSSilloITsrFOJfsnw0mDUP2h8Ls+lRt8oRsudtz2RWFhLv+Toiwg6NW7hUpdTDc2hzR7DztJid6+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/storybook/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/storybook/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/storybook/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/storybook/node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/streamx": {
@@ -13360,6 +15737,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-indent": {
@@ -13790,6 +16177,20 @@
         "tldts-core": "^6.1.86"
       }
     },
+    "node_modules/tmcp": {
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/tmcp/-/tmcp-1.19.4.tgz",
+      "integrity": "sha512-fMoUJ3Gef9iA0yKZNeW2SQCCKTluCwghUyOz/qxPS8XxrQk6Jlw4lgql3S+s6L//FteLeSJ7erKxMWl727mZoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "json-rpc-2.0": "^1.7.1",
+        "sqids": "^0.3.0",
+        "uri-template-matcher": "^1.1.1",
+        "valibot": "^1.1.0"
+      }
+    },
     "node_modules/tmp": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
@@ -13971,11 +16372,36 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -14269,6 +16695,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -14277,6 +16713,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -14319,6 +16771,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/uri-template-matcher": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/uri-template-matcher/-/uri-template-matcher-1.1.2.tgz",
+      "integrity": "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
@@ -14397,6 +16856,21 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/valibot": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.2.0.tgz",
+      "integrity": "sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vary": {
@@ -14652,6 +17126,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
@@ -14971,6 +17452,38 @@
         }
       }
     },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xdg-basedir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
@@ -15015,6 +17528,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,9 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:always": "playwright test --grep-invert @oauth-real --pass-with-no-tests",
-    "test:e2e:oauth-smoke": "playwright test --project=chromium --workers=1 --grep @oauth-real --pass-with-no-tests"
+    "test:e2e:oauth-smoke": "playwright test --project=chromium --workers=1 --grep @oauth-real --pass-with-no-tests",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.1",
@@ -73,7 +75,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.2",
     "@typescript-eslint/parser": "^8.59.2",
     "@vitejs/plugin-react-swc": "^3.5.0",
-    "@vitest/coverage-v8": "^2.1.6",
+    "@vitest/coverage-v8": "^2.1.4",
     "autoprefixer": "^10.5.0",
     "axios-mock-adapter": "^2.1.0",
     "dotenv": "^16.6.1",
@@ -91,6 +93,14 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.2",
     "vite": "^5.4.10",
-    "vitest": "^2.1.4"
+    "vitest": "^2.1.4",
+    "storybook": "^10.4.6",
+    "@storybook/react-vite": "^10.4.6",
+    "@chromatic-com/storybook": "^5.2.1",
+    "@storybook/addon-a11y": "^10.4.6",
+    "@storybook/addon-docs": "^10.4.6",
+    "@storybook/addon-mcp": "^0.6.0",
+    "eslint-plugin-storybook": "^10.4.6",
+    "playwright": "^1.61.1"
   }
 }

--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -4,12 +4,21 @@ import { FileText, Sparkles } from "lucide-react";
 
 import type { FeatureItem } from "@/types/about";
 import type { DayInfo, WeekInfo } from "@/types/activity";
-import type { ChartPlatform } from "@/types/chart";
-import type { ChatType } from "@/types/chat";
+import type { ChartPlatform, ChartType } from "@/types/chart";
+import type { AdminChatRoom, ChatType } from "@/types/chat";
 import type { FeedDetail, FeedList } from "@/types/post";
-import type { CertifiedRss, User } from "@/types/profile";
+import type {
+  CertifiedRss,
+  CommentItem,
+  CursorPage,
+  LikedItem,
+  ProfileActivity,
+  User,
+  UserProfile,
+} from "@/types/profile";
 import type { AdminRssData } from "@/types/rss";
 import type { SearchResult, UserSearchResult } from "@/types/search";
+import type { ChildAdmin } from "@/types/admin";
 
 export const mockFeedList: FeedList = {
   id: 1,
@@ -163,3 +172,108 @@ export const mockWeeks: WeekInfo[] = [
 export const mockSidebarIcon = FileText;
 
 export const mockDailyActivities = mockUser.dailyActivities;
+
+export const mockUserProfile: UserProfile = {
+  userName: "조민석",
+  profileImage: "https://picsum.photos/seed/profile/120/120",
+  introduction: "기술 블로그를 운영하는 개발자입니다.",
+  maxStreak: 30,
+  currentStreak: 7,
+  totalViews: 98765,
+};
+
+export const mockProfileActivity: ProfileActivity = {
+  dailyActivities: [
+    { date: "2026-06-20", viewCount: 12 },
+    { date: "2026-06-21", viewCount: 30 },
+    { date: "2026-06-22", viewCount: 8 },
+    { date: "2026-06-23", viewCount: 5 },
+    { date: "2026-06-24", viewCount: 20 },
+    { date: "2026-06-25", viewCount: 15 },
+    { date: "2026-06-26", viewCount: 3 },
+  ],
+};
+
+export const mockActivityYears: number[] = [2026, 2025, 2024];
+
+export const mockLikedItemsPage: CursorPage<LikedItem> = {
+  result: [
+    { id: 1, likeDate: "2026-06-25T09:00:00.000Z", feed: { id: 1, title: "Storybook으로 컴포넌트 문서화하기", path: "https://example.com/post/1" } },
+    { id: 2, likeDate: "2026-06-24T09:00:00.000Z", feed: { id: 2, title: "TypeScript 5.0 새로운 기능 살펴보기", path: "https://example.com/post/2" } },
+    { id: 3, likeDate: "2026-06-23T09:00:00.000Z", feed: { id: 3, title: "React Query v5 마이그레이션 가이드", path: "https://example.com/post/3" } },
+  ],
+  lastId: 3,
+  hasMore: false,
+};
+
+export const mockCommentItemsPage: CursorPage<CommentItem> = {
+  result: [
+    { id: 1, comment: "좋은 글 감사합니다!", date: "2026-06-25T09:00:00.000Z", feed: { id: 1, title: "Storybook으로 컴포넌트 문서화하기", path: "https://example.com/post/1" } },
+    { id: 2, comment: "정말 유익한 내용이네요. 특히 마이그레이션 가이드 부분이 도움이 많이 됐습니다.", date: "2026-06-24T09:00:00.000Z", feed: { id: 2, title: "TypeScript 5.0 새로운 기능 살펴보기", path: "https://example.com/post/2" } },
+  ],
+  lastId: 2,
+  hasMore: false,
+};
+
+export const mockAdminChatRooms: AdminChatRoom[] = [
+  { roomId: "room-1", roomName: "일반 채팅", messageCount: 15, userCount: 3 },
+  { roomId: "room-2", roomName: "기술 채팅", messageCount: 8, userCount: 1 },
+  { roomId: "room-3", roomName: "공지사항", messageCount: 2, userCount: 5 },
+];
+
+export const mockAdminChatMessages: ChatType[] = [
+  { userName: "사용자1", timestamp: "2026-06-25T09:00:00.000Z", message: "안녕하세요!", userId: "user-1", messageId: "msg-1" },
+  { userName: "사용자2", timestamp: "2026-06-25T09:01:00.000Z", message: "반갑습니다. Storybook 설정 완료했나요?", userId: "user-2", messageId: "msg-2" },
+  { userName: "사용자1", timestamp: "2026-06-25T09:02:00.000Z", message: "네, 방금 완료했습니다!", userId: "user-1", messageId: "msg-3" },
+];
+
+export const mockChildAdmins: ChildAdmin[] = [
+  { id: 1, email: "child1@denamu.dev", name: "부관리자1" },
+  { id: 2, email: "child2@denamu.dev", name: "부관리자2" },
+];
+
+export const mockAdminProfileData = {
+  email: "admin@denamu.dev",
+  name: "메인 관리자",
+  emailNotification: true,
+  parent: null as { email: string; name: string } | null,
+};
+
+export const mockChartTodayData: ChartType[] = [
+  { id: 1, title: "Storybook으로 컴포넌트 문서화하기", viewCount: 1234 },
+  { id: 2, title: "TypeScript 5.0 새로운 기능 살펴보기", viewCount: 987 },
+  { id: 3, title: "React Query v5 마이그레이션 가이드", viewCount: 856 },
+  { id: 4, title: "NestJS 모듈 설계 패턴", viewCount: 645 },
+  { id: 5, title: "Docker Compose로 로컬 개발환경 구성", viewCount: 532 },
+];
+
+export const mockChartAllData: ChartType[] = [
+  { id: 10, title: "프론트엔드 아키텍처 설계", viewCount: 98765 },
+  { id: 11, title: "TypeScript 제네릭 완전 정복", viewCount: 87654 },
+  { id: 12, title: "React 성능 최적화 가이드", viewCount: 76543 },
+  { id: 13, title: "Node.js 스트림 처리", viewCount: 65432 },
+  { id: 14, title: "PostgreSQL 인덱스 전략", viewCount: 54321 },
+];
+
+export const mockFeedsList: FeedList[] = Array.from({ length: 8 }, (_, i) => ({
+  id: i + 1,
+  createdAt: new Date(Date.now() - i * 86400000).toISOString(),
+  title: `블로그 포스트 #${i + 1} - Storybook 데모`,
+  viewCount: (i + 1) * 100,
+  path: `https://example.com/post/${i + 1}`,
+  author: `작성자 ${(i % 4) + 1}`,
+  thumbnail: `https://picsum.photos/seed/feed${i}/400/240`,
+  authorImageUrl: `https://picsum.photos/seed/author${i}/80/80`,
+  tag: i % 2 === 0 ? ["React", "TypeScript"] : ["NestJS", "Node.js"],
+  likes: (i + 1) * 5,
+  comments: i + 1,
+  blogPlatform: i % 3 === 0 ? "tistory" : i % 3 === 1 ? "velog" : "medium",
+  isNew: i < 2,
+}));
+
+export const mockNoSummaryFeeds = mockFeedsList.slice(0, 3).map(({ id, title, likes, comments }) => ({
+  id,
+  title,
+  likes,
+  comments,
+}));

--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -1,0 +1,165 @@
+// Shared mock data for Storybook stories.
+// Not part of the app bundle or test coverage scope (coverage targets components/** & hooks/**).
+import { FileText, Sparkles } from "lucide-react";
+
+import type { FeatureItem } from "@/types/about";
+import type { DayInfo, WeekInfo } from "@/types/activity";
+import type { ChartPlatform } from "@/types/chart";
+import type { ChatType } from "@/types/chat";
+import type { FeedDetail, FeedList } from "@/types/post";
+import type { CertifiedRss, User } from "@/types/profile";
+import type { AdminRssData } from "@/types/rss";
+import type { SearchResult, UserSearchResult } from "@/types/search";
+
+export const mockFeedList: FeedList = {
+  id: 1,
+  createdAt: "2026-06-20T09:00:00.000Z",
+  title: "Storybook으로 컴포넌트 문서화하기",
+  viewCount: 1234,
+  path: "https://example.com/post/1",
+  author: "데나무",
+  thumbnail: "https://picsum.photos/seed/denamu/400/240",
+  authorImageUrl: "https://picsum.photos/seed/author/80/80",
+  tag: ["React", "Storybook", "TypeScript"],
+  likes: 42,
+  comments: 7,
+  blogPlatform: "tistory",
+  isNew: true,
+};
+
+export const mockFeedDetail: FeedDetail = {
+  ...mockFeedList,
+  summary: "이 글은 Storybook을 활용해 프론트엔드 컴포넌트를 문서화하고 테스트하는 방법을 다룹니다.",
+  isOwner: false,
+};
+
+export const mockUser: User = {
+  name: "조민석",
+  email: "denamu@example.com",
+  avatar: "https://picsum.photos/seed/user/120/120",
+  bio: "기술 블로그를 운영하는 개발자입니다.",
+  blogUrl: "https://denamu.dev",
+  rssRegistered: true,
+  lastPosted: "2026-06-22T09:00:00.000Z",
+  totalPosts: 42,
+  totalViews: 98765,
+  topics: ["React", "Node.js", "Infra"],
+  dailyActivities: [
+    { date: "2026-06-20", viewCount: 12 },
+    { date: "2026-06-21", viewCount: 30 },
+    { date: "2026-06-22", viewCount: 8 },
+  ],
+  streakCount: 7,
+  longestStreak: 30,
+};
+
+export const mockCertifiedRss: CertifiedRss = {
+  id: 1,
+  name: "데나무 블로그",
+  userName: "조민석",
+  rssUrl: "https://denamu.dev/rss",
+  blogPlatform: "tistory",
+  feedCount: 42,
+};
+
+export const mockChatItem: ChatType = {
+  chatImg: "https://picsum.photos/seed/chat/64/64",
+  userName: "데나무",
+  timestamp: "2026-06-25T09:00:00.000Z",
+  message: "안녕하세요! Storybook 데모 메시지입니다.",
+  userId: "user-1",
+  messageId: "msg-1",
+  isSend: false,
+};
+
+export const mockSearchResult: SearchResult = {
+  id: 1,
+  title: "Storybook으로 컴포넌트 문서화하기",
+  blogName: "데나무 블로그",
+  path: "https://example.com/post/1",
+  createdAt: "2026-06-20T09:00:00.000Z",
+  author: "조민석",
+  blogPlatform: "tistory",
+  thumbnail: "https://picsum.photos/seed/search/400/240",
+  viewCount: 1234,
+  tag: ["React", "Storybook"],
+  likes: 42,
+  comments: 7,
+};
+
+export const mockUserSearchResult: UserSearchResult = {
+  id: 1,
+  userName: "조민석",
+  profileImage: "https://picsum.photos/seed/usearch/80/80",
+};
+
+export const mockAdminRssList: AdminRssData[] = [
+  {
+    id: 1,
+    name: "데나무 블로그",
+    userName: "조민석",
+    email: "denamu@example.com",
+    rssUrl: "https://denamu.dev/rss",
+    description: "기술 블로그",
+  },
+  {
+    id: 2,
+    name: "벨로그 블로그",
+    userName: "홍길동",
+    email: "hong@example.com",
+    rssUrl: "https://velog.io/@hong/rss",
+  },
+];
+
+export const mockFeatureItem: FeatureItem = {
+  shortTitle: "실시간 트렌딩",
+  longTitle: "실시간 트렌딩 포스트",
+  description: "개발자들이 지금 가장 많이 보는 글을 실시간으로 확인하세요.",
+  icon: Sparkles,
+};
+
+export const mockChartPlatforms: ChartPlatform[] = [
+  { platform: "tistory", count: 120 },
+  { platform: "velog", count: 80 },
+  { platform: "medium", count: 40 },
+];
+
+export const mockPlatforms = [
+  { value: "tistory", label: "Tistory" },
+  { value: "velog", label: "Velog" },
+  { value: "medium", label: "Medium" },
+];
+
+const makeDay = (day: number, count: number): DayInfo => {
+  const date = new Date(2026, 5, day);
+  return {
+    date,
+    dateStr: `2026-06-${String(day).padStart(2, "0")}`,
+    count,
+    empty: false,
+  };
+};
+
+export const mockWeekInfo: WeekInfo = {
+  weekNumber: 1,
+  days: [
+    makeDay(1, 0),
+    makeDay(2, 2),
+    makeDay(3, 5),
+    makeDay(4, 1),
+    makeDay(5, 8),
+    makeDay(6, 3),
+    makeDay(7, 0),
+  ],
+};
+
+export const mockDayInfo: DayInfo = makeDay(5, 8);
+
+export const mockWeeks: WeekInfo[] = [
+  mockWeekInfo,
+  { weekNumber: 2, days: Array.from({ length: 7 }, (_, i) => makeDay(8 + i, i)) },
+];
+
+export const mockSidebarIcon = FileText;
+
+export const mockDailyActivities = mockUser.dailyActivities;

--- a/client/src/__storybook__/mockApi.ts
+++ b/client/src/__storybook__/mockApi.ts
@@ -1,0 +1,39 @@
+// Storybook-only mock adapter on the real service axios instance (axiosInstance),
+// letting stories drive success/error UI states. Unmatched requests pass through.
+import MockAdapter from "axios-mock-adapter";
+
+import { nav } from "@/utils/redirect";
+
+import { axiosInstance } from "@/api/instance";
+import { action } from "storybook/actions";
+import { fn } from "storybook/test";
+
+export const mockApi = new MockAdapter(axiosInstance, { onNoMatch: "passthrough" });
+
+const logApiRequest = action("API");
+axiosInstance.interceptors.request.use((config) => {
+  const method = config.method?.toUpperCase();
+  const url = config.url ?? "";
+  if (method) {
+    logApiRequest(`${method} ${url}`);
+  }
+  return config;
+});
+
+export const ok = (data: unknown, message = "성공"): [number, { message: string; data: unknown }] => [
+  200,
+  { message, data },
+];
+export const fail = (status = 500, message = "서버 오류가 발생했습니다."): [number, { message: string }] => [
+  status,
+  { message },
+];
+
+const logRedirect = action("REDIRECT");
+export const mockRedirect = () => {
+  const orig = nav.redirect;
+  nav.redirect = fn((url: string) => logRedirect(url));
+  return () => {
+    nav.redirect = orig;
+  };
+};

--- a/client/src/__storybook__/queryClient.ts
+++ b/client/src/__storybook__/queryClient.ts
@@ -1,0 +1,7 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+  },
+});

--- a/client/src/components/RssRegistration/FormInput.stories.tsx
+++ b/client/src/components/RssRegistration/FormInput.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { FormInput } from "@/components/RssRegistration/FormInput";
+
+const meta = {
+  title: "RssRegistration/FormInput",
+  component: FormInput,
+  args: { id: "url", label: "RSS URL", value: "", placeholder: "URL을 입력하세요", type: "text", onChange: fn() },
+} satisfies Meta<typeof FormInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/RssRegistration/PlatformBadge.stories.tsx
+++ b/client/src/components/RssRegistration/PlatformBadge.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PlatformBadge } from "@/components/RssRegistration/PlatformBadge";
+
+const meta = {
+  title: "RssRegistration/PlatformBadge",
+  component: PlatformBadge,
+  args: { platform: "tistory" },
+} satisfies Meta<typeof PlatformBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/RssRegistration/PlatformSelector.stories.tsx
+++ b/client/src/components/RssRegistration/PlatformSelector.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { BlogPlatformSelector } from "@/components/RssRegistration/PlatformSelector";
+import { mockPlatforms } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "RssRegistration/BlogPlatformSelector",
+  component: BlogPlatformSelector,
+  args: { platforms: mockPlatforms, value: "tistory", onChange: fn() },
+} satisfies Meta<typeof BlogPlatformSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/RssRegistration/RssRegistrationModal.stories.tsx
+++ b/client/src/components/RssRegistration/RssRegistrationModal.stories.tsx
@@ -1,0 +1,22 @@
+import { RssRegistrationModal } from "@/components/RssRegistration/RssRegistrationModal";
+
+import { BLOG } from "@/constants/endpoints";
+
+import { mockApi, ok} from "@/__storybook__/mockApi";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+const meta = {
+  title: "RssRegistration/RssRegistrationModal",
+  component: RssRegistrationModal,
+  args: { onClose: fn(), rssOpen: true },
+} satisfies Meta<typeof RssRegistrationModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPost(BLOG.RSS.REGISTRER_RSS).reply(...ok(null));
+  },
+};

--- a/client/src/components/RssRegistration/RssUrlInput.stories.tsx
+++ b/client/src/components/RssRegistration/RssUrlInput.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { RssUrlInput } from "@/components/RssRegistration/RssUrlInput";
+
+const meta = {
+  title: "RssRegistration/RssUrlInput",
+  component: RssUrlInput,
+  args: { platform: "tistory", value: "", onChange: fn() },
+} satisfies Meta<typeof RssUrlInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/about/CTASection.stories.tsx
+++ b/client/src/components/about/CTASection.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+
+import { CTASection } from "@/components/about/CTASection";
+
+const meta = {
+  title: "about/CTASection",
+  component: CTASection,
+  decorators: [
+    (Story) => (
+      <div
+        onClickCapture={(e) => {
+          const button = (e.target as HTMLElement).closest("button");
+          if (button) action(button.textContent?.trim() || "button 클릭")(e);
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof CTASection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/about/ExtraFeatureSection.stories.tsx
+++ b/client/src/components/about/ExtraFeatureSection.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ExtraFeatureSection } from "@/components/about/ExtraFeatureSection";
+
+const meta = {
+  title: "about/ExtraFeatureSection",
+  component: ExtraFeatureSection,
+} satisfies Meta<typeof ExtraFeatureSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/about/FeatureCard.stories.tsx
+++ b/client/src/components/about/FeatureCard.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FeatureCard } from "@/components/about/FeatureCard";
+import { mockFeatureItem } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "about/FeatureCard",
+  component: FeatureCard,
+  args: { feature: mockFeatureItem },
+} satisfies Meta<typeof FeatureCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/about/FeatureSection.stories.tsx
+++ b/client/src/components/about/FeatureSection.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FeatureSection } from "@/components/about/FeatureSection";
+
+const meta = {
+  title: "about/FeatureSection",
+  component: FeatureSection,
+} satisfies Meta<typeof FeatureSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/about/Footer.stories.tsx
+++ b/client/src/components/about/Footer.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Footer } from "@/components/about/Footer";
+
+const meta = {
+  title: "about/Footer",
+  component: Footer,
+} satisfies Meta<typeof Footer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/about/HeroSection.stories.tsx
+++ b/client/src/components/about/HeroSection.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+
+import { HeroSection } from "@/components/about/HeroSection";
+
+const meta = {
+  title: "about/HeroSection",
+  component: HeroSection,
+  decorators: [
+    (Story) => (
+      <div
+        onClickCapture={(e) => {
+          const button = (e.target as HTMLElement).closest("button");
+          if (button) action(button.textContent?.trim() || "button 클릭")(e);
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof HeroSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/about/Section.stories.tsx
+++ b/client/src/components/about/Section.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Section } from "@/components/about/Section";
+
+const meta = {
+  title: "about/Section",
+  component: Section,
+  args: { children: "Section 콘텐츠" },
+} satisfies Meta<typeof Section>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/chat/AdminChatTab.stories.tsx
+++ b/client/src/components/admin/chat/AdminChatTab.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+import { fn } from "storybook/test";
+
+import AdminChatTab from "@/components/admin/chat/AdminChatTab";
+import { ADMIN } from "@/constants/endpoints";
+import { mockAdminChatMessages, mockAdminChatRooms } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "admin/chat/AdminChatTab",
+  component: AdminChatTab,
+} satisfies Meta<typeof AdminChatTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithRooms: Story = {
+  name: "채팅방 있음",
+  beforeEach: () => {
+    const origConfirm = window.confirm;
+    window.confirm = fn().mockReturnValue(true) as never;
+    mockApi.onGet(ADMIN.CHAT.ROOMS).reply(...ok(mockAdminChatRooms));
+    mockAdminChatRooms.forEach((room) => {
+      mockApi.onGet(ADMIN.CHAT.MESSAGES(room.roomId)).reply(...ok(mockAdminChatMessages));
+    });
+    mockApi.onDelete(/\/api\/admins\/chats\/[^/]+\/[^/]+/).reply(...ok(null));
+    return () => { window.confirm = origConfirm; };
+  },
+};
+
+export const DeleteMessage: Story = {
+  name: "채팅 삭제",
+  beforeEach: () => {
+    const origConfirm = window.confirm;
+    // Show the real native confirm dialog; log an action when OK is pressed.
+    window.confirm = ((message?: string) => {
+      const confirmed = origConfirm(message);
+      if (confirmed) action("채팅 삭제 확인")(message);
+      return confirmed;
+    }) as never;
+    mockApi.onGet(ADMIN.CHAT.ROOMS).reply(...ok(mockAdminChatRooms));
+    mockAdminChatRooms.forEach((room) => {
+      mockApi.onGet(ADMIN.CHAT.MESSAGES(room.roomId)).reply(...ok(mockAdminChatMessages));
+    });
+    mockApi.onDelete(/\/api\/admins\/chats\/[^/]+\/[^/]+/).reply(...ok(null));
+    return () => { window.confirm = origConfirm; };
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.CHAT.ROOMS).reply(() => new Promise(() => {}));
+  },
+};
+
+export const NoRooms: Story = {
+  name: "채팅방 없음",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.CHAT.ROOMS).reply(...ok([]));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.CHAT.ROOMS).reply(...fail());
+  },
+};

--- a/client/src/components/admin/layout/AdminHeader.stories.tsx
+++ b/client/src/components/admin/layout/AdminHeader.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { AdminHeader } from "@/components/admin/layout/AdminHeader";
+
+const meta = {
+  title: "admin/layout/AdminHeader",
+  component: AdminHeader,
+  args: { setLogin: fn(), handleTap: fn() },
+} satisfies Meta<typeof AdminHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/layout/AdminMember.stories.tsx
+++ b/client/src/components/admin/layout/AdminMember.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import AdminMember from "@/components/admin/layout/AdminMember";
+import { ADMIN } from "@/constants/endpoints";
+import { mockChildAdmins } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "admin/layout/AdminMember",
+  component: AdminMember,
+} satisfies Meta<typeof AdminMember>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithChildren: Story = {
+  name: "하위 관리자 있음",
+  beforeEach: () => {
+    const origAlert = window.alert;
+    window.alert = fn() as never;
+    mockApi.onGet(ADMIN.CHILDREN).reply(...ok(mockChildAdmins));
+    mockApi.onDelete(/\/api\/admins\/children\/\d+/).reply(...ok({ message: "삭제되었습니다." }));
+    mockApi.onPost(ADMIN.REGISTER).reply(...ok({ message: "인증 이메일을 발송했습니다." }));
+    return () => { window.alert = origAlert; };
+  },
+};
+
+export const NoChildren: Story = {
+  name: "하위 관리자 없음",
+  beforeEach: () => {
+    const origAlert = window.alert;
+    window.alert = fn() as never;
+    mockApi.onGet(ADMIN.CHILDREN).reply(...ok([]));
+    mockApi.onPost(ADMIN.REGISTER).reply(...ok({ message: "인증 이메일을 발송했습니다." }));
+    return () => { window.alert = origAlert; };
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.CHILDREN).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.CHILDREN).reply(...fail());
+  },
+};

--- a/client/src/components/admin/layout/AdminMyPage.stories.tsx
+++ b/client/src/components/admin/layout/AdminMyPage.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import AdminMyPage from "@/components/admin/layout/AdminMyPage";
+import { ADMIN } from "@/constants/endpoints";
+import { mockAdminProfileData } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "admin/layout/AdminMyPage",
+  component: AdminMyPage,
+  args: { onBack: fn() },
+} satisfies Meta<typeof AdminMyPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+let _origAlert: typeof window.alert;
+const setupProfileMutations = () => {
+  _origAlert = window.alert;
+  window.alert = fn() as never;
+  mockApi.onPatch(ADMIN.UPDATE_ME).reply(...ok({ message: "수정되었습니다." }));
+  mockApi.onPost(ADMIN.WITHDRAW_REQUEST).reply(...ok({ message: "탈퇴 요청이 완료되었습니다." }));
+  return () => { window.alert = _origAlert; };
+};
+
+export const WithProfile: Story = {
+  name: "프로필 로드됨",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...ok(mockAdminProfileData));
+    return setupProfileMutations();
+  },
+};
+
+export const RootAdmin: Story = {
+  name: "루트 관리자",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...ok({ ...mockAdminProfileData, parent: null }));
+    return setupProfileMutations();
+  },
+};
+
+export const ChildAdmin: Story = {
+  name: "하위 관리자",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...ok({
+      ...mockAdminProfileData,
+      parent: { email: "root@denamu.dev", name: "루트 관리자" },
+    }));
+    return setupProfileMutations();
+  },
+};
+
+export const EditProfile: Story = {
+  name: "프로필 수정",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...ok(mockAdminProfileData));
+    return setupProfileMutations();
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: "수정하기" }));
+    await userEvent.click(canvas.getByRole("button", { name: "수정 완료" }));
+    await expect(mockApi.history.patch).toHaveLength(1);
+    await expect(window.alert).toHaveBeenCalled();
+  },
+};
+
+export const ToggleNotification: Story = {
+  name: "이메일 수신 전환",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...ok(mockAdminProfileData));
+    return setupProfileMutations();
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("switch"));
+    await expect(mockApi.history.patch).toHaveLength(1);
+  },
+};
+
+export const Withdraw: Story = {
+  name: "회원 탈퇴 요청",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...ok(mockAdminProfileData));
+    return setupProfileMutations();
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await canvas.findByRole("button", { name: "회원 탈퇴" }));
+    await userEvent.click(await body.findByRole("button", { name: "인증 메일 발송" }));
+    await expect(mockApi.history.post).toHaveLength(1);
+    await expect(window.alert).toHaveBeenCalled();
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...fail(401, "인증이 필요합니다."));
+  },
+};

--- a/client/src/components/admin/layout/AdminNavigationMenu.stories.tsx
+++ b/client/src/components/admin/layout/AdminNavigationMenu.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { AdminNavigationMenu } from "@/components/admin/layout/AdminNavigationMenu";
+
+const meta = {
+  title: "admin/layout/AdminNavigationMenu",
+  component: AdminNavigationMenu,
+  args: { handleTap: fn() },
+} satisfies Meta<typeof AdminNavigationMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/layout/AdminTabs.stories.tsx
+++ b/client/src/components/admin/layout/AdminTabs.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { AdminTabs } from "@/components/admin/layout/AdminTabs";
+import { ADMIN } from "@/constants/endpoints";
+import { mockAdminRssList } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "admin/layout/AdminTabs",
+  component: AdminTabs,
+  args: { setLogout: fn() },
+} satisfies Meta<typeof AdminTabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const setupSuccess = () => {
+  mockApi.onGet(ADMIN.GET.RSS).reply(...ok(mockAdminRssList));
+  mockApi.onGet(ADMIN.GET.ACCEPT).reply(...ok(mockAdminRssList.slice(0, 1)));
+  mockApi.onGet(ADMIN.GET.REJECT).reply(...ok([]));
+  mockApi.onPost(/\/api\/rss\/accept\/\d+/).reply(...ok({ message: "승인되었습니다." }));
+  mockApi.onPost(/\/api\/rss\/reject\/\d+/).reply(...ok({ message: "거부되었습니다." }));
+};
+
+export const WithPending: Story = {
+  name: "대기 중 RSS 있음",
+  beforeEach: setupSuccess,
+};
+
+export const AcceptPending: Story = {
+  name: "대기 RSS 승인",
+  beforeEach: setupSuccess,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const approveButtons = await canvas.findAllByRole("button", { name: "승인" });
+    await userEvent.click(approveButtons[0]);
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};
+
+export const RejectPending: Story = {
+  name: "대기 RSS 거부",
+  beforeEach: setupSuccess,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    const rejectButtons = await canvas.findAllByRole("button", { name: "거부" });
+    await userEvent.click(rejectButtons[0]);
+    await userEvent.type(await body.findByPlaceholderText("거부 사유를 입력하세요..."), "기술 블로그가 아닙니다.");
+    await userEvent.click(body.getByRole("button", { name: "거부하기" }));
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};
+
+export const AllEmpty: Story = {
+  name: "모든 탭 비어있음",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.GET.RSS).reply(...ok([]));
+    mockApi.onGet(ADMIN.GET.ACCEPT).reply(...ok([]));
+    mockApi.onGet(ADMIN.GET.REJECT).reply(...ok([]));
+    mockApi.onPost(/\/api\/rss\/accept\/\d+/).reply(...ok({ message: "승인되었습니다." }));
+    mockApi.onPost(/\/api\/rss\/reject\/\d+/).reply(...ok({ message: "거부되었습니다." }));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.GET.RSS).reply(() => new Promise(() => {}));
+    mockApi.onGet(ADMIN.GET.ACCEPT).reply(() => new Promise(() => {}));
+    mockApi.onGet(ADMIN.GET.REJECT).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류 (세션 만료)",
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.GET.RSS).reply(...fail(401, "세션이 만료되었습니다."));
+    mockApi.onGet(ADMIN.GET.ACCEPT).reply(...fail(401, "세션이 만료되었습니다."));
+    mockApi.onGet(ADMIN.GET.REJECT).reply(...fail(401, "세션이 만료되었습니다."));
+  },
+};

--- a/client/src/components/admin/login/AdminLoginModal.stories.tsx
+++ b/client/src/components/admin/login/AdminLoginModal.stories.tsx
@@ -1,0 +1,22 @@
+import AdminLoginModal from "@/components/admin/login/AdminLoginModal";
+
+import { ADMIN } from "@/constants/endpoints";
+
+import { mockApi, ok } from "@/__storybook__/mockApi";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+const meta = {
+  title: "admin/login/AdminLoginModal",
+  component: AdminLoginModal,
+  args: { setLogin: fn() },
+} satisfies Meta<typeof AdminLoginModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPost(ADMIN.LOGIN).reply(...ok(null));
+  },
+};

--- a/client/src/components/admin/post/AdminPostDetail.stories.tsx
+++ b/client/src/components/admin/post/AdminPostDetail.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import AdminPostDetail from "@/components/admin/post/AdminPostDetail";
+import { BLOG } from "@/constants/endpoints";
+import { mockFeedDetail } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "admin/post/AdminPostDetail",
+  component: AdminPostDetail,
+  args: { feedId: 1, onClose: fn() },
+} satisfies Meta<typeof AdminPostDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...ok(mockFeedDetail));
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
+    mockApi.onPost(BLOG.AI_SUMMARY(1)).reply(...ok(null));
+    mockApi.onDelete(/\/api\/admins\/comments\/\d+/).reply(...ok(null));
+  },
+};
+
+export const RetrySummary: Story = {
+  name: "AI 요약 재시도 클릭",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...ok(mockFeedDetail));
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
+    mockApi.onPost(BLOG.AI_SUMMARY(1)).reply(...ok(null));
+    mockApi.onDelete(/\/api\/admins\/comments\/\d+/).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: "AI 요약 재시도" }));
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};
+
+export const WithComments: Story = {
+  name: "댓글 있음",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...ok(mockFeedDetail));
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([
+      { id: 1, comment: "좋은 글이네요!", date: "2026-06-25T09:00:00.000Z", parentId: null, isDeleted: false, user: { id: 99, userName: "독자", profileImage: null } },
+    ]));
+    mockApi.onPost(BLOG.AI_SUMMARY(1)).reply(...ok(null));
+    mockApi.onDelete(/\/api\/admins\/comments\/\d+/).reply(...ok(null));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...fail(404, "게시글을 찾을 수 없습니다."));
+  },
+};

--- a/client/src/components/admin/post/AdminPostTab.stories.tsx
+++ b/client/src/components/admin/post/AdminPostTab.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import AdminPostTab from "@/components/admin/post/AdminPostTab";
+import { BLOG } from "@/constants/endpoints";
+import { mockFeedsList, mockNoSummaryFeeds, mockFeedDetail } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "admin/post/AdminPostTab",
+  component: AdminPostTab,
+} satisfies Meta<typeof AdminPostTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const setupSuccess = () => {
+  mockApi.onGet(BLOG.POST).reply(...ok({ result: mockFeedsList, hasMore: false, lastId: null }));
+  mockApi.onGet(BLOG.NO_SUMMARY).reply(...ok(mockNoSummaryFeeds));
+  mockApi.onPost(/\/api\/feeds\/\d+\/ai-summary-requests/).reply(...ok(null));
+  // For post detail panel when card is clicked
+  mockApi.onGet(/\/api\/feeds\/\d+$/).reply(...ok(mockFeedDetail));
+  mockApi.onGet(/\/api\/feeds\/\d+\/comments/).reply(...ok([]));
+  mockApi.onDelete(/\/api\/admins\/comments\/\d+/).reply(...ok(null));
+};
+
+export const WithPosts: Story = {
+  name: "게시글 있음",
+  beforeEach: setupSuccess,
+};
+
+export const ClickPost: Story = {
+  name: "게시글 클릭 → 상세",
+  beforeEach: setupSuccess,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const titles = await canvas.findAllByText(mockFeedsList[0].title);
+    await userEvent.click(titles[titles.length - 1]);
+    await expect(await canvas.findByRole("button", { name: "AI 요약 재시도" })).toBeInTheDocument();
+  },
+};
+
+export const NoSummaryOnly: Story = {
+  name: "AI 요약 없는 게시글만",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...ok({ result: [], hasMore: false, lastId: null }));
+    mockApi.onGet(BLOG.NO_SUMMARY).reply(...ok(mockNoSummaryFeeds));
+    mockApi.onPost(/\/api\/feeds\/\d+\/ai-summary-requests/).reply(...ok(null));
+  },
+};
+
+export const AllEmpty: Story = {
+  name: "게시글 없음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...ok({ result: [], hasMore: false, lastId: null }));
+    mockApi.onGet(BLOG.NO_SUMMARY).reply(...ok([]));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(() => new Promise(() => {}));
+    mockApi.onGet(BLOG.NO_SUMMARY).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...fail());
+    mockApi.onGet(BLOG.NO_SUMMARY).reply(...fail());
+  },
+};

--- a/client/src/components/admin/rss/RejectModal.stories.tsx
+++ b/client/src/components/admin/rss/RejectModal.stories.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+
+import { RejectModal } from "@/components/admin/rss/RejectModal";
+import { ADMIN } from "@/constants/endpoints";
+
+const meta = {
+  title: "admin/rss/RejectModal",
+  component: RejectModal,
+  args: { blogName: "데나무 블로그" },
+} satisfies Meta<typeof RejectModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [reason, setReason] = useState("");
+    return (
+      <RejectModal
+        {...args}
+        rejectMessage={reason}
+        handleReason={setReason}
+        onSubmit={() => action("API")(`POST ${ADMIN.ACTION.REJECT}/1`)}
+        onCancel={() => setReason("")}
+      />
+    );
+  },
+};

--- a/client/src/components/admin/rss/RejectModal.stories.tsx
+++ b/client/src/components/admin/rss/RejectModal.stories.tsx
@@ -9,7 +9,13 @@ import { ADMIN } from "@/constants/endpoints";
 const meta = {
   title: "admin/rss/RejectModal",
   component: RejectModal,
-  args: { blogName: "데나무 블로그" },
+  args: {
+    blogName: "데나무 블로그",
+    rejectMessage: "",
+    handleReason: () => {},
+    onSubmit: () => {},
+    onCancel: () => {},
+  },
 } satisfies Meta<typeof RejectModal>;
 
 export default meta;

--- a/client/src/components/admin/rss/RssRequestCard.stories.tsx
+++ b/client/src/components/admin/rss/RssRequestCard.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { action } from "storybook/actions";
+
+import { RssRequestCard } from "@/components/admin/rss/RssRequestCard";
+import { ADMIN } from "@/constants/endpoints";
+import { mockAdminRssList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "admin/rss/RssRequestCard",
+  component: RssRequestCard,
+  args: {
+    request: mockAdminRssList[0],
+    onApprove: (request) => action("API")(`POST ${ADMIN.ACTION.ACCEPT}/${request.id}`),
+    onReject: (request) => action("API")(`POST ${ADMIN.ACTION.REJECT}/${request.id}`),
+  },
+} satisfies Meta<typeof RssRequestCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/rss/RssResponseCard.stories.tsx
+++ b/client/src/components/admin/rss/RssResponseCard.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RssResponseCard } from "@/components/admin/rss/RssResponseCard";
+import { mockAdminRssList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "admin/rss/RssResponseCard",
+  component: RssResponseCard,
+  args: { request: mockAdminRssList[0] },
+} satisfies Meta<typeof RssResponseCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/rss/RssSearchBar.stories.tsx
+++ b/client/src/components/admin/rss/RssSearchBar.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RssRequestSearchBar } from "@/components/admin/rss/RssSearchBar";
+
+const meta = {
+  title: "admin/rss/RssRequestSearchBar",
+  component: RssRequestSearchBar,
+} satisfies Meta<typeof RssRequestSearchBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/tabs/AcceptedTab.stories.tsx
+++ b/client/src/components/admin/tabs/AcceptedTab.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import AcceptedTab from "@/components/admin/tabs/AcceptedTab";
+import { Tabs } from "@/components/ui/tabs";
+import { mockAdminRssList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "admin/tabs/AcceptedTab",
+  component: AcceptedTab,
+  decorators: [
+    (Story) => (
+        <Tabs defaultValue="accepted">
+        <Story />
+        </Tabs>
+    ),
+  ],
+  args: { data: mockAdminRssList },
+} satisfies Meta<typeof AcceptedTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/tabs/PendingTab.stories.tsx
+++ b/client/src/components/admin/tabs/PendingTab.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import PendingTab from "@/components/admin/tabs/PendingTab";
+import { Tabs } from "@/components/ui/tabs";
+import { mockAdminRssList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "admin/tabs/PendingTab",
+  component: PendingTab,
+  decorators: [
+    (Story) => (
+      <Tabs defaultValue="pending">
+        <Story />
+      </Tabs>
+    ),
+  ],
+  args: { data: mockAdminRssList, onApprove: fn(), onReject: fn() },
+} satisfies Meta<typeof PendingTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/admin/tabs/RejectedTab.stories.tsx
+++ b/client/src/components/admin/tabs/RejectedTab.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import RejectedTab from "@/components/admin/tabs/RejectedTab";
+import { Tabs } from "@/components/ui/tabs";
+import { mockAdminRssList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "admin/tabs/RejectedTab",
+  component: RejectedTab,
+  decorators: [
+    (Story) => (
+      <Tabs defaultValue="rejected">
+        <Story />
+      </Tabs>
+    ),
+  ],
+  args: { data: mockAdminRssList },
+} satisfies Meta<typeof RejectedTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/auth/AuthBanner.stories.tsx
+++ b/client/src/components/auth/AuthBanner.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AuthBanner } from "@/components/auth/AuthBanner";
+
+const meta = {
+  title: "auth/AuthBanner",
+  component: AuthBanner,
+} satisfies Meta<typeof AuthBanner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/auth/AuthCard.stories.tsx
+++ b/client/src/components/auth/AuthCard.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AuthCard } from "@/components/auth/AuthCard";
+
+const meta = {
+  title: "auth/AuthCard",
+  component: AuthCard,
+  args: { title: "인증", description: "설명 텍스트", children: "카드 내용" },
+} satisfies Meta<typeof AuthCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/auth/AuthSignInForm.stories.tsx
+++ b/client/src/components/auth/AuthSignInForm.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
+import { USER } from "@/constants/endpoints";
+import { mockApi, mockRedirect, ok, fail } from "@/__storybook__/mockApi";
+import { nav } from "@/utils/redirect";
+
+const meta = {
+  title: "auth/AuthSignInForm",
+  component: AuthSignInForm,
+} satisfies Meta<typeof AuthSignInForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const fillCredentials = async (canvas: ReturnType<typeof within>) => {
+  await userEvent.type(canvas.getByPlaceholderText("이메일을 입력하세요"), "test@test.com");
+  await userEvent.type(canvas.getByPlaceholderText("비밀번호를 입력하세요"), "password123");
+};
+
+export const Default: Story = {
+  beforeEach: () => {
+    const cleanup = mockRedirect();
+    mockApi.onPost(USER.LOGIN).reply(...ok({ accessToken: null }));
+    return cleanup;
+  },
+};
+
+export const LoginSuccess: Story = {
+  name: "로그인 제출",
+  beforeEach: () => {
+    const cleanup = mockRedirect();
+    mockApi.onPost(USER.LOGIN).reply(...ok({ accessToken: null }));
+    return cleanup;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await fillCredentials(canvas);
+    await userEvent.click(canvas.getByRole("button", { name: "로그인" }));
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};
+
+export const LoginError: Story = {
+  name: "로그인 실패",
+  beforeEach: () => {
+    const cleanup = mockRedirect();
+    mockApi.onPost(USER.LOGIN).reply(...fail(401, "아이디 혹은 비밀번호가 잘못되었습니다."));
+    return cleanup;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await fillCredentials(canvas);
+    await userEvent.click(canvas.getByRole("button", { name: "로그인" }));
+    // 401 응답은 axiosInstance 인터셉터의 refresh 요청을 추가로 유발하므로 최소 1건(로그인)만 확인.
+    await expect(mockApi.history.post.length).toBeGreaterThanOrEqual(1);
+  },
+};
+
+export const SocialLogin: Story = {
+  name: "소셜 로그인 클릭",
+  beforeEach: () => mockRedirect(),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId("oauth-github-button"));
+    await expect(nav.redirect).toHaveBeenCalledWith(expect.stringContaining("type=github"));
+  },
+};

--- a/client/src/components/auth/AuthSignUpForm.stories.tsx
+++ b/client/src/components/auth/AuthSignUpForm.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { AuthSignUpForm } from "@/components/auth/AuthSignUpForm";
+import { USER } from "@/constants/endpoints";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "auth/AuthSignUpForm",
+  component: AuthSignUpForm,
+} satisfies Meta<typeof AuthSignUpForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const fillForm = async (canvas: ReturnType<typeof within>) => {
+  await userEvent.type(canvas.getByPlaceholderText("이메일을 입력하세요"), "test@test.com");
+  await userEvent.type(canvas.getByPlaceholderText("비밀번호를 입력하세요"), "password123");
+  await userEvent.type(canvas.getByPlaceholderText("이름을 입력해주세요"), "데나무");
+};
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPost(USER.REGISTER).reply(...ok(null));
+  },
+};
+
+export const RegisterSuccess: Story = {
+  name: "회원가입 제출",
+  beforeEach: () => {
+    mockApi.onPost(USER.REGISTER).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await fillForm(canvas);
+    await userEvent.click(canvas.getByRole("button", { name: "회원가입" }));
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};
+
+export const RegisterError: Story = {
+  name: "회원가입 실패",
+  beforeEach: () => {
+    mockApi.onPost(USER.REGISTER).reply(...fail(409, "이미 사용 중인 이메일입니다."));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await fillForm(canvas);
+    await userEvent.click(canvas.getByRole("button", { name: "회원가입" }));
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};

--- a/client/src/components/auth/AuthSocialLoginButtons.stories.tsx
+++ b/client/src/components/auth/AuthSocialLoginButtons.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { AuthSocialLoginButtons } from "@/components/auth/AuthSocialLoginButtons";
+import { mockRedirect } from "@/__storybook__/mockApi";
+import { nav } from "@/utils/redirect";
+
+const meta = {
+  title: "auth/AuthSocialLoginButtons",
+  component: AuthSocialLoginButtons,
+} satisfies Meta<typeof AuthSocialLoginButtons>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => mockRedirect(),
+};
+
+export const GithubLogin: Story = {
+  name: "Github 로그인 클릭",
+  beforeEach: () => mockRedirect(),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId("oauth-github-button"));
+    await expect(nav.redirect).toHaveBeenCalledWith(expect.stringContaining("type=github"));
+  },
+};
+
+export const GoogleLogin: Story = {
+  name: "Google 로그인 클릭",
+  beforeEach: () => mockRedirect(),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId("oauth-google-button"));
+    await expect(nav.redirect).toHaveBeenCalledWith(expect.stringContaining("type=google"));
+  },
+};

--- a/client/src/components/auth/AuthSocialLoginButtons.tsx
+++ b/client/src/components/auth/AuthSocialLoginButtons.tsx
@@ -3,10 +3,11 @@ import { Google } from "@/components/icons/social/Google.tsx";
 import { Button } from "@/components/ui/button.tsx";
 
 import { BASE_URL, OAUTH } from "@/constants/endpoints.ts";
+import { nav } from "@/utils/redirect.ts";
 
 export const AuthSocialLoginButtons = () => {
   const handleSocialLogin = (provider: "google" | "github") => {
-    window.location.href = `${BASE_URL}${OAUTH.LOGIN}?type=${provider}`;
+    nav.redirect(`${BASE_URL}${OAUTH.LOGIN}?type=${provider}`);
   };
 
   return (

--- a/client/src/components/chart/BarChartItem.stories.tsx
+++ b/client/src/components/chart/BarChartItem.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import BarChartItem from "@/components/chart/BarChartItem";
+import { ChartType } from "@/types/chart";
+
+const meta = {
+  title: "chart/BarChartItem",
+  component: BarChartItem,
+  args: {
+    data: [{ id: 1, title: "게시글 제목", viewCount: 100 }] as ChartType[],
+    title: "차트 제목",
+    description: "차트 설명",
+    color: false,
+  },
+} satisfies Meta<typeof BarChartItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chart/Chart.stories.tsx
+++ b/client/src/components/chart/Chart.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import Chart from "@/components/chart/Chart";
+import { CHART } from "@/constants/endpoints";
+import { mockChartPlatforms } from "@/__storybook__/fixtures";
+import { mockApi } from "@/__storybook__/mockApi";
+
+const mockBarData = [
+  { id: 1, title: "TypeScript 완벽 가이드", viewCount: 3200 },
+  { id: 2, title: "React 18 새로운 기능들", viewCount: 2800 },
+  { id: 3, title: "NestJS로 API 만들기", viewCount: 2400 },
+  { id: 4, title: "Docker Compose 실전", viewCount: 1900 },
+  { id: 5, title: "Storybook 컴포넌트 문서화", viewCount: 1500 },
+];
+
+const meta = {
+  title: "chart/Chart",
+  component: Chart,
+} satisfies Meta<typeof Chart>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  name: "데이터 있음",
+  beforeEach: () => {
+    mockApi.onGet(CHART.ALL).reply(200, { message: "성공", data: mockBarData });
+    mockApi.onGet(CHART.TODAY).reply(200, { message: "성공", data: mockBarData.slice(0, 3) });
+    mockApi.onGet(CHART.PLATFORM).reply(200, { message: "성공", data: mockChartPlatforms });
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(CHART.ALL).reply(() => new Promise(() => {}));
+    mockApi.onGet(CHART.TODAY).reply(() => new Promise(() => {}));
+    mockApi.onGet(CHART.PLATFORM).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류 발생",
+  beforeEach: () => {
+    mockApi.onGet(CHART.ALL).reply(500, { message: "서버 오류가 발생했습니다." });
+    mockApi.onGet(CHART.TODAY).reply(500, { message: "서버 오류가 발생했습니다." });
+    mockApi.onGet(CHART.PLATFORM).reply(500, { message: "서버 오류가 발생했습니다." });
+  },
+};

--- a/client/src/components/chart/ChartSkeleton.stories.tsx
+++ b/client/src/components/chart/ChartSkeleton.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChartSkeleton from "@/components/chart/ChartSkeleton";
+
+const meta = {
+  title: "chart/ChartSkeleton",
+  component: ChartSkeleton,
+} satisfies Meta<typeof ChartSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chart/ChartTab.stories.tsx
+++ b/client/src/components/chart/ChartTab.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChartTab from "@/components/chart/ChartTab";
+import { CHART } from "@/constants/endpoints";
+import { mockChartAllData, mockChartTodayData, mockChartPlatforms } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "chart/ChartTab",
+  component: ChartTab,
+} satisfies Meta<typeof ChartTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// CHART.TODAY/ALL have embedded query strings ("/api/statistics/today?limit=5").
+// Regex match is safer than exact string since axios may normalize the URL.
+const setupChartMocks = (allData: unknown, todayData: unknown, platformData: unknown) => {
+  mockApi.onGet(/\/api\/statistics\/all/).reply(...ok(allData));
+  mockApi.onGet(/\/api\/statistics\/today/).reply(...ok(todayData));
+  mockApi.onGet(CHART.PLATFORM).reply(...ok(platformData));
+};
+
+export const WithData: Story = {
+  name: "데이터 있음",
+  beforeEach: () => setupChartMocks(mockChartAllData, mockChartTodayData, mockChartPlatforms),
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(/\/api\/statistics\/all/).reply(() => new Promise(() => {}));
+    mockApi.onGet(/\/api\/statistics\/today/).reply(() => new Promise(() => {}));
+    mockApi.onGet(CHART.PLATFORM).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Empty: Story = {
+  name: "데이터 없음",
+  beforeEach: () => setupChartMocks([], [], []),
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(/\/api\/statistics\/all/).reply(...fail());
+    mockApi.onGet(/\/api\/statistics\/today/).reply(...fail());
+    mockApi.onGet(CHART.PLATFORM).reply(...fail());
+  },
+};

--- a/client/src/components/chart/PieChartItem.stories.tsx
+++ b/client/src/components/chart/PieChartItem.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import PieChartItem from "@/components/chart/PieChartItem";
+import { mockChartPlatforms } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "chart/PieChartItem",
+  component: PieChartItem,
+  args: { data: mockChartPlatforms, title: "플랫폼별 게시글" },
+} satisfies Meta<typeof PieChartItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/Chat.stories.tsx
+++ b/client/src/components/chat/Chat.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Chat } from "@/components/chat/Chat";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+const meta = {
+  title: "chat/Chat",
+  component: Chat,
+  decorators: [
+    (Story) => (
+        <SidebarProvider>
+        <Story />
+        </SidebarProvider>
+    ),
+  ],
+} satisfies Meta<typeof Chat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/ChatButton.stories.tsx
+++ b/client/src/components/chat/ChatButton.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChatButton from "@/components/chat/ChatButton";
+
+const meta = {
+  title: "chat/ChatButton",
+  component: ChatButton,
+} satisfies Meta<typeof ChatButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/ChatItem.stories.tsx
+++ b/client/src/components/chat/ChatItem.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChatItem from "@/components/chat/ChatItem";
+import { mockChatItem } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "chat/ChatItem",
+  component: ChatItem,
+  args: { chatItem: mockChatItem, isSameUser: false },
+} satisfies Meta<typeof ChatItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/layout/ChatFooter.stories.tsx
+++ b/client/src/components/chat/layout/ChatFooter.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChatFooter from "@/components/chat/layout/ChatFooter";
+
+const meta = {
+  title: "chat/layout/ChatFooter",
+  component: ChatFooter,
+} satisfies Meta<typeof ChatFooter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/layout/ChatHeader.stories.tsx
+++ b/client/src/components/chat/layout/ChatHeader.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChatHeader from "@/components/chat/layout/ChatHeader";
+import { SidebarProvider } from "@/components/ui/sidebar";
+
+const meta = {
+  title: "chat/layout/ChatHeader",
+  component: ChatHeader,
+  decorators: [
+    (Story) => (
+      <SidebarProvider>
+        <Story />
+      </SidebarProvider>
+    ),
+  ],
+} satisfies Meta<typeof ChatHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/layout/ChatHistory.stories.tsx
+++ b/client/src/components/chat/layout/ChatHistory.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChatHistory from "@/components/chat/layout/ChatHistory";
+
+const meta = {
+  title: "chat/layout/ChatHistory",
+  component: ChatHistory,
+  args: { isFull: false, isConnected: true },
+} satisfies Meta<typeof ChatHistory>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/layout/ChatSection.stories.tsx
+++ b/client/src/components/chat/layout/ChatSection.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChatSection from "@/components/chat/layout/ChatSection";
+
+const meta = {
+  title: "chat/layout/ChatSection",
+  component: ChatSection,
+  args: { isFull: false, isConnected: true },
+} satisfies Meta<typeof ChatSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/chat/layout/ChatSkeleton.stories.tsx
+++ b/client/src/components/chat/layout/ChatSkeleton.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ChatSkeleton from "@/components/chat/layout/ChatSkeleton";
+
+const meta = {
+  title: "chat/layout/ChatSkeleton",
+  component: ChatSkeleton,
+  args: { number: 3 },
+} satisfies Meta<typeof ChatSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Alert.stories.tsx
+++ b/client/src/components/common/Alert.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import Alert from "@/components/common/Alert";
+
+const meta = {
+  title: "common/Alert",
+  component: Alert,
+  args: { alertOpen: { isOpen: true, title: "알림", content: "내용입니다." }, onClose: fn() },
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/PostAvatar.stories.tsx
+++ b/client/src/components/common/Card/PostAvatar.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import PostAvatar from "@/components/common/Card/PostAvatar";
+
+const meta = {
+  title: "common/Card/PostAvatar",
+  component: PostAvatar,
+  args: { author: "홍길동", className: "", blogPlatform: "tistory" },
+} satisfies Meta<typeof PostAvatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/PostCard.stories.tsx
+++ b/client/src/components/common/Card/PostCard.stories.tsx
@@ -1,0 +1,22 @@
+import { PostCard } from "@/components/common/Card/PostCard";
+
+import { BLOG } from "@/constants/endpoints";
+
+import { mockFeedList } from "@/__storybook__/fixtures";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+const meta = {
+  title: "common/Card/PostCard",
+  component: PostCard,
+  args: { post: mockFeedList },
+} satisfies Meta<typeof PostCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPost(`${BLOG.POST}/${mockFeedList.id}`).reply(...ok(null));
+  },
+};

--- a/client/src/components/common/Card/PostCardContent.stories.tsx
+++ b/client/src/components/common/Card/PostCardContent.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import PostCardContent from "@/components/common/Card/PostCardContent";
+import { mockFeedList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "common/Card/PostCardContent",
+  component: PostCardContent,
+  args: { post: mockFeedList },
+} satisfies Meta<typeof PostCardContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/PostCardGrid.stories.tsx
+++ b/client/src/components/common/Card/PostCardGrid.stories.tsx
@@ -1,0 +1,25 @@
+import { PostCardGrid } from "@/components/common/Card/PostCardGrid";
+
+import { BLOG } from "@/constants/endpoints";
+
+import { mockFeedList } from "@/__storybook__/fixtures";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+const meta = {
+  title: "common/Card/PostCardGrid",
+  component: PostCardGrid,
+  args: {
+    posts: [mockFeedList, { ...mockFeedList, id: 2, isNew: false, title: "TypeScript 5.0 새로운 기능 살펴보기" }],
+  },
+} satisfies Meta<typeof PostCardGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPost(`${BLOG.POST}/1`).reply(...ok(null));
+    mockApi.onPost(`${BLOG.POST}/2`).reply(...ok(null));
+  },
+};

--- a/client/src/components/common/Card/PostCardImage.stories.tsx
+++ b/client/src/components/common/Card/PostCardImage.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PostCardImage } from "@/components/common/Card/PostCardImage";
+
+const meta = {
+  title: "common/Card/PostCardImage",
+  component: PostCardImage,
+  args: { alt: "썸네일 이미지" },
+} satisfies Meta<typeof PostCardImage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/PostCardSkeleton.stories.tsx
+++ b/client/src/components/common/Card/PostCardSkeleton.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PostCardSkeleton } from "@/components/common/Card/PostCardSkeleton";
+
+const meta = {
+  title: "common/Card/PostCardSkeleton",
+  component: PostCardSkeleton,
+} satisfies Meta<typeof PostCardSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/PostDetail.stories.tsx
+++ b/client/src/components/common/Card/PostDetail.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import PostDetail from "@/components/common/Card/PostDetail";
+import { BLOG } from "@/constants/endpoints";
+import { mockFeedDetail } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+import { useAuthStore } from "@/store/useAuthStore";
+
+const meta = {
+  title: "common/Card/PostDetail",
+  component: PostDetail,
+  parameters: {
+    router: { initialEntries: ["/1"], path: "/:id" },
+  },
+} satisfies Meta<typeof PostDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const setupCommentMutations = () => {
+  mockApi.onPost(BLOG.COMMENT.LIST(1)).reply(...ok(null));
+  mockApi.onPatch(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+  mockApi.onDelete(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+  mockApi.onPost(BLOG.LIKE(1)).reply(...ok(null));
+  mockApi.onDelete(BLOG.LIKE(1)).reply(...ok(null));
+};
+
+export const WithPost: Story = {
+  name: "포스트 있음",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...ok(mockFeedDetail));
+    mockApi.onGet(BLOG.LIKE(1)).reply(...ok({ isLike: false }));
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
+    setupCommentMutations();
+  },
+};
+
+export const WithLiked: Story = {
+  name: "좋아요한 포스트 (로그인됨)",
+  beforeEach: () => {
+    useAuthStore.setState({
+      isAuthenticated: true,
+      role: "user",
+      userInfo: { id: 1, email: "test@test.com", userName: "테스터" },
+    });
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...ok({ ...mockFeedDetail, likes: 100 }));
+    mockApi.onGet(BLOG.LIKE(1)).reply(...ok({ isLike: true }));
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
+    setupCommentMutations();
+    return () => {
+      useAuthStore.setState({
+        isAuthenticated: false,
+        role: "guest",
+        userInfo: { id: null, email: null, userName: null },
+      });
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: /좋아요/ }));
+    await expect(mockApi.history.delete).toHaveLength(1);
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...fail(404, "게시글을 찾을 수 없습니다."));
+  },
+};

--- a/client/src/components/common/Card/PostTag.stories.tsx
+++ b/client/src/components/common/Card/PostTag.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import PostTag from "@/components/common/Card/PostTag";
+
+const meta = {
+  title: "common/Card/PostTag",
+  component: PostTag,
+  args: { tags: ["React", "TypeScript", "Storybook", "Vite"] },
+} satisfies Meta<typeof PostTag>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/detail/CommentAction.stories.tsx
+++ b/client/src/components/common/Card/detail/CommentAction.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import CommentAction from "@/components/common/Card/detail/CommentAction";
+
+const meta = {
+  title: "common/Card/detail/CommentAction",
+  component: CommentAction,
+  args: { id: 1, canEdit: true, canDelete: true, handleModify: fn(), onDelete: fn() },
+} satisfies Meta<typeof CommentAction>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/detail/FixedHeader.stories.tsx
+++ b/client/src/components/common/Card/detail/FixedHeader.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { FixedHeader } from "@/components/common/Card/detail/FixedHeader";
+
+const meta = {
+  title: "common/Card/detail/FixedHeader",
+  component: FixedHeader,
+  args: { title: "게시글 제목", onClose: fn(), scrollbarWidth: 0 },
+} satisfies Meta<typeof FixedHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/detail/LikeButton.stories.tsx
+++ b/client/src/components/common/Card/detail/LikeButton.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import LikeButton from "@/components/common/Card/detail/LikeButton";
+import { BLOG } from "@/constants/endpoints";
+import { mockFeedDetail } from "@/__storybook__/fixtures";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+import { useAuthStore } from "@/store/useAuthStore";
+
+const meta = {
+  title: "common/Card/detail/LikeButton",
+  component: LikeButton,
+  args: { post: mockFeedDetail },
+} satisfies Meta<typeof LikeButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NotLiked: Story = {
+  name: "좋아요 안 함 (로그인)",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(BLOG.LIKE(mockFeedDetail.id)).reply(...ok({ isLike: false }));
+    mockApi.onPost(BLOG.LIKE(mockFeedDetail.id)).reply(...ok(null));
+    mockApi.onDelete(BLOG.LIKE(mockFeedDetail.id)).reply(...ok(null));
+  },
+};
+
+export const ClickLike: Story = {
+  name: "좋아요 클릭 (로그인)",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(BLOG.LIKE(mockFeedDetail.id)).reply(...ok({ isLike: false }));
+    mockApi.onPost(BLOG.LIKE(mockFeedDetail.id)).reply(...ok(null));
+    mockApi.onDelete(BLOG.LIKE(mockFeedDetail.id)).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("button", { name: /좋아요/ }));
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};
+
+export const Liked: Story = {
+  name: "좋아요 함 (로그인)",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(BLOG.LIKE(mockFeedDetail.id)).reply(...ok({ isLike: true }));
+    mockApi.onPost(BLOG.LIKE(mockFeedDetail.id)).reply(...ok(null));
+    mockApi.onDelete(BLOG.LIKE(mockFeedDetail.id)).reply(...ok(null));
+  },
+};
+
+export const NotAuthenticated: Story = {
+  name: "비로그인",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: false, accessToken: null });
+  },
+};

--- a/client/src/components/common/Card/detail/PostComment.stories.tsx
+++ b/client/src/components/common/Card/detail/PostComment.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import PostComment from "@/components/common/Card/detail/PostComment";
+import { BLOG } from "@/constants/endpoints";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+
+const mockComments = [
+  {
+    id: 1,
+    comment: "좋은 글 감사합니다!",
+    date: "2026-06-25T09:00:00.000Z",
+    parentId: null,
+    isDeleted: false,
+    user: { id: 99, userName: "다른유저", profileImage: null },
+  },
+  {
+    id: 2,
+    comment: "정말 유익한 내용이네요.",
+    date: "2026-06-24T09:00:00.000Z",
+    parentId: null,
+    isDeleted: false,
+    user: { id: 98, userName: "또다른유저", profileImage: null },
+  },
+];
+
+const meta = {
+  title: "common/Card/detail/PostComment",
+  component: PostComment,
+  args: { feedId: 1 },
+} satisfies Meta<typeof PostComment>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: "댓글 없음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
+    mockApi.onPost(BLOG.COMMENT.LIST(1)).reply(...ok(null));
+    mockApi.onPatch(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+    mockApi.onDelete(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+  },
+};
+
+export const WithComments: Story = {
+  name: "댓글 있음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok(mockComments));
+    mockApi.onPost(BLOG.COMMENT.LIST(1)).reply(...ok(null));
+    mockApi.onPatch(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+    mockApi.onDelete(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+  },
+};

--- a/client/src/components/common/Card/detail/PostContent.stories.tsx
+++ b/client/src/components/common/Card/detail/PostContent.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PostContent } from "@/components/common/Card/detail/PostContent";
+import { mockFeedDetail } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "common/Card/detail/PostContent",
+  component: PostContent,
+  args: { post: mockFeedDetail },
+} satisfies Meta<typeof PostContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/detail/PostHeader.stories.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PostHeader } from "@/components/common/Card/detail/PostHeader";
+import { mockFeedDetail } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "common/Card/detail/PostHeader",
+  component: PostHeader,
+  args: { data: mockFeedDetail },
+} satisfies Meta<typeof PostHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/Card/detail/ShareButton.stories.tsx
+++ b/client/src/components/common/Card/detail/ShareButton.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ShareButton from "@/components/common/Card/detail/ShareButton";
+import { mockFeedDetail } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "common/Card/detail/ShareButton",
+  component: ShareButton,
+  args: { post: mockFeedDetail },
+} satisfies Meta<typeof ShareButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/EmptyPost.stories.tsx
+++ b/client/src/components/common/EmptyPost.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import EmptyPost from "@/components/common/EmptyPost";
+
+const meta = {
+  title: "common/EmptyPost",
+  component: EmptyPost,
+} satisfies Meta<typeof EmptyPost>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/LazyImage.stories.tsx
+++ b/client/src/components/common/LazyImage.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { LazyImage } from "@/components/common/LazyImage";
+
+const meta = {
+  title: "common/LazyImage",
+  component: LazyImage,
+  args: { src: "https://picsum.photos/200/150", alt: "이미지" },
+} satisfies Meta<typeof LazyImage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/LoadingIndicator.stories.tsx
+++ b/client/src/components/common/LoadingIndicator.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { LoadingIndicator } from "@/components/common/LoadingIndicator";
+
+const meta = {
+  title: "common/LoadingIndicator",
+  component: LoadingIndicator,
+} satisfies Meta<typeof LoadingIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/SectionHeader.stories.tsx
+++ b/client/src/components/common/SectionHeader.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Flame } from "lucide-react";
+
+import { SectionHeader } from "@/components/common/SectionHeader";
+
+const meta = {
+  title: "common/SectionHeader",
+  component: SectionHeader,
+  args: { icon: Flame, text: "섹션 제목", iconColor: "#ff6b6b", description: "섹션 설명" },
+} satisfies Meta<typeof SectionHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/common/UserProfileMenu.stories.tsx
+++ b/client/src/components/common/UserProfileMenu.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { UserProfileMenu } from "@/components/common/UserProfileMenu";
+
+const meta = {
+  title: "common/UserProfileMenu",
+  component: UserProfileMenu,
+} satisfies Meta<typeof UserProfileMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/filter/Filter.stories.tsx
+++ b/client/src/components/filter/Filter.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import Filter from "@/components/filter/Filter";
+import { TAG } from "@/constants/endpoints";
+import { mockApi } from "@/__storybook__/mockApi";
+
+const mockCategories = [
+  { category: "프론트엔드", tags: ["React", "TypeScript", "Vite", "Next.js", "Storybook"] },
+  { category: "백엔드", tags: ["NestJS", "Node.js", "Express", "PostgreSQL", "Redis"] },
+  { category: "인프라", tags: ["Docker", "Kubernetes", "AWS", "CI/CD", "Nginx"] },
+];
+
+const meta = {
+  title: "filter/Filter",
+  component: Filter,
+} satisfies Meta<typeof Filter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithTags: Story = {
+  name: "태그 있음",
+  beforeEach: () => {
+    mockApi.onGet(TAG.LIST).reply(200, { message: "성공", data: mockCategories });
+  },
+};
+
+export const NoTags: Story = {
+  name: "태그 없음",
+  beforeEach: () => {
+    mockApi.onGet(TAG.LIST).reply(200, { message: "성공", data: [] });
+  },
+};

--- a/client/src/components/icons/social/GitHub.stories.tsx
+++ b/client/src/components/icons/social/GitHub.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { GitHub } from "@/components/icons/social/GitHub";
+
+const meta = {
+  title: "icons/social/GitHub",
+  component: GitHub,
+} satisfies Meta<typeof GitHub>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/icons/social/Google.stories.tsx
+++ b/client/src/components/icons/social/Google.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Google } from "@/components/icons/social/Google";
+
+const meta = {
+  title: "icons/social/Google",
+  component: Google,
+} satisfies Meta<typeof Google>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/icons/social/Kakao.stories.tsx
+++ b/client/src/components/icons/social/Kakao.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Kakao } from "@/components/icons/social/Kakao";
+
+const meta = {
+  title: "icons/social/Kakao",
+  component: Kakao,
+} satisfies Meta<typeof Kakao>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/Header.stories.tsx
+++ b/client/src/components/layout/Header.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import Header from "@/components/layout/Header";
+import { BLOG, SEARCH } from "@/constants/endpoints";
+import { mockSearchResult, mockUserSearchResult } from "@/__storybook__/fixtures";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "layout/Header",
+  component: Header,
+} satisfies Meta<typeof Header>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ result: [mockSearchResult], totalCount: 1, totalPages: 1 }));
+    mockApi.onGet(SEARCH.GET_USER_RESULT).reply(...ok([mockUserSearchResult]));
+    mockApi.onPost(BLOG.RSS.REGISTRER_RSS).reply(...ok(null));
+  },
+};
+
+export const SearchFlow: Story = {
+  name: "검색 (모달 열기 → 입력 → 결과)",
+  beforeEach: () => {
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ result: [mockSearchResult], totalCount: 1, totalPages: 1 }));
+    mockApi.onGet(SEARCH.GET_USER_RESULT).reply(...ok([mockUserSearchResult]));
+    mockApi.onPost(BLOG.RSS.REGISTRER_RSS).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "검색" }));
+    await userEvent.type(await canvas.findByPlaceholderText("검색어를 입력하세요"), "Storybook");
+    await expect(await canvas.findByText(/검색결과 \(총 1건\)/)).toBeInTheDocument();
+  },
+};
+
+export const SearchNoResults: Story = {
+  name: "검색 결과 없음",
+  beforeEach: () => {
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ result: [], totalCount: 0, totalPages: 0 }));
+    mockApi.onGet(SEARCH.GET_USER_RESULT).reply(...ok([]));
+    mockApi.onPost(BLOG.RSS.REGISTRER_RSS).reply(...ok(null));
+  },
+};

--- a/client/src/components/layout/Layout.stories.tsx
+++ b/client/src/components/layout/Layout.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import Layout from "@/components/layout/Layout";
+
+const meta = {
+  title: "layout/Layout",
+  component: Layout,
+  args: { children: "레이아웃 콘텐츠" },
+} satisfies Meta<typeof Layout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/SideButton.stories.tsx
+++ b/client/src/components/layout/SideButton.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SideButton from "@/components/layout/SideButton";
+
+const meta = {
+  title: "layout/SideButton",
+  component: SideButton,
+} satisfies Meta<typeof SideButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/Sidebar.stories.tsx
+++ b/client/src/components/layout/Sidebar.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import Sidebar from "@/components/layout/Sidebar";
+
+const meta = {
+  title: "layout/Sidebar",
+  component: Sidebar,
+  args: { handleRssModal: fn(), handleSidebar: fn() },
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/SplitLayout.stories.tsx
+++ b/client/src/components/layout/SplitLayout.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SplitLayout from "@/components/layout/SplitLayout";
+
+const meta = {
+  title: "layout/SplitLayout",
+  component: SplitLayout,
+  args: { children: "콘텐츠" },
+} satisfies Meta<typeof SplitLayout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/navigation/DesktopNavigation.stories.tsx
+++ b/client/src/components/layout/navigation/DesktopNavigation.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import DesktopNavigation from "@/components/layout/navigation/DesktopNavigation";
+
+const meta = {
+  title: "layout/navigation/DesktopNavigation",
+  component: DesktopNavigation,
+  args: { toggleModal: fn() },
+} satisfies Meta<typeof DesktopNavigation>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/navigation/MobileNavigation.stories.tsx
+++ b/client/src/components/layout/navigation/MobileNavigation.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import MobileNavigation from "@/components/layout/navigation/MobileNavigation";
+
+const meta = {
+  title: "layout/navigation/MobileNavigation",
+  component: MobileNavigation,
+  args: { toggleModal: fn() },
+} satisfies Meta<typeof MobileNavigation>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/sidebar/AuthSection.stories.tsx
+++ b/client/src/components/layout/sidebar/AuthSection.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { AuthSection } from "@/components/layout/sidebar/AuthSection";
+
+const meta = {
+  title: "layout/sidebar/AuthSection",
+  component: AuthSection,
+  args: { onAction: fn() },
+} satisfies Meta<typeof AuthSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/sidebar/ChatSection.stories.tsx
+++ b/client/src/components/layout/sidebar/ChatSection.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ChatSection } from "@/components/layout/sidebar/ChatSection";
+
+const meta = {
+  title: "layout/sidebar/ChatSection",
+  component: ChatSection,
+} satisfies Meta<typeof ChatSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/sidebar/NavigationButtons.stories.tsx
+++ b/client/src/components/layout/sidebar/NavigationButtons.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { NavigationButtons } from "@/components/layout/sidebar/NavigationButtons";
+
+const meta = {
+  title: "layout/sidebar/NavigationButtons",
+  component: NavigationButtons,
+  args: { onAction: fn() },
+} satisfies Meta<typeof NavigationButtons>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/layout/sidebar/RssButton.stories.tsx
+++ b/client/src/components/layout/sidebar/RssButton.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { RssButton } from "@/components/layout/sidebar/RssButton";
+
+const meta = {
+  title: "layout/sidebar/RssButton",
+  component: RssButton,
+  args: { onRssClick: fn(), onAction: fn() },
+} satisfies Meta<typeof RssButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/CertifiedRssList.stories.tsx
+++ b/client/src/components/profile/CertifiedRssList.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { CertifiedRssList } from "@/components/profile/CertifiedRssList";
+import { PROFILE } from "@/constants/endpoints";
+import { mockCertifiedRss } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const mockRssFeeds = {
+  result: [
+    { id: 1, title: "첫 번째 포스트", createdAt: "2026-06-20T09:00:00.000Z", commentCount: 2, likeCount: 10 },
+    { id: 2, title: "두 번째 포스트", createdAt: "2026-06-21T09:00:00.000Z", commentCount: 0, likeCount: 5 },
+  ],
+  lastId: 2,
+  hasMore: false,
+};
+
+const meta = {
+  title: "profile/CertifiedRssList",
+  component: CertifiedRssList,
+  args: { userId: 1, rssList: [mockCertifiedRss] },
+} satisfies Meta<typeof CertifiedRssList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS_FEEDS(1, mockCertifiedRss.id)).reply(...ok(mockRssFeeds));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "게시글 목록 펼치기" }));
+    await expect(await canvas.findByText("첫 번째 포스트")).toBeInTheDocument();
+  },
+};
+
+export const MultipleRss: Story = {
+  name: "RSS 여러 개",
+  args: {
+    rssList: [
+      mockCertifiedRss,
+      { ...mockCertifiedRss, id: 2, name: "두 번째 블로그", rssUrl: "https://velog.io/@user/rss", blogPlatform: "velog" as const, feedCount: 12 },
+    ],
+  },
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS_FEEDS(1, 1)).reply(...ok(mockRssFeeds));
+    mockApi.onGet(PROFILE.RSS_FEEDS(1, 2)).reply(...ok({ ...mockRssFeeds, result: mockRssFeeds.result.slice(0, 1) }));
+  },
+};
+
+export const Empty: Story = {
+  name: "RSS 없음",
+  args: { rssList: [] },
+};
+
+export const FeedError: Story = {
+  name: "게시글 로드 실패",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS_FEEDS(1, mockCertifiedRss.id)).reply(...fail(500, "게시글을 불러오지 못했습니다."));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "게시글 목록 펼치기" }));
+    await expect(await canvas.findByText("게시글을 불러오지 못했습니다.")).toBeInTheDocument();
+  },
+};

--- a/client/src/components/profile/CommentList.stories.tsx
+++ b/client/src/components/profile/CommentList.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CommentList } from "@/components/profile/CommentList";
+import { PROFILE } from "@/constants/endpoints";
+import { mockCommentItemsPage } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/CommentList",
+  component: CommentList,
+  args: { userId: 1 },
+} satisfies Meta<typeof CommentList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithComments: Story = {
+  name: "댓글 있음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(...ok(mockCommentItemsPage));
+  },
+};
+
+export const WithMorePages: Story = {
+  name: "더 보기 있음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(...ok({ ...mockCommentItemsPage, hasMore: true, lastId: 10 }));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Empty: Story = {
+  name: "댓글 없음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(...ok({ result: [], lastId: 0, hasMore: false }));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(...fail());
+  },
+};

--- a/client/src/components/profile/LikedList.stories.tsx
+++ b/client/src/components/profile/LikedList.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { LikedList } from "@/components/profile/LikedList";
+import { PROFILE } from "@/constants/endpoints";
+import { mockLikedItemsPage } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/LikedList",
+  component: LikedList,
+  args: { userId: 1 },
+} satisfies Meta<typeof LikedList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithLikes: Story = {
+  name: "좋아요 있음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.LIKES(1)).reply(...ok(mockLikedItemsPage));
+  },
+};
+
+export const WithMorePages: Story = {
+  name: "더 보기 있음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.LIKES(1)).reply(...ok({ ...mockLikedItemsPage, hasMore: true, lastId: 10 }));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.LIKES(1)).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Empty: Story = {
+  name: "좋아요 없음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.LIKES(1)).reply(...ok({ result: [], lastId: 0, hasMore: false }));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.LIKES(1)).reply(...fail());
+  },
+};

--- a/client/src/components/profile/MyPage.stories.tsx
+++ b/client/src/components/profile/MyPage.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MyPage } from "@/components/profile/MyPage";
+import { PROFILE } from "@/constants/endpoints";
+import {
+  mockUserProfile,
+  mockProfileActivity,
+  mockActivityYears,
+  mockCertifiedRss,
+  mockLikedItemsPage,
+  mockCommentItemsPage,
+} from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/MyPage",
+  component: MyPage,
+  args: { userId: 1, name: "홍길동", email: "test@test.com" },
+} satisfies Meta<typeof MyPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const setupSuccess = () => {
+  mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok(mockUserProfile));
+  mockApi.onGet(PROFILE.ACTIVITIES(1)).reply(...ok(mockProfileActivity));
+  mockApi.onGet(PROFILE.ACTIVITY_YEARS(1)).reply(...ok(mockActivityYears));
+  mockApi.onGet(PROFILE.RSS(1)).reply(...ok([mockCertifiedRss]));
+  mockApi.onGet(PROFILE.LIKES(1)).reply(...ok(mockLikedItemsPage));
+  mockApi.onGet(PROFILE.COMMENTS(1)).reply(...ok(mockCommentItemsPage));
+};
+
+export const WithData: Story = {
+  name: "데이터 있음",
+  beforeEach: setupSuccess,
+};
+
+export const NoActivities: Story = {
+  name: "활동 없음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok(mockUserProfile));
+    mockApi.onGet(PROFILE.ACTIVITIES(1)).reply(...ok({ dailyActivities: [] }));
+    mockApi.onGet(PROFILE.ACTIVITY_YEARS(1)).reply(...ok([2026]));
+    mockApi.onGet(PROFILE.RSS(1)).reply(...ok([]));
+    mockApi.onGet(PROFILE.LIKES(1)).reply(...ok({ result: [], lastId: 0, hasMore: false }));
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(...ok({ result: [], lastId: 0, hasMore: false }));
+  },
+};
+
+export const NoProfileImage: Story = {
+  name: "프로필 이미지 없음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok({ ...mockUserProfile, profileImage: null, introduction: null }));
+    mockApi.onGet(PROFILE.ACTIVITIES(1)).reply(...ok(mockProfileActivity));
+    mockApi.onGet(PROFILE.ACTIVITY_YEARS(1)).reply(...ok(mockActivityYears));
+    mockApi.onGet(PROFILE.RSS(1)).reply(...ok([mockCertifiedRss]));
+    mockApi.onGet(PROFILE.LIKES(1)).reply(...ok(mockLikedItemsPage));
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(...ok(mockCommentItemsPage));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(() => new Promise(() => {}));
+    mockApi.onGet(PROFILE.ACTIVITIES(1)).reply(() => new Promise(() => {}));
+    mockApi.onGet(PROFILE.ACTIVITY_YEARS(1)).reply(() => new Promise(() => {}));
+    mockApi.onGet(PROFILE.RSS(1)).reply(() => new Promise(() => {}));
+    mockApi.onGet(PROFILE.LIKES(1)).reply(() => new Promise(() => {}));
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...fail());
+    mockApi.onGet(PROFILE.ACTIVITIES(1)).reply(...fail());
+    mockApi.onGet(PROFILE.ACTIVITY_YEARS(1)).reply(...fail());
+    mockApi.onGet(PROFILE.RSS(1)).reply(...fail());
+    mockApi.onGet(PROFILE.LIKES(1)).reply(...fail());
+    mockApi.onGet(PROFILE.COMMENTS(1)).reply(...fail());
+  },
+};

--- a/client/src/components/profile/ProfileHeader.stories.tsx
+++ b/client/src/components/profile/ProfileHeader.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ProfileHeader } from "@/components/profile/ProfileHeader";
+
+const meta = {
+  title: "profile/ProfileHeader",
+  component: ProfileHeader,
+  args: { name: "홍길동", email: "test@test.com", profileImage: null, introduction: null },
+} satisfies Meta<typeof ProfileHeader>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/ProfileSidebar.stories.tsx
+++ b/client/src/components/profile/ProfileSidebar.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { ProfileSidebar } from "@/components/profile/ProfileSidebar";
+import { USER } from "@/constants/endpoints";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/ProfileSidebar",
+  component: ProfileSidebar,
+  args: { activeTab: "mypage" as const, onTabChange: fn(), isOwner: true },
+} satisfies Meta<typeof ProfileSidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPost(USER.LOGOUT).reply(...ok(null));
+  },
+};
+
+export const Logout: Story = {
+  name: "로그아웃 클릭",
+  beforeEach: () => {
+    mockApi.onPost(USER.LOGOUT).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "로그아웃" }));
+    await expect(mockApi.history.post).toHaveLength(1);
+  },
+};
+
+export const NotOwner: Story = {
+  name: "다른 사용자 프로필",
+  args: { isOwner: false },
+};

--- a/client/src/components/profile/StreakStats.stories.tsx
+++ b/client/src/components/profile/StreakStats.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { StreakStats } from "@/components/profile/StreakStats";
+
+const meta = {
+  title: "profile/StreakStats",
+  component: StreakStats,
+  args: { maxStreak: 30, currentStreak: 7, totalViews: 12345 },
+} satisfies Meta<typeof StreakStats>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/common/Section.stories.tsx
+++ b/client/src/components/profile/common/Section.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Section } from "@/components/profile/common/Section";
+
+const meta = {
+  title: "profile/common/Section",
+  component: Section,
+  args: { title: "섹션 제목" },
+} satisfies Meta<typeof Section>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/ActivityGraph/ActivityGraph.stories.tsx
+++ b/client/src/components/profile/header/ui/ActivityGraph/ActivityGraph.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { ActivityGraph } from "@/components/profile/header/ui/ActivityGraph/ActivityGraph";
+import { mockDailyActivities } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/header/ui/ActivityGraph/ActivityGraph",
+  component: ActivityGraph,
+  args: { dailyActivities: mockDailyActivities, year: 2026, years: [2025, 2026], onYearChange: fn() },
+} satisfies Meta<typeof ActivityGraph>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/ActivityGraph/DayCell.stories.tsx
+++ b/client/src/components/profile/header/ui/ActivityGraph/DayCell.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DayCell } from "@/components/profile/header/ui/ActivityGraph/DayCell";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { mockDayInfo } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/header/ui/ActivityGraph/DayCell",
+  component: DayCell,
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  args: { dayInfo: mockDayInfo },
+} satisfies Meta<typeof DayCell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/ActivityGraph/DayLabels.stories.tsx
+++ b/client/src/components/profile/header/ui/ActivityGraph/DayLabels.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { DayLabels } from "@/components/profile/header/ui/ActivityGraph/DayLabels";
+
+const meta = {
+  title: "profile/header/ui/ActivityGraph/DayLabels",
+  component: DayLabels,
+} satisfies Meta<typeof DayLabels>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/ActivityGraph/Legend.stories.tsx
+++ b/client/src/components/profile/header/ui/ActivityGraph/Legend.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Legend } from "@/components/profile/header/ui/ActivityGraph/Legend";
+
+const meta = {
+  title: "profile/header/ui/ActivityGraph/Legend",
+  component: Legend,
+} satisfies Meta<typeof Legend>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/ActivityGraph/MonthLabels.stories.tsx
+++ b/client/src/components/profile/header/ui/ActivityGraph/MonthLabels.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { MonthLabels } from "@/components/profile/header/ui/ActivityGraph/MonthLabels";
+import { mockWeeks } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/header/ui/ActivityGraph/MonthLabels",
+  component: MonthLabels,
+  args: { weeks: mockWeeks },
+} satisfies Meta<typeof MonthLabels>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/ActivityGraph/Week.stories.tsx
+++ b/client/src/components/profile/header/ui/ActivityGraph/Week.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Week } from "@/components/profile/header/ui/ActivityGraph/Week";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { mockWeekInfo } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/header/ui/ActivityGraph/Week",
+  component: Week,
+  decorators: [
+    (Story) => (
+      <TooltipProvider>
+        <Story />
+      </TooltipProvider>
+    ),
+  ],
+  args: { weekInfo: mockWeekInfo },
+} satisfies Meta<typeof Week>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/Avatar.stories.tsx
+++ b/client/src/components/profile/header/ui/Avatar.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Avatar } from "@/components/profile/header/ui/Avatar";
+import { mockUser } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/header/ui/Avatar",
+  component: Avatar,
+  args: { user: mockUser },
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/Banner.stories.tsx
+++ b/client/src/components/profile/header/ui/Banner.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Banner } from "@/components/profile/header/ui/Banner";
+
+const meta = {
+  title: "profile/header/ui/Banner",
+  component: Banner,
+  args: { lastPosted: "2024-01-15" },
+} satisfies Meta<typeof Banner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/Info.stories.tsx
+++ b/client/src/components/profile/header/ui/Info.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Info } from "@/components/profile/header/ui/Info";
+import { mockUser } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/header/ui/Info",
+  component: Info,
+  args: { user: mockUser },
+} satisfies Meta<typeof Info>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/header/ui/Stats.stories.tsx
+++ b/client/src/components/profile/header/ui/Stats.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Stats } from "@/components/profile/header/ui/Stats";
+
+const meta = {
+  title: "profile/header/ui/Stats",
+  component: Stats,
+  args: { totalPosts: 42, totalViews: 9999, topicsCount: 8 },
+} satisfies Meta<typeof Stats>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/rss/CertifiedRssCard.stories.tsx
+++ b/client/src/components/profile/rss/CertifiedRssCard.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CertifiedRssCard } from "@/components/profile/rss/CertifiedRssCard";
+import { mockCertifiedRss } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/rss/CertifiedRssCard",
+  component: CertifiedRssCard,
+  args: { userId: 1, rss: mockCertifiedRss },
+} satisfies Meta<typeof CertifiedRssCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/rss/OwnedRssCard.stories.tsx
+++ b/client/src/components/profile/rss/OwnedRssCard.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import { OwnedRssCard } from "@/components/profile/rss/OwnedRssCard";
+import { mockCertifiedRss } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/rss/OwnedRssCard",
+  component: OwnedRssCard,
+  args: { rss: mockCertifiedRss, onEdit: fn(), onDelete: fn() },
+} satisfies Meta<typeof OwnedRssCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/rss/PlatformIcon.stories.tsx
+++ b/client/src/components/profile/rss/PlatformIcon.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
+
+const meta = {
+  title: "profile/rss/PlatformIcon",
+  component: PlatformIcon,
+  args: { platform: "tistory" },
+} satisfies Meta<typeof PlatformIcon>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/rss/RssClaimModal.stories.tsx
+++ b/client/src/components/profile/rss/RssClaimModal.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { RssClaimModal } from "@/components/profile/rss/RssClaimModal";
+import { BLOG } from "@/constants/endpoints";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/rss/RssClaimModal",
+  component: RssClaimModal,
+  args: { open: true, onClose: fn(), userId: 1 },
+} satisfies Meta<typeof RssClaimModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "입력 단계 (즉시 등록)",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.CERTIFICATION_PREVIEW).reply(...ok({
+      name: "데나무 블로그",
+      userName: "조민석",
+      rssUrl: "https://denamu.dev/rss",
+      blogPlatform: "tistory",
+      requiresEmailVerification: false,
+    }));
+    mockApi.onPost(BLOG.RSS.CERTIFICATION).reply(...ok({ certified: true, certificationId: 1 }));
+    mockApi.onPost(BLOG.RSS.CERTIFICATION_VERIFY).reply(...ok({ message: "인증되었습니다." }));
+  },
+};
+
+export const RegisterFlow: Story = {
+  name: "조회 → 확인 → 등록",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.CERTIFICATION_PREVIEW).reply(...ok({
+      name: "데나무 블로그",
+      userName: "조민석",
+      rssUrl: "https://denamu.dev/rss",
+      blogPlatform: "tistory",
+      requiresEmailVerification: false,
+    }));
+    mockApi.onPost(BLOG.RSS.CERTIFICATION).reply(...ok({ certified: true, certificationId: 1 }));
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.type(await body.findByLabelText("블로그 이름"), "데나무 블로그");
+    await userEvent.click(body.getByRole("button", { name: "확인" }));
+    await body.findByText("RSS 정보 확인");
+    await userEvent.click(body.getByRole("button", { name: "확인" }));
+    // 미리보기는 GET, 등록은 POST(CERTIFICATION) 1건.
+    await expect(mockApi.history.post.length).toBeGreaterThanOrEqual(1);
+  },
+};
+
+export const WithEmailVerification: Story = {
+  name: "입력 단계 (이메일 인증 필요)",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.CERTIFICATION_PREVIEW).reply(...ok({
+      name: "데나무 블로그",
+      userName: "조민석",
+      rssUrl: "https://denamu.dev/rss",
+      blogPlatform: "tistory",
+      requiresEmailVerification: true,
+    }));
+    mockApi.onPost(BLOG.RSS.CERTIFICATION).reply(...ok({ certified: false, certificationId: 1 }));
+    mockApi.onPost(BLOG.RSS.CERTIFICATION_VERIFY).reply(...ok({ message: "인증되었습니다." }));
+  },
+};
+
+export const PreviewError: Story = {
+  name: "블로그 조회 실패",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.CERTIFICATION_PREVIEW).reply(...fail(404, "등록된 블로그를 찾을 수 없습니다."));
+  },
+};
+
+export const Closed: Story = {
+  name: "닫힌 상태",
+  args: { open: false },
+};

--- a/client/src/components/profile/rss/RssEditModal.stories.tsx
+++ b/client/src/components/profile/rss/RssEditModal.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import { RssEditModal } from "@/components/profile/rss/RssEditModal";
+import { mockCertifiedRss } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/rss/RssEditModal",
+  component: RssEditModal,
+  args: { target: mockCertifiedRss, userId: 1, onClose: fn() },
+} satisfies Meta<typeof RssEditModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "수정 모달",
+  beforeEach: () => {
+    mockApi.onPatch(/\/api\/rss\/certifications\/\d+/).reply(...ok({ message: "수정되었습니다." }));
+  },
+};
+
+export const SaveFlow: Story = {
+  name: "이름 수정 → 저장",
+  beforeEach: () => {
+    mockApi.onPatch(/\/api\/rss\/certifications\/\d+/).reply(...ok({ message: "수정되었습니다." }));
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    const nameInput = await body.findByLabelText("블로그 이름");
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "수정된 블로그");
+    await userEvent.click(body.getByRole("button", { name: "저장" }));
+    await expect(mockApi.history.patch).toHaveLength(1);
+  },
+};
+
+export const SaveError: Story = {
+  name: "저장 실패",
+  beforeEach: () => {
+    mockApi.onPatch(/\/api\/rss\/certifications\/\d+/).reply(...fail(400, "이미 사용 중인 블로그 이름입니다."));
+  },
+};
+
+export const Closed: Story = {
+  name: "닫힌 상태",
+  args: { target: null },
+};

--- a/client/src/components/profile/rss/RssFeedRow.stories.tsx
+++ b/client/src/components/profile/rss/RssFeedRow.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RssFeedRow } from "@/components/profile/rss/RssFeedRow";
+
+const meta = {
+  title: "profile/rss/RssFeedRow",
+  component: RssFeedRow,
+  args: { id: 1, title: "피드 제목", createdAt: "2024-01-15", commentCount: 0, likeCount: 0 },
+} satisfies Meta<typeof RssFeedRow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/rss/RssManagementTab.stories.tsx
+++ b/client/src/components/profile/rss/RssManagementTab.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { RssManagementTab } from "@/components/profile/rss/RssManagementTab";
+import { BLOG, PROFILE } from "@/constants/endpoints";
+import { mockCertifiedRss } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/rss/RssManagementTab",
+  component: RssManagementTab,
+  args: { userId: 1 },
+} satisfies Meta<typeof RssManagementTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const setupMutations = () => {
+  mockApi.onDelete(/\/api\/rss\/certifications\/\d+/).reply(...ok({ message: "해제되었습니다." }));
+  mockApi.onPatch(/\/api\/rss\/certifications\/\d+/).reply(...ok({ message: "수정되었습니다." }));
+  mockApi.onPost(BLOG.RSS.CERTIFICATION).reply(...ok({ certified: true, certificationId: 1 }));
+  mockApi.onGet(BLOG.RSS.CERTIFICATION_PREVIEW).reply(...ok({
+    name: "데나무 블로그",
+    userName: "조민석",
+    rssUrl: "https://denamu.dev/rss",
+    blogPlatform: "tistory",
+    requiresEmailVerification: false,
+  }));
+  mockApi.onPost(BLOG.RSS.CERTIFICATION_VERIFY).reply(...ok({ message: "인증되었습니다." }));
+};
+
+export const WithRss: Story = {
+  name: "RSS 있음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(1)).reply(...ok([mockCertifiedRss]));
+    setupMutations();
+  },
+};
+
+export const SaveEdit: Story = {
+  name: "RSS 정보 수정 → 저장",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(1)).reply(...ok([mockCertifiedRss]));
+    setupMutations();
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await canvas.findByLabelText("RSS 정보 수정"));
+    await userEvent.click(await body.findByRole("button", { name: "저장" }));
+    await expect(mockApi.history.patch).toHaveLength(1);
+  },
+};
+
+export const MultipleRss: Story = {
+  name: "RSS 여러 개",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(1)).reply(...ok([
+      mockCertifiedRss,
+      { ...mockCertifiedRss, id: 2, name: "두 번째 블로그", rssUrl: "https://velog.io/@user/rss", blogPlatform: "velog", feedCount: 12 },
+    ]));
+    setupMutations();
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(1)).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Empty: Story = {
+  name: "RSS 없음",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(1)).reply(...ok([]));
+    setupMutations();
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(1)).reply(...fail());
+  },
+};

--- a/client/src/components/profile/sections/LikedPosts.stories.tsx
+++ b/client/src/components/profile/sections/LikedPosts.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { LikedPosts } from "@/components/profile/sections/LikedPosts";
+
+const meta = {
+  title: "profile/sections/LikedPosts",
+  component: LikedPosts,
+} satisfies Meta<typeof LikedPosts>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/sections/ProfileEditTab.stories.tsx
+++ b/client/src/components/profile/sections/ProfileEditTab.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { ProfileEditTab } from "@/components/profile/sections/ProfileEditTab";
+import { FILE, OAUTH, PROFILE, USER } from "@/constants/endpoints";
+import { mockUserProfile } from "@/__storybook__/fixtures";
+import { mockApi, mockRedirect, ok } from "@/__storybook__/mockApi";
+import { nav } from "@/utils/redirect";
+
+const mockLinkedProviders = {
+  hasPassword: true,
+  providers: [
+    { provider: "github", providerUserName: "min-d", linkedAt: "2026-01-01T00:00:00.000Z" },
+  ],
+};
+
+const setupMutations = () => {
+  mockApi.onPatch(PROFILE.UPDATE).reply(...ok({ message: "프로필이 수정되었습니다." }));
+  mockApi.onPatch(USER.PASSWORD).reply(...ok({ message: "비밀번호가 변경되었습니다." }));
+  mockApi.onPost(USER.DELETE_REQUEST).reply(...ok({ message: "탈퇴 신청이 완료되었습니다." }));
+  mockApi.onPost(FILE.UPLOAD).reply(...ok({ url: "https://picsum.photos/seed/upload/120/120" }));
+  mockApi.onGet(USER.USERNAME_AVAILABILITY).reply(...ok({ exists: false }));
+  mockApi.onPost(OAUTH.LINKS).reply(...ok({ authUrl: "https://accounts.google.com/mock" }));
+  mockApi.onDelete(/\/api\/oauth\/links\/[^/]+/).reply(...ok({ message: "연결이 해제되었습니다." }));
+};
+
+const meta = {
+  title: "profile/sections/ProfileEditTab",
+  component: ProfileEditTab,
+  args: { userId: 1, email: "test@test.com" },
+} satisfies Meta<typeof ProfileEditTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "프로필 수정 탭",
+  beforeEach: () => {
+    const cleanup = mockRedirect();
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok(mockUserProfile));
+    mockApi.onGet(OAUTH.LINKS).reply(...ok(mockLinkedProviders));
+    setupMutations();
+    return cleanup;
+  },
+};
+
+export const SaveProfile: Story = {
+  name: "프로필 저장",
+  beforeEach: () => {
+    const cleanup = mockRedirect();
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok(mockUserProfile));
+    mockApi.onGet(OAUTH.LINKS).reply(...ok(mockLinkedProviders));
+    setupMutations();
+    return cleanup;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(await canvas.findByLabelText("자기소개"), " 추가 소개");
+    await userEvent.click(canvas.getByRole("button", { name: "저장" }));
+    await expect(mockApi.history.patch).toHaveLength(1);
+  },
+};
+
+export const NoOAuthLinked: Story = {
+  name: "OAuth 미연결",
+  beforeEach: () => {
+    const cleanup = mockRedirect();
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok(mockUserProfile));
+    mockApi.onGet(OAUTH.LINKS).reply(...ok({ hasPassword: true, providers: [] }));
+    setupMutations();
+    return cleanup;
+  },
+};
+
+export const ConnectOAuth: Story = {
+  name: "OAuth 연결 클릭",
+  beforeEach: () => {
+    const cleanup = mockRedirect();
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok(mockUserProfile));
+    mockApi.onGet(OAUTH.LINKS).reply(...ok({ hasPassword: true, providers: [] }));
+    setupMutations();
+    return cleanup;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const connectButtons = await canvas.findAllByRole("button", { name: "연결" });
+    await userEvent.click(connectButtons[0]);
+    await expect(nav.redirect).toHaveBeenCalledWith("https://accounts.google.com/mock");
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(() => new Promise(() => {}));
+    mockApi.onGet(OAUTH.LINKS).reply(() => new Promise(() => {}));
+  },
+};
+
+export const UsernameTaken: Story = {
+  name: "닉네임 중복 (중복 확인 시)",
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.PROFILE(1)).reply(...ok(mockUserProfile));
+    mockApi.onGet(OAUTH.LINKS).reply(...ok(mockLinkedProviders));
+    mockApi.onGet(USER.USERNAME_AVAILABILITY).reply(...ok({ exists: true }));
+    mockApi.onPatch(PROFILE.UPDATE).reply(...ok({ message: "프로필이 수정되었습니다." }));
+    mockApi.onPatch(USER.PASSWORD).reply(...ok({ message: "비밀번호가 변경되었습니다." }));
+    mockApi.onPost(USER.DELETE_REQUEST).reply(...ok({ message: "탈퇴 신청이 완료되었습니다." }));
+    mockApi.onPost(FILE.UPLOAD).reply(...ok({ url: "https://picsum.photos/seed/upload/120/120" }));
+    mockApi.onPost(OAUTH.LINKS).reply(...ok({ authUrl: "https://accounts.google.com/mock" }));
+    mockApi.onDelete(/\/api\/oauth\/links\/[^/]+/).reply(...ok({ message: "연결이 해제되었습니다." }));
+  },
+};

--- a/client/src/components/profile/sections/ProfileEditTab.tsx
+++ b/client/src/components/profile/sections/ProfileEditTab.tsx
@@ -42,6 +42,7 @@ import { checkUserNameAvailability } from "@/api/services/profile.ts";
 import { initiateOAuthLink } from "@/api/services/oauthLink.ts";
 import { useAuthStore } from "@/store/useAuthStore.ts";
 import { OAuthProviderType, UpdateProfilePayload } from "@/types/profile.ts";
+import { nav } from "@/utils/redirect.ts";
 
 const OAUTH_PROVIDERS: { type: OAuthProviderType; label: string; Icon: typeof GitHub }[] = [
   { type: "google", label: "Google", Icon: Google },
@@ -140,7 +141,7 @@ export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
     setConnecting(provider);
     try {
       const authUrl = await initiateOAuthLink(provider);
-      window.location.href = authUrl;
+      nav.redirect(authUrl);
     } catch (error) {
       setConnecting(null);
       toast({

--- a/client/src/components/profile/sections/RecentPosts.stories.tsx
+++ b/client/src/components/profile/sections/RecentPosts.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { RecentPosts } from "@/components/profile/sections/RecentPosts";
+import { mockUser } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/sections/RecentPosts",
+  component: RecentPosts,
+  args: { user: mockUser },
+} satisfies Meta<typeof RecentPosts>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/sections/Settings.stories.tsx
+++ b/client/src/components/profile/sections/Settings.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Settings } from "@/components/profile/sections/Settings";
+
+const meta = {
+  title: "profile/sections/Settings",
+  component: Settings,
+} satisfies Meta<typeof Settings>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/sidebar/Item.stories.tsx
+++ b/client/src/components/profile/sidebar/Item.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Item } from "@/components/profile/sidebar/Item";
+import { mockSidebarIcon } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "profile/sidebar/Item",
+  component: Item,
+  args: { icon: mockSidebarIcon, label: "프로필", id: "profile" },
+} satisfies Meta<typeof Item>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/profile/sidebar/Sidebar.stories.tsx
+++ b/client/src/components/profile/sidebar/Sidebar.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Sidebar } from "@/components/profile/sidebar/Sidebar";
+
+const meta = {
+  title: "profile/sidebar/Sidebar",
+  component: Sidebar,
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchButton.stories.tsx
+++ b/client/src/components/search/SearchButton.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import SearchButton from "@/components/search/SearchButton";
+
+const meta = {
+  title: "search/SearchButton",
+  component: SearchButton,
+  args: { handleSearchModal: fn() },
+} satisfies Meta<typeof SearchButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchFilters/FilterButton.stories.tsx
+++ b/client/src/components/search/SearchFilters/FilterButton.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import FilterButton from "@/components/search/SearchFilters/FilterButton";
+import { Command } from "@/components/ui/command";
+
+const meta = {
+  title: "search/SearchFilters/FilterButton",
+  component: FilterButton,
+  decorators: [
+    (Story) => (
+        <Command>
+        <Story />
+        </Command>
+    ),
+  ],
+} satisfies Meta<typeof FilterButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchHeader/SearchInput.stories.tsx
+++ b/client/src/components/search/SearchHeader/SearchInput.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import SearchInput from "@/components/search/SearchHeader/SearchInput";
+import { SEARCH } from "@/constants/endpoints";
+import { mockSearchResult, mockUserSearchResult } from "@/__storybook__/fixtures";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "search/SearchHeader/SearchInput",
+  component: SearchInput,
+  args: { onClose: fn() },
+} satisfies Meta<typeof SearchInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ result: [mockSearchResult], totalCount: 1, totalPages: 1 }));
+    mockApi.onGet(SEARCH.GET_USER_RESULT).reply(...ok([mockUserSearchResult]));
+  },
+};
+
+export const NoResults: Story = {
+  name: "검색 결과 없음",
+  beforeEach: () => {
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ result: [], totalCount: 0, totalPages: 0 }));
+    mockApi.onGet(SEARCH.GET_USER_RESULT).reply(...ok([]));
+  },
+};

--- a/client/src/components/search/SearchHigilight.stories.tsx
+++ b/client/src/components/search/SearchHigilight.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SearchHigilight from "@/components/search/SearchHigilight";
+
+const meta = {
+  title: "search/SearchHigilight",
+  component: SearchHigilight,
+  args: { text: "React Storybook 컴포넌트 가이드", highlight: "Storybook" },
+} satisfies Meta<typeof SearchHigilight>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchModal.stories.tsx
+++ b/client/src/components/search/SearchModal.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+
+import SearchModal from "@/components/search/SearchModal";
+import { SEARCH } from "@/constants/endpoints";
+import { mockSearchResult, mockUserSearchResult } from "@/__storybook__/fixtures";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "search/SearchModal",
+  component: SearchModal,
+  args: { onClose: fn() },
+  beforeEach: () => {
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ result: [mockSearchResult], totalCount: 1, totalPages: 1 }));
+    mockApi.onGet(SEARCH.GET_USER_RESULT).reply(...ok([mockUserSearchResult]));
+  },
+} satisfies Meta<typeof SearchModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const SearchFlow: Story = {
+  name: "검색어 입력 → 결과",
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(await canvas.findByPlaceholderText("검색어를 입력하세요"), "Storybook");
+    await expect(await canvas.findByText(/검색결과 \(총 1건\)/)).toBeInTheDocument();
+  },
+};

--- a/client/src/components/search/SearchModeTabs.stories.tsx
+++ b/client/src/components/search/SearchModeTabs.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SearchModeTabs from "@/components/search/SearchModeTabs";
+
+const meta = {
+  title: "search/SearchModeTabs",
+  component: SearchModeTabs,
+} satisfies Meta<typeof SearchModeTabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchResults/SearchResultItem.stories.tsx
+++ b/client/src/components/search/SearchResults/SearchResultItem.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SearchResultItem from "@/components/search/SearchResults/SearchResultItem";
+import { Command } from "@/components/ui/command";
+import { mockSearchResult } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "search/SearchResults/SearchResultItem",
+  component: SearchResultItem,
+  decorators: [
+    (Story) => (
+      <Command>
+        <Story />
+      </Command>
+    ),
+  ],
+  args: { ...mockSearchResult },
+} satisfies Meta<typeof SearchResultItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchResults/SearchResultList.stories.tsx
+++ b/client/src/components/search/SearchResults/SearchResultList.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SearchResultList from "@/components/search/SearchResults/SearchResultList";
+import { Command } from "@/components/ui/command";
+import { SEARCH } from "@/constants/endpoints";
+import { mockSearchResult } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+import { useSearchStore } from "@/store/useSearchStore";
+
+const meta = {
+  title: "search/SearchResults/SearchResultList",
+  component: SearchResultList,
+  decorators: [
+    (Story) => (
+      <Command>
+        <Story />
+      </Command>
+    ),
+  ],
+} satisfies Meta<typeof SearchResultList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const mockSearchData = {
+  totalCount: 3,
+  totalPages: 1,
+  result: [mockSearchResult, { ...mockSearchResult, id: 2, title: "TypeScript 5.0 새로운 기능" }, { ...mockSearchResult, id: 3, title: "React Query v5 마이그레이션" }],
+};
+
+export const NoQuery: Story = {
+  name: "검색 전",
+  beforeEach: () => {
+    useSearchStore.setState({ searchParam: "", page: 1 });
+  },
+};
+
+export const WithResults: Story = {
+  name: "검색 결과 있음",
+  beforeEach: () => {
+    useSearchStore.setState({ searchParam: "React", page: 1 });
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok(mockSearchData));
+  },
+};
+
+export const Loading: Story = {
+  name: "검색 중",
+  beforeEach: () => {
+    useSearchStore.setState({ searchParam: "React", page: 1 });
+    mockApi.onGet(SEARCH.GET_RESULT).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Empty: Story = {
+  name: "검색 결과 없음",
+  beforeEach: () => {
+    useSearchStore.setState({ searchParam: "없는검색어", page: 1 });
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ totalCount: 0, totalPages: 0, result: [] }));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    useSearchStore.setState({ searchParam: "React", page: 1 });
+    mockApi.onGet(SEARCH.GET_RESULT).reply(...fail());
+  },
+};

--- a/client/src/components/search/SearchResults/UserSearchResultItem.stories.tsx
+++ b/client/src/components/search/SearchResults/UserSearchResultItem.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import UserSearchResultItem from "@/components/search/SearchResults/UserSearchResultItem";
+import { Command } from "@/components/ui/command";
+import { mockUserSearchResult } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "search/SearchResults/UserSearchResultItem",
+  component: UserSearchResultItem,
+  decorators: [
+    (Story) => (
+      <Command>
+        <Story />
+      </Command>
+    ),
+  ],
+  args: { ...mockUserSearchResult, onSelect: fn() },
+} satisfies Meta<typeof UserSearchResultItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchResults/UserSearchResultList.stories.tsx
+++ b/client/src/components/search/SearchResults/UserSearchResultList.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import UserSearchResultList from "@/components/search/SearchResults/UserSearchResultList";
+import { Command } from "@/components/ui/command";
+
+const meta = {
+  title: "search/SearchResults/UserSearchResultList",
+  component: UserSearchResultList,
+  decorators: [
+    (Story) => (
+      <Command>
+        <Story />
+      </Command>
+    ),
+  ],
+  args: { onClose: fn() },
+} satisfies Meta<typeof UserSearchResultList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/searchPages/SearchPages.stories.tsx
+++ b/client/src/components/search/searchPages/SearchPages.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SearchPages from "@/components/search/searchPages/SearchPages";
+
+const meta = {
+  title: "search/searchPages/SearchPages",
+  component: SearchPages,
+  args: { totalPages: 5 },
+} satisfies Meta<typeof SearchPages>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/sections/AnimatedPostGrid.stories.tsx
+++ b/client/src/components/sections/AnimatedPostGrid.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import AnimatedPostGrid from "@/components/sections/AnimatedPostGrid";
+import { FeedBase } from "@/types/post";
+
+const meta = {
+  title: "sections/AnimatedPostGrid",
+  component: AnimatedPostGrid,
+  args: {
+    posts: [
+      {
+        id: 1,
+        createdAt: "2024-01-15",
+        title: "게시글 제목",
+        viewCount: 100,
+        path: "https://example.com/post",
+        author: "홍길동",
+        thumbnail: "",
+        tag: ["React", "TypeScript"],
+        likes: 5,
+        comments: 2,
+        blogPlatform: "tistory",
+      },
+    ] as FeedBase[],
+  },
+} satisfies Meta<typeof AnimatedPostGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/sections/LatestSection.stories.tsx
+++ b/client/src/components/sections/LatestSection.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import LatestSection from "@/components/sections/LatestSection";
+import { BLOG } from "@/constants/endpoints";
+import { mockFeedsList } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "sections/LatestSection",
+  component: LatestSection,
+} satisfies Meta<typeof LatestSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithPosts: Story = {
+  name: "포스트 있음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...ok({ result: mockFeedsList, hasMore: false, lastId: null }));
+  },
+};
+
+export const WithMorePages: Story = {
+  name: "더 보기 있음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...ok({ result: mockFeedsList, hasMore: true, lastId: mockFeedsList[mockFeedsList.length - 1].id }));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Empty: Story = {
+  name: "포스트 없음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...ok({ result: [], hasMore: false, lastId: null }));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...fail());
+  },
+};

--- a/client/src/components/sections/LatestSectionTimer.stories.tsx
+++ b/client/src/components/sections/LatestSectionTimer.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import LatestSectionTimer from "@/components/sections/LatestSectionTimer";
+
+const meta = {
+  title: "sections/LatestSectionTimer",
+  component: LatestSectionTimer,
+} satisfies Meta<typeof LatestSectionTimer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/sections/MainContent.stories.tsx
+++ b/client/src/components/sections/MainContent.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import MainContent from "@/components/sections/MainContent";
+import { BLOG, TAG } from "@/constants/endpoints";
+import { mockFeedsList } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+import { queryClient } from "@/__storybook__/queryClient";
+
+const meta = {
+  title: "sections/MainContent",
+  component: MainContent,
+} satisfies Meta<typeof MainContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const latestPage = { result: mockFeedsList, hasMore: false, lastId: null };
+const trendingData = { message: "성공", data: mockFeedsList.slice(0, 5) };
+
+export const WithData: Story = {
+  name: "데이터 있음",
+  beforeEach: () => {
+    queryClient.setQueryData(["trending-posts"], trendingData);
+    mockApi.onGet(BLOG.POST).reply(...ok(latestPage));
+    mockApi.onGet(TAG.LIST).reply(...ok([]));
+  },
+};
+
+export const Empty: Story = {
+  name: "데이터 없음",
+  beforeEach: () => {
+    queryClient.setQueryData(["trending-posts"], { message: "", data: [] });
+    mockApi.onGet(BLOG.POST).reply(...ok({ result: [], hasMore: false, lastId: null }));
+    mockApi.onGet(TAG.LIST).reply(...ok([]));
+  },
+};
+
+export const LatestError: Story = {
+  name: "최신 포스트 오류",
+  beforeEach: () => {
+    queryClient.setQueryData(["trending-posts"], trendingData);
+    mockApi.onGet(BLOG.POST).reply(...fail());
+    mockApi.onGet(TAG.LIST).reply(...ok([]));
+  },
+};

--- a/client/src/components/sections/TrendingSection.stories.tsx
+++ b/client/src/components/sections/TrendingSection.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import TrendingSection from "@/components/sections/TrendingSection";
+import { mockFeedsList } from "@/__storybook__/fixtures";
+import { queryClient } from "@/__storybook__/queryClient";
+
+const meta = {
+  title: "sections/TrendingSection",
+  component: TrendingSection,
+} satisfies Meta<typeof TrendingSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithPosts: Story = {
+  name: "트렌딩 포스트 있음",
+  beforeEach: () => {
+    queryClient.setQueryData(["trending-posts"], { message: "", data: mockFeedsList.slice(0, 4) });
+  },
+};
+
+export const Empty: Story = {
+  name: "트렌딩 포스트 없음",
+  beforeEach: () => {
+    queryClient.setQueryData(["trending-posts"], { message: "", data: [] });
+  },
+};

--- a/client/src/components/ui/accordion.stories.tsx
+++ b/client/src/components/ui/accordion.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+
+const meta = {
+  title: "ui/Accordion",
+  component: Accordion,
+  args: { type: "single" as const },
+} satisfies Meta<typeof Accordion>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Accordion type="single" collapsible defaultValue="item-1" className="w-[400px]">
+      <AccordionItem value="item-1">
+        <AccordionTrigger>RSS 피드란 무엇인가요?</AccordionTrigger>
+        <AccordionContent>RSS는 블로그나 뉴스 사이트의 컨텐츠를 구독할 수 있는 표준 형식입니다.</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger>어떤 플랫폼을 지원하나요?</AccordionTrigger>
+        <AccordionContent>Tistory, Velog, Medium 플랫폼을 지원합니다.</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionTrigger>등록 후 얼마나 걸리나요?</AccordionTrigger>
+        <AccordionContent>관리자 승인 후 피드 크롤링이 시작되며 보통 1시간 내에 반영됩니다.</AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  ),
+};

--- a/client/src/components/ui/alert-dialog.stories.tsx
+++ b/client/src/components/ui/alert-dialog.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/AlertDialog",
+  component: AlertDialog,
+} satisfies Meta<typeof AlertDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <AlertDialog defaultOpen>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">삭제</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>정말 삭제하시겠습니까?</AlertDialogTitle>
+          <AlertDialogDescription>이 작업은 되돌릴 수 없습니다. RSS 피드가 영구적으로 삭제됩니다.</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <AlertDialogAction>삭제</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+};

--- a/client/src/components/ui/alert.stories.tsx
+++ b/client/src/components/ui/alert.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Alert } from "@/components/ui/alert";
+
+const meta = {
+  title: "ui/Alert",
+  component: Alert,
+} satisfies Meta<typeof Alert>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/avatar.stories.tsx
+++ b/client/src/components/ui/avatar.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+const meta = {
+  title: "ui/Avatar",
+  component: Avatar,
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithImage: Story = {
+  name: "이미지 있음",
+  render: () => (
+    <Avatar>
+      <AvatarImage src="https://picsum.photos/seed/avatar/40/40" alt="프로필" />
+      <AvatarFallback>조민</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+export const Fallback: Story = {
+  name: "이미지 없음 (폴백)",
+  render: () => (
+    <Avatar>
+      <AvatarImage src="invalid-url" alt="프로필" />
+      <AvatarFallback>조민</AvatarFallback>
+    </Avatar>
+  ),
+};

--- a/client/src/components/ui/badge.stories.tsx
+++ b/client/src/components/ui/badge.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Badge } from "@/components/ui/badge";
+
+const meta = {
+  title: "ui/Badge",
+  component: Badge,
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/button.stories.tsx
+++ b/client/src/components/ui/button.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/Button",
+  component: Button,
+  tags: ["autodocs"],
+  args: {
+    children: "Button",
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/card.stories.tsx
+++ b/client/src/components/ui/card.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/Card",
+  component: Card,
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Card className="w-[360px]">
+      <CardHeader>
+        <CardTitle>데나무 블로그</CardTitle>
+        <CardDescription>기술 블로그 RSS 피드 서비스</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-muted-foreground">개발자 블로그 콘텐츠를 한 곳에서 모아 볼 수 있는 서비스입니다.</p>
+      </CardContent>
+      <CardFooter className="flex justify-end gap-2">
+        <Button variant="outline">취소</Button>
+        <Button>등록하기</Button>
+      </CardFooter>
+    </Card>
+  ),
+};

--- a/client/src/components/ui/chart.stories.tsx
+++ b/client/src/components/ui/chart.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
+
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart";
+
+const config = {
+  views: { label: "조회수", color: "hsl(220, 70%, 60%)" },
+} satisfies ChartConfig;
+
+const data = [
+  { month: "1월", views: 120 },
+  { month: "2월", views: 200 },
+  { month: "3월", views: 150 },
+  { month: "4월", views: 80 },
+];
+
+const meta = {
+  title: "ui/ChartContainer",
+  component: ChartContainer,
+  args: { config },
+} satisfies Meta<typeof ChartContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  render: () => (
+    <ChartContainer config={config} className="h-[240px] w-[360px]">
+      <BarChart data={data}>
+        <CartesianGrid vertical={false} />
+        <XAxis dataKey="month" tickLine={false} axisLine={false} />
+        <ChartTooltip content={<ChartTooltipContent />} />
+        <Bar dataKey="views" fill="var(--color-views)" radius={4} />
+      </BarChart>
+    </ChartContainer>
+  ),
+} as unknown as Story;

--- a/client/src/components/ui/command.stories.tsx
+++ b/client/src/components/ui/command.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+
+const meta = {
+  title: "ui/Command",
+  component: Command,
+} satisfies Meta<typeof Command>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Command className="rounded-lg border shadow-md w-[360px]">
+      <CommandInput placeholder="검색어를 입력하세요..." />
+      <CommandList>
+        <CommandEmpty>검색 결과가 없습니다.</CommandEmpty>
+        <CommandGroup heading="블로그">
+          <CommandItem>Storybook으로 컴포넌트 문서화하기</CommandItem>
+          <CommandItem>TypeScript 5.0 새로운 기능</CommandItem>
+          <CommandItem>React Query v5 마이그레이션</CommandItem>
+        </CommandGroup>
+        <CommandSeparator />
+        <CommandGroup heading="작성자">
+          <CommandItem>조민석</CommandItem>
+          <CommandItem>홍길동</CommandItem>
+        </CommandGroup>
+      </CommandList>
+    </Command>
+  ),
+};

--- a/client/src/components/ui/dialog.stories.tsx
+++ b/client/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/Dialog",
+  component: Dialog,
+} satisfies Meta<typeof Dialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Dialog defaultOpen>
+      <DialogTrigger asChild>
+        <Button variant="outline">다이얼로그 열기</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>RSS 등록</DialogTitle>
+          <DialogDescription>블로그 RSS 주소를 입력하여 등록하세요.</DialogDescription>
+        </DialogHeader>
+        <div className="py-4 text-sm text-muted-foreground">내용이 여기에 들어갑니다.</div>
+        <DialogFooter>
+          <Button variant="outline">취소</Button>
+          <Button>확인</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/client/src/components/ui/dropdown-menu.stories.tsx
+++ b/client/src/components/ui/dropdown-menu.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/DropdownMenu",
+  component: DropdownMenu,
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu defaultOpen>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">메뉴 열기</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuLabel>내 계정</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>프로필</DropdownMenuItem>
+        <DropdownMenuItem>설정</DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-destructive">로그아웃</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};

--- a/client/src/components/ui/input.stories.tsx
+++ b/client/src/components/ui/input.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Input } from "@/components/ui/input";
+
+const meta = {
+  title: "ui/Input",
+  component: Input,
+} satisfies Meta<typeof Input>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/label.stories.tsx
+++ b/client/src/components/ui/label.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Label } from "@/components/ui/label";
+
+const meta = {
+  title: "ui/Label",
+  component: Label,
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/navigation-menu.stories.tsx
+++ b/client/src/components/ui/navigation-menu.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+  navigationMenuTriggerStyle,
+} from "@/components/ui/navigation-menu";
+
+const meta = {
+  title: "ui/NavigationMenu",
+  component: NavigationMenu,
+} satisfies Meta<typeof NavigationMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <NavigationMenu>
+      <NavigationMenuList>
+        <NavigationMenuItem>
+          <NavigationMenuTrigger>피드</NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <ul className="grid gap-3 p-4 w-[200px]">
+              <li>
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>최신 글</NavigationMenuLink>
+              </li>
+              <li>
+                <NavigationMenuLink className={navigationMenuTriggerStyle()}>트렌딩</NavigationMenuLink>
+              </li>
+            </ul>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <NavigationMenuLink className={navigationMenuTriggerStyle()}>어바웃</NavigationMenuLink>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  ),
+};

--- a/client/src/components/ui/pagination.stories.tsx
+++ b/client/src/components/ui/pagination.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
+
+const meta = {
+  title: "ui/Pagination",
+  component: Pagination,
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Pagination>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious href="#" />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">1</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#" isActive>2</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationLink href="#">3</PaginationLink>
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationEllipsis />
+        </PaginationItem>
+        <PaginationItem>
+          <PaginationNext href="#" />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  ),
+};

--- a/client/src/components/ui/popover.stories.tsx
+++ b/client/src/components/ui/popover.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/Popover",
+  component: Popover,
+} satisfies Meta<typeof Popover>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Popover defaultOpen>
+      <PopoverTrigger asChild>
+        <Button variant="outline">팝오버 열기</Button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <p className="text-sm text-muted-foreground">팝오버 내용입니다.</p>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/client/src/components/ui/scroll-area.stories.tsx
+++ b/client/src/components/ui/scroll-area.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+const meta = {
+  title: "ui/ScrollArea",
+  component: ScrollArea,
+} satisfies Meta<typeof ScrollArea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const items = Array.from({ length: 20 }, (_, i) => `블로그 포스트 #${i + 1} - Storybook 데모`);
+
+export const Default: Story = {
+  render: () => (
+    <ScrollArea className="h-[300px] w-[360px] rounded-md border p-4">
+      <div className="space-y-2">
+        {items.map((item) => (
+          <div key={item} className="text-sm py-2 border-b last:border-0">
+            {item}
+          </div>
+        ))}
+      </div>
+    </ScrollArea>
+  ),
+};

--- a/client/src/components/ui/select.stories.tsx
+++ b/client/src/components/ui/select.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const meta = {
+  title: "ui/Select",
+  component: Select,
+} satisfies Meta<typeof Select>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Select>
+      <SelectTrigger className="w-[200px]">
+        <SelectValue placeholder="플랫폼 선택" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="tistory">Tistory</SelectItem>
+        <SelectItem value="velog">Velog</SelectItem>
+        <SelectItem value="medium">Medium</SelectItem>
+      </SelectContent>
+    </Select>
+  ),
+};

--- a/client/src/components/ui/separator.stories.tsx
+++ b/client/src/components/ui/separator.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Separator } from "@/components/ui/separator";
+
+const meta = {
+  title: "ui/Separator",
+  component: Separator,
+} satisfies Meta<typeof Separator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/sheet.stories.tsx
+++ b/client/src/components/ui/sheet.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/Sheet",
+  component: Sheet,
+} satisfies Meta<typeof Sheet>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Sheet defaultOpen>
+      <SheetTrigger asChild>
+        <Button variant="outline">사이드 패널 열기</Button>
+      </SheetTrigger>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>메뉴</SheetTitle>
+          <SheetDescription>사이드 패널 내용입니다.</SheetDescription>
+        </SheetHeader>
+        <div className="py-4 text-sm text-muted-foreground">내용이 여기에 들어갑니다.</div>
+      </SheetContent>
+    </Sheet>
+  ),
+};

--- a/client/src/components/ui/sidebar.stories.tsx
+++ b/client/src/components/ui/sidebar.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+} from "@/components/ui/sidebar";
+
+const meta = {
+  title: "ui/Sidebar",
+  component: Sidebar,
+} satisfies Meta<typeof Sidebar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <SidebarProvider>
+      <Sidebar>
+        <SidebarHeader className="p-4 font-bold">데나무</SidebarHeader>
+        <SidebarContent>
+          <SidebarGroup>
+            <SidebarGroupLabel>메뉴</SidebarGroupLabel>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton>홈</SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton>트렌딩</SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroup>
+        </SidebarContent>
+      </Sidebar>
+    </SidebarProvider>
+  ),
+};

--- a/client/src/components/ui/skeleton.stories.tsx
+++ b/client/src/components/ui/skeleton.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Skeleton } from "@/components/ui/skeleton";
+
+const meta = {
+  title: "ui/Skeleton",
+  component: Skeleton,
+} satisfies Meta<typeof Skeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/switch.stories.tsx
+++ b/client/src/components/ui/switch.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Switch } from "@/components/ui/switch";
+
+const meta = {
+  title: "ui/Switch",
+  component: Switch,
+} satisfies Meta<typeof Switch>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/tabs.stories.tsx
+++ b/client/src/components/ui/tabs.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const meta = {
+  title: "ui/Tabs",
+  component: Tabs,
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Tabs defaultValue="pending" className="w-[400px]">
+      <TabsList>
+        <TabsTrigger value="pending">대기중</TabsTrigger>
+        <TabsTrigger value="accepted">승인됨</TabsTrigger>
+        <TabsTrigger value="rejected">거절됨</TabsTrigger>
+      </TabsList>
+      <TabsContent value="pending">
+        <p className="text-sm text-muted-foreground py-4">승인 대기 중인 RSS 피드 목록입니다.</p>
+      </TabsContent>
+      <TabsContent value="accepted">
+        <p className="text-sm text-muted-foreground py-4">승인된 RSS 피드 목록입니다.</p>
+      </TabsContent>
+      <TabsContent value="rejected">
+        <p className="text-sm text-muted-foreground py-4">거절된 RSS 피드 목록입니다.</p>
+      </TabsContent>
+    </Tabs>
+  ),
+};

--- a/client/src/components/ui/textarea.stories.tsx
+++ b/client/src/components/ui/textarea.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Textarea } from "@/components/ui/textarea";
+
+const meta = {
+  title: "ui/Textarea",
+  component: Textarea,
+} satisfies Meta<typeof Textarea>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/ui/toast.stories.tsx
+++ b/client/src/components/ui/toast.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Toast, ToastDescription, ToastProvider, ToastTitle, ToastViewport } from "@/components/ui/toast";
+
+const meta = {
+  title: "ui/Toast",
+  component: Toast,
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <ToastProvider>
+      <Toast open>
+        <div className="grid gap-1">
+          <ToastTitle>알림</ToastTitle>
+          <ToastDescription>RSS가 성공적으로 등록되었습니다.</ToastDescription>
+        </div>
+      </Toast>
+      <ToastViewport />
+    </ToastProvider>
+  ),
+};

--- a/client/src/components/ui/toaster.stories.tsx
+++ b/client/src/components/ui/toaster.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect } from "react";
+
+import { Toaster } from "@/components/ui/toaster";
+import { toast as fireToast } from "@/hooks/common/useCustomToast";
+import { Button } from "@/components/ui/button";
+
+const meta = {
+  title: "ui/Toaster",
+  component: Toaster,
+} satisfies Meta<typeof Toaster>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const ToastTrigger = () => {
+  return (
+    <div className="flex flex-col gap-2">
+      <Button onClick={() => fireToast({ title: "성공", description: "RSS 피드가 등록되었습니다." })}>
+        성공 토스트
+      </Button>
+      <Button variant="destructive" onClick={() => fireToast({ title: "오류", description: "요청을 처리할 수 없습니다.", variant: "destructive" })}>
+        오류 토스트
+      </Button>
+      <Toaster />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: () => <ToastTrigger />,
+};
+
+const AutoToast = () => {
+  useEffect(() => {
+    fireToast({ title: "알림", description: "RSS 피드가 성공적으로 등록되었습니다." });
+  }, []);
+  return <Toaster />;
+};
+
+export const AutoShow: Story = {
+  name: "자동 표시",
+  render: () => <AutoToast />,
+};

--- a/client/src/components/ui/toggle.stories.tsx
+++ b/client/src/components/ui/toggle.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Toggle } from "@/components/ui/toggle";
+
+const meta = {
+  title: "ui/Toggle",
+  component: Toggle,
+  args: { children: "토글" },
+} satisfies Meta<typeof Toggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Pressed: Story = {
+  name: "활성화됨",
+  args: { pressed: true, children: "토글 활성화" },
+};
+
+export const Disabled: Story = {
+  name: "비활성화됨",
+  args: { disabled: true, children: "비활성화" },
+};

--- a/client/src/components/ui/tooltip.stories.tsx
+++ b/client/src/components/ui/tooltip.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+const meta = {
+  title: "ui/Tooltip",
+  component: Tooltip,
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <TooltipProvider>
+      <Tooltip defaultOpen>
+        <TooltipTrigger asChild>
+          <Button variant="outline">Hover</Button>
+        </TooltipTrigger>
+        <TooltipContent>툴팁 내용입니다</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ),
+};

--- a/client/src/pages/AboutService.stories.tsx
+++ b/client/src/pages/AboutService.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import AboutService from "@/pages/AboutService";
+
+const meta = {
+  title: "pages/AboutService",
+  component: AboutService,
+} satisfies Meta<typeof AboutService>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/Admin.stories.tsx
+++ b/client/src/pages/Admin.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import Admin from "@/pages/Admin";
+
+import { ADMIN } from "@/constants/endpoints";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+import { mockAdminRssList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "pages/Admin",
+  component: Admin,
+} satisfies Meta<typeof Admin>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 인증 성공 → 대시보드. RSS 목록 조회도 함께 mock.
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...ok({ name: "관리자" }, "조회 완료"));
+    mockApi.onGet(ADMIN.GET.RSS).reply(...ok(mockAdminRssList));
+    mockApi.onGet(ADMIN.GET.ACCEPT).reply(...ok([]));
+    mockApi.onGet(ADMIN.GET.REJECT).reply(...ok([]));
+  },
+};
+
+// 인증 실패 → 로그인 모달.
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onGet(ADMIN.ME).reply(...fail(500, "인증되지 않은 요청입니다."));
+  },
+};

--- a/client/src/pages/Home.stories.tsx
+++ b/client/src/pages/Home.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import Home from "@/pages/Home";
+
+import { BLOG } from "@/constants/endpoints";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+import { mockFeedList } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "pages/Home",
+  component: Home,
+} satisfies Meta<typeof Home>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 최신 피드는 HTTP로 mock. 트렌딩은 SSE(EventSource)라 mock 불가 → 빈 상태로 표시됨.
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(
+      ...ok(
+        {
+          result: [mockFeedList, { ...mockFeedList, id: 2, title: "두 번째 최신 글" }],
+          hasMore: false,
+          lastId: null,
+        },
+        "피드 조회 완료"
+      )
+    );
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onGet(BLOG.POST).reply(...fail(500, "피드 조회 실패"));
+  },
+};

--- a/client/src/pages/Loading.stories.tsx
+++ b/client/src/pages/Loading.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import Loading from "@/pages/Loading";
+
+const meta = {
+  title: "pages/Loading",
+  component: Loading,
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/NotFound.stories.tsx
+++ b/client/src/pages/NotFound.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import NotFound from "@/pages/NotFound";
+
+const meta = {
+  title: "pages/NotFound",
+  component: NotFound,
+} satisfies Meta<typeof NotFound>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/OAuthSignUpPage.stories.tsx
+++ b/client/src/pages/OAuthSignUpPage.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import OAuthSignUpPage from "@/pages/OAuthSignUpPage";
+
+const meta = {
+  title: "pages/OAuthSignUpPage",
+  component: OAuthSignUpPage,
+} satisfies Meta<typeof OAuthSignUpPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/OAuthSuccessPage.stories.tsx
+++ b/client/src/pages/OAuthSuccessPage.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import OAuthSuccessPage from "@/pages/OAuthSuccessPage";
+
+const meta = {
+  title: "pages/OAuthSuccessPage",
+  component: OAuthSuccessPage,
+} satisfies Meta<typeof OAuthSuccessPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/PostDetailPage.stories.tsx
+++ b/client/src/pages/PostDetailPage.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import PostDetailPage from "@/pages/PostDetailPage";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+import { mockFeedDetail } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "pages/PostDetailPage",
+  component: PostDetailPage,
+  parameters: {
+    router: { path: "/:id", initialEntries: ["/1"] },
+  },
+} satisfies Meta<typeof PostDetailPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onGet("/api/feeds/1").reply(...ok(mockFeedDetail, "피드 상세 조회 완료"));
+  },
+};
+
+// 조회 실패 시 페이지는 NotFound 화면을 렌더한다.
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onGet("/api/feeds/1").reply(...fail(404, "게시글을 찾을 수 없습니다."));
+  },
+};

--- a/client/src/pages/Profile.stories.tsx
+++ b/client/src/pages/Profile.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import Profile from "@/pages/Profile";
+
+const meta = {
+  title: "pages/Profile",
+  component: Profile,
+} satisfies Meta<typeof Profile>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/SignIn.stories.tsx
+++ b/client/src/pages/SignIn.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SignIn from "@/pages/SignIn";
+
+const meta = {
+  title: "pages/SignIn",
+  component: SignIn,
+} satisfies Meta<typeof SignIn>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/SignUp.stories.tsx
+++ b/client/src/pages/SignUp.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import SignUp from "@/pages/SignUp";
+
+const meta = {
+  title: "pages/SignUp",
+  component: SignUp,
+} satisfies Meta<typeof SignUp>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/pages/email-actions/AdminCertificate.stories.tsx
+++ b/client/src/pages/email-actions/AdminCertificate.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import AdminCertificate from "@/pages/email-actions/AdminCertificate";
+
+import { ADMIN } from "@/constants/endpoints";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "pages/email-actions/AdminCertificate",
+  component: AdminCertificate,
+  parameters: {
+    router: { initialEntries: ["/admin/certificate?token=test-token"] },
+  },
+} satisfies Meta<typeof AdminCertificate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onPost(ADMIN.CERTIFICATE).reply(...ok(null, "인증 성공"));
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onPost(ADMIN.CERTIFICATE).reply(...fail(400, "인증 링크가 만료되었습니다."));
+  },
+};

--- a/client/src/pages/email-actions/AdminWithdraw.stories.tsx
+++ b/client/src/pages/email-actions/AdminWithdraw.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import AdminWithdraw from "@/pages/email-actions/AdminWithdraw";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+
+const ENDPOINT = /\/api\/admins\/deletion-requests\/.+/;
+
+const meta = {
+  title: "pages/email-actions/AdminWithdraw",
+  component: AdminWithdraw,
+  parameters: {
+    router: { initialEntries: ["/admin/withdraw?token=test-token"] },
+  },
+} satisfies Meta<typeof AdminWithdraw>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onDelete(ENDPOINT).reply(...ok(null, "탈퇴 완료"));
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onDelete(ENDPOINT).reply(...fail(400, "탈퇴 링크가 만료되었습니다."));
+  },
+};

--- a/client/src/pages/email-actions/RssCertificate.stories.tsx
+++ b/client/src/pages/email-actions/RssCertificate.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import RssCertificate from "@/pages/email-actions/RssCertificate";
+
+import { BLOG } from "@/constants/endpoints";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "pages/email-actions/RssCertificate",
+  component: RssCertificate,
+  parameters: {
+    router: { initialEntries: ["/rss/certificate?code=test-code"] },
+  },
+} satisfies Meta<typeof RssCertificate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onPost(BLOG.RSS.CERTIFICATION_VERIFY).reply(...ok(null, "인증 성공"));
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    // 400 (not 401) so the page shows its failure UI instead of redirecting to /signin.
+    mockApi.onPost(BLOG.RSS.CERTIFICATION_VERIFY).reply(...fail(400, "인증 코드가 유효하지 않습니다."));
+  },
+};

--- a/client/src/pages/email-actions/RssRemoval.stories.tsx
+++ b/client/src/pages/email-actions/RssRemoval.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import RssRemoval from "@/pages/email-actions/RssRemoval";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+
+const ENDPOINT = /\/api\/rss\/remove\/.+/;
+
+const clickConfirm = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const btn = [...canvasElement.querySelectorAll("button")].find((b) => b.textContent?.includes("삭제 확인"));
+  btn?.click();
+};
+
+const meta = {
+  title: "pages/email-actions/RssRemoval",
+  component: RssRemoval,
+  parameters: {
+    router: { initialEntries: ["/rss/removal?code=test-code"] },
+  },
+} satisfies Meta<typeof RssRemoval>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// 삭제는 버튼 클릭으로 트리거됨 — Default는 확인 화면.
+export const Default: Story = {};
+
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onDelete(ENDPOINT).reply(...ok(null, "삭제 완료"));
+  },
+  play: clickConfirm,
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onDelete(ENDPOINT).reply(...fail(400, "삭제 링크가 유효하지 않습니다."));
+  },
+  play: clickConfirm,
+};

--- a/client/src/pages/email-actions/UserCertificate.stories.tsx
+++ b/client/src/pages/email-actions/UserCertificate.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import UserCertificate from "@/pages/email-actions/UserCertificate";
+
+import { USER } from "@/constants/endpoints";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "pages/email-actions/UserCertificate",
+  component: UserCertificate,
+  parameters: {
+    router: { initialEntries: ["/user/certificate?token=test-token"] },
+  },
+} satisfies Meta<typeof UserCertificate>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onPost(USER.CERTIFICATE).reply(...ok(null, "인증 성공"));
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onPost(USER.CERTIFICATE).reply(...fail(400, "인증 링크가 만료되었습니다."));
+  },
+};

--- a/client/src/pages/email-actions/UserWithdraw.stories.tsx
+++ b/client/src/pages/email-actions/UserWithdraw.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import UserWithdraw from "@/pages/email-actions/UserWithdraw";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+
+const ENDPOINT = /\/api\/users\/deletion-requests\/.+/;
+
+const meta = {
+  title: "pages/email-actions/UserWithdraw",
+  component: UserWithdraw,
+  parameters: {
+    router: { initialEntries: ["/user/withdraw?token=test-token"] },
+  },
+} satisfies Meta<typeof UserWithdraw>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Success: Story = {
+  beforeEach: () => {
+    mockApi.onDelete(ENDPOINT).reply(...ok(null, "탈퇴 완료"));
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onDelete(ENDPOINT).reply(...fail(400, "탈퇴 링크가 만료되었습니다."));
+  },
+};

--- a/client/src/utils/redirect.ts
+++ b/client/src/utils/redirect.ts
@@ -1,0 +1,5 @@
+export const nav = {
+  redirect: (url: string) => {
+    window.location.href = url;
+  },
+};

--- a/client/tsconfig.app.json
+++ b/client/tsconfig.app.json
@@ -22,7 +22,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
 
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -25,6 +25,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"],
+  "include": ["src", ".storybook"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #773 

### Client Storybook 도입

- 컴포넌트 단위 시각 확인/문서화 기반 마련을 위해 client 전 영역(`components`, `pages`)에 Storybook을 도입했습니다.
- `@storybook/addon-vitest`는 기존 vitest 설정과 peer 충돌이 있어 제외하고, 격리된 story harness(`.storybook/preview.tsx`)를 직접 구성했습니다.
- story 공용 의존성(fixture / mockApi / queryClient)을 `src/__storybook__/`로 분리해 story 간 결합을 최소화했습니다.

### `nav` redirect 래퍼의 필요성

문제: `window.location.href = url` 직접 할당은 **테스트/Storybook 환경(jsdom)에서 가로채거나 spy 할 수 없습니다.**
- jsdom은 `location` 할당을 막거나 `Not implemented: navigation` 경고를 던지고, Storybook iframe에서는 실제 페이지 이탈이 발생해 story가 깨집니다.
- OAuth 로그인 버튼(`AuthSocialLoginButtons`)·계정 연동(`ProfileEditTab`)처럼 redirect가 트리거되는 컴포넌트는 story로 띄우는 순간 외부 URL로 튀어버립니다.

해결: redirect를 단일 진입점 `utils/redirect.ts`의 `nav.redirect()`로 감쌌습니다.
- `mockApi.ts`의 `mockRedirect()`가 `nav.redirect`를 `fn()`으로 교체 → 실제 네비게이션 없이 redirect 대상 URL을 Storybook `action("REDIRECT")`로 로깅만 합니다. (teardown 시 원복)
- 프로덕션 동작은 기존과 동일(`window.location.href` 할당), 주입 지점만 한 겹 추가한 최소 변경입니다.

```ts
// utils/redirect.ts
export const nav = {
  redirect: (url: string) => { window.location.href = url; },
};
```

### `queryClient`(story 전용)의 필요성

대상 컴포넌트 다수가 React Query 훅에 의존하므로 Storybook에도 `QueryClientProvider`가 필요합니다. 단, **앱 기본 QueryClient를 그대로 쓰면 story가 비결정적으로 동작**합니다. 그래서 story 전용 설정을 별도로 둡니다.

```ts
new QueryClient({
  defaultOptions: {
    queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
  },
});
```

- `retry: false` — mock 실패 응답에서 즉시 에러 UI 노출. 기본 재시도(지수 백오프)는 에러 story 확인을 지연시킴.
- `refetchOnWindowFocus: false` — 개발 중 탭 포커스 전환마다 재요청 → story 상태가 흔들리는 것 방지.
- `staleTime: Infinity` — 불필요한 background refetch 제거로 캐시 결정성 확보.
- `preview.tsx`의 `beforeEach`에서 `queryClient.clear()` 호출 → **story 간 캐시 격리**(이전 story의 캐시가 다음 story에 새지 않도록).

# 📋 작업 내용

- `.storybook/` 설정 추가 (main / preview / tsconfig)
  - `MemoryRouter` 데코레이터 + `NavigationLogger`(라우팅 `action` 로깅), `StoryErrorBoundary`, Kakao SDK stub
- client 전 컴포넌트·페이지 `*.stories.tsx` 작성
- story 공용 유틸 `src/__storybook__/` 추가
  - `fixtures.ts`(목 데이터), `mockApi.ts`(axios-mock-adapter 기반 success/error 상태 주입 + redirect mock), `queryClient.ts`
- `nav` redirect 래퍼 도입 및 OAuth redirect 경로 적용(`AuthSocialLoginButtons`, `ProfileEditTab`)
- eslint / tsconfig / gitignore Storybook 대응 설정

# 📷 스크린 샷(선택 사항)

<img width="2552" height="1269" alt="image" src="https://github.com/user-attachments/assets/0b1d3e0c-b49b-459c-995a-4e40fd4ebdde" />