### PR TITLE
✨ feat: Google Analytics 수집 및 게시글 오픈 이벤트 태깅

### DIFF
--- a/client/.env.prod
+++ b/client/.env.prod
@@ -1,1 +1,2 @@
 VITE_DENAMU_URL=https://denamu.dev
+VITE_GA_ID=G-4FXZ9MS445

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -39,6 +39,7 @@
         "lucide-react": "^0.577.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-ga4": "^3.0.1",
         "react-helmet": "^6.1.0",
         "react-markdown": "^9.0.3",
         "react-router-dom": "^6.30.3",
@@ -14109,6 +14110,12 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-ga4": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-3.0.1.tgz",
+      "integrity": "sha512-GyCc01bSheWXjzGDyHsXMOqk/SP5Cf/JrcJTg4hcpKx4eeSwaJKpJUc+ipF4ffLTZkmabmf3ZGBv4OKHTXNXyA==",
       "license": "MIT"
     },
     "node_modules/react-helmet": {

--- a/client/package.json
+++ b/client/package.json
@@ -51,6 +51,7 @@
     "lucide-react": "^0.577.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-ga4": "^3.0.1",
     "react-helmet": "^6.1.0",
     "react-markdown": "^9.0.3",
     "react-router-dom": "^6.30.3",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,12 +3,14 @@ import { Navigate } from "react-router-dom";
 import { Toaster } from "@/components/ui/toaster";
 
 import { useAppInitialization } from "@/hooks/useAppInitialization";
+import { useGoogleAnalytics } from "@/hooks/useGoogleAnalytics";
 
 import { QueryProvider } from "@/providers/QueryProvider";
 import { AppRouter } from "@/routes";
 
 export default function App() {
   const { state, location, shouldRedirectToAbout, setVisited } = useAppInitialization();
+  useGoogleAnalytics();
   if (shouldRedirectToAbout) {
     setVisited();
     return <Navigate to="/about" replace />;

--- a/client/src/components/common/Card/PostCard.tsx
+++ b/client/src/components/common/Card/PostCard.tsx
@@ -10,6 +10,17 @@ import { PostCardImage } from "./PostCardImage";
 import { cn } from "@/lib/utils";
 import { useMediaStore } from "@/store/useMediaStore";
 import { PostCardProps } from "@/types/card";
+import { FeedList } from "@/types/post";
+import { trackEvent } from "@/utils/analytics";
+
+const trackPostDetailOpen = (post: FeedList) => {
+  trackEvent("post_detail_open", {
+    post_id: post.id,
+    post_title: post.title,
+    platform: post.blogPlatform,
+    author: post.author,
+  });
+};
 
 export const PostCard = ({ post, className }: PostCardProps) => {
   const isMobile = useMediaStore((state) => state.isMobile);
@@ -26,6 +37,7 @@ const DesktopCard = ({ post, className }: PostCardProps) => {
   const location = useLocation();
   const { incrementView } = usePostCardActions(post);
   const openPostDetail = (modalUrl: string) => {
+    trackPostDetailOpen(post);
     incrementView({ post, isWindowOpened: true });
     useUpdateRecentTags(post.tag);
     navigate(modalUrl, { state: { backgroundLocation: location } });
@@ -49,6 +61,7 @@ const MobileCard = ({ post, className }: PostCardProps) => {
   return (
     <MCard
       onClick={() => {
+        trackPostDetailOpen(post);
         navigate(`/${post.id}`);
       }}
       className={cn("aspect-[5/3] transition-all duration-300 flex flex-col gap-2", className)}

--- a/client/src/hooks/useGoogleAnalytics.ts
+++ b/client/src/hooks/useGoogleAnalytics.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+import { trackPageView } from "@/utils/analytics";
+
+export const useGoogleAnalytics = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    trackPageView(location.pathname + location.search);
+  }, [location.pathname, location.search]);
+};

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,10 +4,13 @@ import { BrowserRouter } from "react-router-dom";
 import App from "./App.tsx";
 import "./index.css";
 import { setupMocks } from "@/api/mocks";
+import { initGA } from "@/utils/analytics";
 
 if (import.meta.env.DEV) {
   setupMocks();
 }
+
+initGA();
 
 createRoot(document.getElementById("root")!).render(
   <BrowserRouter>

--- a/client/src/utils/analytics.ts
+++ b/client/src/utils/analytics.ts
@@ -1,0 +1,20 @@
+import ReactGA from "react-ga4";
+
+const GA_ID = import.meta.env.VITE_GA_ID;
+
+export const isGAEnabled = Boolean(GA_ID) && import.meta.env.PROD;
+
+export const initGA = () => {
+  if (!isGAEnabled) return;
+  ReactGA.initialize(GA_ID);
+};
+
+export const trackPageView = (path: string) => {
+  if (!isGAEnabled) return;
+  ReactGA.send({ hitType: "pageview", page: path, title: document.title });
+};
+
+export const trackEvent = (action: string, params?: Record<string, string | number | boolean>) => {
+  if (!isGAEnabled) return;
+  ReactGA.event(action, params);
+};

--- a/client/src/utils/analytics.ts
+++ b/client/src/utils/analytics.ts
@@ -6,7 +6,7 @@ export const isGAEnabled = Boolean(GA_ID) && import.meta.env.PROD;
 
 export const initGA = () => {
   if (!isGAEnabled) return;
-  ReactGA.initialize(GA_ID);
+  ReactGA.initialize(GA_ID, { gtagOptions: { send_page_view: false } });
 };
 
 export const trackPageView = (path: string) => {

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_DENAMU_URL: string;
+  readonly VITE_GA_ID: string;
+}


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #808

### Google Analytics(GA4) 연동

- `react-ga4` 도입, 프로덕션 환경에서만 동작하도록 `isGAEnabled = Boolean(VITE_GA_ID) && import.meta.env.PROD` 가드
- dev/local 트래픽이 실측정에 섞이지 않도록 차단
- `VITE_GA_ID` 환경변수 및 타입 선언(`vite-env.d.ts`) 추가

### SPA 페이지뷰 추적

- `useGoogleAnalytics` 훅에서 `useLocation` 의존 `useEffect`로 라우팅마다 page_view 전송
- CSR 특성상 초기 로드 이후 페이지 전환은 서버 요청이 없으므로 훅으로 직접 집계

### 게시글 오픈 이벤트 태깅

- 카드 클릭 시 `post_detail_open` 커스텀 이벤트 전송
- params: `post_id`, `post_title`, `platform`, `author` — 어떤 글/플랫폼/저자가 열리는지 분류 가능
- desktop / mobile 카드 모두 커버

### 메인 페이지 집계 2배 버그 수정 (send_page_view: false)

- **문제**: `ReactGA.initialize(GA_ID)` 내부는 `gtag('config', id)`를 호출하는데, GA4 `config` 명령은 **기본값으로 page_view를 자동 1회 전송**함. 여기에 `useGoogleAnalytics` 훅의 `useEffect`가 mount 시 동일 경로로 page_view를 **또** 전송 → 앱 첫 진입 페이지만 page_view 2회 집계
- **영향**: 랜딩 페이지 지표 뻥튀기, bounce rate·entrance·세션당 pageview 왜곡
- **수정**: `ReactGA.initialize(GA_ID, { gtagOptions: { send_page_view: false } })`로 initialize의 자동 전송을 끔
- **이유**: SPA 라우팅 전체를 추적해야 하는 `useGoogleAnalytics` 훅은 필수라 끌 수 없음. 반면 initialize의 자동 전송은 최초 1회만 담당하며 훅이 이미 그 시점을 커버하므로 잉여. 자동 전송을 끄면 **모든 page_view 소스가 라우터 훅으로 단일화**되어 중복 제거 + 로직 일원화

# 📋 작업 내용

- `react-ga4` 설치 및 `utils/analytics.ts` 유틸(`initGA` / `trackPageView` / `trackEvent`) 구현
- `main.tsx`에서 `initGA()` 1회 초기화, `App`에서 `useGoogleAnalytics()` 연결
- `PostCard`에 `post_detail_open` 이벤트 태깅
- initialize 자동 page_view 비활성화로 첫 페이지 중복 집계 제거

# 📷 스크린 샷(선택 사항)

<img width="1543" height="691" alt="image" src="https://github.com/user-attachments/assets/bb57bc0a-fde3-40dd-9e3e-4873e2f7b341" />