### PR TITLE
✨ feat: 관리자 비밀번호 변경 시 전체 기기 로그아웃

### DIFF
--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -324,8 +324,6 @@ export class AdminService {
     await this.invalidateAdminSession(admin.email);
   }
 
-  // 비밀번호 재설정 시 기존 활성 세션을 강제 종료한다(로그아웃과 동일 메커니즘).
-  // ADMIN_INVALIDATED_PREFIX(탈퇴용 플래그)는 재로그인 후에도 SESSION_TTL 동안 차단하므로 사용하지 않는다.
   private async invalidateAdminSession(email: string) {
     const prevSessionId = await this.redisService.get(
       `${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:${email}`,
@@ -402,7 +400,8 @@ export class AdminService {
       admin.name = name;
     }
 
-    if (password !== undefined) {
+    const passwordChanged = password !== undefined;
+    if (passwordChanged) {
       const saltRounds = 10;
       admin.password = await bcrypt.hash(password, saltRounds);
     }
@@ -418,6 +417,10 @@ export class AdminService {
         throw new ConflictException('이미 존재하는 이름입니다.');
       }
       throw error;
+    }
+
+    if (passwordChanged) {
+      await this.invalidateAdminSession(admin.email);
     }
   }
 }

--- a/server/test/admin/e2e/update.e2e-spec.ts
+++ b/server/test/admin/e2e/update.e2e-spec.ts
@@ -20,6 +20,8 @@ describe(`PATCH ${URL} E2E Test`, () => {
   let adminRepository: AdminRepository;
   const sessionKey = 'admin-session-update-key';
   const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+  const sessionByEmailKeyMake = (email: string) =>
+    `${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:${email}`;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
@@ -72,6 +74,45 @@ describe(`PATCH ${URL} E2E Test`, () => {
     const updated = await adminRepository.findOne({ where: { id: adminId } });
     expect(updated.password).not.toBe('newPass1!');
     expect(await bcrypt.compare('newPass1!', updated.password)).toBe(true);
+  });
+
+  it('[200] 비밀번호를 변경하면 활성 세션을 무효화하고 이후 같은 쿠키 요청이 401이 된다.', async () => {
+    // given: 단일 세션 모델의 이메일→세션 매핑 등록
+    await redisService.set(sessionByEmailKeyMake(adminEmail), sessionKey);
+
+    // when
+    const response = await agent
+      .patch(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send({ password: 'newPass1!' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(await redisService.get(redisKeyMake(sessionKey))).toBeNull();
+    expect(await redisService.get(sessionByEmailKeyMake(adminEmail))).toBeNull();
+
+    const afterResponse = await agent
+      .get(URL)
+      .set('Cookie', `sessionId=${sessionKey}`);
+    expect(afterResponse.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[200] 비밀번호를 변경하지 않으면 세션이 유지된다.', async () => {
+    // given
+    await redisService.set(sessionByEmailKeyMake(adminEmail), sessionKey);
+
+    // when
+    const response = await agent
+      .patch(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send({ name: 'keep-session-name' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(await redisService.get(redisKeyMake(sessionKey))).toBe(adminEmail);
+    expect(await redisService.get(sessionByEmailKeyMake(adminEmail))).toBe(
+      sessionKey,
+    );
   });
 
   it('[200] 이메일 수신 여부를 끄면 DB에 반영된다.', async () => {

--- a/server/test/admin/unit/admin.service.unit.spec.ts
+++ b/server/test/admin/unit/admin.service.unit.spec.ts
@@ -736,10 +736,11 @@ describe(`${AdminService.name} Unit Test`, () => {
       expect(adminRepository.save).toHaveBeenCalledTimes(1);
     });
 
-    it('비밀번호를 변경하면 해시해서 저장한다.', async () => {
+    it('비밀번호를 변경하면 해시해서 저장하고 활성 세션을 무효화한다.', async () => {
       // given
       const admin = await AdminFixture.createAdminCryptFixture({ email });
       adminRepository.findOne.mockResolvedValueOnce(admin);
+      redisService.get.mockResolvedValueOnce('active-session-id');
 
       // when
       await adminService.updateAdminProfile(email, {
@@ -750,6 +751,27 @@ describe(`${AdminService.name} Unit Test`, () => {
       const saved = adminRepository.save.mock.calls[0][0] as Admin;
       expect(saved.password).not.toBe('newPass1!');
       expect(await bcrypt.compare('newPass1!', saved.password)).toBe(true);
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.ADMIN_SESSION_BY_EMAIL}:${email}`,
+        `${REDIS_KEYS.ADMIN_AUTH_KEY}:active-session-id`,
+      );
+    });
+
+    it('비밀번호를 변경하지 않으면 세션을 무효화하지 않는다.', async () => {
+      // given
+      const admin = await AdminFixture.createAdminCryptFixture({
+        email,
+        name: 'old-name',
+      });
+      adminRepository.findOne
+        .mockResolvedValueOnce(admin)
+        .mockResolvedValueOnce(null);
+
+      // when
+      await adminService.updateAdminProfile(email, { name: 'new-name' });
+
+      // then
+      expect(redisService.del).not.toHaveBeenCalled();
     });
 
     it('이메일 수신 여부만 변경하면 해당 값만 저장한다.', async () => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #711

### 로그인 상태 비밀번호 변경 시 세션 무효화

-   로그인된 관리자가 마이페이지에서 비밀번호를 변경해도 기존 세션이 그대로 살아 있어, 유출된 비밀번호로 이미 로그인한 세션을 끊을 방법이 없었습니다.
-   `updateAdminProfile`에서 비밀번호가 실제로 변경된 경우에만 `invalidateAdminSession`을 호출해 기존 세션을 강제 종료합니다. 이름/이메일 수신 여부만 수정한 경우에는 세션을 유지합니다.
-   비밀번호 재설정(`resetPassword`)과 동일한 메커니즘(세션 삭제, 재로그인 허용)을 재사용했습니다. 탈퇴용 무효화 플래그(`ADMIN_INVALIDATED_PREFIX`)는 재로그인을 영구 차단하므로 비밀번호 변경 경로에는 부적합하여 사용하지 않았습니다.

### 단일 세션 모델 전제

-   관리자는 로그인 시 기존 `ADMIN_AUTH_KEY`를 삭제하는 단일 세션 구조이므로, 무효화 대상 세션이 항상 1개입니다. 따라서 매핑된 세션 하나만 끊으면 "전체 기기 로그아웃"이 성립합니다.

# 📋 작업 내용

-   `updateAdminProfile`: 비밀번호 변경 시 `invalidateAdminSession(admin.email)` 호출 (변경된 경우에만).
-   unit 테스트 2건 추가: 비밀번호 변경 시 세션 무효화 / 비밀번호 미변경 시 세션 유지.
-   e2e 테스트 2건 추가: 비밀번호 변경 후 같은 쿠키 요청이 401, 비밀번호 미변경 시 세션 유지.