### PR TITLE
✨ feat: 메인 페이지 최신 RSS 목록 제공

### DIFF
--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -16,7 +16,7 @@ import type {
   User,
   UserProfile,
 } from "@/types/profile";
-import type { AdminRssData } from "@/types/rss";
+import type { AdminRssData, RecentRss } from "@/types/rss";
 import type { SearchResult, UserSearchResult } from "@/types/search";
 import type { ChildAdmin } from "@/types/admin";
 import type { SubscribedRss } from "@/types/subscription";
@@ -303,3 +303,14 @@ export const mockNoSummaryFeeds = mockFeedsList.slice(0, 3).map(({ id, title, li
   likes,
   comments,
 }));
+
+const RECENT_RSS_PLATFORMS = ["velog", "tistory", "medium", "github", "etc"];
+
+export const makeRecentRssList = (count: number, publishedHoursAgo: (index: number) => number): RecentRss[] =>
+  Array.from({ length: count }, (_, i) => ({
+    id: i + 1,
+    name: `블로그 ${i + 1}.log`,
+    blogPlatform: RECENT_RSS_PLATFORMS[i % RECENT_RSS_PLATFORMS.length],
+    lastPublishedAt: new Date(Date.now() - publishedHoursAgo(i) * 3600000).toISOString(),
+    latestFeedId: (i + 1) * 100,
+  }));

--- a/client/src/__tests__/components/sections/MainContent.test.tsx
+++ b/client/src/__tests__/components/sections/MainContent.test.tsx
@@ -14,6 +14,10 @@ vi.mock("@/components/sections/TrendingSection", () => ({
   default: () => <div data-testid="trending-section" />,
 }));
 
+vi.mock("@/components/sections/RecentRssSection", () => ({
+  default: () => <div data-testid="recent-rss-section" />,
+}));
+
 vi.mock("@/components/sections/LatestSection", () => ({
   default: () => <div data-testid="latest-section" />,
 }));
@@ -29,6 +33,7 @@ describe("MainContent", () => {
     render(<MainContent />);
 
     expect(screen.getByTestId("trending-section")).toBeInTheDocument();
+    expect(screen.getByTestId("recent-rss-section")).toBeInTheDocument();
     expect(screen.getByTestId("latest-section")).toBeInTheDocument();
     expect(scrollSpy).toHaveBeenCalledWith(0, 0);
     scrollSpy.mockRestore();

--- a/client/src/__tests__/components/sections/RecentRssSection.test.tsx
+++ b/client/src/__tests__/components/sections/RecentRssSection.test.tsx
@@ -4,9 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import RecentRssSection from "@/components/sections/RecentRssSection.tsx";
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 const useRecentRssMock = vi.fn();
+const incrementViewMock = vi.fn();
 
 vi.mock("lucide-react", async () => {
   const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
@@ -15,6 +16,10 @@ vi.mock("lucide-react", async () => {
 
 vi.mock("@/hooks/queries/useRecentRss", () => ({
   useRecentRss: () => useRecentRssMock(),
+}));
+
+vi.mock("@/hooks/common/usePostCardActions", () => ({
+  useIncrementViewByPostId: () => incrementViewMock,
 }));
 
 vi.mock("@/components/common/SectionHeader", () => ({
@@ -34,6 +39,8 @@ const renderSection = () =>
     </MemoryRouter>
   );
 
+const hoursAgo = (hours: number) => new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
 describe("RecentRssSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -50,8 +57,8 @@ describe("RecentRssSection", () => {
   it("RSS 목록의 이름과 플랫폼을 렌더링해야 한다", () => {
     useRecentRssMock.mockReturnValue({
       data: [
-        { id: 1, name: "블로그A", blogPlatform: "velog", lastPublishedAt: "2026-01-01T00:00:00.000Z" },
-        { id: 2, name: "블로그B", blogPlatform: "tistory", lastPublishedAt: "2026-01-02T00:00:00.000Z" },
+        { id: 1, name: "블로그A", blogPlatform: "velog", lastPublishedAt: hoursAgo(48), latestFeedId: 11 },
+        { id: 2, name: "블로그B", blogPlatform: "tistory", lastPublishedAt: hoursAgo(72), latestFeedId: 22 },
       ],
       isLoading: false,
     });
@@ -63,14 +70,58 @@ describe("RecentRssSection", () => {
     expect(screen.getByText("tistory")).toBeInTheDocument();
   });
 
-  it("RSS 클릭 시 RSS 페이지로 이동하는 링크를 가져야 한다", () => {
+  it("24시간이 지난 RSS 클릭 시 RSS 페이지로 이동하는 링크를 가져야 한다", () => {
     useRecentRssMock.mockReturnValue({
-      data: [{ id: 7, name: "블로그A", blogPlatform: "velog", lastPublishedAt: "2026-01-01T00:00:00.000Z" }],
+      data: [{ id: 7, name: "블로그A", blogPlatform: "velog", lastPublishedAt: hoursAgo(25), latestFeedId: 77 }],
       isLoading: false,
     });
     renderSection();
 
     expect(screen.getByRole("link")).toHaveAttribute("href", "/rss/7");
+  });
+
+  it("24시간 이내 게시글이 있으면 스토리 테두리를 표시하고 최신 게시글로 이동해야 한다", () => {
+    useRecentRssMock.mockReturnValue({
+      data: [{ id: 7, name: "블로그A", blogPlatform: "velog", lastPublishedAt: hoursAgo(1), latestFeedId: 77 }],
+      isLoading: false,
+    });
+    renderSection();
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/77");
+    expect(link.querySelector("[data-story]")).not.toBeNull();
+  });
+
+  it("24시간이 지난 RSS는 스토리 테두리를 표시하지 않아야 한다", () => {
+    useRecentRssMock.mockReturnValue({
+      data: [{ id: 7, name: "블로그A", blogPlatform: "velog", lastPublishedAt: hoursAgo(25), latestFeedId: 77 }],
+      isLoading: false,
+    });
+    renderSection();
+
+    expect(screen.getByRole("link").querySelector("[data-story]")).toBeNull();
+  });
+
+  it("스토리 클릭 시 조회수를 증가시켜야 한다", () => {
+    useRecentRssMock.mockReturnValue({
+      data: [{ id: 7, name: "블로그A", blogPlatform: "velog", lastPublishedAt: hoursAgo(1), latestFeedId: 77 }],
+      isLoading: false,
+    });
+    renderSection();
+
+    fireEvent.click(screen.getByRole("link"));
+    expect(incrementViewMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("24시간이 지난 RSS 클릭 시 조회수를 증가시키지 않아야 한다", () => {
+    useRecentRssMock.mockReturnValue({
+      data: [{ id: 7, name: "블로그A", blogPlatform: "velog", lastPublishedAt: hoursAgo(25), latestFeedId: 77 }],
+      isLoading: false,
+    });
+    renderSection();
+
+    fireEvent.click(screen.getByRole("link"));
+    expect(incrementViewMock).not.toHaveBeenCalled();
   });
 
   it("목록이 비어 있으면 아무것도 렌더링하지 않아야 한다", () => {
@@ -83,10 +134,10 @@ describe("RecentRssSection", () => {
   it("플랫폼별 뱃지 색상을 적용하고 미지정 플랫폼은 기본 색상을 사용해야 한다", () => {
     useRecentRssMock.mockReturnValue({
       data: [
-        { id: 1, name: "블로그A", blogPlatform: "tistory", lastPublishedAt: "2026-01-01T00:00:00.000Z" },
-        { id: 2, name: "블로그B", blogPlatform: "velog", lastPublishedAt: "2026-01-02T00:00:00.000Z" },
-        { id: 3, name: "블로그C", blogPlatform: "github", lastPublishedAt: "2026-01-03T00:00:00.000Z" },
-        { id: 4, name: "블로그D", blogPlatform: "etc", lastPublishedAt: "2026-01-04T00:00:00.000Z" },
+        { id: 1, name: "블로그A", blogPlatform: "tistory", lastPublishedAt: hoursAgo(48), latestFeedId: 11 },
+        { id: 2, name: "블로그B", blogPlatform: "velog", lastPublishedAt: hoursAgo(48), latestFeedId: 22 },
+        { id: 3, name: "블로그C", blogPlatform: "github", lastPublishedAt: hoursAgo(48), latestFeedId: 33 },
+        { id: 4, name: "블로그D", blogPlatform: "etc", lastPublishedAt: hoursAgo(48), latestFeedId: 44 },
       ],
       isLoading: false,
     });
@@ -103,7 +154,8 @@ describe("RecentRssSection", () => {
       id,
       name: `블로그${id}`,
       blogPlatform: "velog",
-      lastPublishedAt: "2026-01-01T00:00:00.000Z",
+      lastPublishedAt: hoursAgo(48),
+      latestFeedId: id * 100,
     });
 
     useRecentRssMock.mockReturnValue({

--- a/client/src/__tests__/components/sections/RecentRssSection.test.tsx
+++ b/client/src/__tests__/components/sections/RecentRssSection.test.tsx
@@ -1,0 +1,125 @@
+import { MemoryRouter } from "react-router-dom";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RecentRssSection from "@/components/sections/RecentRssSection.tsx";
+
+import { render, screen } from "@testing-library/react";
+
+const useRecentRssMock = vi.fn();
+
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
+
+vi.mock("@/hooks/queries/useRecentRss", () => ({
+  useRecentRss: () => useRecentRssMock(),
+}));
+
+vi.mock("@/components/common/SectionHeader", () => ({
+  SectionHeader: ({ text }: { text: string }) => <div data-testid="section-header">{text}</div>,
+}));
+
+vi.mock("@/components/profile/rss/PlatformIcon", () => ({
+  PlatformIcon: ({ platform }: { platform: string }) => (
+    <div data-testid="platform-icon" data-platform={platform} />
+  ),
+}));
+
+const renderSection = () =>
+  render(
+    <MemoryRouter>
+      <RecentRssSection />
+    </MemoryRouter>
+  );
+
+describe("RecentRssSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("로딩 중이면 스켈레톤을 렌더링해야 한다", () => {
+    useRecentRssMock.mockReturnValue({ data: undefined, isLoading: true });
+    renderSection();
+
+    expect(screen.getByTestId("section-header")).toBeInTheDocument();
+    expect(screen.queryAllByRole("link")).toHaveLength(0);
+  });
+
+  it("RSS 목록의 이름과 플랫폼을 렌더링해야 한다", () => {
+    useRecentRssMock.mockReturnValue({
+      data: [
+        { id: 1, name: "블로그A", blogPlatform: "velog", lastPublishedAt: "2026-01-01T00:00:00.000Z" },
+        { id: 2, name: "블로그B", blogPlatform: "tistory", lastPublishedAt: "2026-01-02T00:00:00.000Z" },
+      ],
+      isLoading: false,
+    });
+    renderSection();
+
+    expect(screen.getByText("블로그A")).toBeInTheDocument();
+    expect(screen.getByText("velog")).toBeInTheDocument();
+    expect(screen.getByText("블로그B")).toBeInTheDocument();
+    expect(screen.getByText("tistory")).toBeInTheDocument();
+  });
+
+  it("RSS 클릭 시 RSS 페이지로 이동하는 링크를 가져야 한다", () => {
+    useRecentRssMock.mockReturnValue({
+      data: [{ id: 7, name: "블로그A", blogPlatform: "velog", lastPublishedAt: "2026-01-01T00:00:00.000Z" }],
+      isLoading: false,
+    });
+    renderSection();
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/rss/7");
+  });
+
+  it("목록이 비어 있으면 아무것도 렌더링하지 않아야 한다", () => {
+    useRecentRssMock.mockReturnValue({ data: [], isLoading: false });
+    const { container } = renderSection();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("플랫폼별 뱃지 색상을 적용하고 미지정 플랫폼은 기본 색상을 사용해야 한다", () => {
+    useRecentRssMock.mockReturnValue({
+      data: [
+        { id: 1, name: "블로그A", blogPlatform: "tistory", lastPublishedAt: "2026-01-01T00:00:00.000Z" },
+        { id: 2, name: "블로그B", blogPlatform: "velog", lastPublishedAt: "2026-01-02T00:00:00.000Z" },
+        { id: 3, name: "블로그C", blogPlatform: "github", lastPublishedAt: "2026-01-03T00:00:00.000Z" },
+        { id: 4, name: "블로그D", blogPlatform: "etc", lastPublishedAt: "2026-01-04T00:00:00.000Z" },
+      ],
+      isLoading: false,
+    });
+    renderSection();
+
+    expect(screen.getByText("tistory")).toHaveStyle({ backgroundColor: "#EB531F" });
+    expect(screen.getByText("velog")).toHaveStyle({ backgroundColor: "#20C997" });
+    expect(screen.getByText("github")).toHaveStyle({ backgroundColor: "#000000" });
+    expect(screen.getByText("etc")).toHaveStyle({ backgroundColor: "#6B7280" });
+  });
+
+  it("10개일 때는 justify-between으로, 미만이면 왼쪽 정렬로 배치해야 한다", () => {
+    const makeRss = (id: number) => ({
+      id,
+      name: `블로그${id}`,
+      blogPlatform: "velog",
+      lastPublishedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    useRecentRssMock.mockReturnValue({
+      data: Array.from({ length: 10 }, (_, i) => makeRss(i + 1)),
+      isLoading: false,
+    });
+    const { unmount } = renderSection();
+    expect(screen.getByRole("list")).toHaveClass("justify-between");
+    unmount();
+
+    useRecentRssMock.mockReturnValue({
+      data: Array.from({ length: 4 }, (_, i) => makeRss(i + 1)),
+      isLoading: false,
+    });
+    renderSection();
+    expect(screen.getByRole("list")).not.toHaveClass("justify-between");
+    expect(screen.getByRole("list")).toHaveClass("gap-6");
+  });
+});

--- a/client/src/api/services/rss.ts
+++ b/client/src/api/services/rss.ts
@@ -11,11 +11,16 @@ import {
   RssFeedItem,
   RssInfo,
 } from "@/types/profile";
-import { RegisterRss, RegisterResponse } from "@/types/rss";
+import { RecentRss, RegisterRss, RegisterResponse } from "@/types/rss";
 
 export const registerRss = async (data: RegisterRss): Promise<RegisterResponse> => {
   const response = await axiosInstance.post<RegisterResponse>(BLOG.RSS.REGISTRER_RSS, data);
   return response.data;
+};
+
+export const getRecentRss = async (): Promise<RecentRss[]> => {
+  const response = await axiosInstance.get<ApiData<RecentRss[]>>(BLOG.RSS.RECENT);
+  return response.data.data;
 };
 
 export const getRssInfo = async (rssId: number): Promise<RssInfo> => {

--- a/client/src/components/sections/MainContent.tsx
+++ b/client/src/components/sections/MainContent.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 
 import LatestSection from "@/components/sections/LatestSection";
+import RecentRssSection from "@/components/sections/RecentRssSection";
 import TrandingSection from "@/components/sections/TrendingSection";
 
 import { useMediaStore } from "@/store/useMediaStore";
@@ -13,6 +14,8 @@ export default function MainContent() {
   return (
     <div className="flex flex-col px-4 md:p-8 md:gap-8">
       <TrandingSection />
+      {isMobile && <hr className="border-t-2 border-dotted border-gray-500 my-4 " />}
+      <RecentRssSection />
       {isMobile && <hr className="border-t-2 border-dotted border-gray-500 my-4 " />}
       <LatestSection />
     </div>

--- a/client/src/components/sections/RecentRssSection.stories.tsx
+++ b/client/src/components/sections/RecentRssSection.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import RecentRssSection from "@/components/sections/RecentRssSection";
+import { BLOG } from "@/constants/endpoints";
+import { makeRecentRssList } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "sections/RecentRssSection",
+  component: RecentRssSection,
+} satisfies Meta<typeof RecentRssSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const MixedStories: Story = {
+  name: "스토리 혼합 (24시간 이내/이후)",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.RECENT).reply(...ok(makeRecentRssList(10, (i) => (i % 2 === 0 ? i + 1 : 48))));
+  },
+};
+
+export const AllStories: Story = {
+  name: "전체 스토리 (24시간 이내)",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.RECENT).reply(...ok(makeRecentRssList(10, (i) => i + 1)));
+  },
+};
+
+export const NoStories: Story = {
+  name: "스토리 없음 (24시간 경과)",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.RECENT).reply(...ok(makeRecentRssList(10, (i) => 48 + i)));
+  },
+};
+
+export const FewItems: Story = {
+  name: "항목 적음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.RECENT).reply(...ok(makeRecentRssList(3, (i) => (i === 0 ? 1 : 48))));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.RECENT).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Empty: Story = {
+  name: "목록 없음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.RECENT).reply(...ok([]));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.RECENT).reply(...fail());
+  },
+};

--- a/client/src/components/sections/RecentRssSection.tsx
+++ b/client/src/components/sections/RecentRssSection.tsx
@@ -1,0 +1,65 @@
+import { Link } from "react-router-dom";
+
+import { Rss } from "lucide-react";
+
+import { SectionHeader } from "@/components/common/SectionHeader";
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
+
+import { DEFAULT_BADGE_COLOR, PLATFORM_BADGE_COLORS } from "@/constants/rss";
+
+import { useRecentRss } from "@/hooks/queries/useRecentRss";
+
+export default function RecentRssSection() {
+  const { data: rssList = [], isLoading } = useRecentRss();
+
+  if (!isLoading && rssList.length === 0) return null;
+
+  return (
+    <section className="flex flex-col md:p-4">
+      <SectionHeader
+        icon={Rss}
+        text="RSS"
+        description="최근 게시글을 발행한 블로그"
+        iconColor="text-orange-500"
+      />
+
+      <div className="p-4 md:mt-4 md:p-0">
+        {isLoading ? (
+          <ul className="flex gap-6 overflow-hidden">
+            {Array.from({ length: 10 }).map((_, i) => (
+              <li key={i} className="flex flex-col items-center flex-shrink-0 w-20 gap-2">
+                <div className="rounded-full w-14 h-14 bg-gray-200 animate-pulse" />
+                <div className="w-16 h-3 bg-gray-200 rounded animate-pulse" />
+                <div className="w-12 h-4 bg-gray-200 rounded-full animate-pulse" />
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <ul className={`flex overflow-x-auto ${rssList.length >= 10 ? "justify-between gap-2" : "gap-6"}`}>
+            {rssList.map((rss) => (
+              <li key={rss.id} className="flex-shrink-0 w-20">
+                <Link to={`/rss/${rss.id}`} className="flex flex-col items-center gap-1 group">
+                  <div className="overflow-hidden bg-white border rounded-full w-14 h-14">
+                    <PlatformIcon platform={rss.blogPlatform} className="object-cover w-full h-full" />
+                  </div>
+                  <span className="w-full mt-1 text-xs font-medium text-center truncate group-hover:underline">
+                    {rss.name}
+                  </span>
+                  <span
+                    className="px-2 py-0.5 text-[10px] text-white rounded-full max-w-full truncate"
+                    style={{
+                      backgroundColor:
+                        PLATFORM_BADGE_COLORS[rss.blogPlatform.toLowerCase()] ?? DEFAULT_BADGE_COLOR,
+                    }}
+                  >
+                    {rss.blogPlatform}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/sections/RecentRssSection.tsx
+++ b/client/src/components/sections/RecentRssSection.tsx
@@ -1,13 +1,62 @@
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 
 import { Rss } from "lucide-react";
 
 import { SectionHeader } from "@/components/common/SectionHeader";
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
 
+import { useIncrementViewByPostId } from "@/hooks/common/usePostCardActions";
+
 import { DEFAULT_BADGE_COLOR, PLATFORM_BADGE_COLORS } from "@/constants/rss";
+import { RecentRss } from "@/types/rss";
 
 import { useRecentRss } from "@/hooks/queries/useRecentRss";
+
+const STORY_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+const isRecentlyPublished = (lastPublishedAt: string) =>
+  Date.now() - new Date(lastPublishedAt).getTime() < STORY_WINDOW_MS;
+
+function RssStoryItem({ rss }: { rss: RecentRss }) {
+  const location = useLocation();
+  const incrementView = useIncrementViewByPostId(rss.latestFeedId);
+  const isStory = isRecentlyPublished(rss.lastPublishedAt);
+
+  return (
+    <li className="flex-shrink-0 w-20">
+      <Link
+        to={isStory ? `/${rss.latestFeedId}` : `/rss/${rss.id}`}
+        state={isStory ? { backgroundLocation: location } : undefined}
+        onClick={isStory ? () => incrementView() : undefined}
+        className="flex flex-col items-center gap-1 group"
+      >
+        <div
+          className={`rounded-full p-[2.5px] ${
+            isStory ? "bg-gradient-to-tr from-lime-400 via-green-500 to-emerald-600" : ""
+          }`}
+          data-story={isStory || undefined}
+        >
+          <div className={`rounded-full p-[2px] ${isStory ? "bg-white" : ""}`}>
+            <div className="overflow-hidden bg-white border rounded-full w-14 h-14">
+              <PlatformIcon platform={rss.blogPlatform} className="object-cover w-full h-full" />
+            </div>
+          </div>
+        </div>
+        <span className="w-full mt-1 text-xs font-medium text-center truncate group-hover:underline">
+          {rss.name}
+        </span>
+        <span
+          className="px-2 py-0.5 text-[10px] text-white rounded-full max-w-full truncate"
+          style={{
+            backgroundColor: PLATFORM_BADGE_COLORS[rss.blogPlatform.toLowerCase()] ?? DEFAULT_BADGE_COLOR,
+          }}
+        >
+          {rss.blogPlatform}
+        </span>
+      </Link>
+    </li>
+  );
+}
 
 export default function RecentRssSection() {
   const { data: rssList = [], isLoading } = useRecentRss();
@@ -37,25 +86,7 @@ export default function RecentRssSection() {
         ) : (
           <ul className={`flex overflow-x-auto ${rssList.length >= 10 ? "justify-between gap-2" : "gap-6"}`}>
             {rssList.map((rss) => (
-              <li key={rss.id} className="flex-shrink-0 w-20">
-                <Link to={`/rss/${rss.id}`} className="flex flex-col items-center gap-1 group">
-                  <div className="overflow-hidden bg-white border rounded-full w-14 h-14">
-                    <PlatformIcon platform={rss.blogPlatform} className="object-cover w-full h-full" />
-                  </div>
-                  <span className="w-full mt-1 text-xs font-medium text-center truncate group-hover:underline">
-                    {rss.name}
-                  </span>
-                  <span
-                    className="px-2 py-0.5 text-[10px] text-white rounded-full max-w-full truncate"
-                    style={{
-                      backgroundColor:
-                        PLATFORM_BADGE_COLORS[rss.blogPlatform.toLowerCase()] ?? DEFAULT_BADGE_COLOR,
-                    }}
-                  >
-                    {rss.blogPlatform}
-                  </span>
-                </Link>
-              </li>
+              <RssStoryItem key={rss.id} rss={rss} />
             ))}
           </ul>
         )}

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -44,6 +44,7 @@ export const BLOG = {
   },
   RSS: {
     REGISTRER_RSS: "/api/rss",
+    RECENT: "/api/rss/recent",
     INFO: (id: number) => `/api/rss/${id}`,
     FEEDS: (id: number) => `/api/rss/${id}/feeds`,
     ACTIVITIES: (id: number) => `/api/rss/${id}/activities`,

--- a/client/src/constants/rss.ts
+++ b/client/src/constants/rss.ts
@@ -8,6 +8,14 @@ interface Platform {
   placeholder: string;
 }
 
+export const PLATFORM_BADGE_COLORS: Record<string, string> = {
+  tistory: "#EB531F",
+  velog: "#20C997",
+  github: "#000000",
+};
+
+export const DEFAULT_BADGE_COLOR = "#6B7280";
+
 export const PLATFORMS: Record<PlatformType, Platform> = {
   tistory: {
     name: "Tistory",

--- a/client/src/hooks/queries/useRecentRss.ts
+++ b/client/src/hooks/queries/useRecentRss.ts
@@ -1,0 +1,8 @@
+import { getRecentRss } from "@/api/services/rss";
+import { useQuery } from "@tanstack/react-query";
+
+export const useRecentRss = () =>
+  useQuery({
+    queryKey: ["recentRss"],
+    queryFn: getRecentRss,
+  });

--- a/client/src/types/rss.ts
+++ b/client/src/types/rss.ts
@@ -46,4 +46,5 @@ export interface RecentRss {
   name: string;
   blogPlatform: string;
   lastPublishedAt: string;
+  latestFeedId: number;
 }

--- a/client/src/types/rss.ts
+++ b/client/src/types/rss.ts
@@ -40,3 +40,10 @@ export interface RegisterRss {
 }
 
 export type RegisterResponse = ApiMessage;
+
+export interface RecentRss {
+  id: number;
+  name: string;
+  blogPlatform: string;
+  lastPublishedAt: string;
+}

--- a/server/src/rss/api-docs/getRecentRss.api-docs.ts
+++ b/server/src/rss/api-docs/getRecentRss.api-docs.ts
@@ -1,0 +1,38 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiExtraModels,
+  ApiOkResponse,
+  ApiOperation,
+  getSchemaPath,
+} from '@nestjs/swagger';
+
+import { ApiResponse } from '@common/response/common.response';
+
+import { GetRecentRssResponseDto } from '@rss/dto/response/getRecentRss.dto';
+
+export function ApiGetRecentRss() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '최근 발행 RSS 목록 조회 API',
+      description:
+        '가장 최근에 공개 게시글을 발행한 순서대로 RSS 목록을 최대 10개 조회합니다.',
+    }),
+    ApiExtraModels(ApiResponse, GetRecentRssResponseDto),
+    ApiOkResponse({
+      description: '최근 발행 RSS 목록 조회 성공',
+      schema: {
+        allOf: [
+          { $ref: getSchemaPath(ApiResponse) },
+          {
+            properties: {
+              data: {
+                type: 'array',
+                items: { $ref: getSchemaPath(GetRecentRssResponseDto) },
+              },
+            },
+          },
+        ],
+      },
+    }),
+  );
+}

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -25,6 +25,7 @@ import { ApiDeleteCertificateRss } from '@rss/api-docs/deleteCertificateRss.api-
 import { ApiDeleteRss } from '@rss/api-docs/deleteRss.api-docs';
 import { ApiDeleteRssCertification } from '@rss/api-docs/deleteRssCertification.api-docs';
 import { ApiGetOwnedRssFeeds } from '@rss/api-docs/getOwnedRssFeeds.api-docs';
+import { ApiGetRecentRss } from '@rss/api-docs/getRecentRss.api-docs';
 import { ApiGetRssActivities } from '@rss/api-docs/getRssActivities.api-docs';
 import { ApiGetRssActivityYears } from '@rss/api-docs/getRssActivityYears.api-docs';
 import { ApiGetRssFeeds } from '@rss/api-docs/getRssFeeds.api-docs';
@@ -254,6 +255,16 @@ export class RssController {
       bodyDto.isPublic,
     );
     return ApiResponse.responseWithNoContent('게시글 공개 상태를 변경했습니다.');
+  }
+
+  @ApiGetRecentRss()
+  @Get('recent')
+  @HttpCode(HttpStatus.OK)
+  async getRecentRss() {
+    return ApiResponse.responseWithData(
+      '최근 발행 RSS 목록 조회를 처리했습니다.',
+      await this.rssService.getRecentRss(),
+    );
   }
 
   @ApiGetRssActivityYears()

--- a/server/src/rss/dto/response/getRecentRss.dto.ts
+++ b/server/src/rss/dto/response/getRecentRss.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetRecentRssResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: 'RSS(rss_accept) ID',
+  })
+  id: number;
+
+  @ApiProperty({
+    example: 'seok3765.log',
+    description: 'RSS 블로그 이름',
+  })
+  name: string;
+
+  @ApiProperty({
+    example: 'velog',
+    description: 'RSS 블로그 플랫폼 종류',
+  })
+  blogPlatform: string;
+
+  @ApiProperty({
+    example: '2025-01-01T00:00:00.000Z',
+    description: '가장 최근 공개 게시글의 발행 일자',
+  })
+  lastPublishedAt: Date;
+
+  constructor(partial: Partial<GetRecentRssResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(row: {
+    id: number;
+    name: string;
+    blogPlatform: string;
+    lastPublishedAt: Date;
+  }) {
+    return new GetRecentRssResponseDto({
+      id: row.id,
+      name: row.name,
+      blogPlatform: row.blogPlatform,
+      lastPublishedAt: row.lastPublishedAt,
+    });
+  }
+}

--- a/server/src/rss/dto/response/getRecentRss.dto.ts
+++ b/server/src/rss/dto/response/getRecentRss.dto.ts
@@ -25,6 +25,12 @@ export class GetRecentRssResponseDto {
   })
   lastPublishedAt: Date;
 
+  @ApiProperty({
+    example: 10,
+    description: '가장 최근 공개 게시글의 Feed ID',
+  })
+  latestFeedId: number;
+
   constructor(partial: Partial<GetRecentRssResponseDto>) {
     Object.assign(this, partial);
   }
@@ -34,12 +40,14 @@ export class GetRecentRssResponseDto {
     name: string;
     blogPlatform: string;
     lastPublishedAt: Date;
+    latestFeedId: string;
   }) {
     return new GetRecentRssResponseDto({
       id: row.id,
       name: row.name,
       blogPlatform: row.blogPlatform,
       lastPublishedAt: row.lastPublishedAt,
+      latestFeedId: Number(row.latestFeedId),
     });
   }
 }

--- a/server/src/rss/repository/rss.repository.ts
+++ b/server/src/rss/repository/rss.repository.ts
@@ -32,4 +32,26 @@ export class RssAcceptRepository extends Repository<RssAccept> {
       .orderBy('count', 'DESC')
       .getRawMany();
   }
+
+  findRecentlyPublished(limit: number) {
+    return this.createQueryBuilder('rss')
+      .innerJoin(
+        'feed',
+        'feed',
+        'feed.blog_id = rss.id AND feed.is_public = 1',
+      )
+      .select('rss.id', 'id')
+      .addSelect('rss.name', 'name')
+      .addSelect('rss.blog_platform', 'blogPlatform')
+      .addSelect('MAX(feed.created_at)', 'lastPublishedAt')
+      .groupBy('rss.id')
+      .orderBy('MAX(feed.created_at)', 'DESC')
+      .limit(limit)
+      .getRawMany<{
+        id: number;
+        name: string;
+        blogPlatform: string;
+        lastPublishedAt: Date;
+      }>();
+  }
 }

--- a/server/src/rss/repository/rss.repository.ts
+++ b/server/src/rss/repository/rss.repository.ts
@@ -44,6 +44,20 @@ export class RssAcceptRepository extends Repository<RssAccept> {
       .addSelect('rss.name', 'name')
       .addSelect('rss.blog_platform', 'blogPlatform')
       .addSelect('MAX(feed.created_at)', 'lastPublishedAt')
+      .addSelect(
+        (qb) =>
+          qb
+            .subQuery()
+            .select('latest_feed.id')
+            .from('feed', 'latest_feed')
+            .where(
+              'latest_feed.blog_id = rss.id AND latest_feed.is_public = 1',
+            )
+            .orderBy('latest_feed.created_at', 'DESC')
+            .addOrderBy('latest_feed.id', 'DESC')
+            .limit(1),
+        'latestFeedId',
+      )
       .groupBy('rss.id')
       .orderBy('MAX(feed.created_at)', 'DESC')
       .limit(limit)
@@ -52,6 +66,7 @@ export class RssAcceptRepository extends Repository<RssAccept> {
         name: string;
         blogPlatform: string;
         lastPublishedAt: Date;
+        latestFeedId: string;
       }>();
   }
 }

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -307,10 +307,10 @@ export class RssService {
   }
 
   async getRecentRss() {
-    const rows = await this.rssAcceptRepository.findRecentlyPublished(
+    const recentRssList = await this.rssAcceptRepository.findRecentlyPublished(
       RssService.RECENT_RSS_LIMIT,
     );
-    return rows.map((row) => GetRecentRssResponseDto.toResponseDto(row));
+    return recentRssList.map((row) => GetRecentRssResponseDto.toResponseDto(row));
   }
 
   async getRssInfo(rssId: number, viewerId?: number) {

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -29,6 +29,7 @@ import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
 import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
 import { GetOwnedRssFeedsResponseDto } from '@rss/dto/response/getOwnedRssFeeds.dto';
 import { GetRssFeedsResponseDto } from '@rss/dto/response/getRssFeeds.dto';
+import { GetRecentRssResponseDto } from '@rss/dto/response/getRecentRss.dto';
 import { GetRssInfoResponseDto } from '@rss/dto/response/getRssInfo.dto';
 import { PreviewRssCertificationResponseDto } from '@rss/dto/response/previewRssCertification.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
@@ -58,6 +59,8 @@ type FullFeedCrawlMessage = {
 
 @Injectable()
 export class RssService {
+  private static readonly RECENT_RSS_LIMIT = 10;
+
   constructor(
     private readonly rssRepository: RssRepository,
     private readonly rssAcceptRepository: RssAcceptRepository,
@@ -301,6 +304,13 @@ export class RssService {
     } finally {
       await this.redisService.del(redisKey);
     }
+  }
+
+  async getRecentRss() {
+    const rows = await this.rssAcceptRepository.findRecentlyPublished(
+      RssService.RECENT_RSS_LIMIT,
+    );
+    return rows.map((row) => GetRecentRssResponseDto.toResponseDto(row));
   }
 
   async getRssInfo(rssId: number, viewerId?: number) {

--- a/server/test/rss/e2e/recent.e2e-spec.ts
+++ b/server/test/rss/e2e/recent.e2e-spec.ts
@@ -1,0 +1,91 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { GetRecentRssResponseDto } from '@rss/dto/response/getRecentRss.dto';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/rss/recent';
+
+describe(`GET ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  const createRssWithFeed = async (
+    createdAt: Date,
+    isPublic: boolean = true,
+  ) => {
+    const rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { createdAt, isPublic }),
+    );
+    return rssAccept;
+  };
+
+  it('[200] 최신 공개 게시글 발행 순서대로 RSS 목록을 반환한다.', async () => {
+    // given
+    const oldRss = await createRssWithFeed(new Date('2025-12-01'));
+    const newRss = await createRssWithFeed(new Date('2025-12-10'));
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRecentRssResponseDto[] } = response.body;
+    const ids = data.map((rss) => rss.id);
+    expect(ids.indexOf(newRss.id)).toBeLessThan(ids.indexOf(oldRss.id));
+    expect(data[0]).toEqual({
+      id: newRss.id,
+      name: newRss.name,
+      blogPlatform: newRss.blogPlatform,
+      lastPublishedAt: expect.any(String),
+    });
+  });
+
+  it('[200] 비공개 게시글만 있는 RSS는 목록에 포함하지 않는다.', async () => {
+    // given
+    const privateRss = await createRssWithFeed(new Date('2025-12-10'), false);
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRecentRssResponseDto[] } = response.body;
+    expect(data.map((rss) => rss.id)).not.toContain(privateRss.id);
+  });
+
+  it('[200] 목록은 최대 10개까지만 반환한다.', async () => {
+    // given
+    for (let i = 0; i < 12; i++) {
+      await createRssWithFeed(
+        new Date(new Date('2025-12-01').getTime() + i * 60 * 60 * 1000),
+      );
+    }
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRecentRssResponseDto[] } = response.body;
+    expect(data.length).toBe(10);
+  });
+});

--- a/server/test/rss/e2e/recent.e2e-spec.ts
+++ b/server/test/rss/e2e/recent.e2e-spec.ts
@@ -32,16 +32,20 @@ describe(`GET ${URL} E2E Test`, () => {
     const rssAccept = await rssAcceptRepository.save(
       RssAcceptFixture.createRssAcceptFixture(),
     );
-    await feedRepository.save(
+    const feed = await feedRepository.save(
       FeedFixture.createFeedFixture(rssAccept, { createdAt, isPublic }),
     );
-    return rssAccept;
+    return { rssAccept, feed };
   };
 
   it('[200] 최신 공개 게시글 발행 순서대로 RSS 목록을 반환한다.', async () => {
     // given
-    const oldRss = await createRssWithFeed(new Date('2025-12-01'));
-    const newRss = await createRssWithFeed(new Date('2025-12-10'));
+    const { rssAccept: oldRss } = await createRssWithFeed(
+      new Date('2025-12-01'),
+    );
+    const { rssAccept: newRss, feed: newFeed } = await createRssWithFeed(
+      new Date('2025-12-10'),
+    );
 
     // when
     const response = await agent.get(URL);
@@ -56,12 +60,44 @@ describe(`GET ${URL} E2E Test`, () => {
       name: newRss.name,
       blogPlatform: newRss.blogPlatform,
       lastPublishedAt: expect.any(String),
+      latestFeedId: newFeed.id,
     });
+  });
+
+  it('[200] 게시글이 여러 개면 가장 최근 공개 게시글의 Feed ID를 반환한다.', async () => {
+    // given
+    const { rssAccept, feed: oldFeed } = await createRssWithFeed(
+      new Date('2025-12-01'),
+    );
+    const latestFeed = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, {
+        createdAt: new Date('2025-12-10'),
+      }),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, {
+        createdAt: new Date('2025-12-15'),
+        isPublic: false,
+      }),
+    );
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRecentRssResponseDto[] } = response.body;
+    const target = data.find((rss) => rss.id === rssAccept.id);
+    expect(target.latestFeedId).toBe(latestFeed.id);
+    expect(target.latestFeedId).not.toBe(oldFeed.id);
   });
 
   it('[200] 비공개 게시글만 있는 RSS는 목록에 포함하지 않는다.', async () => {
     // given
-    const privateRss = await createRssWithFeed(new Date('2025-12-10'), false);
+    const { rssAccept: privateRss } = await createRssWithFeed(
+      new Date('2025-12-10'),
+      false,
+    );
 
     // when
     const response = await agent.get(URL);

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -40,7 +40,10 @@ describe(`${RssService.name} Unit Test`, () => {
     Pick<RssRepository, 'findOne' | 'find' | 'insert' | 'delete'>
   >;
   let rssAcceptRepository: jest.Mocked<
-    Pick<RssAcceptRepository, 'findOne' | 'find' | 'delete' | 'update'>
+    Pick<
+      RssAcceptRepository,
+      'findOne' | 'find' | 'delete' | 'update' | 'findRecentlyPublished'
+    >
   >;
   let rssRejectRepository: jest.Mocked<Pick<RssRejectRepository, 'find'>>;
   let feedRepository: jest.Mocked<
@@ -88,6 +91,7 @@ describe(`${RssService.name} Unit Test`, () => {
       find: jest.fn(),
       delete: jest.fn(),
       update: jest.fn().mockResolvedValue({ affected: 1 }),
+      findRecentlyPublished: jest.fn().mockResolvedValue([]),
     };
     rssRejectRepository = { find: jest.fn() };
     feedRepository = {
@@ -680,6 +684,40 @@ describe(`${RssService.name} Unit Test`, () => {
       await rssService.setFeedVisibility(user, 1, 5, false);
 
       expect(feedRepository.setVisibilityForBlog).toHaveBeenCalledWith(5, 1, false);
+    });
+  });
+
+  describe('getRecentRss', () => {
+    it('limit 10으로 조회하고 응답 DTO 배열로 변환한다.', async () => {
+      // given
+      const lastPublishedAt = new Date('2025-12-10T00:00:00.000Z');
+      rssAcceptRepository.findRecentlyPublished.mockResolvedValue([
+        { id: 1, name: 'blogA', blogPlatform: 'velog', lastPublishedAt },
+        { id: 2, name: 'blogB', blogPlatform: 'tistory', lastPublishedAt },
+      ]);
+
+      // when
+      const result = await rssService.getRecentRss();
+
+      // then
+      expect(rssAcceptRepository.findRecentlyPublished).toHaveBeenCalledWith(
+        10,
+      );
+      expect(result).toEqual([
+        { id: 1, name: 'blogA', blogPlatform: 'velog', lastPublishedAt },
+        { id: 2, name: 'blogB', blogPlatform: 'tistory', lastPublishedAt },
+      ]);
+    });
+
+    it('발행된 RSS가 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      rssAcceptRepository.findRecentlyPublished.mockResolvedValue([]);
+
+      // when
+      const result = await rssService.getRecentRss();
+
+      // then
+      expect(result).toEqual([]);
     });
   });
 

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -692,8 +692,20 @@ describe(`${RssService.name} Unit Test`, () => {
       // given
       const lastPublishedAt = new Date('2025-12-10T00:00:00.000Z');
       rssAcceptRepository.findRecentlyPublished.mockResolvedValue([
-        { id: 1, name: 'blogA', blogPlatform: 'velog', lastPublishedAt },
-        { id: 2, name: 'blogB', blogPlatform: 'tistory', lastPublishedAt },
+        {
+          id: 1,
+          name: 'blogA',
+          blogPlatform: 'velog',
+          lastPublishedAt,
+          latestFeedId: '11',
+        },
+        {
+          id: 2,
+          name: 'blogB',
+          blogPlatform: 'tistory',
+          lastPublishedAt,
+          latestFeedId: '22',
+        },
       ]);
 
       // when
@@ -704,8 +716,20 @@ describe(`${RssService.name} Unit Test`, () => {
         10,
       );
       expect(result).toEqual([
-        { id: 1, name: 'blogA', blogPlatform: 'velog', lastPublishedAt },
-        { id: 2, name: 'blogB', blogPlatform: 'tistory', lastPublishedAt },
+        {
+          id: 1,
+          name: 'blogA',
+          blogPlatform: 'velog',
+          lastPublishedAt,
+          latestFeedId: 11,
+        },
+        {
+          id: 2,
+          name: 'blogB',
+          blogPlatform: 'tistory',
+          lastPublishedAt,
+          latestFeedId: 22,
+        },
       ]);
     });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #809

### 최신 RSS 목록 API — `findRecentlyPublished` 쿼리 설계

`RssAcceptRepository.findRecentlyPublished(limit)`가 생성하는 SQL은 아래와 같습니다.

```sql
SELECT
  rss.id                AS id,
  rss.name              AS name,
  rss.blog_platform     AS blogPlatform,
  MAX(feed.created_at)  AS lastPublishedAt,
  (
    SELECT latest_feed.id
    FROM feed latest_feed
    WHERE latest_feed.blog_id = rss.id
      AND latest_feed.is_public = 1
    ORDER BY latest_feed.created_at DESC, latest_feed.id DESC
    LIMIT 1
  )                     AS latestFeedId
FROM rss_accept rss
INNER JOIN feed
  ON feed.blog_id = rss.id
 AND feed.is_public = 1
GROUP BY rss.id
ORDER BY MAX(feed.created_at) DESC
LIMIT ?;
```

**동작 방식**

1. **INNER JOIN + `is_public = 1` 조건을 ON 절에 배치**
   - `rss_accept`(승인된 블로그)와 `feed`(게시글)를 조인하면서 공개 게시글만 대상으로 제한합니다.
   - INNER JOIN이므로 **공개 게시글이 하나도 없는 블로그는 결과에서 자연스럽게 제외**됩니다. WHERE 절이 아닌 ON 절에 두어 "공개 게시글 기준의 조인"이라는 의미를 명확히 했습니다.

2. **`GROUP BY rss.id` + `MAX(feed.created_at)`**
   - 블로그별로 그룹핑하여 가장 최근 공개 게시글의 발행 시각(`lastPublishedAt`)을 구합니다. 이 값이 정렬 키가 됩니다.
   - `GROUP BY rss.id`만 지정하고 `name`, `blog_platform`을 비집계 컬럼으로 SELECT하는 것은 PK 기반 functional dependency로 MySQL `ONLY_FULL_GROUP_BY` 모드에서도 유효합니다.

3. **상관 스칼라 서브쿼리로 `latestFeedId` 추출**
   - `MAX(created_at)`은 최신 발행 *시각*만 알려줄 뿐, 해당 게시글의 *ID*는 알 수 없습니다. 프론트에서 최신 게시글로 바로 이동하려면 feed ID가 필요하므로, 블로그별로 상관 서브쿼리를 실행해 최신 공개 게시글 ID를 함께 가져옵니다.
   - `ORDER BY created_at DESC, id DESC` 이중 정렬로 **동일 시각에 발행된 게시글이 있어도 결정적(deterministic)으로 하나의 ID가 선택**되도록 tie-break를 걸었습니다.

4. **`ORDER BY MAX(feed.created_at) DESC LIMIT n`**
   - 최근 발행 순으로 상위 n개 블로그만 반환합니다. limit은 서비스 계층 상수 `RECENT_RSS_LIMIT = 10`으로 관리합니다.

**고민했던 점**

-   최신 게시글 ID를 구하는 방법으로 window function(`ROW_NUMBER() OVER`) 방식과 상관 서브쿼리 방식을 비교했는데, 반환 대상이 상위 10개 블로그뿐이라 상관 서브쿼리 비용이 작고 QueryBuilder 표현도 단순해 서브쿼리 방식을 선택했습니다.
-   `getRawMany`는 서브쿼리 컬럼(`latestFeedId`)을 문자열로 반환하므로, DTO 변환 시 `Number()`로 명시 변환해 응답 타입을 보장했습니다.

### 24시간 스토리 표시 (FE)

-   쿼리에는 시간 조건이 없고, 프론트에서 `lastPublishedAt` 기준 24시간 이내 여부를 계산해 스토리(하이라이트) 표시를 결정합니다. 시간 판정 로직을 클라이언트에 두어 서버 캐시/쿼리를 단순하게 유지했습니다.
- 24시간 내 게시글이 작성된 게 있을 경우에는 해당 게시글로 이동 / 아닐 경우에는 RSS 정보 페이지로 이동되게 구현했습니다.

# 📋 작업 내용

-   [BE] `GET /api/rss/recent` API 추가 — 최근 발행 순 상위 10개 블로그 + 최신 게시글 ID 반환 (Swagger 문서 포함)
-   [BE] `RssAcceptRepository.findRecentlyPublished` 쿼리 구현 및 unit / e2e 테스트 작성
-   [FE] 메인 페이지 `RecentRssSection` 컴포넌트 구현 — 최신 RSS 목록 출력, 24시간 이내 발행 블로그 스토리 표시
-   [FE] `useRecentRss` 쿼리 훅, API 서비스, 타입 정의 추가
-   [FE] 컴포넌트 테스트 및 Storybook 스토리 작성
-   [Docs] 최신 RSS 24시간 스토리 명세서 작성

# 📷 스크린 샷(선택 사항)
<img width="1270" height="802" alt="image" src="https://github.com/user-attachments/assets/426a0508-f3f0-4a00-b742-8178ff1fc1d8" />
<img width="1575" height="197" alt="image" src="https://github.com/user-attachments/assets/198f4bbc-43c8-4d9e-99e8-ac3d2fabaee4" />
