### PR TITLE
✨ feat: 관리자 비밀번호 찾기 기능 구현 (BE/FE/Email)

### DIFF
--- a/client/src/__tests__/components/admin/login/AdminForgotPasswordModal.test.tsx
+++ b/client/src/__tests__/components/admin/login/AdminForgotPasswordModal.test.tsx
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AdminForgotPasswordModal from "@/components/admin/login/AdminForgotPasswordModal";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mutate = vi.fn();
+
+vi.mock("@/hooks/queries/useAdminAuth", () => ({
+  useAdminForgotPassword: () => ({ mutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/common/useCustomToast", () => ({
+  useCustomToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/components/RssRegistration/FormInput", () => ({
+  FormInput: ({ id, value, onChange, placeholder }: { id: string; value: string; onChange: (v: string) => void; placeholder: string }) => (
+    <input data-testid={id} value={value} placeholder={placeholder} onChange={(e) => onChange(e.target.value)} />
+  ),
+}));
+
+describe("AdminForgotPasswordModal", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("열린 상태에서 비밀번호 찾기 폼을 렌더링해야 한다", () => {
+    render(<AdminForgotPasswordModal open={true} onOpenChange={vi.fn()} />);
+
+    expect(screen.getByText("비밀번호 찾기")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "재설정 링크 받기" })).toBeInTheDocument();
+  });
+
+  it("이메일 입력 후 제출 시 mutate를 호출해야 한다", () => {
+    render(<AdminForgotPasswordModal open={true} onOpenChange={vi.fn()} />);
+
+    fireEvent.change(screen.getByTestId("forgot-email"), { target: { value: "admin@test.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "재설정 링크 받기" }));
+
+    expect(mutate).toHaveBeenCalledWith({ email: "admin@test.com" });
+  });
+
+  it("이메일이 비어 있으면 mutate를 호출하지 않아야 한다", () => {
+    render(<AdminForgotPasswordModal open={true} onOpenChange={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "재설정 링크 받기" }));
+
+    expect(mutate).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/components/admin/login/AdminLoginModal.test.tsx
+++ b/client/src/__tests__/components/admin/login/AdminLoginModal.test.tsx
@@ -10,6 +10,7 @@ vi.mock("@/hooks/common/useKeyboardShortcut", () => ({ useKeyboardShortcut: vi.f
 
 vi.mock("@/hooks/queries/useAdminAuth", () => ({
   useAdminAuth: () => ({ mutate }),
+  useAdminForgotPassword: () => ({ mutate: vi.fn(), isPending: false }),
 }));
 
 vi.mock("@/components/RssRegistration/FormInput", () => ({

--- a/client/src/api/services/admin/auth.ts
+++ b/client/src/api/services/admin/auth.ts
@@ -5,7 +5,9 @@ import { ApiMessage } from "@/types/api";
 import {
   AdminAuthRequest,
   AdminAuthResponse,
+  AdminForgotPasswordRequest,
   AdminProfileResponse,
+  AdminResetPasswordRequest,
   AdminUpdateRequest,
   AdminUpdateResponse,
 } from "@/types/auth";
@@ -33,6 +35,16 @@ export const auth = {
   },
   confirmWithdraw: async (token: string): Promise<ApiMessage> => {
     const response = await axiosInstance.delete<ApiMessage>(ADMIN.WITHDRAW_CONFIRM(token));
+    return response.data;
+  },
+  forgotPassword: async (data: AdminForgotPasswordRequest): Promise<ApiMessage> => {
+    const response = await axiosInstance.post<ApiMessage>(ADMIN.PASSWORD_RESET_REQUEST, data);
+    return response.data;
+  },
+  resetPassword: async ({ token, password }: AdminResetPasswordRequest): Promise<ApiMessage> => {
+    const response = await axiosInstance.patch<ApiMessage>(ADMIN.PASSWORD_RESET_CONFIRM(token), {
+      password,
+    });
     return response.data;
   },
 };

--- a/client/src/components/admin/login/AdminForgotPasswordModal.stories.tsx
+++ b/client/src/components/admin/login/AdminForgotPasswordModal.stories.tsx
@@ -1,0 +1,28 @@
+import AdminForgotPasswordModal from "@/components/admin/login/AdminForgotPasswordModal";
+
+import { ADMIN } from "@/constants/endpoints";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+const meta = {
+  title: "admin/login/AdminForgotPasswordModal",
+  component: AdminForgotPasswordModal,
+  args: { open: true, onOpenChange: fn() },
+} satisfies Meta<typeof AdminForgotPasswordModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPost(ADMIN.PASSWORD_RESET_REQUEST).reply(...ok(null, "비밀번호 재설정 이메일 발송 완료"));
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onPost(ADMIN.PASSWORD_RESET_REQUEST).reply(...fail(400, "요청 데이터 검증에 실패했습니다."));
+  },
+};

--- a/client/src/components/admin/login/AdminForgotPasswordModal.tsx
+++ b/client/src/components/admin/login/AdminForgotPasswordModal.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+
+import axios from "axios";
+
+import { FormInput } from "@/components/RssRegistration/FormInput";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast";
+import { useAdminForgotPassword } from "@/hooks/queries/useAdminAuth";
+
+interface AdminForgotPasswordModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function AdminForgotPasswordModal({ open, onOpenChange }: AdminForgotPasswordModalProps) {
+  const [email, setEmail] = useState<string>("");
+  const { toast } = useCustomToast();
+
+  const { mutate, isPending } = useAdminForgotPassword(
+    () => {
+      toast({
+        title: "이메일 발송 완료",
+        description: "입력하신 이메일로 비밀번호 재설정 링크를 발송했습니다.",
+      });
+      setEmail("");
+      onOpenChange(false);
+    },
+    (error) => {
+      toast({
+        title: "요청 실패",
+        description:
+          (axios.isAxiosError(error) && (error.response?.data as { message?: string })?.message) ||
+          "비밀번호 재설정 요청 중 오류가 발생했습니다.",
+        variant: "destructive",
+      });
+    }
+  );
+
+  const handleSubmit = () => {
+    if (!email) {
+      return;
+    }
+    mutate({ email });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[400px]">
+        <DialogHeader>
+          <DialogTitle>비밀번호 찾기</DialogTitle>
+          <DialogDescription>가입하신 관리자 이메일로 비밀번호 재설정 링크를 보내드립니다.</DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            handleSubmit();
+          }}
+        >
+          <div className="py-4">
+            <FormInput
+              id="forgot-email"
+              label="이메일"
+              onChange={setEmail}
+              placeholder="이메일을 입력해주세요."
+              value={email}
+              type="email"
+            />
+          </div>
+          <DialogFooter>
+            <Button type="submit" disabled={isPending}>
+              {isPending ? "발송 중..." : "재설정 링크 받기"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/admin/login/AdminLoginModal.tsx
+++ b/client/src/components/admin/login/AdminLoginModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import AdminForgotPasswordModal from "@/components/admin/login/AdminForgotPasswordModal";
 import { FormInput } from "@/components/RssRegistration/FormInput";
 import {
   AlertDialog,
@@ -19,6 +20,7 @@ import { useAdminAuth } from "@/hooks/queries/useAdminAuth";
 export default function AdminLogin({ setLogin }: { setLogin: () => void }) {
   const [loginData, setLoginData] = useState<{ email: string; password: string }>({ email: "", password: "" });
   const [loginError, setLoginError] = useState<boolean>(false);
+  const [forgotOpen, setForgotOpen] = useState<boolean>(false);
   const handleChange = (field: "email" | "password", value: string) => {
     setLoginData((prevData) => ({
       ...prevData,
@@ -71,13 +73,22 @@ export default function AdminLogin({ setLogin }: { setLogin: () => void }) {
               />
             </div>
           </CardContent>
-          <CardFooter className="flex justify-end">
-            <Button type="submit" className="bg-black hover:bg-gray-800 text-white">
+          <CardFooter className="flex items-center justify-between">
+            <button
+              type="button"
+              onClick={() => setForgotOpen(true)}
+              className="text-sm text-muted-foreground underline-offset-4 hover:underline"
+            >
+              비밀번호를 잊으셨나요?
+            </button>
+            <Button type="submit" className="bg-primary hover:bg-primary/90 text-primary-foreground">
               로그인
             </Button>
           </CardFooter>
         </form>
       </Card>
+
+      <AdminForgotPasswordModal open={forgotOpen} onOpenChange={setForgotOpen} />
 
       <AlertDialog open={loginError}>
         <AlertDialogContent>

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -12,6 +12,8 @@ export const ADMIN = {
   DELETE_CHILD: (id: number) => `/api/admins/children/${id}`,
   WITHDRAW_REQUEST: "/api/admins/me/deletion-requests",
   WITHDRAW_CONFIRM: (token: string) => `/api/admins/deletion-requests/${token}`,
+  PASSWORD_RESET_REQUEST: "/api/admins/password-resets",
+  PASSWORD_RESET_CONFIRM: (token: string) => `/api/admins/password-resets/${token}`,
   DELETE_COMMENT: (commentId: number) => `/api/admins/comments/${commentId}`,
   CHAT: {
     ROOMS: "/api/admins/chats",

--- a/client/src/hooks/queries/useAdminAuth.ts
+++ b/client/src/hooks/queries/useAdminAuth.ts
@@ -4,7 +4,15 @@ import { auth } from "@/api/services/admin/auth";
 import { register } from "@/api/services/admin/register";
 import { useAuthStore } from "@/store/useAuthStore";
 import { DeleteChildResponse, RegisterRequest, RegisterResponse } from "@/types/admin";
-import { AdminAuthRequest, AdminAuthResponse, AdminUpdateRequest, AdminUpdateResponse } from "@/types/auth";
+import {
+  AdminAuthRequest,
+  AdminAuthResponse,
+  AdminForgotPasswordRequest,
+  AdminResetPasswordRequest,
+  AdminUpdateRequest,
+  AdminUpdateResponse,
+} from "@/types/auth";
+import { ApiMessage } from "@/types/api";
 import { useMutation, UseMutationResult, useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useAdminAuth = (
@@ -56,6 +64,28 @@ export const useAdminWithdraw = (
 ): UseMutationResult<{ message: string }, AxiosError<unknown, unknown>, void, unknown> => {
   return useMutation<{ message: string }, AxiosError<unknown, unknown>, void>({
     mutationFn: () => auth.requestWithdraw(),
+    onSuccess,
+    onError,
+  });
+};
+
+export const useAdminForgotPassword = (
+  onSuccess: (data: ApiMessage) => void,
+  onError: (error: AxiosError<unknown, unknown>) => void
+): UseMutationResult<ApiMessage, AxiosError<unknown, unknown>, AdminForgotPasswordRequest, unknown> => {
+  return useMutation<ApiMessage, AxiosError<unknown, unknown>, AdminForgotPasswordRequest>({
+    mutationFn: (data) => auth.forgotPassword(data),
+    onSuccess,
+    onError,
+  });
+};
+
+export const useAdminResetPassword = (
+  onSuccess: (data: ApiMessage) => void,
+  onError: (error: AxiosError<unknown, unknown>) => void
+): UseMutationResult<ApiMessage, AxiosError<unknown, unknown>, AdminResetPasswordRequest, unknown> => {
+  return useMutation<ApiMessage, AxiosError<unknown, unknown>, AdminResetPasswordRequest>({
+    mutationFn: (data) => auth.resetPassword(data),
     onSuccess,
     onError,
   });

--- a/client/src/pages/email-actions/AdminPasswordReset.stories.tsx
+++ b/client/src/pages/email-actions/AdminPasswordReset.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import AdminPasswordReset from "@/pages/email-actions/AdminPasswordReset";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+
+const ENDPOINT = /\/api\/admins\/password-resets\/.+/;
+
+const meta = {
+  title: "pages/email-actions/AdminPasswordReset",
+  component: AdminPasswordReset,
+  parameters: {
+    router: { initialEntries: ["/admins/password-resets/confirm?token=test-token"] },
+  },
+} satisfies Meta<typeof AdminPasswordReset>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  beforeEach: () => {
+    mockApi.onPatch(ENDPOINT).reply(...ok(null, "비밀번호 변경 완료"));
+  },
+};
+
+export const Error: Story = {
+  beforeEach: () => {
+    mockApi.onPatch(ENDPOINT).reply(...fail(404, "인증에 실패했습니다."));
+  },
+};

--- a/client/src/pages/email-actions/AdminPasswordReset.tsx
+++ b/client/src/pages/email-actions/AdminPasswordReset.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+import axios from "axios";
+
+import { FormInput } from "@/components/RssRegistration/FormInput";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast";
+import { useAdminResetPassword } from "@/hooks/queries/useAdminAuth";
+
+const PASSWORD_REG = /^(?=.*[!@#$%^&*()_+])[A-Za-z0-9!@#$%^&*()_+]{6,60}$/;
+
+export default function AdminPasswordReset() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const navigate = useNavigate();
+  const { toast } = useCustomToast();
+
+  const [password, setPassword] = useState<string>("");
+  const [confirmPassword, setConfirmPassword] = useState<string>("");
+  const [isSuccess, setIsSuccess] = useState<boolean>(false);
+
+  const { mutate, isPending } = useAdminResetPassword(
+    () => {
+      setIsSuccess(true);
+      toast({
+        title: "비밀번호 변경 완료",
+        description: "새 비밀번호로 다시 로그인해주세요.",
+      });
+    },
+    (error) => {
+      toast({
+        title: "비밀번호 변경 실패",
+        description:
+          (axios.isAxiosError(error) && (error.response?.data as { message?: string })?.message) ||
+          "인증 링크가 만료되었거나 유효하지 않습니다.",
+        variant: "destructive",
+      });
+    }
+  );
+
+  const handleSubmit = () => {
+    if (!token) {
+      toast({
+        title: "비밀번호 변경 실패",
+        description: "유효하지 않은 인증 링크입니다.",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (!PASSWORD_REG.test(password)) {
+      toast({
+        title: "비밀번호 형식 오류",
+        description: "비밀번호는 6~60자이며 특수문자를 1개 이상 포함해야 합니다.",
+        variant: "destructive",
+      });
+      return;
+    }
+    if (password !== confirmPassword) {
+      toast({
+        title: "비밀번호 불일치",
+        description: "두 비밀번호가 일치하지 않습니다.",
+        variant: "destructive",
+      });
+      return;
+    }
+    mutate({ token, password });
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <Card className="w-[450px]">
+        <CardHeader>
+          <CardTitle>{isSuccess ? "비밀번호 변경 완료" : "관리자 비밀번호 재설정"}</CardTitle>
+          <CardDescription>
+            {isSuccess ? "새 비밀번호로 다시 로그인해주세요." : "새로 사용할 비밀번호를 입력해주세요."}
+          </CardDescription>
+        </CardHeader>
+        {isSuccess ? (
+          <>
+            <CardContent>
+              <div className="text-center text-green-600">
+                <p>비밀번호가 성공적으로 변경되었습니다.</p>
+                <p>기존 로그인 세션은 모두 만료되었습니다.</p>
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-center">
+              <Button onClick={() => navigate("/admin")}>관리자 페이지로 가기</Button>
+            </CardFooter>
+          </>
+        ) : (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleSubmit();
+            }}
+          >
+            <CardContent>
+              <div className="grid gap-4 py-4">
+                <FormInput
+                  id="password"
+                  label="새 비밀번호"
+                  onChange={setPassword}
+                  placeholder="새 비밀번호를 입력해주세요."
+                  value={password}
+                  type="password"
+                />
+                <FormInput
+                  id="confirm-password"
+                  label="비밀번호 확인"
+                  onChange={setConfirmPassword}
+                  placeholder="비밀번호를 다시 입력해주세요."
+                  value={confirmPassword}
+                  type="password"
+                />
+              </div>
+            </CardContent>
+            <CardFooter className="flex justify-end">
+              <Button type="submit" disabled={isPending}>
+                {isPending ? "변경 중..." : "비밀번호 변경"}
+              </Button>
+            </CardFooter>
+          </form>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -15,6 +15,7 @@ const SignUp = lazy(() => import("@/pages/SignUp"));
 const UserCertificate = lazy(() => import("@/pages/email-actions/UserCertificate"));
 const AdminCertificate = lazy(() => import("@/pages/email-actions/AdminCertificate"));
 const AdminWithdraw = lazy(() => import("@/pages/email-actions/AdminWithdraw"));
+const AdminPasswordReset = lazy(() => import("@/pages/email-actions/AdminPasswordReset"));
 const UserWithdraw = lazy(() => import("@/pages/email-actions/UserWithdraw"));
 const RssCertificate = lazy(() => import("@/pages/email-actions/RssCertificate"));
 const RssRemoval = lazy(() => import("@/pages/email-actions/RssRemoval"));
@@ -107,6 +108,14 @@ export const AppRouter = ({ location, state }: RouterProps) => {
           element={
             <Suspense fallback={<Loading />}>
               <AdminWithdraw />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/admins/password-resets/confirm"
+          element={
+            <Suspense fallback={<Loading />}>
+              <AdminPasswordReset />
             </Suspense>
           }
         />

--- a/client/src/types/auth.ts
+++ b/client/src/types/auth.ts
@@ -22,6 +22,15 @@ export type AdminUpdateRequest = {
 
 export type AdminUpdateResponse = ApiMessage;
 
+export type AdminForgotPasswordRequest = {
+  email: string;
+};
+
+export type AdminResetPasswordRequest = {
+  token: string;
+  password: string;
+};
+
 export interface UserSignUpRequest {
   email: string;
   password: string;

--- a/email-worker/src/email/constant.ts
+++ b/email-worker/src/email/constant.ts
@@ -8,4 +8,5 @@ export const EmailPayloadConstant = {
   ACCOUNT_DELETION: 'accountDeletion',
   ADMIN_CERTIFICATION: 'adminCertification',
   ADMIN_ACCOUNT_DELETION: 'adminAccountDeletion',
+  ADMIN_PASSWORD_RESET: 'adminPasswordReset',
 } as const;

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -133,6 +133,10 @@ export class EmailConsumer implements Lifecycle {
         await this.emailService.sendAdminDeleteAccountMail(payload.data);
         break;
 
+      case EmailPayloadConstant.ADMIN_PASSWORD_RESET:
+        await this.emailService.sendAdminPasswordResetEmail(payload.data);
+        break;
+
       default:
         logger.info(`처리할 수 없는 이메일 타입이 입력되었습니다.`);
     }

--- a/email-worker/src/email/email.service.ts
+++ b/email-worker/src/email/email.service.ts
@@ -121,6 +121,29 @@ export class EmailService {
     };
   }
 
+  async sendAdminPasswordResetEmail(admin: AdminCertification): Promise<void> {
+    const mailOptions = this.createAdminPasswordResetMail(admin);
+
+    await this.sendMail(mailOptions);
+  }
+
+  private createAdminPasswordResetMail(
+    admin: AdminCertification,
+  ): nodemailer.SendMailOptions {
+    const redirectUrl = `${PRODUCT_DOMAIN}/admins/password-resets/confirm?token=${admin.uuid}`;
+
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: admin.email,
+      subject: `[🎋 Denamu] 관리자 비밀번호 재설정`,
+      html: createPasswordResetMailContent(
+        admin.name,
+        redirectUrl,
+        this.emailUser,
+      ),
+    };
+  }
+
   async sendRssMail(rssRegistrationReuslt: RssRegistration): Promise<void> {
     const mailOptions = this.createRssRegistrationMail(
       rssRegistrationReuslt.rss,

--- a/email-worker/src/email/types.ts
+++ b/email-worker/src/email/types.ts
@@ -33,6 +33,10 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.ADMIN_ACCOUNT_DELETION;
       data: AdminCertification;
+    }
+  | {
+      type: typeof EmailPayloadConstant.ADMIN_PASSWORD_RESET;
+      data: AdminCertification;
     };
 
 export type NodeMailerError = Error & {

--- a/email-worker/test/unit/consumer.spec.ts
+++ b/email-worker/test/unit/consumer.spec.ts
@@ -40,6 +40,7 @@ describe('email consumer unit test', () => {
     let sendRssRegistrationRequestMail: jest.Mock;
     let sendAdminCertificationMail: jest.Mock;
     let sendAdminDeleteAccountMail: jest.Mock;
+    let sendAdminPasswordResetEmail: jest.Mock;
 
     beforeEach(() => {
       sendUserCertificationMail = jest.fn().mockResolvedValue(undefined);
@@ -51,6 +52,7 @@ describe('email consumer unit test', () => {
       sendRssRegistrationRequestMail = jest.fn().mockResolvedValue(undefined);
       sendAdminCertificationMail = jest.fn().mockResolvedValue(undefined);
       sendAdminDeleteAccountMail = jest.fn().mockResolvedValue(undefined);
+      sendAdminPasswordResetEmail = jest.fn().mockResolvedValue(undefined);
 
       emailService = {
         sendUserCertificationMail,
@@ -62,6 +64,7 @@ describe('email consumer unit test', () => {
         sendRssRegistrationRequestMail,
         sendAdminCertificationMail,
         sendAdminDeleteAccountMail,
+        sendAdminPasswordResetEmail,
       } as any;
       rabbitmqService = {
         sendMessageToQueue: jest.fn().mockResolvedValue(null),
@@ -244,6 +247,23 @@ describe('email consumer unit test', () => {
 
       expect(sendAdminDeleteAccountMail).toHaveBeenCalledTimes(1);
       expect(sendAdminDeleteAccountMail).toHaveBeenCalledWith(adminData);
+    });
+
+    it('ADMIN_PASSWORD_RESET 타입일 때 sendAdminPasswordResetEmail을 호출한다', async () => {
+      const adminData: AdminCertification = {
+        email: 'admin@test.com',
+        name: 'admin',
+        uuid: 'admin-uuid',
+      };
+      const payload: EmailPayload = {
+        type: EmailPayloadConstant.ADMIN_PASSWORD_RESET,
+        data: adminData,
+      };
+
+      await emailConsumer.handleEmailByType(payload);
+
+      expect(sendAdminPasswordResetEmail).toHaveBeenCalledTimes(1);
+      expect(sendAdminPasswordResetEmail).toHaveBeenCalledWith(adminData);
     });
 
     it('알 수 없는 타입일 때 아무 메서드도 호출하지 않는다', async () => {

--- a/email-worker/test/unit/emailService.spec.ts
+++ b/email-worker/test/unit/emailService.spec.ts
@@ -389,6 +389,33 @@ describe('EmailService unit test', () => {
     });
   });
 
+  describe('sendAdminPasswordResetEmail unit test', () => {
+    it('관리자 비밀번호 재설정 메일을 올바르게 전송한다', async () => {
+      const admin: AdminCertification = {
+        email: 'admin@test.com',
+        name: 'adminUser',
+        uuid: 'admin-uuid',
+      };
+
+      await emailService.sendAdminPasswordResetEmail(admin);
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: admin.email,
+          subject: '[🎋 Denamu] 관리자 비밀번호 재설정',
+        }),
+      );
+
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(admin.name);
+      expect(callArgs.html).toContain(
+        `${PRODUCT_DOMAIN}/admins/password-resets/confirm?token=${admin.uuid}`,
+      );
+    });
+  });
+
   describe('sendRssRegistrationRequestMail unit test', () => {
     it('RSS 등록 신청 접수 메일을 관리자에게 올바르게 전송한다', async () => {
       const request: RssRegistrationRequest = {

--- a/server/src/admin/api-docs/forgotPasswordAdmin.api-docs.ts
+++ b/server/src/admin/api-docs/forgotPasswordAdmin.api-docs.ts
@@ -1,0 +1,18 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiMessageResponse,
+} from '@common/swagger/swagger.helper';
+
+import { ForgotPasswordAdminRequestDto } from '@admin/dto/request/forgotPasswordAdmin.dto';
+
+export function ApiForgotPasswordAdmin() {
+  return applyDecorators(
+    ApiOperation({ summary: '관리자 비밀번호 변경 요청 API' }),
+    ApiBody({ type: ForgotPasswordAdminRequestDto }),
+    ApiMessageResponse('비밀번호 재설정 이메일 발송 완료'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/admin/api-docs/resetPasswordAdmin.api-docs.ts
+++ b/server/src/admin/api-docs/resetPasswordAdmin.api-docs.ts
@@ -1,0 +1,26 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiMessageResponse,
+  ApiNotFoundDoc,
+} from '@common/swagger/swagger.helper';
+
+import { ResetPasswordAdminRequestDto } from '@admin/dto/request/resetPasswordAdmin.dto';
+
+export function ApiResetPasswordAdmin() {
+  return applyDecorators(
+    ApiOperation({ summary: '관리자 비밀번호 변경 API' }),
+    ApiParam({
+      name: 'uuid',
+      type: String,
+      description: '비밀번호 재설정 인증 코드',
+      example: 'd2ba0d98-95ce-4905-87fc-384965ffe7c9',
+    }),
+    ApiBody({ type: ResetPasswordAdminRequestDto }),
+    ApiMessageResponse('비밀번호 변경 완료'),
+    ApiNotFoundDoc('인증에 실패했습니다.'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -20,17 +20,22 @@ import { Request, Response } from 'express';
 import { ApiCertificateAdmin } from '@admin/api-docs/certificateAdmin.api-docs';
 import { ApiConfirmDeleteAdmin } from '@admin/api-docs/confirmDeleteAdmin.api-docs';
 import { ApiDeleteChildAdmin } from '@admin/api-docs/deleteChildAdmin.api-docs';
+import { ApiForgotPasswordAdmin } from '@admin/api-docs/forgotPasswordAdmin.api-docs';
 import { ApiGetChildrenAdmin } from '@admin/api-docs/getChildrenAdmin.api-docs';
 import { ApiGetCurrentAdmin } from '@admin/api-docs/getCurrentAdmin.api-docs';
 import { ApiLoginAdmin } from '@admin/api-docs/loginAdmin.api-docs';
 import { ApiLogoutAdmin } from '@admin/api-docs/logoutAdmin.api-docs';
 import { ApiRegisterAdmin } from '@admin/api-docs/registerAdmin.api-docs';
 import { ApiRequestDeleteAdmin } from '@admin/api-docs/requestDeleteAdmin.api-docs';
+import { ApiResetPasswordAdmin } from '@admin/api-docs/resetPasswordAdmin.api-docs';
 import { ApiUpdateAdminProfile } from '@admin/api-docs/updateAdminProfile.api-docs';
 import { CertificateAdminRequestDto } from '@admin/dto/request/certificateAdmin.dto';
 import { ConfirmDeleteAdminParamRequestDto } from '@admin/dto/request/confirmDeleteAdminParam.dto';
+import { ForgotPasswordAdminRequestDto } from '@admin/dto/request/forgotPasswordAdmin.dto';
 import { LoginAdminRequestDto } from '@admin/dto/request/loginAdmin.dto';
 import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
+import { ResetPasswordAdminRequestDto } from '@admin/dto/request/resetPasswordAdmin.dto';
+import { ResetPasswordAdminParamRequestDto } from '@admin/dto/request/resetPasswordAdminParam.dto';
 import { UpdateAdminProfileRequestDto } from '@admin/dto/request/updateAdminProfile.dto';
 import { AdminService } from '@admin/service/admin.service';
 
@@ -142,6 +147,34 @@ export class AdminController {
   ) {
     await this.adminService.confirmDeleteAccount(paramDto.token);
     return ApiResponse.responseWithNoContent('회원탈퇴가 완료되었습니다.');
+  }
+
+  @ApiForgotPasswordAdmin()
+  @Post('/password-resets')
+  @HttpCode(HttpStatus.OK)
+  async forgotPasswordAdmin(
+    @Body() forgotPasswordAdminBodyDto: ForgotPasswordAdminRequestDto,
+  ) {
+    await this.adminService.forgotPassword(forgotPasswordAdminBodyDto.email);
+    return ApiResponse.responseWithNoContent(
+      '비밀번호 재설정 링크를 이메일로 발송했습니다.',
+    );
+  }
+
+  @ApiResetPasswordAdmin()
+  @Patch('/password-resets/:uuid')
+  @HttpCode(HttpStatus.OK)
+  async resetPasswordAdmin(
+    @Param() paramDto: ResetPasswordAdminParamRequestDto,
+    @Body() resetPasswordAdminBodyDto: ResetPasswordAdminRequestDto,
+  ) {
+    await this.adminService.resetPassword(
+      paramDto.uuid,
+      resetPasswordAdminBodyDto.password,
+    );
+    return ApiResponse.responseWithNoContent(
+      '비밀번호가 성공적으로 수정되었습니다.',
+    );
   }
 
   @ApiGetCurrentAdmin()

--- a/server/src/admin/dto/request/forgotPasswordAdmin.dto.ts
+++ b/server/src/admin/dto/request/forgotPasswordAdmin.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsEmail, IsNotEmpty } from 'class-validator';
+
+export class ForgotPasswordAdminRequestDto {
+  @ApiProperty({
+    example: 'admin@example.com',
+    description: '관리자 이메일을 입력해주세요.',
+  })
+  @IsEmail(
+    {},
+    {
+      message: '이메일 주소 형식에 맞춰서 작성해주세요.',
+    },
+  )
+  @IsNotEmpty({
+    message: '이메일이 없습니다.',
+  })
+  email: string;
+
+  constructor(partial: Partial<ForgotPasswordAdminRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/admin/dto/request/resetPasswordAdmin.dto.ts
+++ b/server/src/admin/dto/request/resetPasswordAdmin.dto.ts
@@ -1,0 +1,31 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsString, Length, Matches } from 'class-validator';
+
+const PASSWORD_REG = /^(?=.*[!@#$%^&*()_+])[A-Za-z0-9!@#$%^&*()_+]+$/;
+
+export class ResetPasswordAdminRequestDto {
+  @ApiProperty({
+    example: 'test1234!',
+    description:
+      '패스워드를 입력해주세요. (최소 6자, 영문/숫자/특수문자로 이루어질 수 있으며 특수문자 1개 이상 포함)',
+  })
+  @IsNotEmpty({
+    message: '비밀번호가 없습니다.',
+  })
+  @IsString({
+    message: '문자열을 입력해주세요',
+  })
+  @Matches(PASSWORD_REG, {
+    message:
+      '영문, 숫자, 특수문자로 이루어질 수 있으며 특수문자는 1개 이상 포함해주세요.',
+  })
+  @Length(6, 60, {
+    message: '패스워드의 길이는 6자 이상, 60자 이하로 작성해주세요.',
+  })
+  password: string;
+
+  constructor(partial: Partial<ResetPasswordAdminRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/admin/dto/request/resetPasswordAdminParam.dto.ts
+++ b/server/src/admin/dto/request/resetPasswordAdminParam.dto.ts
@@ -1,0 +1,17 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsNotEmpty, IsUUID } from 'class-validator';
+
+export class ResetPasswordAdminParamRequestDto {
+  @ApiProperty({
+    example: 'd2ba0d98-95ce-4905-87fc-384965ffe7c9',
+    description: '비밀번호 재설정 인증 코드',
+  })
+  @IsNotEmpty({ message: '인증 코드를 입력해주세요.' })
+  @IsUUID(4, { message: 'UUID v4 형식이어야 합니다.' })
+  uuid: string;
+
+  constructor(partial: Partial<ResetPasswordAdminParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -273,6 +273,70 @@ export class AdminService {
     );
   }
 
+  async forgotPassword(email: string) {
+    const admin = await this.adminRepository.findOne({
+      where: { email },
+    });
+
+    // 계정 열거(enumeration) 방지를 위해 미존재 시에도 동일 응답을 반환한다.
+    if (!admin) {
+      return;
+    }
+
+    const resetCode = uuid.v4();
+    await this.redisService.set(
+      `${REDIS_KEYS.ADMIN_RESET_PASSWORD_KEY}:${resetCode}`,
+      admin.id.toString(),
+      'EX',
+      ADMIN_REGISTER_TTL,
+    );
+    await this.emailProducer.produceAdminPasswordReset(
+      admin.email,
+      admin.name,
+      resetCode,
+    );
+  }
+
+  async resetPassword(token: string, password: string) {
+    const resetRequestKey = `${REDIS_KEYS.ADMIN_RESET_PASSWORD_KEY}:${token}`;
+
+    const data = await this.redisService.get(resetRequestKey);
+
+    if (!data) {
+      throw new NotFoundException('인증에 실패했습니다.');
+    }
+
+    const adminId = parseInt(data, 10);
+    const admin = await this.adminRepository.findOne({
+      where: { id: adminId },
+    });
+
+    if (!admin) {
+      await this.redisService.del(resetRequestKey);
+      throw new NotFoundException('인증에 실패했습니다.');
+    }
+
+    const saltRounds = 10;
+    admin.password = await bcrypt.hash(password, saltRounds);
+    await this.adminRepository.save(admin);
+
+    await this.redisService.del(resetRequestKey);
+    await this.invalidateAdminSession(admin.email);
+  }
+
+  // 비밀번호 재설정 시 기존 활성 세션을 강제 종료한다(로그아웃과 동일 메커니즘).
+  // ADMIN_INVALIDATED_PREFIX(탈퇴용 플래그)는 재로그인 후에도 SESSION_TTL 동안 차단하므로 사용하지 않는다.
+  private async invalidateAdminSession(email: string) {
+    const prevSessionId = await this.redisService.get(
+      `${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:${email}`,
+    );
+    const keysToDelete = [`${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:${email}`];
+    if (prevSessionId) {
+      keysToDelete.push(`${REDIS_KEYS.ADMIN_AUTH_KEY}:${prevSessionId}`);
+    }
+    await this.redisService.del(...keysToDelete);
+  }
+
   private async collectSubtreeEmails(root: Admin): Promise<string[]> {
     const emails = [root.email];
     let frontier = [root.id];

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -79,6 +79,19 @@ export class EmailProducer {
     await this.produceMessage(payload);
   }
 
+  async produceAdminPasswordReset(email: string, name: string, uuid: string) {
+    const payload = {
+      type: EmailPayloadConstant.ADMIN_PASSWORD_RESET,
+      data: {
+        email,
+        name,
+        uuid,
+      },
+    };
+
+    await this.produceMessage(payload);
+  }
+
   async produceRssRegistration(
     rss: Rss,
     approveFlag: boolean,

--- a/server/src/common/email/email.type.ts
+++ b/server/src/common/email/email.type.ts
@@ -52,6 +52,7 @@ export const EmailPayloadConstant = {
   ACCOUNT_DELETION: 'accountDeletion',
   ADMIN_CERTIFICATION: 'adminCertification',
   ADMIN_ACCOUNT_DELETION: 'adminAccountDeletion',
+  ADMIN_PASSWORD_RESET: 'adminPasswordReset',
 } as const;
 
 export type EmailPayload =
@@ -77,5 +78,9 @@ export type EmailPayload =
     }
   | {
       type: typeof EmailPayloadConstant.ADMIN_ACCOUNT_DELETION;
+      data: AdminCertification;
+    }
+  | {
+      type: typeof EmailPayloadConstant.ADMIN_PASSWORD_RESET;
       data: AdminCertification;
     };

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -13,6 +13,7 @@ export const REDIS_KEYS = {
   ADMIN_INVALIDATED_PREFIX: 'admin:invalidated',
   ADMIN_REGISTER_KEY: 'admin:signup',
   ADMIN_DELETE_ACCOUNT_KEY: 'admin:delete-account',
+  ADMIN_RESET_PASSWORD_KEY: 'admin:password_reset',
   RSS_REMOVE_KEY: 'rss:remove',
   RSS_CERTIFICATION_KEY: 'rss:certification',
   CHAT_HISTORY_KEY: (roomId: string) => `chat:history:${roomId}`,

--- a/server/test/admin/dto/forgotPasswordAdmin.dto.spec.ts
+++ b/server/test/admin/dto/forgotPasswordAdmin.dto.spec.ts
@@ -1,0 +1,34 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { ForgotPasswordAdminRequestDto } from '@admin/dto/request/forgotPasswordAdmin.dto';
+
+describe(`${ForgotPasswordAdminRequestDto.name} Test`, () => {
+  const toDto = (partial: Partial<ForgotPasswordAdminRequestDto>) =>
+    plainToInstance(ForgotPasswordAdminRequestDto, partial);
+
+  it('올바른 이메일 형식이면 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(toDto({ email: 'admin@test.com' }));
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('이메일 형식이 아니면 유효성 검사에 실패한다.', async () => {
+    // when
+    const errors = await validate(toDto({ email: 'not-an-email' }));
+
+    // then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isEmail');
+  });
+
+  it('이메일이 비어 있으면 유효성 검사에 실패한다.', async () => {
+    // when
+    const errors = await validate(toDto({ email: '' }));
+
+    // then
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/server/test/admin/dto/resetPasswordAdmin.dto.spec.ts
+++ b/server/test/admin/dto/resetPasswordAdmin.dto.spec.ts
@@ -1,0 +1,43 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { ResetPasswordAdminRequestDto } from '@admin/dto/request/resetPasswordAdmin.dto';
+
+describe(`${ResetPasswordAdminRequestDto.name} Test`, () => {
+  const toDto = (partial: Partial<ResetPasswordAdminRequestDto>) =>
+    plainToInstance(ResetPasswordAdminRequestDto, partial);
+
+  it('정책에 부합하는 비밀번호면 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(toDto({ password: 'test1234!' }));
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('비밀번호 길이가 6 미만이면 유효성 검사에 실패한다.', async () => {
+    // when
+    const errors = await validate(toDto({ password: 'a1!' }));
+
+    // then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isLength');
+  });
+
+  it('특수문자가 없으면 유효성 검사에 실패한다.', async () => {
+    // when
+    const errors = await validate(toDto({ password: 'testAdminPassword' }));
+
+    // then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('matches');
+  });
+
+  it('비밀번호가 비어 있으면 유효성 검사에 실패한다.', async () => {
+    // when
+    const errors = await validate(toDto({ password: '' }));
+
+    // then
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/test/admin/dto/resetPasswordAdminParam.dto.spec.ts
+++ b/server/test/admin/dto/resetPasswordAdminParam.dto.spec.ts
@@ -1,0 +1,36 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { ResetPasswordAdminParamRequestDto } from '@admin/dto/request/resetPasswordAdminParam.dto';
+
+describe(`${ResetPasswordAdminParamRequestDto.name} Test`, () => {
+  const toDto = (partial: Partial<ResetPasswordAdminParamRequestDto>) =>
+    plainToInstance(ResetPasswordAdminParamRequestDto, partial);
+
+  it('UUID v4 형식이면 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(
+      toDto({ uuid: 'd2ba0d98-95ce-4905-87fc-384965ffe7c9' }),
+    );
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('UUID v4 형식이 아니면 유효성 검사에 실패한다.', async () => {
+    // when
+    const errors = await validate(toDto({ uuid: 'not-a-uuid' }));
+
+    // then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isUuid');
+  });
+
+  it('인증 코드가 비어 있으면 유효성 검사에 실패한다.', async () => {
+    // when
+    const errors = await validate(toDto({ uuid: '' }));
+
+    // then
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/server/test/admin/e2e/forgotPassword.e2e-spec.ts
+++ b/server/test/admin/e2e/forgotPassword.e2e-spec.ts
@@ -1,0 +1,98 @@
+import { HttpStatus } from '@nestjs/common';
+
+import * as uuid from 'uuid';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { ForgotPasswordAdminRequestDto } from '@admin/dto/request/forgotPasswordAdmin.dto';
+import { Admin } from '@admin/entity/admin.entity';
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/admins/password-resets';
+
+describe(`POST ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let admin: Admin;
+  const passwordResetCode = 'admin-password-reset-code';
+  const redisKeyMake = (data: string) =>
+    `${REDIS_KEYS.ADMIN_RESET_PASSWORD_KEY}:${data}`;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+  });
+
+  beforeEach(async () => {
+    jest.spyOn(uuid, 'v4').mockReturnValue(passwordResetCode as any);
+    admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture({
+        email: 'admin-forgot@test.com',
+        name: 'admin-forgot',
+      }),
+    );
+  });
+
+  it('[400] 이메일 형식이 아닌 값으로 요청할 경우 비밀번호 재설정 요청을 실패한다.', async () => {
+    // given
+    const requestDto = new ForgotPasswordAdminRequestDto({
+      email: 'not-an-email',
+    });
+
+    // Http when
+    const response = await agent.post(URL).send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[200] 존재하지 않는 이메일로 요청한 경우 계정 열거 방지를 위해 요청을 성공으로 처리한다.', async () => {
+    // given
+    const requestDto = new ForgotPasswordAdminRequestDto({
+      email: 'invalid@test.com',
+    });
+
+    // Http when
+    const response = await agent.post(URL).send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toBeUndefined();
+
+    // Redis then - 존재하지 않는 계정이므로 재설정 코드를 발급하지 않는다.
+    const savedResetCode = await redisService.get(
+      redisKeyMake(passwordResetCode),
+    );
+    expect(savedResetCode).toBeNull();
+  });
+
+  it('[200] 존재하는 이메일로 요청한 경우 비밀번호 재설정 코드를 발급한다.', async () => {
+    // given
+    const requestDto = new ForgotPasswordAdminRequestDto({
+      email: admin.email,
+    });
+
+    // Http when
+    const response = await agent.post(URL).send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toBeUndefined();
+
+    // Redis then - 발급된 재설정 코드는 관리자 ID를 가리킨다.
+    const savedResetCode = await redisService.get(
+      redisKeyMake(passwordResetCode),
+    );
+    expect(savedResetCode).toBe(admin.id.toString());
+  });
+});

--- a/server/test/admin/e2e/resetPassword.e2e-spec.ts
+++ b/server/test/admin/e2e/resetPassword.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { HttpStatus } from '@nestjs/common';
+
+import * as bcrypt from 'bcrypt';
+import * as uuid from 'uuid';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { ResetPasswordAdminRequestDto } from '@admin/dto/request/resetPasswordAdmin.dto';
+import { Admin } from '@admin/entity/admin.entity';
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const makeURL = (code: string) => `/api/admins/password-resets/${code}`;
+
+describe(`PATCH /api/admins/password-resets/:uuid E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let admin: Admin;
+  const passwordResetCode = uuid.v4();
+  const redisKeyMake = (data: string) =>
+    `${REDIS_KEYS.ADMIN_RESET_PASSWORD_KEY}:${data}`;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+  });
+
+  beforeEach(async () => {
+    admin = await adminRepository.save(AdminFixture.createAdminFixture());
+  });
+
+  it('[400] UUID v4 형식이 아닌 코드로 요청할 경우 비밀번호 변경을 실패한다.', async () => {
+    // given
+    const requestDto = new ResetPasswordAdminRequestDto({
+      password: 'reset1234!',
+    });
+
+    // Http when
+    const response = await agent.patch(makeURL('invalid-code')).send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[404] 존재하지 않는 재설정 코드로 요청할 경우 비밀번호 변경을 실패한다.', async () => {
+    // given
+    const nonExistentCode = uuid.v4();
+    const requestDto = new ResetPasswordAdminRequestDto({
+      password: 'reset1234!',
+    });
+
+    // Http when
+    const response = await agent
+      .patch(makeURL(nonExistentCode))
+      .send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 유효한 재설정 코드로 요청할 경우 비밀번호를 변경하고 기존 세션을 무효화한다.', async () => {
+    // given
+    const updatedPassword = 'reset1234!';
+    const sessionId = 'admin-reset-session-id';
+    const requestDto = new ResetPasswordAdminRequestDto({
+      password: updatedPassword,
+    });
+    await Promise.all([
+      redisService.set(redisKeyMake(passwordResetCode), admin.id.toString()),
+      redisService.set(
+        `${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:${admin.email}`,
+        sessionId,
+      ),
+      redisService.set(`${REDIS_KEYS.ADMIN_AUTH_KEY}:${sessionId}`, admin.email),
+    ]);
+
+    // Http when
+    const response = await agent
+      .patch(makeURL(passwordResetCode))
+      .send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toBeUndefined();
+
+    // DB, Redis then
+    const [savedAdmin, savedResetCode, savedSession, savedAuth] =
+      await Promise.all([
+        adminRepository.findOneBy({ id: admin.id }),
+        redisService.get(redisKeyMake(passwordResetCode)),
+        redisService.get(`${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:${admin.email}`),
+        redisService.get(`${REDIS_KEYS.ADMIN_AUTH_KEY}:${sessionId}`),
+      ]);
+
+    expect(
+      await bcrypt.compare(updatedPassword, savedAdmin.password),
+    ).toBeTruthy();
+    expect(savedResetCode).toBeNull();
+    expect(savedSession).toBeNull();
+    expect(savedAuth).toBeNull();
+  });
+});

--- a/server/test/admin/unit/admin.service.unit.spec.ts
+++ b/server/test/admin/unit/admin.service.unit.spec.ts
@@ -35,7 +35,9 @@ describe(`${AdminService.name} Unit Test`, () => {
   let emailProducer: jest.Mocked<
     Pick<
       EmailProducer,
-      'produceAdminCertification' | 'produceAdminAccountDeletion'
+      | 'produceAdminCertification'
+      | 'produceAdminAccountDeletion'
+      | 'produceAdminPasswordReset'
     >
   >;
 
@@ -64,6 +66,7 @@ describe(`${AdminService.name} Unit Test`, () => {
     emailProducer = {
       produceAdminCertification: jest.fn(),
       produceAdminAccountDeletion: jest.fn(),
+      produceAdminPasswordReset: jest.fn(),
     };
 
     adminService = new AdminService(
@@ -490,6 +493,121 @@ describe(`${AdminService.name} Unit Test`, () => {
         `${REDIS_KEYS.ADMIN_INVALIDATED_PREFIX}:grandchild-admin@test.com`,
         SESSION_TTL,
         '1',
+      );
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('존재하지 않는 이메일이면 계정 열거 방지를 위해 아무 동작도 하지 않는다.', async () => {
+      // given
+      adminRepository.findOne.mockResolvedValue(null);
+
+      // when
+      await adminService.forgotPassword('ghost@test.com');
+
+      // then
+      expect(redisService.set).not.toHaveBeenCalled();
+      expect(emailProducer.produceAdminPasswordReset).not.toHaveBeenCalled();
+    });
+
+    it('존재하는 이메일이면 코드를 Redis에 저장하고 재설정 메일을 발행한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email: 'self-admin@test.com',
+      });
+      admin.id = 7;
+      adminRepository.findOne.mockResolvedValue(admin);
+
+      // when
+      await adminService.forgotPassword('self-admin@test.com');
+
+      // then
+      const [redisKey, storedValue] = redisService.set.mock.calls[0];
+      expect(redisKey).toContain(REDIS_KEYS.ADMIN_RESET_PASSWORD_KEY);
+      expect(storedValue).toBe('7');
+      expect(emailProducer.produceAdminPasswordReset).toHaveBeenCalledWith(
+        admin.email,
+        admin.name,
+        expect.any(String),
+      );
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('존재하지 않거나 만료된 토큰이면 NotFoundException을 던진다.', async () => {
+      // given
+      redisService.get.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        adminService.resetPassword('expired-token', 'newPass1!'),
+      ).rejects.toThrow(NotFoundException);
+      expect(adminRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('토큰은 유효하지만 관리자가 없으면 키를 삭제하고 NotFoundException을 던진다.', async () => {
+      // given
+      redisService.get.mockResolvedValue('7');
+      adminRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        adminService.resetPassword('valid-token', 'newPass1!'),
+      ).rejects.toThrow(NotFoundException);
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_RESET_PASSWORD_KEY}:valid-token`,
+      );
+      expect(adminRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('유효한 토큰이면 비밀번호를 해시 저장하고 코드와 활성 세션을 무효화한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email: 'self-admin@test.com',
+      });
+      admin.id = 7;
+      // 1st get: 토큰 → adminId, 2nd get: 활성 세션 조회
+      redisService.get
+        .mockResolvedValueOnce('7')
+        .mockResolvedValueOnce('active-session-id');
+      adminRepository.findOne.mockResolvedValue(admin);
+
+      // when
+      await adminService.resetPassword('valid-token', 'newPass1!');
+
+      // then
+      const saved = adminRepository.save.mock.calls[0][0] as Admin;
+      expect(saved.password).not.toBe('newPass1!');
+      expect(await bcrypt.compare('newPass1!', saved.password)).toBe(true);
+
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_RESET_PASSWORD_KEY}:valid-token`,
+      );
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:self-admin@test.com`,
+        `${REDIS_KEYS.ADMIN_AUTH_KEY}:active-session-id`,
+      );
+      // 재로그인을 영구 차단하는 탈퇴용 무효화 플래그는 사용하지 않는다.
+      expect(redisService.setex).not.toHaveBeenCalled();
+    });
+
+    it('활성 세션이 없으면 이메일 매핑 키만 삭제한다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email: 'self-admin@test.com',
+      });
+      admin.id = 7;
+      redisService.get
+        .mockResolvedValueOnce('7')
+        .mockResolvedValueOnce(null);
+      adminRepository.findOne.mockResolvedValue(admin);
+
+      // when
+      await adminService.resetPassword('valid-token', 'newPass1!');
+
+      // then
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:self-admin@test.com`,
       );
     });
   });


### PR DESCRIPTION
# 🔨 테스크

### Issue

-  #349
-  #350
-   #711

### 관리자 비밀번호 찾기 (BE)

-   관리자가 비밀번호를 분실했을 때 이메일 인증을 통해 재설정할 수 있는 플로우를 추가했습니다.
-   `forgotPassword` → 가입된 관리자 이메일 검증 후 재설정 토큰을 발급하고 RabbitMQ를 통해 이메일 발송을 트리거합니다.
-   `resetPassword` → 토큰 검증 후 비밀번호를 갱신합니다. 토큰은 Redis에 TTL과 함께 저장하여 만료/일회성을 보장합니다.
-   토큰은 추측 불가능한 값으로 발급하고, 재설정 완료 시 즉시 폐기하여 재사용을 차단했습니다.

### 비밀번호 재설정 이메일 (Email Worker)

-   기존 이메일 인증 컨슈머에 비밀번호 재설정 메일 타입을 추가했습니다.
-   재설정 링크가 포함된 메일을 발송하며, 실패 시 기존 에러 분류/DLQ 정책을 그대로 따릅니다.

### 관리자 비밀번호 찾기 (FE)

-   로그인 모달에 "비밀번호를 잊으셨나요?" 진입점과 `AdminForgotPasswordModal`을 추가해 이메일 입력 → 재설정 메일 요청 플로우를 구현했습니다.
-   메일 링크로 진입하는 `/email-actions` 비밀번호 재설정 페이지(`AdminPasswordReset`)를 추가했습니다.
-   `useAdminAuth` 훅과 엔드포인트/타입을 확장하여 API를 연동했습니다.
-   로그인 버튼 색상을 브랜드 컬러(`bg-primary`)로 통일했습니다.

# 📋 작업 내용

-   [BE] 관리자 비밀번호 찾기/재설정 API (controller, service, DTO, api-docs, Redis 토큰)
-   [Email] 비밀번호 재설정 메일 컨슈머/서비스 타입 추가
-   [FE] 비밀번호 찾기 모달 + 재설정 페이지 + 훅/엔드포인트/타입 연동
-   [Test] BE DTO/E2E/Unit, Email Worker Unit, FE 컴포넌트/페이지 테스트, Storybook

# 📷 스크린 샷(선택 사항)

<img width="603" height="408" alt="image" src="https://github.com/user-attachments/assets/8fc580e3-5896-4c90-a349-d7e735585a81" />
<img width="557" height="361" alt="image" src="https://github.com/user-attachments/assets/d2d6131e-7148-48c8-8e34-0642e41d89b9" />
<img width="489" height="343" alt="image" src="https://github.com/user-attachments/assets/efd6462e-be8e-4c79-9ab4-ff9feee9df71" />
<img width="1057" height="414" alt="image" src="https://github.com/user-attachments/assets/ba47e994-66d8-4912-a9b6-b2d99c00e1f8" />
