### PR TITLE
📦 chore: Blue-Green 무중단 배포 구축

### DIFF
--- a/.github/workflows/deploy_nginx.yml
+++ b/.github/workflows/deploy_nginx.yml
@@ -6,12 +6,26 @@ on:
     paths: ["nginx.conf", ".github/workflows/deploy_nginx.yml"]
   workflow_dispatch:
 
+env:
+  # Blue-Green host publish 포트 (SSOT: GitHub repo variable)
+  # 미설정 시 8080/8081 fallback. deploy_server.yml 과 동일 값 사용.
+  BLUE_PORT: ${{ vars.BLUE_PORT || '8080' }}
+  GREEN_PORT: ${{ vars.GREEN_PORT || '8081' }}
+
 jobs:
   deploy:
     runs-on: [self-hosted, prod]
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v6
+
+      - name: Blue-Green active backend 시드 (최초 1회 보장)
+        run: |
+          ACTIVE_FILE=/etc/nginx/conf.d/denamu_active_backend.conf
+          if [ ! -f "$ACTIVE_FILE" ]; then
+            echo "ℹ️  $ACTIVE_FILE 없음 → blue(${BLUE_PORT}) 로 시드 (upstream include 검증 통과용)"
+            echo "server 127.0.0.1:${BLUE_PORT};" | sudo tee "$ACTIVE_FILE"
+          fi
 
       - name: nginx 설정 검사 및 reload
         run: |

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -18,9 +18,10 @@ env:
   SERVER_ENV_FILE: /var/prod_config/server/.env.prod
   INFRA_ENV_FILE: /var/prod_config/infra/.env.prod
   COMPOSE_FILE: docker-compose/docker-compose.prod.yml
-  # Blue-Green host publish 포트 (nginx active backend 와 일치해야 함)
-  BLUE_PORT: '8080'
-  GREEN_PORT: '8081'
+  # Blue-Green host publish 포트 (SSOT: GitHub repo variable)
+  # 미설정 시 8080/8081 fallback. deploy_nginx.yml 과 동일 값 사용.
+  BLUE_PORT: ${{ vars.BLUE_PORT || '8080' }}
+  GREEN_PORT: ${{ vars.GREEN_PORT || '8081' }}
 
 jobs:
   build-and-push:

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -14,11 +14,13 @@ env:
   GHCR_URL: ${{ vars.GHCR }}
   APP_IMAGE: ${{ vars.GHCR }}/server
   APP_TAG: sha-${{ github.sha }}
-  SERVICE: app
   SERVER_ENV_DIR: /var/prod_config/server
   SERVER_ENV_FILE: /var/prod_config/server/.env.prod
   INFRA_ENV_FILE: /var/prod_config/infra/.env.prod
   COMPOSE_FILE: docker-compose/docker-compose.prod.yml
+  # Blue-Green host publish 포트 (nginx active backend 와 일치해야 함)
+  BLUE_PORT: '8080'
+  GREEN_PORT: '8081'
 
 jobs:
   build-and-push:
@@ -98,13 +100,16 @@ jobs:
             echo "SERVER_DISCORD_WEBHOOK_URL=${{ secrets.SERVER_DISCORD_WEBHOOK_URL }}"
           } | sudo tee "${{env.SERVER_ENV_FILE}}" >/dev/null
 
-      - name: Docker 이미지 Pull & 서비스 재시작
+      - name: Blue-Green 무중단 배포
         run: |
           set -a
           source ${{ env.SERVER_ENV_FILE }}
           source ${{ env.INFRA_ENV_FILE }}
           set +a
 
-          docker compose -f "${{env.COMPOSE_FILE}}" pull "${{env.SERVICE}}"
-          docker compose -f "${{env.COMPOSE_FILE}}" up -d --no-deps --force-recreate "${{env.SERVICE}}"
-          docker image prune -f
+          chmod +x docker-compose/scripts/blue-green-deploy.sh
+          ./docker-compose/scripts/blue-green-deploy.sh
+        env:
+          COMPOSE_FILE: ${{ env.COMPOSE_FILE }}
+          BLUE_PORT: ${{ env.BLUE_PORT }}
+          GREEN_PORT: ${{ env.GREEN_PORT }}

--- a/docker-compose/docker-compose.prod.yml
+++ b/docker-compose/docker-compose.prod.yml
@@ -3,29 +3,49 @@ name: denamu-production
 include:
   - docker-compose.prod.infra.yml
 
+x-app-base: &app-base
+  image: ${GHCR_URL}/server:latest
+  env_file:
+    - /var/prod_config/server/.env.prod
+  networks:
+    - Denamu
+  depends_on:
+    mysql-db:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+    rabbitmq:
+      condition: service_healthy
+  volumes:
+    - /var/prod_data/server/logs:/app/logs
+    - /var/prod_data/objects:/app/objects
+  environment:
+    NODE_ENV: 'PROD'
+    TZ: 'Asia/Seoul'
+  stop_grace_period: 30s
+  healthcheck:
+    test:
+      [
+        'CMD-SHELL',
+        "node -e \"require('http').get('http://127.0.0.1:'+(process.env.SERVER_PORT||3000)+'/api/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))\"",
+      ]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+    start_period: 20s
+
 services:
-  # WAS 서비스
-  app:
-    image: ${GHCR_URL}/server:latest
+  # WAS 서비스 (Blue)
+  app-blue:
+    <<: *app-base
     ports:
-      - '$SERVER_PORT:$SERVER_PORT'
-    env_file:
-      - /var/prod_config/server/.env.prod
-    networks:
-      - Denamu
-    depends_on:
-      mysql-db:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      rabbitmq:
-        condition: service_healthy
-    volumes:
-      - /var/prod_data/server/logs:/app/logs
-      - /var/prod_data/objects:/app/objects
-    environment:
-      NODE_ENV: 'PROD'
-      TZ: 'Asia/Seoul'
+      - '$BLUE_PORT:$SERVER_PORT'
+
+  # WAS 서비스 (Green)
+  app-green:
+    <<: *app-base
+    ports:
+      - '$GREEN_PORT:$SERVER_PORT'
 
   # Feed Crawler 서비스
   feed-crawler:

--- a/docker-compose/scripts/blue-green-deploy.sh
+++ b/docker-compose/scripts/blue-green-deploy.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Blue-Green 무중단 배포 스크립트 (prod self-hosted runner 전용)
+#
+#   1. 현재 active 색상 파악 (nginx active backend 파일 기준)
+#   2. idle 색상 컨테이너에 신규 이미지 기동
+#   3. /api/health readiness gate 통과까지 대기
+#   4. nginx upstream(active backend 파일) 전환 + reload (graceful)
+#   5. 구 색상 컨테이너 drain 후 stop/rm
+#
+# health gate 실패 시 nginx 전환을 하지 않고 종료한다.
+# 구 색상이 그대로 트래픽을 받고 있으므로 사용자 영향은 0 이다.
+
+set -euo pipefail
+
+# ── 설정 (workflow env 로 override 가능) ──────────────────────────────
+COMPOSE_FILE="${COMPOSE_FILE:?COMPOSE_FILE 미설정}"
+BLUE_PORT="${BLUE_PORT:-8080}"
+GREEN_PORT="${GREEN_PORT:-8081}"
+ACTIVE_FILE="${ACTIVE_FILE:-/etc/nginx/conf.d/denamu_active_backend.conf}"
+HEALTH_PATH="${HEALTH_PATH:-/api/health}"
+HEALTH_RETRIES="${HEALTH_RETRIES:-30}"   # 30 회 x 2s = 최대 60s 대기
+HEALTH_INTERVAL="${HEALTH_INTERVAL:-2}"
+DRAIN_SECONDS="${DRAIN_SECONDS:-15}"      # reload 후 구 커넥션 drain 시간
+
+compose() { docker compose -f "$COMPOSE_FILE" "$@"; }
+
+write_active_backend() {
+  # $1 = port
+  echo "server 127.0.0.1:$1;" | sudo tee "$ACTIVE_FILE" >/dev/null
+}
+
+# ── 1. active backend 파일 부트스트랩 (최초 1회) ──────────────────────
+if [ ! -f "$ACTIVE_FILE" ]; then
+  echo "ℹ️  active backend 파일 없음 → blue($BLUE_PORT) 로 시드"
+  write_active_backend "$BLUE_PORT"
+fi
+
+# ── 2. 현재 active / 배포 대상(idle) 색상 결정 ────────────────────────
+CURRENT_PORT="$(grep -oE '127\.0\.0\.1:[0-9]+' "$ACTIVE_FILE" | grep -oE '[0-9]+$')"
+
+if [ "$CURRENT_PORT" = "$BLUE_PORT" ]; then
+  TARGET_COLOR="green"; TARGET_PORT="$GREEN_PORT"; OLD_SVC="app-blue"
+else
+  TARGET_COLOR="blue";  TARGET_PORT="$BLUE_PORT";  OLD_SVC="app-green"
+fi
+TARGET_SVC="app-${TARGET_COLOR}"
+
+echo "🔵🟢 현재 active 포트=$CURRENT_PORT → 배포 대상=$TARGET_SVC(:$TARGET_PORT)"
+
+# ── 3. idle 색상에 신규 이미지 기동 ──────────────────────────────────
+compose pull "$TARGET_SVC"
+compose up -d --no-deps --force-recreate "$TARGET_SVC"
+
+# ── 4. health readiness gate ─────────────────────────────────────────
+echo "⏳ health gate: http://127.0.0.1:${TARGET_PORT}${HEALTH_PATH}"
+HEALTHY=0
+for i in $(seq 1 "$HEALTH_RETRIES"); do
+  if curl -fsS --max-time 3 "http://127.0.0.1:${TARGET_PORT}${HEALTH_PATH}" >/dev/null 2>&1; then
+    HEALTHY=1
+    echo "✅ health OK (${i}회차)"
+    break
+  fi
+  sleep "$HEALTH_INTERVAL"
+done
+
+if [ "$HEALTHY" -ne 1 ]; then
+  echo "❌ health gate 실패 → nginx 전환 취소. 구 버전이 계속 트래픽 처리 중."
+  compose logs --tail=100 "$TARGET_SVC" || true
+  compose stop "$TARGET_SVC" || true
+  compose rm -f "$TARGET_SVC" || true
+  exit 1
+fi
+
+# ── 5. nginx upstream 전환 (graceful reload) ─────────────────────────
+echo "🔀 nginx upstream → :$TARGET_PORT 전환"
+write_active_backend "$TARGET_PORT"
+
+if ! sudo nginx -t; then
+  echo "❌ nginx 설정 검증 실패 → 롤백(:$CURRENT_PORT)"
+  write_active_backend "$CURRENT_PORT"
+  compose stop "$TARGET_SVC" || true
+  exit 1
+fi
+sudo systemctl reload nginx
+echo "✅ nginx reload 완료. 신규 트래픽은 $TARGET_SVC 로 라우팅."
+
+# ── 6. 구 색상 drain 후 종료 ─────────────────────────────────────────
+echo "🧹 구 커넥션 drain ${DRAIN_SECONDS}s 후 $OLD_SVC 종료"
+sleep "$DRAIN_SECONDS"
+compose stop "$OLD_SVC" || true
+compose rm -f "$OLD_SVC" || true
+docker image prune -f || true
+
+echo "🎉 Blue-Green 배포 완료: active=$TARGET_SVC(:$TARGET_PORT)"

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,11 @@
+# Blue-Green 무중단 배포용 backend upstream.
+# 실제 active 포트(blue=8080 / green=8081)는 배포 스크립트가 관리하는
+# /etc/nginx/conf.d/denamu_active_backend.conf (server 127.0.0.1:<port>;) 에서 결정된다.
+# 이 파일은 런타임에 동적으로 교체되므로 git 으로 관리하지 않는다.
+upstream denamu_backend {
+    include /etc/nginx/conf.d/denamu_active_backend.conf;
+}
+
 # HTTP로 들어오는 요청을 HTTPS로 Redirect
 server {
     listen 80;
@@ -99,7 +107,7 @@ server {
 
     # API 요청을 NestJS로 프록시
     location /api {
-        proxy_pass http://127.0.0.1:8080;
+        proxy_pass http://denamu_backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
@@ -114,7 +122,7 @@ server {
 
     # WebSocket 요청 프록시
     location /socket.io {
-        proxy_pass http://127.0.0.1:8080;
+        proxy_pass http://denamu_backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";

--- a/server/.prettierrc.js
+++ b/server/.prettierrc.js
@@ -18,6 +18,7 @@ module.exports = {
     '^@common/(.*)?$',
     '^@feed/(.*)?$',
     '^@file/(.*)?$',
+    '^@health/(.*)?$',
     '^@like/(.*)?$',
     '^@rss/(.*)?$',
     '^@statistic/(.*)?$',

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -17,6 +17,7 @@ import { CommentModule } from '@comment/module/comment.module';
 
 import { loadDBSetting } from '@common/database/load.config';
 import { EmailModule } from '@common/email/email.module';
+import { HealthController } from '@health/health.controller';
 import { WinstonLoggerModule } from '@common/logger/logger.module';
 import { MetricsModule } from '@common/metrics/metrics.module';
 import { RabbitMQModule } from '@common/rabbitmq/rabbitmq.module';
@@ -89,6 +90,6 @@ const exists = !!chosen && fs.existsSync(chosen);
     FileModule,
     RabbitMQModule,
   ],
-  controllers: [],
+  controllers: [HealthController],
 })
 export class AppModule {}

--- a/server/src/health/health.controller.ts
+++ b/server/src/health/health.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { ApiResponse } from '@common/response/common.response';
+
+@Controller('health')
+export class HealthController {
+  @Get()
+  check() {
+    return ApiResponse.responseWithNoContent('OK');
+  }
+}

--- a/server/test/health/e2e/check.e2e-spec.ts
+++ b/server/test/health/e2e/check.e2e-spec.ts
@@ -1,0 +1,27 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/health';
+
+describe(`GET ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+  });
+
+  it('[200] 헬스 체크 요청을 받은 경우 OK 메시지를 응답한다.', async () => {
+    // Http when
+    const response = await agent.get(URL);
+
+    // Http then
+    const { message, data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(message).toBe('OK');
+    expect(data).toBeUndefined();
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -25,6 +25,7 @@
       "@common/*": ["./src/common/*"],
       "@feed/*": ["./src/feed/*"],
       "@file/*": ["./src/file/*"],
+      "@health/*": ["./src/health/*"],
       "@like/*": ["./src/like/*"],
       "@rss/*": ["./src/rss/*"],
       "@statistic/*": ["./src/statistic/*"],


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #762

### Blue-Green 무중단 배포 도입

-   기존 단일 컨테이너 배포는 재기동 사이 트래픽이 끊겼습니다. blue(8080)/green(8081) 두 색상을 번갈아 띄우고, idle 색상이 health gate를 통과한 뒤에만 nginx upstream을 전환해 다운타임 0을 목표로 했습니다.
-   `docker-compose/scripts/blue-green-deploy.sh` 가 active 색상 판별 → idle 기동 → `/api/health` readiness gate → nginx 전환 + graceful reload → 구 색상 drain/정리 순으로 동작합니다.
-   **failure containment**: health gate 실패 시 nginx 전환을 하지 않고 종료합니다. 구 색상이 계속 트래픽을 처리하므로 배포 실패가 사용자에게 노출되지 않습니다. nginx -t 검증 실패 시에도 직전 포트로 롤백합니다.

### nginx upstream 동적 전환

-   `nginx.conf` 의 `denamu_backend` upstream 이 `/etc/nginx/conf.d/denamu_active_backend.conf` 를 include 하도록 변경했습니다. 트래픽 컷오버 지점을 런타임 파일 한 곳으로 격리해, 색상 전환 시 nginx.conf 수정 없이 active backend 파일 한 줄 교체 + reload 만으로 스위칭됩니다.
-   active backend 파일은 배포 산출물(런타임 상태)이라 git 으로 추적하지 않습니다. upstream include 는 파일 부재 시 `nginx -t` 가 실패하므로, 워크플로/스크립트가 최초 1회 blue 포트로 시드합니다(멱등).

### 포트 설정 SSOT

-   `BLUE_PORT`/`GREEN_PORT` 를 GitHub repo variable 로 단일화했습니다(`${{ vars.X || '8080' }}`). nginx 시드와 서버 배포가 서로 다른 워크플로 파일이라 리터럴이 어긋날 위험이 있어, 변수 미설정 시 8080/8081 fallback 으로 기존 동작을 보존하면서 단일 진실 공급원을 확보했습니다.

### health check API

-   무중단 배포의 readiness gate 가 의존할 `/api/health` 엔드포인트를 추가했습니다.

# 📋 작업 내용

-   `docker-compose/scripts/blue-green-deploy.sh` 무중단 배포 스크립트 작성
-   `docker-compose.prod.yml` app-blue/app-green 서비스 분리 (`x-app-base` anchor 공통화)
-   `nginx.conf` upstream include 기반 동적 backend 전환
-   `deploy_server.yml` / `deploy_nginx.yml` Blue-Green 배포 연동 및 포트 repo variable 화
-   `/api/health` health check 엔드포인트 추가
