### PR TITLE
🐛 fix: 시차 있는 국가에서 recent 갱신 타이머가 KST 기준과 어긋나는 문제

### DIFF
--- a/client/src/components/sections/LatestSectionTimer.tsx
+++ b/client/src/components/sections/LatestSectionTimer.tsx
@@ -6,16 +6,18 @@ import { useUpdatePost } from "@/hooks/queries/useUpdatePost";
 
 const calculateTime = () => {
   const now = new Date();
-  const currentMinutes = now.getMinutes();
+  const currentMinutes = now.getUTCMinutes();
 
   const targetMinutes = currentMinutes < 31 ? 31 : 1;
-  let targetHours = now.getHours();
+  let targetHours = now.getUTCHours();
 
   if (currentMinutes >= 31) {
     targetHours = (targetHours + 1) % 24;
   }
 
-  const targetTime = new Date(now.getFullYear(), now.getMonth(), now.getDate(), targetHours, targetMinutes, 0);
+  const targetTime = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate(), targetHours, targetMinutes, 0)
+  );
   return Math.floor((targetTime.getTime() - now.getTime()) / 1000);
 };
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   해당 작업과 연결된 오픈 이슈 없음

### 시차 있는 국가에서 recent 갱신 타이머 어긋남

-   서버 크론은 KST 매시 :01, :31에 `/api/feeds/recent` 데이터를 갱신하는데, 클라이언트 카운트다운 타이머(`LatestSectionTimer`)가 `getMinutes()`/`getHours()` 등 **로컬 타임존** 기준으로 다음 갱신 시각을 계산하고 있었음.
-   정시 단위(예: UTC+9) 오프셋 국가는 분 경계가 같아 우연히 동작했지만, **네팔(UTC+5:45)처럼 분 단위 오프셋을 가진 국가**에서는 로컬 분이 KST 분과 달라 타이머가 잘못된 시각에 0이 되어 `mutate()`가 KST :01/:31과 어긋나게 발생함.
-   KST는 UTC+9의 **정시 오프셋**이라 분 경계가 UTC와 동일하다는 점을 이용해, `calculateTime`의 모든 계산을 UTC 기준(`getUTCMinutes`/`getUTCHours`/`Date.UTC`)으로 변경. 남은 시간(delta)은 절대 시각 간 차이라 로컬 타임존과 무관하게 정확히 KST :01/:31 순간에 0이 됨.

# 📋 작업 내용

-   `client/src/components/sections/LatestSectionTimer.tsx`의 `calculateTime`을 로컬 시간 기반에서 UTC 기반으로 변경
    -   `getMinutes()` → `getUTCMinutes()`
    -   `getHours()` → `getUTCHours()`
    -   `new Date(year, month, date, ...)` → `new Date(Date.UTC(...))`
-   분 단위 시차(예: 네팔 +5:45)를 포함한 모든 타임존에서 KST 매시 :01, :31에 정확히 갱신되도록 보장

# 📷 스크린 샷(선택 사항)

해당 없음 (타이머 계산 로직 변경)