### PR TITLE
✨ feat: OAuth 유저 비밀번호 찾기 지원 및 유저 이메일 unique 제약 추가

### DIFF
--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -45,7 +45,8 @@ CREATE TABLE `user` (
   `lastActiveDate` date DEFAULT NULL,
   `maxStreak` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_d34106f8ec1ebaf66f4f8609dd` (`user_name`)
+  UNIQUE KEY `IDX_d34106f8ec1ebaf66f4f8609dd` (`user_name`),
+  UNIQUE KEY `IDX_e12875dfb3b1d92d7d7c5377e2` (`email`)
 );
 
 -- denamu.rss_accept definition

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -8,9 +8,9 @@ CREATE TABLE `admin` (
   `email_notification` tinyint NOT NULL DEFAULT 1,
   `parent_admin_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `UQ_admin_email` (`email`),
-  UNIQUE KEY `UQ_admin_name` (`name`),
-    CONSTRAINT `FK_admin_parent_admin`
+  UNIQUE KEY `IDX_a026be7ca12f8999cbdf96dec2` (`name`),
+  UNIQUE KEY `IDX_de87485f6489f5d0995f584195` (`email`),
+    CONSTRAINT `FK_78ba73b3dd2c586476eccd1867f`
     FOREIGN KEY (`parent_admin_id`)
     REFERENCES `admin` (`id`)
     ON DELETE CASCADE
@@ -25,8 +25,8 @@ CREATE TABLE `rss` (
   `email` varchar(255) NOT NULL,
   `rss_url` varchar(255) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `UQ_21beac47feacb87e57c59d6958f` (`name`),
-  UNIQUE KEY `UQ_af1d102908727aa95ef09e16065` (`rss_url`)
+  UNIQUE KEY `IDX_21beac47feacb87e57c59d6958` (`name`),
+  UNIQUE KEY `IDX_af1d102908727aa95ef09e1606` (`rss_url`)
 );
 
 -- denamu.`user` definition
@@ -45,7 +45,7 @@ CREATE TABLE `user` (
   `lastActiveDate` date DEFAULT NULL,
   `maxStreak` int NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `UQ_user_user_name` (`user_name`)
+  UNIQUE KEY `IDX_d34106f8ec1ebaf66f4f8609dd` (`user_name`)
 );
 
 -- denamu.rss_accept definition
@@ -59,10 +59,10 @@ CREATE TABLE `rss_accept` (
   `blog_platform` varchar(255) NOT NULL DEFAULT 'etc',
   `user_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `UQ_59f4be4de3817b3f975acff0766` (`name`),
-  UNIQUE KEY `UQ_b3a5d4196368864d938dae4e9ff` (`rss_url`),
+  UNIQUE KEY `IDX_59f4be4de3817b3f975acff076` (`name`),
+  UNIQUE KEY `IDX_b3a5d4196368864d938dae4e9f` (`rss_url`),
   KEY `FK_c6af67149ff8aa87d001091acbe` (`user_id`),
-  FULLTEXT KEY (`name`),
+  FULLTEXT KEY `FT_rss_accept_name` (`name`),
   CONSTRAINT `FK_c6af67149ff8aa87d001091acbe` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
@@ -95,7 +95,7 @@ CREATE TABLE `feed` (
   UNIQUE KEY `IDX_cbdceca2d71f784a8bb160268e` (`path`),
   KEY `IDX_fda780ffdcc013b739cdc6f31d` (`created_at`),
   KEY `FK_7474d489d05b8051874b227f868` (`blog_id`),
-  FULLTEXT KEY `IDX_7d93e66e624232af470d2f7bb3` (`title`) /*!50100 WITH PARSER `ngram` */ ,
+  FULLTEXT KEY `IDX_7d93e66e624232af470d2f7bb3` (`title`),
   CONSTRAINT `FK_7474d489d05b8051874b227f868` FOREIGN KEY (`blog_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
@@ -116,19 +116,21 @@ CREATE TABLE `activity` (
 
 CREATE TABLE `category` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `name` varchar(30) NOT NULL UNIQUE,
+  `name` varchar(30) NOT NULL,
   `display_order` int NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `IDX_23c05c292c439d77b0de816b50` (`name`)
 );
 
 -- denamu.tag definition
 
 CREATE TABLE `tag` (
   `id` int NOT NULL AUTO_INCREMENT,
-  `name` varchar(50) NOT NULL UNIQUE,
+  `name` varchar(50) NOT NULL,
   `category_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  CONSTRAINT `FK_tag_category` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`) ON DELETE SET NULL
+  UNIQUE KEY `IDX_6a9775008add570dc3e5a0bab7` (`name`),
+  CONSTRAINT `FK_3249fd70734f41f513a1d5d3ef7` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`) ON DELETE SET NULL
 );
 
 -- denamu.tag_map definition
@@ -136,8 +138,11 @@ CREATE TABLE `tag` (
 CREATE TABLE `tag_map` (
   `tag_id` int NOT NULL,
   `feed_id` int NOT NULL,
-  CONSTRAINT `FK_170d19639c49b5735ae8261ff0b` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_9a3ed1e034e7f378f89f5902941` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  PRIMARY KEY (`feed_id`,`tag_id`),
+  KEY `IDX_170d19639c49b5735ae8261ff0` (`feed_id`),
+  KEY `IDX_9a3ed1e034e7f378f89f590294` (`tag_id`),
+  CONSTRAINT `FK_170d19639c49b5735ae8261ff0b` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_9a3ed1e034e7f378f89f5902941` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`)
 );
 
 -- denamu.comment definition
@@ -182,10 +187,25 @@ CREATE TABLE `subscription` (
   `rss_accept_id` int NOT NULL,
   `user_id` int NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `UQ_subscription_user_rss` (`user_id`,`rss_accept_id`),
-  KEY `FK_subscription_rss` (`rss_accept_id`),
-  CONSTRAINT `FK_subscription_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_subscription_rss` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `IDX_be6abee15b8a92cc7fe2a25975` (`user_id`,`rss_accept_id`),
+  KEY `FK_f196cabdcb20cfbcf552ae61321` (`rss_accept_id`),
+  CONSTRAINT `FK_940d49a105d50bbd616be540013` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_f196cabdcb20cfbcf552ae61321` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- denamu.file definition
+
+CREATE TABLE `file` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `original_name` varchar(255) NOT NULL,
+  `mimetype` varchar(255) NOT NULL,
+  `path` varchar(255) NOT NULL,
+  `size` int NOT NULL,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `user_id` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK_516f1cf15166fd07b732b4b6ab0` (`user_id`),
+  CONSTRAINT `FK_516f1cf15166fd07b732b4b6ab0` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 );
 
 -- denamu.provider definition

--- a/server/src/common/database/migration/1781400000000-AddUserEmailUnique.ts
+++ b/server/src/common/database/migration/1781400000000-AddUserEmailUnique.ts
@@ -1,0 +1,41 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserEmailUnique1781400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await this.assertNoDuplicates(queryRunner, 'user', 'email');
+
+    await queryRunner.query(
+      'ALTER TABLE `user` ADD UNIQUE `IDX_e12875dfb3b1d92d7d7c5377e2` (`email`);',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `user` DROP INDEX `IDX_e12875dfb3b1d92d7d7c5377e2`;',
+    );
+  }
+
+  private async assertNoDuplicates(
+    queryRunner: QueryRunner,
+    table: string,
+    column: string,
+  ): Promise<void> {
+    const duplicates: Array<{ value: string; count: number }> =
+      await queryRunner.query(
+        `SELECT \`${column}\` AS value, COUNT(*) AS count
+       FROM \`${table}\`
+       GROUP BY \`${column}\`
+       HAVING COUNT(*) > 1;`,
+      );
+
+    if (duplicates.length > 0) {
+      const detail = duplicates
+        .map((row) => `${row.value}(${row.count})`)
+        .join(', ');
+      throw new Error(
+        `\`${table}\`.\`${column}\`에 중복 값이 존재하여 UNIQUE 제약을 추가할 수 없습니다. ` +
+          `먼저 중복을 정리해주세요: ${detail}`,
+      );
+    }
+  }
+}

--- a/server/src/user/entity/user.entity.ts
+++ b/server/src/user/entity/user.entity.ts
@@ -23,6 +23,7 @@ export class User extends BaseEntity {
     name: 'email',
     length: 255,
     nullable: false,
+    unique: true,
   })
   email: string;
 

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -30,6 +29,7 @@ import { SubscriptionRepository } from '@subscribe/repository/subscription.repos
 
 import { REFRESH_TOKEN_TTL, SALT_ROUNDS } from '@user/constant/user.constants';
 import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
+import { GetUserRssFeedsRequestDto } from '@user/dto/request/getUserRssFeeds.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { SearchUserRequestDto } from '@user/dto/request/searchUser.dto';
@@ -38,13 +38,12 @@ import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailD
 import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUserNameDuplication.dto';
 import { CreateAccessTokenResponseDto } from '@user/dto/response/createAccessToken.dto';
 import { GetUserProfileResponseDto } from '@user/dto/response/getUserProfile.dto';
+import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
+import { GetUserRssFeedsResponseDto } from '@user/dto/response/getUserRssFeeds.dto';
 import {
   SearchUserResponseDto,
   SearchUserResult,
 } from '@user/dto/response/searchUser.dto';
-import { GetUserRssResponseDto } from '@user/dto/response/getUserRss.dto';
-import { GetUserRssFeedsRequestDto } from '@user/dto/request/getUserRssFeeds.dto';
-import { GetUserRssFeedsResponseDto } from '@user/dto/response/getUserRssFeeds.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
@@ -211,7 +210,11 @@ export class UserService {
       where: { email: loginDto.email },
     });
 
-    if (!user || !(await bcrypt.compare(loginDto.password, user.password))) {
+    if (
+      !user ||
+      !user.password ||
+      !(await bcrypt.compare(loginDto.password, user.password))
+    ) {
       throw new UnauthorizedException('아이디 혹은 비밀번호가 잘못되었습니다.');
     }
 
@@ -370,17 +373,10 @@ export class UserService {
   async forgotPassword(email: string) {
     const user = await this.userRepository.findOne({
       where: { email: email },
-      relations: ['providers'],
     });
 
     if (!user) {
       return;
-    }
-
-    if (user.providers.length > 0) {
-      throw new BadRequestException(
-        '소셜 로그인 계정은 비밀번호를 변경할 수 없습니다. 소셜 로그인을 이용해주세요.',
-      );
     }
 
     const forgotPasswordCode = uuid.v4();

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -403,6 +403,14 @@ export class UserService {
     const user = await this.userRepository.findOne({
       where: { id: userId },
     });
+
+    if (!user) {
+      await this.redisService.del(
+        `${REDIS_KEYS.USER_RESET_PASSWORD_KEY}:${uuid}`,
+      );
+      throw new NotFoundException('존재하지 않는 유저입니다.');
+    }
+
     user.password = await this.createHashedPassword(password);
 
     await this.redisService.del(

--- a/server/test/user/e2e/login.e2e-spec.ts
+++ b/server/test/user/e2e/login.e2e-spec.ts
@@ -63,6 +63,25 @@ describe(`POST ${URL} E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
+  it('[401] 비밀번호가 설정되지 않은 소셜 계정일 경우 로그인을 실패한다.', async () => {
+    // given
+    const socialUser = await userRepository.save(
+      UserFixture.createUserFixture({ password: null }),
+    );
+    const requestDto = new LoginUserRequestDto({
+      email: socialUser.email,
+      password: USER_DEFAULT_PASSWORD,
+    });
+
+    // Http when
+    const response = await agent.post(URL).send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+  });
+
   it('[200] 아이디와 비밀번호에 해당하는 유저가 존재할 경우 로그인을 성공한다.', async () => {
     // given
     const requestDto = new LoginUserRequestDto({

--- a/server/test/user/e2e/password-confirm.e2e-spec.ts
+++ b/server/test/user/e2e/password-confirm.e2e-spec.ts
@@ -60,6 +60,34 @@ describe(`PATCH /api/users/password-resets/:uuid E2E Test`, () => {
     expect(savedPasswordCode).toBeNull();
   });
 
+  it('[404] 비밀번호 세션 ID는 유효하지만 유저가 존재하지 않을 경우 코드를 삭제하고 비밀번호 변경을 실패한다.', async () => {
+    // given
+    const nonExistentUserId = 999999;
+    const requestDto = new ResetPasswordRequestDto({ password: 'test1234@' });
+    await redisService.set(
+      redisKeyMake(passwordPatchCode),
+      JSON.stringify(nonExistentUserId),
+    );
+
+    // Http when
+    const response = await agent
+      .patch(makeURL(passwordPatchCode))
+      .send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+
+    // DB, Redis when
+    const savedPasswordCode = await redisService.get(
+      redisKeyMake(passwordPatchCode),
+    );
+
+    // DB, Redis then
+    expect(savedPasswordCode).toBeNull();
+  });
+
   it('[200] 존재하는 비밀번호 세션 ID를 통해 비밀번호 변경 요청을 할 경우 비밀번호 변경을 성공한다.', async () => {
     // given
     const updatedPassword = 'test1234@';

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -560,6 +560,17 @@ describe(`${UserService.name} Unit Test`, () => {
       ).rejects.toThrow(UnauthorizedException);
     });
 
+    it('비밀번호 미설정 소셜 계정이면 UnauthorizedException을 던진다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ password: null });
+      userRepository.findOne.mockResolvedValue(user);
+
+      // when & then
+      await expect(
+        userService.loginUser(dto, createResponse()),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
     it('로그인에 성공하면 refresh 쿠키를 설정하고 access token을 반환한다.', async () => {
       // given
       const user = await UserFixture.createUserCryptFixture();
@@ -819,6 +830,21 @@ describe(`${UserService.name} Unit Test`, () => {
       await expect(
         userService.resetPassword('uuid', 'newPass1!'),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('인증 코드는 유효하지만 유저가 없으면 코드를 삭제하고 NotFoundException을 던진다.', async () => {
+      // given
+      redisService.get.mockResolvedValue('1');
+      userRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(
+        userService.resetPassword('uuid', 'newPass1!'),
+      ).rejects.toThrow(NotFoundException);
+      expect(redisService.del).toHaveBeenCalledWith(
+        `${REDIS_KEYS.USER_RESET_PASSWORD_KEY}:uuid`,
+      );
+      expect(userRepository.save).not.toHaveBeenCalled();
     });
 
     it('인증에 성공하면 비밀번호를 해시해 저장하고 코드를 정리한다.', async () => {

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   ConflictException,
   NotFoundException,
   UnauthorizedException,
@@ -790,18 +789,27 @@ describe(`${UserService.name} Unit Test`, () => {
       expect(emailProducer.producePasswordReset).toHaveBeenCalled();
     });
 
-    it('OAuth 회원가입자면 BadRequestException을 던지고 메일을 발송하지 않는다.', async () => {
+    it('OAuth 회원가입자도 인증 코드를 저장하고 메일을 발송한다.', async () => {
       // given
       userRepository.findOne.mockResolvedValue(
-        UserFixture.createUserFixture({ id: 1, providers: [{}] as any }),
+        UserFixture.createUserFixture({
+          id: 1,
+          password: null,
+          providers: [{}] as any,
+        }),
       );
 
-      // when & then
-      await expect(userService.forgotPassword('a@test.com')).rejects.toThrow(
-        BadRequestException,
+      // when
+      await userService.forgotPassword('a@test.com');
+
+      // then
+      expect(redisService.set).toHaveBeenCalledWith(
+        expect.stringContaining(REDIS_KEYS.USER_RESET_PASSWORD_KEY),
+        expect.any(String),
+        'EX',
+        600,
       );
-      expect(redisService.set).not.toHaveBeenCalled();
-      expect(emailProducer.producePasswordReset).not.toHaveBeenCalled();
+      expect(emailProducer.producePasswordReset).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #711

### OAuth 유저 비밀번호 찾기 허용

- 기존에는 소셜 로그인 계정(providers 존재)이 비밀번호 찾기를 요청하면 `BadRequestException`으로 차단했습니다. OAuth 유저도 비밀번호를 설정하면 로컬 로그인이 가능하도록 차단 로직을 제거했습니다.
- OAuth 전용 계정은 `password`가 null일 수 있으므로, 로그인 시 `user.password` 존재 여부를 먼저 검증하여 `bcrypt.compare`에 null이 전달되는 문제를 방지했습니다.

### 비밀번호 변경 시 유저 검증

- `changePassword`에서 userId로 조회한 유저가 존재하지 않는 경우(탈퇴 등) null 참조가 발생할 수 있어, 유저 부재 시 Redis의 reset code를 삭제하고 `NotFoundException`을 던지도록 검증을 추가했습니다.

### 유저 이메일 unique 제약 추가

- OAuth/로컬 계정이 이메일 기준으로 단일 계정으로 취급되어야 하므로 `user.email`에 unique 제약을 추가했습니다. (entity + migration + init.sql 반영)

# 📋 작업 내용

- `forgotPassword`: 소셜 로그인 계정 차단 로직 제거 (OAuth 유저도 비밀번호 찾기 가능)
- `loginUser`: password가 null인 OAuth 전용 계정 로그인 시도 방어 로직 추가
- `changePassword`: 유저 미존재 시 reset code 삭제 및 `NotFoundException` 처리
- `User` entity email 컬럼 unique 추가 및 `AddUserEmailUnique` migration 작성
- `init.sql` 누락 엔티티 반영 및 명시적 키 명칭 변경
- 관련 unit/e2e 테스트 추가 (login, password-confirm, user.service)

# 📷 스크린 샷(선택 사항)