### PR TITLE
⚡️ perf: 채팅 이모지 선택창 lazy loading으로 초기 번들 분리

### DIFF
--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { Suspense, lazy, useState } from "react";
 
-import EmojiPicker, { EmojiClickData, Theme } from "emoji-picker-react";
+import type { EmojiClickData, Theme } from "emoji-picker-react";
 import { Send, Smile } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,8 @@ import { useKeyboardShortcut } from "@/hooks/common/useKeyboardShortcut";
 
 import { useChatStore } from "@/store/useChatStore";
 import { useMediaStore } from "@/store/useMediaStore";
+
+const EmojiPicker = lazy(() => import("emoji-picker-react"));
 
 export default function ChatFooter() {
   const [message, setMessage] = useState<string>("");
@@ -56,7 +58,15 @@ export default function ChatFooter() {
               </Button>
             </PopoverTrigger>
             <PopoverContent side="top" align="end" className="w-auto border-none p-0 shadow-none">
-              <EmojiPicker onEmojiClick={handleEmojiClick} theme={Theme.AUTO} lazyLoadEmojis width={320} height={400} />
+              <Suspense fallback={<div style={{ width: 320, height: 400 }} />}>
+                <EmojiPicker
+                  onEmojiClick={handleEmojiClick}
+                  theme={"auto" as Theme}
+                  lazyLoadEmojis
+                  width={320}
+                  height={400}
+                />
+              </Suspense>
             </PopoverContent>
           </Popover>
         )}


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #310

### 이모지 선택창 초기 번들 포함 문제

-   `ChatFooter`가 `emoji-picker-react`를 **정적 import** 하고 있었음.
-   import 체인이 `Header(app shell, eager) → DesktopNavigation → SideButton → Chat → ChatFooter → emoji-picker-react`로 전부 eager라, 페이지(`pages/*`)는 lazy split 되어 있음에도 **emoji-picker-react 청크(raw 309KB / gzip 75KB)가 매 첫 방문 시 초기 critical path에 포함**되어 다운로드·파싱됨.
-   이모지 선택창은 **데스크톱에서 사용자가 Popover를 열 때만** 필요(모바일은 `!isMobile`로 렌더 자체 안 함). 굳이 초기 번들에 실을 이유 없음.

### 해결

-   `EmojiPicker`를 `React.lazy(() => import("emoji-picker-react"))` + `Suspense`로 코드 스플릿 → 별도 청크로 분리, 버튼 클릭 시에만 fetch.
-   `Theme` enum은 값 import 시 정적 의존이 다시 생겨 lazy가 무력화되므로 `import type`으로 바꾸고 `"auto" as Theme` 문자열로 대체.
-   `Suspense` fallback에 320×400 고정 박스를 두어 청크 로드 지연 시 레이아웃 흔들림 방지.

# 📋 작업 내용

-   `client/src/components/chat/layout/ChatFooter.tsx`
    -   `import EmojiPicker, { ... } from "emoji-picker-react"` → `const EmojiPicker = lazy(() => import("emoji-picker-react"))`
    -   `EmojiClickData`, `Theme` → `import type`
    -   `<EmojiPicker .../>` → `<Suspense fallback={...}><EmojiPicker .../></Suspense>`
-   빌드 결과: `emoji-picker-react.esm-*.js`(309KB)가 `index`/`Header` 청크에서 분리되어 독립 파일로 떨어짐을 확인.

> 참고: 이 PR은 lazy 분리(초기 로드 개선)까지만 다룸. 309KB 청크 **자체**를 줄이려면 lib 교체(emoji-mart async data 등)가 필요하며 별도 작업으로 분리. #310은 부분 해결.

# 📷 스크린 샷(선택 사항)

해당 없음 (번들 분리 변경)