### PR TITLE
✨ feat: 사용자·RSS 차단 기능 구현

### DIFF
--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -8,6 +8,7 @@ import type { ChartPlatform, ChartType } from "@/types/chart";
 import type { AdminChatRoom, ChatType } from "@/types/chat";
 import type { FeedDetail, FeedList } from "@/types/post";
 import type {
+  BlockedRss,
   BlockedUser,
   CertifiedRss,
   CommentItem,
@@ -46,6 +47,7 @@ export const mockFeedDetail: FeedDetail = {
   ownerName: "조민석",
   isOwnerCertified: true,
   isSubscribed: false,
+  isBlocked: false,
 };
 
 export const mockUser: User = {
@@ -222,6 +224,15 @@ export const mockBlockedUsers: BlockedUser[] = [
     userName: "스팸유저",
     profileImage: null,
     blockedAt: "2026-06-21T12:30:00.000Z",
+  },
+];
+
+export const mockBlockedRss: BlockedRss[] = [
+  {
+    rssId: 5,
+    name: "차단된블로그",
+    blogPlatform: "velog",
+    blockedAt: "2026-06-22T09:00:00.000Z",
   },
 ];
 

--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -8,6 +8,7 @@ import type { ChartPlatform, ChartType } from "@/types/chart";
 import type { AdminChatRoom, ChatType } from "@/types/chat";
 import type { FeedDetail, FeedList } from "@/types/post";
 import type {
+  BlockedUser,
   CertifiedRss,
   CommentItem,
   CursorPage,
@@ -206,7 +207,23 @@ export const mockUserProfile: UserProfile = {
   maxStreak: 30,
   currentStreak: 7,
   totalViews: 98765,
+  isBlocked: false,
 };
+
+export const mockBlockedUsers: BlockedUser[] = [
+  {
+    userId: 2,
+    userName: "차단된개발자",
+    profileImage: "https://picsum.photos/seed/blocked1/80/80",
+    blockedAt: "2026-06-20T09:00:00.000Z",
+  },
+  {
+    userId: 3,
+    userName: "스팸유저",
+    profileImage: null,
+    blockedAt: "2026-06-21T12:30:00.000Z",
+  },
+];
 
 export const mockProfileActivity: ProfileActivity = {
   dailyActivities: [

--- a/client/src/__tests__/components/common/Card/PostDetail.test.tsx
+++ b/client/src/__tests__/components/common/Card/PostDetail.test.tsx
@@ -7,7 +7,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 const mockNavigate = vi.fn();
 let params: { id?: string };
-let detail: { data: { title: string } } | undefined;
+let detail: { data: { title: string; isBlocked?: boolean } } | undefined;
 let isHeaderVisible: boolean;
 
 vi.mock("lucide-react", () => lucideProxy());
@@ -80,5 +80,14 @@ describe("PostDetail", () => {
     render(<PostDetail />);
 
     expect(screen.getByTestId("fixed-header")).toBeInTheDocument();
+  });
+
+  it("차단된 RSS의 게시글이면 차단 안내를 렌더링하고 본문은 숨겨야 한다", () => {
+    detail = { data: { title: "상세 제목", isBlocked: true } };
+    render(<PostDetail />);
+
+    expect(screen.getByText("차단된 RSS의 게시글입니다.")).toBeInTheDocument();
+    expect(screen.queryByTestId("post-header")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("post-content")).not.toBeInTheDocument();
   });
 });

--- a/client/src/__tests__/components/common/Card/detail/BlockedFeedNotice.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/BlockedFeedNotice.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+import { BlockedFeedNotice } from "@/components/common/Card/detail/BlockedFeedNotice.tsx";
+
+import { render, screen } from "@testing-library/react";
+
+vi.mock("lucide-react", () => lucideProxy());
+
+describe("BlockedFeedNotice", () => {
+  it("차단 안내 문구를 렌더링해야 한다", () => {
+    render(<BlockedFeedNotice />);
+
+    expect(screen.getByText("차단된 RSS의 게시글입니다.")).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/profile/BlockManagementTab.test.tsx
+++ b/client/src/__tests__/components/profile/BlockManagementTab.test.tsx
@@ -2,24 +2,41 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { BlockManagementTab } from "@/components/profile/BlockManagementTab.tsx";
 
-import { BlockedUser } from "@/types/profile.ts";
+import { BlockedRss, BlockedUser } from "@/types/profile.ts";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 const mockToast = vi.fn();
 const mockUnblockUser = vi.fn();
+const mockUnblockRss = vi.fn();
 let mockBlockedUsers: BlockedUser[] = [];
+let mockBlockedRss: BlockedRss[] = [];
 let mockIsLoading = false;
 
+vi.mock("react-router-dom", () => ({
+  Link: ({ to, children, ...props }: { to: string; children: React.ReactNode }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+vi.mock("@/components/profile/rss/PlatformIcon.tsx", () => ({ PlatformIcon: () => <div data-testid="platform-icon" /> }));
+vi.mock("@/components/ui/tabs.tsx", () => {
+  const pass = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  return { Tabs: pass, TabsList: pass, TabsTrigger: pass, TabsContent: pass };
+});
 vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
 vi.mock("@/hooks/queries/useBlock.ts", () => ({
   useBlockedUsers: () => ({ data: mockBlockedUsers, isLoading: mockIsLoading }),
   useUnblockUser: () => ({ mutate: mockUnblockUser, isPending: false }),
+  useBlockedRss: () => ({ data: mockBlockedRss, isLoading: false }),
+  useUnblockRss: () => ({ mutate: mockUnblockRss, isPending: false }),
 }));
 
 describe("BlockManagementTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockBlockedUsers = [];
+    mockBlockedRss = [];
     mockIsLoading = false;
   });
 
@@ -58,5 +75,23 @@ describe("BlockManagementTab", () => {
     fireEvent.click(screen.getByRole("button", { name: "차단 해제" }));
 
     expect(mockUnblockUser).toHaveBeenCalledWith(2, expect.any(Object));
+  });
+
+  it("차단한 RSS가 없으면 안내 문구를 표시해야 한다", () => {
+    render(<BlockManagementTab />);
+
+    expect(screen.getByText("차단한 RSS가 없습니다.")).toBeInTheDocument();
+  });
+
+  it("차단한 RSS 목록을 렌더링하고 차단 해제 시 해당 rssId로 mutation을 호출해야 한다", () => {
+    mockBlockedRss = [{ rssId: 5, name: "차단블로그", blogPlatform: "velog", blockedAt: "2025-08-16" }];
+
+    render(<BlockManagementTab />);
+
+    expect(screen.getByText("차단블로그")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "차단 해제" }));
+
+    expect(mockUnblockRss).toHaveBeenCalledWith(5, expect.any(Object));
   });
 });

--- a/client/src/__tests__/components/profile/BlockManagementTab.test.tsx
+++ b/client/src/__tests__/components/profile/BlockManagementTab.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BlockManagementTab } from "@/components/profile/BlockManagementTab.tsx";
+
+import { BlockedUser } from "@/types/profile.ts";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockToast = vi.fn();
+const mockUnblockUser = vi.fn();
+let mockBlockedUsers: BlockedUser[] = [];
+let mockIsLoading = false;
+
+vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
+vi.mock("@/hooks/queries/useBlock.ts", () => ({
+  useBlockedUsers: () => ({ data: mockBlockedUsers, isLoading: mockIsLoading }),
+  useUnblockUser: () => ({ mutate: mockUnblockUser, isPending: false }),
+}));
+
+describe("BlockManagementTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockBlockedUsers = [];
+    mockIsLoading = false;
+  });
+
+  it("로딩 중이면 로딩 문구를 표시해야 한다", () => {
+    mockIsLoading = true;
+
+    render(<BlockManagementTab />);
+
+    expect(screen.getByText("불러오는 중...")).toBeInTheDocument();
+  });
+
+  it("차단한 사용자가 없으면 안내 문구를 표시해야 한다", () => {
+    render(<BlockManagementTab />);
+
+    expect(screen.getByText("차단한 사용자가 없습니다.")).toBeInTheDocument();
+  });
+
+  it("차단한 사용자 목록을 렌더링해야 한다", () => {
+    mockBlockedUsers = [
+      { userId: 2, userName: "차단유저A", profileImage: "img.png", blockedAt: "2025-08-16" },
+      { userId: 3, userName: "차단유저B", profileImage: null, blockedAt: "2025-08-17" },
+    ];
+
+    render(<BlockManagementTab />);
+
+    expect(screen.getByText("차단유저A")).toBeInTheDocument();
+    expect(screen.getByText("차단유저B")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "차단 해제" })).toHaveLength(2);
+  });
+
+  it("차단 해제 버튼 클릭 시 해당 userId로 mutation을 호출해야 한다", () => {
+    mockBlockedUsers = [{ userId: 2, userName: "차단유저A", profileImage: null, blockedAt: "2025-08-16" }];
+
+    render(<BlockManagementTab />);
+
+    fireEvent.click(screen.getByRole("button", { name: "차단 해제" }));
+
+    expect(mockUnblockUser).toHaveBeenCalledWith(2, expect.any(Object));
+  });
+});

--- a/client/src/__tests__/components/profile/BlockedProfileView.test.tsx
+++ b/client/src/__tests__/components/profile/BlockedProfileView.test.tsx
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+import { BlockedProfileView } from "@/components/profile/BlockedProfileView.tsx";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockNavigate = vi.fn();
+const mockToast = vi.fn();
+const mockUnblockUser = vi.fn();
+let mockIsPending = false;
+
+vi.mock("lucide-react", () => lucideProxy());
+vi.mock("react-router-dom", () => ({ useNavigate: () => mockNavigate }));
+vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
+vi.mock("@/hooks/queries/useBlock.ts", () => ({
+  useUnblockUser: () => ({ mutate: mockUnblockUser, isPending: mockIsPending }),
+}));
+
+describe("BlockedProfileView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsPending = false;
+  });
+
+  it("차단 안내 문구와 홈으로/차단 해제 버튼을 렌더링해야 한다", () => {
+    render(<BlockedProfileView userId={2} />);
+
+    expect(screen.getByText("차단한 사용자입니다")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "홈으로" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "차단 해제" })).toBeInTheDocument();
+  });
+
+  it("홈으로 버튼 클릭 시 /로 이동해야 한다", () => {
+    render(<BlockedProfileView userId={2} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "홈으로" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/");
+  });
+
+  it("차단 해제 버튼 클릭 시 unblock mutation을 호출해야 한다", () => {
+    render(<BlockedProfileView userId={2} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "차단 해제" }));
+
+    expect(mockUnblockUser).toHaveBeenCalledWith(2, expect.any(Object));
+  });
+
+  it("차단 해제 요청 중에는 버튼이 비활성화되어야 한다", () => {
+    mockIsPending = true;
+
+    render(<BlockedProfileView userId={2} />);
+
+    expect(screen.getByRole("button", { name: "차단 해제" })).toBeDisabled();
+  });
+});

--- a/client/src/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/client/src/__tests__/components/profile/ProfileHeader.test.tsx
@@ -1,10 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { ProfileHeader } from "@/components/profile/ProfileHeader.tsx";
 
 import { render, screen } from "@testing-library/react";
 
+const mockToast = vi.fn();
+const mockBlockUser = vi.fn();
+
+vi.mock("lucide-react", () => lucideProxy());
+vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
+vi.mock("@/hooks/queries/useBlock.ts", () => ({ useBlockUser: () => ({ mutate: mockBlockUser }) }));
+
 describe("ProfileHeader", () => {
+  beforeEach(() => vi.clearAllMocks());
+
   it("이름, 이메일, 자기소개를 렌더링해야 한다", () => {
     render(<ProfileHeader name="민석" email="min@test.com" profileImage="img.png" introduction="안녕하세요" />);
 
@@ -25,5 +35,17 @@ describe("ProfileHeader", () => {
     render(<ProfileHeader name="" email="" profileImage={null} introduction={null} />);
 
     expect(screen.getByText("사용자")).toBeInTheDocument();
+  });
+
+  it("blockableUserId가 있으면 더보기 버튼을 표시해야 한다", () => {
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    expect(screen.getByRole("button", { name: "더보기" })).toBeInTheDocument();
+  });
+
+  it("blockableUserId가 없으면 더보기 버튼을 표시하지 않아야 한다", () => {
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} />);
+
+    expect(screen.queryByRole("button", { name: "더보기" })).not.toBeInTheDocument();
   });
 });

--- a/client/src/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/client/src/__tests__/components/profile/ProfileHeader.test.tsx
@@ -3,17 +3,28 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { ProfileHeader } from "@/components/profile/ProfileHeader.tsx";
 
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const mockToast = vi.fn();
-const mockBlockUser = vi.fn();
+const mockBlockUser = vi.fn().mockResolvedValue(undefined);
+const mockBlockRss = vi.fn().mockResolvedValue(undefined);
+type RssRow = { id: number; name: string; blogPlatform: string };
+const mockCertifiedRss = vi.fn<() => { data: RssRow[] }>(() => ({ data: [] }));
 
 vi.mock("lucide-react", () => lucideProxy());
 vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
-vi.mock("@/hooks/queries/useBlock.ts", () => ({ useBlockUser: () => ({ mutate: mockBlockUser }) }));
+vi.mock("@/hooks/queries/useBlock.ts", () => ({
+  useBlockUser: () => ({ mutateAsync: mockBlockUser }),
+  useBlockRss: () => ({ mutateAsync: mockBlockRss }),
+}));
+vi.mock("@/hooks/queries/useProfile.ts", () => ({ useCertifiedRss: () => mockCertifiedRss() }));
 
 describe("ProfileHeader", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCertifiedRss.mockReturnValue({ data: [] });
+  });
 
   it("이름, 이메일, 자기소개를 렌더링해야 한다", () => {
     render(<ProfileHeader name="민석" email="min@test.com" profileImage="img.png" introduction="안녕하세요" />);
@@ -47,5 +58,92 @@ describe("ProfileHeader", () => {
     render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} />);
 
     expect(screen.queryByRole("button", { name: "더보기" })).not.toBeInTheDocument();
+  });
+
+  const openBlockModal = async () => {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("차단하기"));
+    return user;
+  };
+
+  it("차단 모달에 대상 유저 소유 RSS 목록과 토글을 표시해야 한다", async () => {
+    mockCertifiedRss.mockReturnValue({
+      data: [{ id: 10, name: "seok.log", blogPlatform: "velog" }],
+    });
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    await openBlockModal();
+
+    expect(await screen.findByText("함께 차단할 RSS")).toBeInTheDocument();
+    expect(screen.getByText("seok.log")).toBeInTheDocument();
+    expect(screen.getByRole("switch", { name: "seok.log 차단" })).toBeInTheDocument();
+  });
+
+  it("토글 ON된 RSS는 유저와 함께 차단되어야 한다", async () => {
+    mockCertifiedRss.mockReturnValue({
+      data: [
+        { id: 10, name: "on.log", blogPlatform: "velog" },
+        { id: 20, name: "off.log", blogPlatform: "tistory" },
+      ],
+    });
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openBlockModal();
+    await user.click(screen.getByRole("switch", { name: "on.log 차단" }));
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+    expect(mockBlockRss).toHaveBeenCalledTimes(1);
+    expect(mockBlockRss).toHaveBeenCalledWith(10);
+  });
+
+  it("'모두 선택'은 전체 RSS를 켜고 유저와 함께 차단해야 한다", async () => {
+    mockCertifiedRss.mockReturnValue({
+      data: [
+        { id: 10, name: "a.log", blogPlatform: "velog" },
+        { id: 20, name: "b.log", blogPlatform: "tistory" },
+      ],
+    });
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openBlockModal();
+    await user.click(await screen.findByRole("button", { name: "모두 선택" }));
+
+    expect(screen.getByRole("switch", { name: "a.log 차단" })).toBeChecked();
+    expect(screen.getByRole("switch", { name: "b.log 차단" })).toBeChecked();
+    expect(screen.getByRole("button", { name: "모두 해제" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    await waitFor(() => expect(mockBlockRss).toHaveBeenCalledTimes(2));
+    expect(mockBlockRss).toHaveBeenCalledWith(10);
+    expect(mockBlockRss).toHaveBeenCalledWith(20);
+  });
+
+  it("'모두 해제'는 전체 RSS 토글을 끈다", async () => {
+    mockCertifiedRss.mockReturnValue({
+      data: [{ id: 10, name: "a.log", blogPlatform: "velog" }],
+    });
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openBlockModal();
+    await user.click(await screen.findByRole("button", { name: "모두 선택" }));
+    await user.click(screen.getByRole("button", { name: "모두 해제" }));
+
+    expect(screen.getByRole("switch", { name: "a.log 차단" })).not.toBeChecked();
+  });
+
+  it("토글하지 않으면 유저만 차단하고 RSS는 차단하지 않아야 한다", async () => {
+    mockCertifiedRss.mockReturnValue({
+      data: [{ id: 10, name: "on.log", blogPlatform: "velog" }],
+    });
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openBlockModal();
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+    expect(mockBlockRss).not.toHaveBeenCalled();
   });
 });

--- a/client/src/__tests__/hooks/queries/useBlock.test.tsx
+++ b/client/src/__tests__/hooks/queries/useBlock.test.tsx
@@ -1,0 +1,104 @@
+import type { ReactNode } from "react";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { blockUser, getBlockedUsers, unblockUser } from "@/api/services/block";
+import { useBlockedUsers, useBlockUser, useUnblockUser } from "@/hooks/queries/useBlock";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("@/api/services/block", () => ({
+  getBlockedUsers: vi.fn(),
+  blockUser: vi.fn(),
+  unblockUser: vi.fn(),
+}));
+
+const mockedGetBlockedUsers = vi.mocked(getBlockedUsers);
+const mockedBlockUser = vi.mocked(blockUser);
+const mockedUnblockUser = vi.mocked(unblockUser);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+describe("useBlockedUsers", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("차단 목록을 조회한다", async () => {
+    const blockedUsers = [{ userId: 2, userName: "차단유저", profileImage: null, blockedAt: "2025-08-16" }];
+    mockedGetBlockedUsers.mockResolvedValue(blockedUsers);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlockedUsers(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toStrictEqual(blockedUsers);
+  });
+
+  it("enabled=false면 조회하지 않는다", () => {
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useBlockedUsers(false), { wrapper });
+
+    expect(mockedGetBlockedUsers).not.toHaveBeenCalled();
+  });
+});
+
+describe("useBlockUser / useUnblockUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedBlockUser.mockResolvedValue({ message: "ok" });
+    mockedUnblockUser.mockResolvedValue({ message: "ok" });
+  });
+
+  it("mutate하면 차단 API를 호출한다", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockUser(), { wrapper });
+
+    result.current.mutate(7);
+
+    await waitFor(() => expect(mockedBlockUser).toHaveBeenCalledWith(7));
+  });
+
+  it("mutate하면 차단 해제 API를 호출한다", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUnblockUser(), { wrapper });
+
+    result.current.mutate(7);
+
+    await waitFor(() => expect(mockedUnblockUser).toHaveBeenCalledWith(7));
+  });
+
+  it("차단 성공 시 관련 쿼리 캐시를 invalidate한다", async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useBlockUser(), { wrapper });
+
+    result.current.mutate(7);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const invalidatedKeys = invalidateSpy.mock.calls.map(([filter]) => filter?.queryKey?.[0]);
+    expect(invalidatedKeys).toEqual(
+      expect.arrayContaining(["blockedUsers", "userProfile", "comments", "getUserSearch"])
+    );
+  });
+
+  it("차단 해제 성공 시 관련 쿼리 캐시를 invalidate한다", async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnblockUser(), { wrapper });
+
+    result.current.mutate(7);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const invalidatedKeys = invalidateSpy.mock.calls.map(([filter]) => filter?.queryKey?.[0]);
+    expect(invalidatedKeys).toEqual(
+      expect.arrayContaining(["blockedUsers", "userProfile", "comments", "getUserSearch"])
+    );
+  });
+});

--- a/client/src/__tests__/hooks/queries/useBlock.test.tsx
+++ b/client/src/__tests__/hooks/queries/useBlock.test.tsx
@@ -2,8 +2,15 @@ import type { ReactNode } from "react";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { blockUser, getBlockedUsers, unblockUser } from "@/api/services/block";
-import { useBlockedUsers, useBlockUser, useUnblockUser } from "@/hooks/queries/useBlock";
+import { blockRss, blockUser, getBlockedRss, getBlockedUsers, unblockRss, unblockUser } from "@/api/services/block";
+import {
+  useBlockedRss,
+  useBlockedUsers,
+  useBlockRss,
+  useBlockUser,
+  useUnblockRss,
+  useUnblockUser,
+} from "@/hooks/queries/useBlock";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -12,11 +19,17 @@ vi.mock("@/api/services/block", () => ({
   getBlockedUsers: vi.fn(),
   blockUser: vi.fn(),
   unblockUser: vi.fn(),
+  getBlockedRss: vi.fn(),
+  blockRss: vi.fn(),
+  unblockRss: vi.fn(),
 }));
 
 const mockedGetBlockedUsers = vi.mocked(getBlockedUsers);
 const mockedBlockUser = vi.mocked(blockUser);
 const mockedUnblockUser = vi.mocked(unblockUser);
+const mockedGetBlockedRss = vi.mocked(getBlockedRss);
+const mockedBlockRss = vi.mocked(blockRss);
+const mockedUnblockRss = vi.mocked(unblockRss);
 
 const createWrapper = () => {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -99,6 +112,99 @@ describe("useBlockUser / useUnblockUser", () => {
     const invalidatedKeys = invalidateSpy.mock.calls.map(([filter]) => filter?.queryKey?.[0]);
     expect(invalidatedKeys).toEqual(
       expect.arrayContaining(["blockedUsers", "userProfile", "comments", "getUserSearch"])
+    );
+  });
+});
+
+describe("useBlockedRss", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("RSS 차단 목록을 조회한다", async () => {
+    const blockedRss = [{ rssId: 5, name: "차단블로그", blogPlatform: "velog", blockedAt: "2025-08-16" }];
+    mockedGetBlockedRss.mockResolvedValue(blockedRss);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlockedRss(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toStrictEqual(blockedRss);
+  });
+
+  it("enabled=false면 조회하지 않는다", () => {
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useBlockedRss(false), { wrapper });
+
+    expect(mockedGetBlockedRss).not.toHaveBeenCalled();
+  });
+});
+
+describe("useBlockRss / useUnblockRss", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedBlockRss.mockResolvedValue({ message: "ok" });
+    mockedUnblockRss.mockResolvedValue({ message: "ok" });
+  });
+
+  it("mutate하면 RSS 차단 API를 호출한다", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockRss(), { wrapper });
+
+    result.current.mutate(5);
+
+    await waitFor(() => expect(mockedBlockRss).toHaveBeenCalledWith(5));
+  });
+
+  it("mutate하면 RSS 차단 해제 API를 호출한다", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUnblockRss(), { wrapper });
+
+    result.current.mutate(5);
+
+    await waitFor(() => expect(mockedUnblockRss).toHaveBeenCalledWith(5));
+  });
+
+  it("RSS 차단 성공 시 관련 쿼리 캐시를 invalidate한다", async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useBlockRss(), { wrapper });
+
+    result.current.mutate(5);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const invalidatedKeys = invalidateSpy.mock.calls.map(([filter]) => filter?.queryKey?.[0]);
+    expect(invalidatedKeys).toEqual(
+      expect.arrayContaining([
+        "blockedRss",
+        "rssInfo",
+        "latest-posts",
+        "getSearch",
+        "getDetail",
+        "recentRss",
+        "subscriptionFeed",
+      ])
+    );
+  });
+
+  it("RSS 차단 해제 성공 시 관련 쿼리 캐시를 invalidate한다", async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useUnblockRss(), { wrapper });
+
+    result.current.mutate(5);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const invalidatedKeys = invalidateSpy.mock.calls.map(([filter]) => filter?.queryKey?.[0]);
+    expect(invalidatedKeys).toEqual(
+      expect.arrayContaining([
+        "blockedRss",
+        "rssInfo",
+        "latest-posts",
+        "getSearch",
+        "getDetail",
+        "recentRss",
+        "subscriptionFeed",
+      ])
     );
   });
 });

--- a/client/src/__tests__/hooks/queries/useTrendingPosts.test.tsx
+++ b/client/src/__tests__/hooks/queries/useTrendingPosts.test.tsx
@@ -1,0 +1,95 @@
+import type { ReactNode } from "react";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useTrendingPosts } from "@/hooks/queries/useTrendingPosts";
+
+import { useAuthStore } from "@/store/useAuthStore";
+import { BlockedRss } from "@/types/profile";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+
+let blockedRssState: BlockedRss[];
+
+vi.mock("@/hooks/queries/useBlock", () => ({
+  useBlockedRss: (enabled: boolean) => ({ data: enabled ? blockedRssState : undefined }),
+}));
+
+let esInstance: MockEventSource | null = null;
+
+class MockEventSource {
+  onmessage: ((event: { data: string }) => void) | null = null;
+  close = vi.fn();
+
+  constructor(public url: string) {
+    setInstance(this);
+  }
+}
+
+function setInstance(instance: MockEventSource) {
+  esInstance = instance;
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+const makePost = (id: number, author: string) => ({ id, author, title: `post ${id}` });
+
+describe("useTrendingPosts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    esInstance = null;
+    blockedRssState = [];
+    useAuthStore.setState({ isAuthenticated: false });
+    vi.stubGlobal("EventSource", MockEventSource);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("SSE로 수신한 트렌딩 포스트를 반환한다", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useTrendingPosts(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    act(() => {
+      esInstance?.onmessage?.({
+        data: JSON.stringify({ message: "", data: [makePost(1, "블로그A"), makePost(2, "블로그B")] }),
+      });
+    });
+
+    await waitFor(() => expect(result.current.posts).toHaveLength(2));
+  });
+
+  it("로그인 상태면 차단한 RSS의 포스트를 필터링한다", async () => {
+    useAuthStore.setState({ isAuthenticated: true });
+    blockedRssState = [{ rssId: 5, name: "블로그B", blogPlatform: "velog", blockedAt: "2025-08-16" }];
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useTrendingPosts(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    act(() => {
+      esInstance?.onmessage?.({
+        data: JSON.stringify({ message: "", data: [makePost(1, "블로그A"), makePost(2, "블로그B")] }),
+      });
+    });
+
+    await waitFor(() => expect(result.current.posts).toHaveLength(1));
+    expect(result.current.posts[0].author).toBe("블로그A");
+  });
+
+  it("unmount 시 EventSource 연결을 닫는다", () => {
+    const { wrapper } = createWrapper();
+    const { unmount } = renderHook(() => useTrendingPosts(), { wrapper });
+
+    unmount();
+
+    expect(esInstance?.close).toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/pages/PostDetailPage.test.tsx
+++ b/client/src/__tests__/pages/PostDetailPage.test.tsx
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { render, screen } from "@testing-library/react";
+
+const mockIncrement = vi.fn();
+let params: { id?: string };
+let detailState: {
+  data: { data: { title: string; isBlocked?: boolean } } | undefined;
+  isLoading: boolean;
+  error: unknown;
+};
+
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
+
+vi.mock("react-router-dom", () => ({
+  useParams: () => params,
+}));
+
+vi.mock("@/hooks/queries/usePostDetail", () => ({
+  usePostDetail: () => detailState,
+}));
+
+vi.mock("@/hooks/common/usePostCardActions", () => ({
+  useIncrementViewByPostId: () => mockIncrement,
+}));
+
+vi.mock("@/components/layout/Header", () => ({ default: () => <div data-testid="header" /> }));
+vi.mock("@/pages/Loading", () => ({ default: () => <div data-testid="loading" /> }));
+vi.mock("@/pages/NotFound", () => ({ default: () => <div data-testid="not-found" /> }));
+vi.mock("@/components/common/Card/detail/PostHeader", () => ({
+  PostHeader: ({ data }: { data: { title: string } }) => <div data-testid="post-header">{data.title}</div>,
+}));
+vi.mock("@/components/common/Card/detail/PostContent", () => ({
+  PostContent: () => <div data-testid="post-content" />,
+}));
+
+import PostDetailPage from "@/pages/PostDetailPage.tsx";
+
+describe("PostDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    params = { id: "1" };
+    detailState = { data: { data: { title: "상세 제목" } }, isLoading: false, error: null };
+  });
+
+  it("id가 숫자가 아니면 NotFound를 렌더링해야 한다", () => {
+    params = { id: "abc" };
+    render(<PostDetailPage />);
+
+    expect(screen.getByTestId("not-found")).toBeInTheDocument();
+  });
+
+  it("로딩 중이면 Loading을 렌더링해야 한다", () => {
+    detailState = { data: undefined, isLoading: true, error: null };
+    render(<PostDetailPage />);
+
+    expect(screen.getByTestId("loading")).toBeInTheDocument();
+  });
+
+  it("정상 data면 PostHeader와 PostContent를 렌더링해야 한다", () => {
+    render(<PostDetailPage />);
+
+    expect(screen.getByTestId("post-header")).toHaveTextContent("상세 제목");
+    expect(screen.getByTestId("post-content")).toBeInTheDocument();
+  });
+
+  it("차단된 RSS의 게시글이면 차단 안내를 렌더링하고 본문은 숨겨야 한다", () => {
+    detailState = { data: { data: { title: "상세 제목", isBlocked: true } }, isLoading: false, error: null };
+    render(<PostDetailPage />);
+
+    expect(screen.getByText("차단된 RSS의 게시글입니다.")).toBeInTheDocument();
+    expect(screen.queryByTestId("post-header")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("post-content")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/pages/RssPage.test.tsx
+++ b/client/src/__tests__/pages/RssPage.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@/components/layout/Layout", () => ({
 }));
 
 const useRssPageFeedsMock = vi.hoisted(() =>
-  vi.fn((_rssId: number, _date?: string) => ({
+  vi.fn<(rssId: number, date?: string) => object>(() => ({
     data: { pages: [{ result: [] }] },
     isLoading: false,
     isError: false,
@@ -60,6 +60,14 @@ vi.mock("@/components/profile/header/ui/ActivityGraph/ActivityGraph.tsx", () => 
   ),
 }));
 
+const blockRssMock = vi.hoisted(() => vi.fn());
+const unblockRssMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/queries/useBlock.ts", () => ({
+  useBlockRss: () => ({ mutate: blockRssMock, isPending: false }),
+  useUnblockRss: () => ({ mutate: unblockRssMock, isPending: false }),
+}));
+
 vi.mock("@/hooks/queries/useRssCertification.ts", () => ({
   useOwnedRssFeeds: () => ({
     data: { pages: [{ result: [] }] },
@@ -84,6 +92,8 @@ vi.mock("@/components/profile/rss/RssEditModal.tsx", () => ({
 
 import RssPage from "@/pages/RssPage.tsx";
 
+import { useAuthStore } from "@/store/useAuthStore";
+
 const baseRss: RssInfo = {
   id: 5,
   name: "데나무 블로그",
@@ -96,11 +106,13 @@ const baseRss: RssInfo = {
   isOwner: false,
   lastPublishedAt: "2025-01-10T00:00:00Z",
   owner: null,
+  isBlocked: false,
 };
 
 describe("RssPage", () => {
   beforeEach(() => {
     rssInfoState = { data: baseRss, isLoading: false, isError: false };
+    useAuthStore.setState({ isAuthenticated: false });
   });
 
   it("소유자 없는 RSS는 인증 배지와 소유자 카드를 노출하지 않는다", () => {
@@ -174,5 +186,49 @@ describe("RssPage", () => {
     render(<RssPage />);
 
     expect(screen.queryByText("데나무 블로그")).not.toBeInTheDocument();
+  });
+
+  it("로그인한 비소유자에게는 더보기(차단) 버튼을 노출한다", () => {
+    useAuthStore.setState({ isAuthenticated: true });
+
+    render(<RssPage />);
+
+    expect(screen.getByRole("button", { name: "더보기" })).toBeInTheDocument();
+  });
+
+  it("비로그인 사용자에게는 더보기 버튼을 노출하지 않는다", () => {
+    render(<RssPage />);
+
+    expect(screen.queryByRole("button", { name: "더보기" })).not.toBeInTheDocument();
+  });
+
+  it("본인 소유 RSS에는 더보기 버튼을 노출하지 않는다", () => {
+    useAuthStore.setState({ isAuthenticated: true });
+    rssInfoState = { data: { ...baseRss, isOwner: true }, isLoading: false, isError: false };
+
+    render(<RssPage />);
+
+    expect(screen.queryByRole("button", { name: "더보기" })).not.toBeInTheDocument();
+  });
+
+  it("차단된 RSS는 차단 안내 뷰를 렌더링하고 본문은 숨긴다", () => {
+    rssInfoState = { data: { ...baseRss, isBlocked: true }, isLoading: false, isError: false };
+
+    render(<RssPage />);
+
+    expect(screen.getByText("차단된 RSS입니다.")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "홈으로" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "차단 해제" })).toBeInTheDocument();
+    expect(screen.queryByText("데나무 블로그")).not.toBeInTheDocument();
+  });
+
+  it("차단 안내 뷰에서 차단 해제 클릭 시 해당 rssId로 mutation을 호출한다", () => {
+    rssInfoState = { data: { ...baseRss, isBlocked: true }, isLoading: false, isError: false };
+
+    render(<RssPage />);
+
+    fireEvent.click(screen.getByRole("button", { name: "차단 해제" }));
+
+    expect(unblockRssMock).toHaveBeenCalledWith(5, expect.any(Object));
   });
 });

--- a/client/src/api/services/block.ts
+++ b/client/src/api/services/block.ts
@@ -1,0 +1,21 @@
+import { BLOCK } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+
+import { ApiData, ApiMessage } from "@/types/api";
+import { BlockedUser } from "@/types/profile";
+
+export const getBlockedUsers = async (): Promise<BlockedUser[]> => {
+  const response = await axiosInstance.get<ApiData<BlockedUser[]>>(BLOCK.LIST);
+  return response.data.data;
+};
+
+export const blockUser = async (userId: number): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(BLOCK.MANAGE(userId));
+  return response.data;
+};
+
+export const unblockUser = async (userId: number): Promise<ApiMessage> => {
+  const response = await axiosInstance.delete<ApiMessage>(BLOCK.MANAGE(userId));
+  return response.data;
+};

--- a/client/src/api/services/block.ts
+++ b/client/src/api/services/block.ts
@@ -3,7 +3,7 @@ import { BLOCK } from "@/constants/endpoints";
 import { axiosInstance } from "@/api/instance";
 
 import { ApiData, ApiMessage } from "@/types/api";
-import { BlockedUser } from "@/types/profile";
+import { BlockedRss, BlockedUser } from "@/types/profile";
 
 export const getBlockedUsers = async (): Promise<BlockedUser[]> => {
   const response = await axiosInstance.get<ApiData<BlockedUser[]>>(BLOCK.LIST);
@@ -17,5 +17,20 @@ export const blockUser = async (userId: number): Promise<ApiMessage> => {
 
 export const unblockUser = async (userId: number): Promise<ApiMessage> => {
   const response = await axiosInstance.delete<ApiMessage>(BLOCK.MANAGE(userId));
+  return response.data;
+};
+
+export const getBlockedRss = async (): Promise<BlockedRss[]> => {
+  const response = await axiosInstance.get<ApiData<BlockedRss[]>>(BLOCK.RSS_LIST);
+  return response.data.data;
+};
+
+export const blockRss = async (rssId: number): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(BLOCK.RSS_MANAGE(rssId));
+  return response.data;
+};
+
+export const unblockRss = async (rssId: number): Promise<ApiMessage> => {
+  const response = await axiosInstance.delete<ApiMessage>(BLOCK.RSS_MANAGE(rssId));
   return response.data;
 };

--- a/client/src/components/common/Card/PostDetail.stories.tsx
+++ b/client/src/components/common/Card/PostDetail.stories.tsx
@@ -63,6 +63,15 @@ export const WithLiked: Story = {
   },
 };
 
+export const Blocked: Story = {
+  name: "차단된 RSS의 게시글",
+  beforeEach: () => {
+    mockApi.onGet(`${BLOG.POST}/1`).reply(...ok({ ...mockFeedDetail, isBlocked: true }));
+    mockApi.onGet(BLOG.LIKE(1)).reply(...ok({ isLike: false }));
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
+  },
+};
+
 export const Loading: Story = {
   name: "로딩 중",
   beforeEach: () => {

--- a/client/src/components/common/Card/PostDetail.tsx
+++ b/client/src/components/common/Card/PostDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { X } from "lucide-react";
 
+import { BlockedFeedNotice } from "@/components/common/Card/detail/BlockedFeedNotice";
 import { FixedHeader } from "@/components/common/Card/detail/FixedHeader";
 import { PostContent } from "@/components/common/Card/detail/PostContent";
 import { PostHeader } from "@/components/common/Card/detail/PostHeader";
@@ -62,10 +63,14 @@ export default function PostDetail() {
           </button>
         </div>
 
-        <div className="mt-5 flex flex-col gap-2 px-10 ">
-          <PostHeader data={data.data} />
-          <PostContent post={data.data} />
-        </div>
+        {data.data.isBlocked ? (
+          <BlockedFeedNotice />
+        ) : (
+          <div className="mt-5 flex flex-col gap-2 px-10 ">
+            <PostHeader data={data.data} />
+            <PostContent post={data.data} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/common/Card/detail/BlockedFeedNotice.stories.tsx
+++ b/client/src/components/common/Card/detail/BlockedFeedNotice.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { BlockedFeedNotice } from "@/components/common/Card/detail/BlockedFeedNotice";
+
+const meta = {
+  title: "common/Card/detail/BlockedFeedNotice",
+  component: BlockedFeedNotice,
+} satisfies Meta<typeof BlockedFeedNotice>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: "기본",
+};

--- a/client/src/components/common/Card/detail/BlockedFeedNotice.tsx
+++ b/client/src/components/common/Card/detail/BlockedFeedNotice.tsx
@@ -1,0 +1,8 @@
+import { Ban } from "lucide-react";
+
+export const BlockedFeedNotice = () => (
+  <div className="flex flex-col items-center justify-center py-32 text-center">
+    <Ban className="w-12 h-12 mb-4 text-gray-400" />
+    <h2 className="text-xl font-semibold text-gray-800">차단된 RSS의 게시글입니다.</h2>
+  </div>
+);

--- a/client/src/components/profile/BlockManagementTab.stories.tsx
+++ b/client/src/components/profile/BlockManagementTab.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { BlockManagementTab } from "@/components/profile/BlockManagementTab";
+import { BLOCK } from "@/constants/endpoints";
+import { mockBlockedUsers } from "@/__storybook__/fixtures";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/BlockManagementTab",
+  component: BlockManagementTab,
+} satisfies Meta<typeof BlockManagementTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithData: Story = {
+  name: "차단 목록 있음",
+  beforeEach: () => {
+    mockApi.onGet(BLOCK.LIST).reply(...ok(mockBlockedUsers));
+  },
+};
+
+export const Empty: Story = {
+  name: "차단 목록 없음",
+  beforeEach: () => {
+    mockApi.onGet(BLOCK.LIST).reply(...ok([]));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(BLOCK.LIST).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(BLOCK.LIST).reply(...fail());
+  },
+};
+
+export const Unblock: Story = {
+  name: "차단 해제 클릭",
+  beforeEach: () => {
+    mockApi.onGet(BLOCK.LIST).reply(...ok(mockBlockedUsers));
+    mockApi.onDelete(BLOCK.MANAGE(mockBlockedUsers[0].userId)).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const buttons = await canvas.findAllByRole("button", { name: "차단 해제" });
+    await userEvent.click(buttons[0]);
+    await waitFor(() => expect(mockApi.history.delete).toHaveLength(1));
+  },
+};

--- a/client/src/components/profile/BlockManagementTab.stories.tsx
+++ b/client/src/components/profile/BlockManagementTab.stories.tsx
@@ -3,7 +3,7 @@ import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { BlockManagementTab } from "@/components/profile/BlockManagementTab";
 import { BLOCK } from "@/constants/endpoints";
-import { mockBlockedUsers } from "@/__storybook__/fixtures";
+import { mockBlockedRss, mockBlockedUsers } from "@/__storybook__/fixtures";
 import { mockApi, ok, fail } from "@/__storybook__/mockApi";
 
 const meta = {
@@ -17,6 +17,7 @@ type Story = StoryObj<typeof meta>;
 export const WithData: Story = {
   name: "차단 목록 있음",
   beforeEach: () => {
+    mockApi.onGet(BLOCK.RSS_LIST).reply(...ok(mockBlockedRss));
     mockApi.onGet(BLOCK.LIST).reply(...ok(mockBlockedUsers));
   },
 };
@@ -24,6 +25,7 @@ export const WithData: Story = {
 export const Empty: Story = {
   name: "차단 목록 없음",
   beforeEach: () => {
+    mockApi.onGet(BLOCK.RSS_LIST).reply(...ok([]));
     mockApi.onGet(BLOCK.LIST).reply(...ok([]));
   },
 };
@@ -31,6 +33,7 @@ export const Empty: Story = {
 export const Loading: Story = {
   name: "로딩 중",
   beforeEach: () => {
+    mockApi.onGet(BLOCK.RSS_LIST).reply(() => new Promise(() => {}));
     mockApi.onGet(BLOCK.LIST).reply(() => new Promise(() => {}));
   },
 };
@@ -38,13 +41,31 @@ export const Loading: Story = {
 export const Error: Story = {
   name: "오류",
   beforeEach: () => {
+    mockApi.onGet(BLOCK.RSS_LIST).reply(...fail());
     mockApi.onGet(BLOCK.LIST).reply(...fail());
+  },
+};
+
+export const RssTab: Story = {
+  name: "RSS 차단 목록",
+  beforeEach: () => {
+    mockApi.onGet(BLOCK.RSS_LIST).reply(...ok(mockBlockedRss));
+    mockApi.onGet(BLOCK.LIST).reply(...ok([]));
+    mockApi.onDelete(`${BLOCK.RSS_LIST}/${mockBlockedRss[0].rssId}`).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(await canvas.findByRole("tab", { name: "RSS" }));
+    await expect(await canvas.findByText(mockBlockedRss[0].name)).toBeInTheDocument();
+    await userEvent.click(await canvas.findByRole("button", { name: "차단 해제" }));
+    await waitFor(() => expect(mockApi.history.delete).toHaveLength(1));
   },
 };
 
 export const Unblock: Story = {
   name: "차단 해제 클릭",
   beforeEach: () => {
+    mockApi.onGet(BLOCK.RSS_LIST).reply(...ok([]));
     mockApi.onGet(BLOCK.LIST).reply(...ok(mockBlockedUsers));
     mockApi.onDelete(BLOCK.MANAGE(mockBlockedUsers[0].userId)).reply(...ok(null));
   },

--- a/client/src/components/profile/BlockManagementTab.tsx
+++ b/client/src/components/profile/BlockManagementTab.tsx
@@ -1,13 +1,19 @@
+import { Link } from "react-router-dom";
+
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent } from "@/components/ui/card.tsx";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs.tsx";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
-import { useBlockedUsers, useUnblockUser } from "@/hooks/queries/useBlock.ts";
+import { useBlockedRss, useBlockedUsers, useUnblockRss, useUnblockUser } from "@/hooks/queries/useBlock.ts";
 
 export const BlockManagementTab = () => {
   const { data: blockedUsers = [], isLoading } = useBlockedUsers();
+  const { data: blockedRss = [], isLoading: isRssLoading } = useBlockedRss();
   const { mutate: unblockUser, isPending } = useUnblockUser();
+  const { mutate: unblockRss, isPending: isRssUnblockPending } = useUnblockRss();
   const { toast } = useCustomToast();
 
   const handleUnblock = (userId: number, userName: string) => {
@@ -21,46 +27,102 @@ export const BlockManagementTab = () => {
     });
   };
 
+  const handleRssUnblock = (rssId: number, name: string) => {
+    unblockRss(rssId, {
+      onSuccess: () => {
+        toast({ title: "차단 해제 완료", description: `${name} RSS의 차단을 해제했습니다.` });
+      },
+      onError: () => {
+        toast({ title: "차단 해제 실패", description: "잠시 후 다시 시도해주세요." });
+      },
+    });
+  };
+
   return (
     <Card>
       <CardContent className="p-6">
         <h3 className="mb-4 text-lg font-semibold">차단 관리</h3>
 
-        {isLoading ? (
-          <p className="text-sm text-gray-400">불러오는 중...</p>
-        ) : blockedUsers.length === 0 ? (
-          <p className="text-sm text-gray-400">차단한 사용자가 없습니다.</p>
-        ) : (
-          <ul className="space-y-3">
-            {blockedUsers.map((user) => {
-              const initials = user.userName ? user.userName.substring(0, 2).toUpperCase() : "사용자";
-              return (
-                <li
-                  key={user.userId}
-                  className="flex items-center justify-between gap-3 p-4 border border-gray-100 rounded-lg"
-                >
-                  <div className="flex items-center min-w-0 gap-3">
-                    <Avatar className="flex-shrink-0 w-10 h-10">
-                      {user.profileImage && <AvatarImage src={user.profileImage} alt={user.userName} />}
-                      <AvatarFallback>{initials}</AvatarFallback>
-                    </Avatar>
-                    <p className="font-medium truncate">{user.userName}</p>
-                  </div>
-                  <div className="flex-shrink-0">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      disabled={isPending}
-                      onClick={() => handleUnblock(user.userId, user.userName)}
+        <Tabs defaultValue="users">
+          <TabsList className="w-full mb-4">
+            <TabsTrigger value="users" className="w-full">
+              사용자
+            </TabsTrigger>
+            <TabsTrigger value="rss" className="w-full">
+              RSS
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="users">
+            {isLoading ? (
+              <p className="text-sm text-gray-400">불러오는 중...</p>
+            ) : blockedUsers.length === 0 ? (
+              <p className="text-sm text-gray-400">차단한 사용자가 없습니다.</p>
+            ) : (
+              <ul className="space-y-3">
+                {blockedUsers.map((user) => {
+                  const initials = user.userName ? user.userName.substring(0, 2).toUpperCase() : "사용자";
+                  return (
+                    <li
+                      key={user.userId}
+                      className="flex items-center justify-between gap-3 p-4 border border-gray-100 rounded-lg"
                     >
-                      차단 해제
-                    </Button>
-                  </div>
-                </li>
-              );
-            })}
-          </ul>
-        )}
+                      <div className="flex items-center min-w-0 gap-3">
+                        <Avatar className="flex-shrink-0 w-10 h-10">
+                          {user.profileImage && <AvatarImage src={user.profileImage} alt={user.userName} />}
+                          <AvatarFallback>{initials}</AvatarFallback>
+                        </Avatar>
+                        <p className="font-medium truncate">{user.userName}</p>
+                      </div>
+                      <div className="flex-shrink-0">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          disabled={isPending}
+                          onClick={() => handleUnblock(user.userId, user.userName)}
+                        >
+                          차단 해제
+                        </Button>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </TabsContent>
+
+          <TabsContent value="rss">
+            {isRssLoading ? (
+              <p className="text-sm text-gray-400">불러오는 중...</p>
+            ) : blockedRss.length === 0 ? (
+              <p className="text-sm text-gray-400">차단한 RSS가 없습니다.</p>
+            ) : (
+              <ul className="space-y-3">
+                {blockedRss.map((rss) => (
+                  <li
+                    key={rss.rssId}
+                    className="flex items-center justify-between gap-3 p-4 border border-gray-100 rounded-lg"
+                  >
+                    <Link to={`/rss/${rss.rssId}`} className="flex items-center min-w-0 gap-3">
+                      <PlatformIcon platform={rss.blogPlatform} className="flex-shrink-0 w-10 h-10" />
+                      <p className="font-medium truncate">{rss.name}</p>
+                    </Link>
+                    <div className="flex-shrink-0">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        disabled={isRssUnblockPending}
+                        onClick={() => handleRssUnblock(rss.rssId, rss.name)}
+                      >
+                        차단 해제
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </TabsContent>
+        </Tabs>
       </CardContent>
     </Card>
   );

--- a/client/src/components/profile/BlockManagementTab.tsx
+++ b/client/src/components/profile/BlockManagementTab.tsx
@@ -1,0 +1,67 @@
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Card, CardContent } from "@/components/ui/card.tsx";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import { useBlockedUsers, useUnblockUser } from "@/hooks/queries/useBlock.ts";
+
+export const BlockManagementTab = () => {
+  const { data: blockedUsers = [], isLoading } = useBlockedUsers();
+  const { mutate: unblockUser, isPending } = useUnblockUser();
+  const { toast } = useCustomToast();
+
+  const handleUnblock = (userId: number, userName: string) => {
+    unblockUser(userId, {
+      onSuccess: () => {
+        toast({ title: "차단 해제 완료", description: `${userName}님의 차단을 해제했습니다.` });
+      },
+      onError: () => {
+        toast({ title: "차단 해제 실패", description: "잠시 후 다시 시도해주세요." });
+      },
+    });
+  };
+
+  return (
+    <Card>
+      <CardContent className="p-6">
+        <h3 className="mb-4 text-lg font-semibold">차단 관리</h3>
+
+        {isLoading ? (
+          <p className="text-sm text-gray-400">불러오는 중...</p>
+        ) : blockedUsers.length === 0 ? (
+          <p className="text-sm text-gray-400">차단한 사용자가 없습니다.</p>
+        ) : (
+          <ul className="space-y-3">
+            {blockedUsers.map((user) => {
+              const initials = user.userName ? user.userName.substring(0, 2).toUpperCase() : "사용자";
+              return (
+                <li
+                  key={user.userId}
+                  className="flex items-center justify-between gap-3 p-4 border border-gray-100 rounded-lg"
+                >
+                  <div className="flex items-center min-w-0 gap-3">
+                    <Avatar className="flex-shrink-0 w-10 h-10">
+                      {user.profileImage && <AvatarImage src={user.profileImage} alt={user.userName} />}
+                      <AvatarFallback>{initials}</AvatarFallback>
+                    </Avatar>
+                    <p className="font-medium truncate">{user.userName}</p>
+                  </div>
+                  <div className="flex-shrink-0">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={isPending}
+                      onClick={() => handleUnblock(user.userId, user.userName)}
+                    >
+                      차단 해제
+                    </Button>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/client/src/components/profile/BlockedProfileView.stories.tsx
+++ b/client/src/components/profile/BlockedProfileView.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { BlockedProfileView } from "@/components/profile/BlockedProfileView";
+import { BLOCK } from "@/constants/endpoints";
+import { mockApi, ok, fail } from "@/__storybook__/mockApi";
+
+const meta = {
+  title: "profile/BlockedProfileView",
+  component: BlockedProfileView,
+  args: { userId: 2 },
+} satisfies Meta<typeof BlockedProfileView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Unblock: Story = {
+  name: "차단 해제 클릭",
+  beforeEach: () => {
+    mockApi.onDelete(BLOCK.MANAGE(2)).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "차단 해제" }));
+    await waitFor(() => expect(mockApi.history.delete).toHaveLength(1));
+  },
+};
+
+export const UnblockError: Story = {
+  name: "차단 해제 실패",
+  beforeEach: () => {
+    mockApi.onDelete(BLOCK.MANAGE(2)).reply(...fail());
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "차단 해제" }));
+  },
+};

--- a/client/src/components/profile/BlockedProfileView.tsx
+++ b/client/src/components/profile/BlockedProfileView.tsx
@@ -1,0 +1,45 @@
+import { useNavigate } from "react-router-dom";
+
+import { Ban } from "lucide-react";
+
+import { Button } from "@/components/ui/button.tsx";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import { useUnblockUser } from "@/hooks/queries/useBlock.ts";
+
+interface BlockedProfileViewProps {
+  userId: number;
+}
+
+export const BlockedProfileView = ({ userId }: BlockedProfileViewProps) => {
+  const navigate = useNavigate();
+  const { toast } = useCustomToast();
+  const { mutate: unblockUser, isPending } = useUnblockUser();
+
+  const handleUnblock = () => {
+    unblockUser(userId, {
+      onSuccess: () => {
+        toast({ title: "차단 해제 완료", description: "차단이 해제되었습니다." });
+      },
+      onError: () => {
+        toast({ title: "차단 해제 실패", description: "잠시 후 다시 시도해주세요." });
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center py-32 text-center">
+      <Ban className="w-12 h-12 mb-4 text-gray-400" />
+      <h2 className="text-xl font-semibold text-gray-800">차단한 사용자입니다</h2>
+      <p className="mt-2 text-sm text-gray-500">차단한 사용자의 프로필은 볼 수 없습니다.</p>
+      <div className="flex gap-3 mt-8">
+        <Button variant="outline" onClick={() => navigate("/")}>
+          홈으로
+        </Button>
+        <Button onClick={handleUnblock} disabled={isPending}>
+          차단 해제
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/profile/MyPage.tsx
+++ b/client/src/components/profile/MyPage.tsx
@@ -18,12 +18,13 @@ interface MyPageProps {
   name: string;
   email: string;
   isOwner: boolean;
+  canBlock?: boolean;
   onShowSubscriptions?: () => void;
 }
 
 const MAX_YEARS = 5;
 
-export const MyPage = ({ userId, name, email, isOwner, onShowSubscriptions }: MyPageProps) => {
+export const MyPage = ({ userId, name, email, isOwner, canBlock, onShowSubscriptions }: MyPageProps) => {
   const currentYear = new Date().getFullYear();
   const [year, setYear] = useState(currentYear);
 
@@ -45,6 +46,7 @@ export const MyPage = ({ userId, name, email, isOwner, onShowSubscriptions }: My
         email={email}
         profileImage={profile?.profileImage ?? null}
         introduction={profile?.introduction ?? null}
+        blockableUserId={canBlock ? userId : undefined}
       />
 
       <StreakStats

--- a/client/src/components/profile/ProfileHeader.stories.tsx
+++ b/client/src/components/profile/ProfileHeader.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
+import { BLOCK } from "@/constants/endpoints";
+import { mockApi, ok } from "@/__storybook__/mockApi";
 
 const meta = {
   title: "profile/ProfileHeader",
@@ -12,3 +15,43 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const OtherUser: Story = {
+  name: "타인 프로필 (차단 메뉴 노출)",
+  args: { email: "", blockableUserId: 2 },
+};
+
+export const BlockFlow: Story = {
+  name: "차단 플로우",
+  args: { email: "", blockableUserId: 2 },
+  beforeEach: () => {
+    mockApi.onPost(BLOCK.MANAGE(2)).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole("button", { name: "더보기" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: "차단" }, { timeout: 5000 }));
+    await expect(await body.findByText("홍길동님을 차단하시겠습니까?", undefined, { timeout: 5000 })).toBeInTheDocument();
+    await userEvent.click(body.getByRole("button", { name: "차단" }));
+
+    await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
+  },
+};
+
+export const BlockCancel: Story = {
+  name: "차단 취소",
+  args: { email: "", blockableUserId: 2 },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole("button", { name: "더보기" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: "차단" }, { timeout: 5000 }));
+    await userEvent.click(await body.findByRole("button", { name: "취소" }, { timeout: 5000 }));
+
+    await waitFor(() => expect(body.queryByText("홍길동님을 차단하시겠습니까?")).not.toBeInTheDocument());
+    await expect(mockApi.history.post).toHaveLength(0);
+  },
+};

--- a/client/src/components/profile/ProfileHeader.stories.tsx
+++ b/client/src/components/profile/ProfileHeader.stories.tsx
@@ -2,8 +2,13 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
-import { BLOCK } from "@/constants/endpoints";
+import { BLOCK, PROFILE } from "@/constants/endpoints";
 import { mockApi, ok } from "@/__storybook__/mockApi";
+
+const ownedRss = [
+  { id: 10, name: "seok3765.log", userName: "홍길동", rssUrl: "https://velog.io/@seok3765", blogPlatform: "velog", feedCount: 12, subscriberCount: 3, isSubscribed: false },
+  { id: 20, name: "hong.tistory", userName: "홍길동", rssUrl: "https://hong.tistory.com/rss", blogPlatform: "tistory", feedCount: 5, subscriberCount: 1, isSubscribed: false },
+];
 
 const meta = {
   title: "profile/ProfileHeader",
@@ -22,36 +27,42 @@ export const OtherUser: Story = {
 };
 
 export const BlockFlow: Story = {
-  name: "차단 플로우",
+  name: "차단 플로우 (RSS 함께 차단)",
   args: { email: "", blockableUserId: 2 },
   beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(2)).reply(...ok(ownedRss));
     mockApi.onPost(BLOCK.MANAGE(2)).reply(...ok(null));
+    mockApi.onPost(BLOCK.RSS_MANAGE(10)).reply(...ok(null));
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const body = within(canvasElement.ownerDocument.body);
 
     await userEvent.click(canvas.getByRole("button", { name: "더보기" }));
-    await userEvent.click(await body.findByRole("menuitem", { name: "차단" }, { timeout: 5000 }));
-    await expect(await body.findByText("홍길동님을 차단하시겠습니까?", undefined, { timeout: 5000 })).toBeInTheDocument();
+    await userEvent.click(await body.findByRole("menuitem", { name: "차단하기" }, { timeout: 5000 }));
+    await expect(await body.findByText("홍길동 유저를 차단하시겠습니까?", undefined, { timeout: 5000 })).toBeInTheDocument();
+    await userEvent.click(await body.findByRole("switch", { name: "seok3765.log 차단" }, { timeout: 5000 }));
     await userEvent.click(body.getByRole("button", { name: "차단" }));
 
-    await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
+    await waitFor(() => expect(mockApi.history.post).toHaveLength(2));
   },
 };
 
 export const BlockCancel: Story = {
   name: "차단 취소",
   args: { email: "", blockableUserId: 2 },
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(2)).reply(...ok(ownedRss));
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const body = within(canvasElement.ownerDocument.body);
 
     await userEvent.click(canvas.getByRole("button", { name: "더보기" }));
-    await userEvent.click(await body.findByRole("menuitem", { name: "차단" }, { timeout: 5000 }));
+    await userEvent.click(await body.findByRole("menuitem", { name: "차단하기" }, { timeout: 5000 }));
     await userEvent.click(await body.findByRole("button", { name: "취소" }, { timeout: 5000 }));
 
-    await waitFor(() => expect(body.queryByText("홍길동님을 차단하시겠습니까?")).not.toBeInTheDocument());
+    await waitFor(() => expect(body.queryByText("홍길동 유저를 차단하시겠습니까?")).not.toBeInTheDocument());
     await expect(mockApi.history.post).toHaveLength(0);
   },
 };

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -1,15 +1,55 @@
+import { useState } from "react";
+
+import { MoreVertical, Ban } from "lucide-react";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
 import { Card, CardContent } from "@/components/ui/card.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.tsx";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import { useBlockUser } from "@/hooks/queries/useBlock.ts";
 
 interface ProfileHeaderProps {
   name: string;
   email: string;
   profileImage: string | null;
   introduction: string | null;
+  blockableUserId?: number;
 }
 
-export const ProfileHeader = ({ name, email, profileImage, introduction }: ProfileHeaderProps) => {
+export const ProfileHeader = ({ name, email, profileImage, introduction, blockableUserId }: ProfileHeaderProps) => {
   const initials = name ? name.substring(0, 2).toUpperCase() : "사용자";
+  const [showBlockConfirm, setShowBlockConfirm] = useState(false);
+  const { toast } = useCustomToast();
+  const { mutate: blockUser } = useBlockUser();
+
+  const handleBlock = () => {
+    if (!blockableUserId) return;
+    blockUser(blockableUserId, {
+      onSuccess: () => {
+        toast({ title: "차단 완료", description: `${name}님을 차단했습니다.` });
+      },
+      onError: () => {
+        toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
+      },
+    });
+    setShowBlockConfirm(false);
+  };
 
   return (
     <Card className="mb-8 overflow-hidden">
@@ -19,15 +59,48 @@ export const ProfileHeader = ({ name, email, profileImage, introduction }: Profi
             {profileImage && <AvatarImage src={profileImage} alt={name} />}
             <AvatarFallback>{initials}</AvatarFallback>
           </Avatar>
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1">
             <h1 className="text-2xl font-bold">{name}</h1>
             {email && <p className="mt-1 text-gray-600">{email}</p>}
             <p className="mt-4 text-gray-800 whitespace-pre-wrap">
               {introduction ? introduction : <span className="text-gray-400">자기소개가 없습니다.</span>}
             </p>
           </div>
+          {blockableUserId && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="flex items-center justify-center flex-shrink-0 w-8 h-8 text-gray-500 transition-colors rounded-lg hover:bg-gray-100"
+                  aria-label="더보기"
+                >
+                  <MoreVertical className="w-5 h-5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={() => setShowBlockConfirm(true)}>
+                  <Ban className="w-4 h-4 mr-2" />
+                  차단하기
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </CardContent>
+
+      <AlertDialog open={showBlockConfirm} onOpenChange={setShowBlockConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{name} 유저를 차단하시겠습니까?</AlertDialogTitle>
+            <AlertDialogDescription>댓글, 프로필 페이지 열람이 제한됩니다.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleBlock}>
+              차단
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </Card>
   );
 };

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-import { MoreVertical, Ban } from "lucide-react";
+import { MoreVertical, Ban, FileText, Users } from "lucide-react";
 
 import {
   AlertDialog,
@@ -20,9 +20,13 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
+import { Badge } from "@/components/ui/badge.tsx";
+import { Switch } from "@/components/ui/switch.tsx";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
-import { useBlockUser } from "@/hooks/queries/useBlock.ts";
+import { useBlockRss, useBlockUser } from "@/hooks/queries/useBlock.ts";
+import { useCertifiedRss } from "@/hooks/queries/useProfile.ts";
 
 interface ProfileHeaderProps {
   name: string;
@@ -35,20 +39,53 @@ interface ProfileHeaderProps {
 export const ProfileHeader = ({ name, email, profileImage, introduction, blockableUserId }: ProfileHeaderProps) => {
   const initials = name ? name.substring(0, 2).toUpperCase() : "사용자";
   const [showBlockConfirm, setShowBlockConfirm] = useState(false);
+  const [selectedRssIds, setSelectedRssIds] = useState<Set<number>>(new Set());
   const { toast } = useCustomToast();
-  const { mutate: blockUser } = useBlockUser();
+  const { mutateAsync: blockUser } = useBlockUser();
+  const { mutateAsync: blockRss } = useBlockRss();
+  const { data: ownedRss = [] } = useCertifiedRss(blockableUserId ?? 0);
 
-  const handleBlock = () => {
-    if (!blockableUserId) return;
-    blockUser(blockableUserId, {
-      onSuccess: () => {
-        toast({ title: "차단 완료", description: `${name}님을 차단했습니다.` });
-      },
-      onError: () => {
-        toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
-      },
+  const allSelected = ownedRss.length > 0 && ownedRss.every((rss) => selectedRssIds.has(rss.id));
+
+  const toggleRss = (rssId: number) => {
+    setSelectedRssIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(rssId)) {
+        next.delete(rssId);
+      } else {
+        next.add(rssId);
+      }
+      return next;
     });
+  };
+
+  const toggleAll = () => {
+    setSelectedRssIds(allSelected ? new Set() : new Set(ownedRss.map((rss) => rss.id)));
+  };
+
+  const handleBlock = async () => {
+    if (!blockableUserId) return;
+    const rssIdsToBlock = [...selectedRssIds];
     setShowBlockConfirm(false);
+
+    try {
+      await blockUser(blockableUserId);
+      const results = await Promise.allSettled(rssIdsToBlock.map((rssId) => blockRss(rssId)));
+      const failedRssCount = results.filter((result) => result.status === "rejected").length;
+
+      if (failedRssCount > 0) {
+        toast({
+          title: "차단 완료",
+          description: `${name}님을 차단했습니다. RSS ${failedRssCount}건은 차단하지 못했습니다.`,
+        });
+      } else {
+        toast({ title: "차단 완료", description: `${name}님을 차단했습니다.` });
+      }
+    } catch {
+      toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
+    } finally {
+      setSelectedRssIds(new Set());
+    }
   };
 
   return (
@@ -93,6 +130,56 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
             <AlertDialogTitle>{name} 유저를 차단하시겠습니까?</AlertDialogTitle>
             <AlertDialogDescription>댓글, 프로필 페이지 열람이 제한됩니다.</AlertDialogDescription>
           </AlertDialogHeader>
+          {ownedRss.length > 0 && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium text-gray-700">함께 차단할 RSS</p>
+                <button
+                  type="button"
+                  onClick={toggleAll}
+                  className="text-xs font-medium text-[#FF870D] hover:underline"
+                >
+                  {allSelected ? "모두 해제" : "모두 선택"}
+                </button>
+              </div>
+              <ul className="pr-1 space-y-2 overflow-y-auto max-h-60">
+                {ownedRss.map((rss) => (
+                  <li
+                    key={rss.id}
+                    className="flex items-center justify-between gap-3 p-3 border border-gray-100 rounded-lg"
+                  >
+                    <div className="flex items-center min-w-0 gap-3">
+                      <PlatformIcon platform={rss.blogPlatform} className="flex-shrink-0 w-9 h-9" />
+                      <div className="min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-medium truncate">{rss.name}</p>
+                          <Badge variant="secondary" className="flex-shrink-0">
+                            {rss.blogPlatform}
+                          </Badge>
+                        </div>
+                        <p className="flex items-center gap-3 mt-0.5 text-xs text-gray-400">
+                          <span className="flex items-center gap-1">
+                            <FileText className="w-3.5 h-3.5" />
+                            게시글 {rss.feedCount}개
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <Users className="w-3.5 h-3.5" />
+                            구독자 {rss.subscriberCount}명
+                          </span>
+                        </p>
+                      </div>
+                    </div>
+                    <Switch
+                      checked={selectedRssIds.has(rss.id)}
+                      onCheckedChange={() => toggleRss(rss.id)}
+                      aria-label={`${rss.name} 차단`}
+                      className="flex-shrink-0"
+                    />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <AlertDialogFooter>
             <AlertDialogCancel>취소</AlertDialogCancel>
             <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleBlock}>

--- a/client/src/components/profile/ProfileSidebar.tsx
+++ b/client/src/components/profile/ProfileSidebar.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 
-import { Home, LogOut, Rss, Settings as SettingsIcon, User as UserIcon } from "lucide-react";
+import { Ban, Home, LogOut, Rss, Settings as SettingsIcon, User as UserIcon } from "lucide-react";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 
@@ -18,6 +18,7 @@ interface ProfileSidebarProps {
 const tabs: { id: ProfileTab; label: string; icon: typeof UserIcon; activeClass: string }[] = [
   { id: "mypage", label: "마이페이지", icon: UserIcon, activeClass: "bg-blue-50 text-blue-600" },
   { id: "rss", label: "RSS 관리", icon: Rss, activeClass: "bg-[#FF870D]/10 text-[#FF870D]" },
+  { id: "blocks", label: "차단 관리", icon: Ban, activeClass: "bg-red-50 text-red-600" },
   { id: "settings", label: "정보 수정", icon: SettingsIcon, activeClass: "bg-purple-50 text-purple-600" },
 ];
 

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -106,6 +106,8 @@ export const OAUTH = {
 export const BLOCK = {
   LIST: "/api/blocks",
   MANAGE: (userId: number) => `/api/blocks/${userId}`,
+  RSS_LIST: "/api/blocks/rss",
+  RSS_MANAGE: (rssId: number) => `/api/blocks/rss/${rssId}`,
 };
 
 export const FILE = {

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -103,6 +103,11 @@ export const OAUTH = {
   UNLINK: (provider: string) => `/api/oauth/links/${provider}`,
 };
 
+export const BLOCK = {
+  LIST: "/api/blocks",
+  MANAGE: (userId: number) => `/api/blocks/${userId}`,
+};
+
 export const FILE = {
   UPLOAD: "/api/files",
 };

--- a/client/src/hooks/queries/useBlock.ts
+++ b/client/src/hooks/queries/useBlock.ts
@@ -1,4 +1,4 @@
-import { blockUser, getBlockedUsers, unblockUser } from "@/api/services/block";
+import { blockRss, blockUser, getBlockedRss, getBlockedUsers, unblockRss, unblockUser } from "@/api/services/block";
 import { QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 const invalidateBlockRelatedQueries = (queryClient: QueryClient) => {
@@ -6,6 +6,16 @@ const invalidateBlockRelatedQueries = (queryClient: QueryClient) => {
   queryClient.invalidateQueries({ queryKey: ["userProfile"] });
   queryClient.invalidateQueries({ queryKey: ["comments"] });
   queryClient.invalidateQueries({ queryKey: ["getUserSearch"] });
+};
+
+const invalidateRssBlockRelatedQueries = (queryClient: QueryClient) => {
+  queryClient.invalidateQueries({ queryKey: ["blockedRss"] });
+  queryClient.invalidateQueries({ queryKey: ["rssInfo"] });
+  queryClient.invalidateQueries({ queryKey: ["latest-posts"] });
+  queryClient.invalidateQueries({ queryKey: ["getSearch"] });
+  queryClient.invalidateQueries({ queryKey: ["getDetail"] });
+  queryClient.invalidateQueries({ queryKey: ["recentRss"] });
+  queryClient.invalidateQueries({ queryKey: ["subscriptionFeed"] });
 };
 
 export const useBlockedUsers = (enabled = true) =>
@@ -28,5 +38,28 @@ export const useUnblockUser = () => {
   return useMutation({
     mutationFn: (userId: number) => unblockUser(userId),
     onSuccess: () => invalidateBlockRelatedQueries(queryClient),
+  });
+};
+
+export const useBlockedRss = (enabled = true) =>
+  useQuery({
+    queryKey: ["blockedRss"],
+    queryFn: getBlockedRss,
+    enabled,
+  });
+
+export const useBlockRss = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (rssId: number) => blockRss(rssId),
+    onSuccess: () => invalidateRssBlockRelatedQueries(queryClient),
+  });
+};
+
+export const useUnblockRss = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (rssId: number) => unblockRss(rssId),
+    onSuccess: () => invalidateRssBlockRelatedQueries(queryClient),
   });
 };

--- a/client/src/hooks/queries/useBlock.ts
+++ b/client/src/hooks/queries/useBlock.ts
@@ -1,0 +1,32 @@
+import { blockUser, getBlockedUsers, unblockUser } from "@/api/services/block";
+import { QueryClient, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+const invalidateBlockRelatedQueries = (queryClient: QueryClient) => {
+  queryClient.invalidateQueries({ queryKey: ["blockedUsers"] });
+  queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+  queryClient.invalidateQueries({ queryKey: ["comments"] });
+  queryClient.invalidateQueries({ queryKey: ["getUserSearch"] });
+};
+
+export const useBlockedUsers = (enabled = true) =>
+  useQuery({
+    queryKey: ["blockedUsers"],
+    queryFn: getBlockedUsers,
+    enabled,
+  });
+
+export const useBlockUser = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId: number) => blockUser(userId),
+    onSuccess: () => invalidateBlockRelatedQueries(queryClient),
+  });
+};
+
+export const useUnblockUser = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (userId: number) => unblockUser(userId),
+    onSuccess: () => invalidateBlockRelatedQueries(queryClient),
+  });
+};

--- a/client/src/hooks/queries/useTrendingPosts.ts
+++ b/client/src/hooks/queries/useTrendingPosts.ts
@@ -3,11 +3,16 @@ import { useEffect } from "react";
 import { BASE_URL } from "@/constants/endpoints";
 import { BLOG } from "@/constants/endpoints";
 
+import { useBlockedRss } from "@/hooks/queries/useBlock";
+
+import { useAuthStore } from "@/store/useAuthStore";
 import { TrendingFeedsApiResponse } from "@/types/post";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export const useTrendingPosts = () => {
   const queryClient = useQueryClient();
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { data: blockedRss = [] } = useBlockedRss(isAuthenticated);
 
   const query = useQuery<TrendingFeedsApiResponse>({
     queryKey: ["trending-posts"],
@@ -32,8 +37,10 @@ export const useTrendingPosts = () => {
     };
   }, [queryClient]);
 
+  const blockedRssNames = new Set(blockedRss.map((rss) => rss.name));
+
   return {
     ...query,
-    posts: query.data?.data || [],
+    posts: (query.data?.data || []).filter((post) => !blockedRssNames.has(post.author)),
   };
 };

--- a/client/src/pages/PostDetailPage.stories.tsx
+++ b/client/src/pages/PostDetailPage.stories.tsx
@@ -28,3 +28,10 @@ export const Error: Story = {
     mockApi.onGet("/api/feeds/1").reply(...fail(404, "게시글을 찾을 수 없습니다."));
   },
 };
+
+export const Blocked: Story = {
+  name: "차단된 RSS의 게시글",
+  beforeEach: () => {
+    mockApi.onGet("/api/feeds/1").reply(...ok({ ...mockFeedDetail, isBlocked: true }, "피드 상세 조회 완료"));
+  },
+};

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { useParams } from "react-router-dom";
 
+import { BlockedFeedNotice } from "@/components/common/Card/detail/BlockedFeedNotice";
 import { PostContent } from "@/components/common/Card/detail/PostContent";
 import { PostHeader } from "@/components/common/Card/detail/PostHeader";
 import Header from "@/components/layout/Header";
@@ -32,6 +33,15 @@ export default function PostDetailPage() {
   }
   if (error || !data) {
     return <NotFound />;
+  }
+
+  if (data.data.isBlocked) {
+    return (
+      <div className="bg-white overflow-y-auto relative">
+        <Header />
+        <BlockedFeedNotice />
+      </div>
+    );
   }
 
   return (

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -3,11 +3,15 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import { Footer } from "@/components/about/Footer";
 import Layout from "@/components/layout/Layout";
+import { BlockManagementTab } from "@/components/profile/BlockManagementTab.tsx";
+import { BlockedProfileView } from "@/components/profile/BlockedProfileView.tsx";
 import { MyPage } from "@/components/profile/MyPage.tsx";
 import { ProfileSidebar } from "@/components/profile/ProfileSidebar.tsx";
 import { SubscriptionManagementTab } from "@/components/profile/SubscriptionManagementTab.tsx";
 import { RssManagementTab } from "@/components/profile/rss/RssManagementTab.tsx";
 import { ProfileEditTab } from "@/components/profile/sections/ProfileEditTab.tsx";
+
+import { useUserProfile } from "@/hooks/queries/useProfile.ts";
 
 import { useAuthStore } from "@/store/useAuthStore.ts";
 import { ProfileTab } from "@/types/profile.ts";
@@ -22,6 +26,12 @@ export default function Profile() {
 
   const targetId = id ? Number(id) : userInfo.id;
   const isOwner = isAuthenticated && userInfo.id !== null && userInfo.id === targetId;
+  const isVisitor = !isOwner && !!targetId && !Number.isNaN(targetId);
+
+  const { data: visitorProfile, isLoading: isVisitorProfileLoading } = useUserProfile(
+    isVisitor ? (targetId as number) : 0
+  );
+  const isBlocked = isVisitor && (visitorProfile?.isBlocked ?? false);
 
   useEffect(() => {
     if (!isInitialized) return;
@@ -55,7 +65,9 @@ export default function Profile() {
 
           <div className="flex-1 min-w-0 px-4 py-8 md:px-8">
             {currentTab === "mypage" &&
-              (showSubscriptions ? (
+              (isBlocked ? (
+                <BlockedProfileView userId={targetId as number} />
+              ) : isVisitor && isVisitorProfileLoading ? null : showSubscriptions ? (
                 <SubscriptionManagementTab
                   userId={targetId as number}
                   isOwner={isOwner}
@@ -67,10 +79,12 @@ export default function Profile() {
                   name={isOwner ? (userInfo.userName ?? "") : ""}
                   email={isOwner ? (userInfo.email ?? "") : ""}
                   isOwner={isOwner}
+                  canBlock={isAuthenticated && isVisitor}
                   onShowSubscriptions={() => setShowSubscriptions(true)}
                 />
               ))}
             {isOwner && currentTab === "rss" && <RssManagementTab userId={targetId as number} />}
+            {isOwner && currentTab === "blocks" && <BlockManagementTab />}
             {isOwner && currentTab === "settings" && (
               <ProfileEditTab userId={targetId as number} email={userInfo.email ?? ""} />
             )}

--- a/client/src/pages/RssPage.stories.tsx
+++ b/client/src/pages/RssPage.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import RssPage from "@/pages/RssPage";
-import { BLOG } from "@/constants/endpoints";
+import { BLOCK, BLOG } from "@/constants/endpoints";
 import { mockApi, ok } from "@/__storybook__/mockApi";
 import { useAuthStore } from "@/store/useAuthStore";
 
@@ -52,6 +53,7 @@ const baseRss: RssInfo = {
   isOwner: false,
   lastPublishedAt: "2025-01-15T00:00:00Z",
   owner: null,
+  isBlocked: false,
 };
 
 const resetAuth = () => {
@@ -96,6 +98,52 @@ export const Certified: Story = {
       .reply(...ok({ ...baseRss, owner: { id: 99, userName: "김개발", profileImage: null } }));
     setupFeeds();
     return resetAuth;
+  },
+};
+
+export const Blocked: Story = {
+  name: "차단된 RSS",
+  beforeEach: () => {
+    useAuthStore.setState({
+      isInitialized: true,
+      isAuthenticated: true,
+      role: "user",
+      userInfo: { id: 1, email: "me@test.com", userName: "테스터" },
+    });
+    mockApi.onGet(BLOG.RSS.INFO(RSS_ID)).reply(...ok({ ...baseRss, isBlocked: true }));
+    mockApi.onDelete(BLOCK.RSS_MANAGE(RSS_ID)).reply(...ok(null));
+    setupFeeds();
+    return resetAuth;
+  },
+};
+
+export const BlockFlow: Story = {
+  name: "차단하기 플로우 (로그인 방문자)",
+  beforeEach: () => {
+    useAuthStore.setState({
+      isInitialized: true,
+      isAuthenticated: true,
+      role: "user",
+      userInfo: { id: 1, email: "me@test.com", userName: "테스터" },
+    });
+    mockApi.onGet(BLOG.RSS.INFO(RSS_ID)).replyOnce(...ok(baseRss));
+    mockApi.onGet(BLOG.RSS.INFO(RSS_ID)).reply(...ok({ ...baseRss, isBlocked: true }));
+    mockApi.onPost(BLOCK.RSS_MANAGE(RSS_ID)).reply(...ok(null));
+    mockApi.onDelete(BLOCK.RSS_MANAGE(RSS_ID)).reply(...ok(null));
+    mockApi.onGet(BLOCK.RSS_LIST).reply(...ok([]));
+    setupFeeds();
+    return resetAuth;
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await body.findByRole("button", { name: "더보기" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: /차단하기/ }));
+    await expect(
+      await body.findByText("데나무 블로그 RSS를 차단하시겠습니까?")
+    ).toBeInTheDocument();
+    await userEvent.click(await body.findByRole("button", { name: "차단" }));
+    await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
+    await expect(await body.findByText("차단된 RSS입니다.")).toBeInTheDocument();
   },
 };
 

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 
-import { CalendarClock, CheckCircle2, FileText, Pencil, Users } from "lucide-react";
+import { Ban, CalendarClock, CheckCircle2, FileText, MoreVertical, Pencil, Users } from "lucide-react";
 
 import { Footer } from "@/components/about/Footer";
 import Layout from "@/components/layout/Layout";
@@ -11,14 +11,31 @@ import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 import { RssEditModal } from "@/components/profile/rss/RssEditModal.tsx";
 import { RssFeedCard } from "@/components/profile/rss/RssFeedCard.tsx";
 import { RssFeedRow } from "@/components/profile/rss/RssFeedRow.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
 import { Badge } from "@/components/ui/badge.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent } from "@/components/ui/card.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu.tsx";
 
 import NotFound from "@/pages/NotFound";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
+import { useBlockRss, useUnblockRss } from "@/hooks/queries/useBlock.ts";
 import { useOwnedRssFeeds, useSetFeedVisibility } from "@/hooks/queries/useRssCertification.ts";
 import {
   useRssActivities,
@@ -29,6 +46,7 @@ import {
 
 import { formatDate } from "@/utils/date.ts";
 
+import { useAuthStore } from "@/store/useAuthStore";
 import { RssInfo } from "@/types/profile.ts";
 
 const OwnerFeedManager = ({ rssId }: { rssId: number }) => {
@@ -89,7 +107,39 @@ const OwnerFeedManager = ({ rssId }: { rssId: number }) => {
   );
 };
 
-const RssHeader = ({ rss, onEdit }: { rss: RssInfo; onEdit: () => void }) => (
+const BlockedRssView = ({ rssId }: { rssId: number }) => {
+  const navigate = useNavigate();
+  const { toast } = useCustomToast();
+  const { mutate: unblockRss, isPending } = useUnblockRss();
+
+  const handleUnblock = () => {
+    unblockRss(rssId, {
+      onSuccess: () => {
+        toast({ title: "차단 해제 완료", description: "차단이 해제되었습니다." });
+      },
+      onError: () => {
+        toast({ title: "차단 해제 실패", description: "잠시 후 다시 시도해주세요." });
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center py-32 text-center">
+      <Ban className="w-12 h-12 mb-4 text-gray-400" />
+      <h2 className="text-xl font-semibold text-gray-800">차단된 RSS입니다.</h2>
+      <div className="flex gap-3 mt-8">
+        <Button variant="outline" onClick={() => navigate("/")}>
+          홈으로
+        </Button>
+        <Button onClick={handleUnblock} disabled={isPending}>
+          차단 해제
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+const RssHeader = ({ rss, onEdit, onBlock }: { rss: RssInfo; onEdit: () => void; onBlock?: () => void }) => (
   <Card className="mb-8">
     <CardContent className="p-6">
       <div className="flex items-start justify-between gap-4">
@@ -133,7 +183,7 @@ const RssHeader = ({ rss, onEdit }: { rss: RssInfo; onEdit: () => void }) => (
             </div>
           </div>
         </div>
-        <div className="flex-shrink-0">
+        <div className="flex items-center flex-shrink-0 gap-1">
           {rss.isOwner ? (
             <Button variant="outline" className="gap-1" onClick={onEdit}>
               <Pencil className="w-4 h-4" />
@@ -145,6 +195,24 @@ const RssHeader = ({ rss, onEdit }: { rss: RssInfo; onEdit: () => void }) => (
               isSubscribed={rss.isSubscribed}
               invalidateKeys={[["rssInfo", rss.id]]}
             />
+          )}
+          {onBlock && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  className="flex items-center justify-center flex-shrink-0 w-8 h-8 text-gray-500 transition-colors rounded-lg hover:bg-gray-100"
+                  aria-label="더보기"
+                >
+                  <MoreVertical className="w-5 h-5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={onBlock}>
+                  <Ban className="w-4 h-4 mr-2" />
+                  차단하기
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
       </div>
@@ -182,6 +250,11 @@ export default function RssPage() {
   const currentYear = new Date().getFullYear();
   const [year, setYear] = useState(currentYear);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const [showBlockConfirm, setShowBlockConfirm] = useState(false);
+
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { toast } = useCustomToast();
+  const { mutate: blockRss } = useBlockRss();
 
   const { data: rss, isLoading, isError } = useRssInfo(numericId);
   const {
@@ -211,7 +284,30 @@ export default function RssPage() {
     return <NotFound />;
   }
 
+  if (rss.isBlocked) {
+    return (
+      <>
+        <Layout>
+          <BlockedRssView rssId={rss.id} />
+        </Layout>
+        <Footer />
+      </>
+    );
+  }
+
   const feeds = feedData?.pages.flatMap((page) => page.result) ?? [];
+
+  const handleBlock = () => {
+    blockRss(rss.id, {
+      onSuccess: () => {
+        toast({ title: "차단 완료", description: `${rss.name} RSS를 차단했습니다.` });
+      },
+      onError: () => {
+        toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
+      },
+    });
+    setShowBlockConfirm(false);
+  };
 
   const handleYearChange = (nextYear: number) => {
     setSelectedDate(null); // 다른 연도로 이동하면 선택한 잔디 칸이 사라지므로 필터 해제
@@ -226,7 +322,11 @@ export default function RssPage() {
     <>
       <Layout>
         <div className="max-w-4xl px-4 py-8 mx-auto md:px-8">
-          <RssHeader rss={rss} onEdit={() => setEditOpen(true)} />
+          <RssHeader
+            rss={rss}
+            onEdit={() => setEditOpen(true)}
+            onBlock={isAuthenticated && !rss.isOwner ? () => setShowBlockConfirm(true) : undefined}
+          />
 
           {rss.owner && <OwnerProfileCard owner={rss.owner} />}
 
@@ -299,6 +399,21 @@ export default function RssPage() {
             </CardContent>
           </Card>
         </div>
+
+        <AlertDialog open={showBlockConfirm} onOpenChange={setShowBlockConfirm}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{rss.name} RSS를 차단하시겠습니까?</AlertDialogTitle>
+              <AlertDialogDescription>게시글 및 RSS 프로필 페이지 조회가 제한됩니다.</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>취소</AlertDialogCancel>
+              <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleBlock}>
+                차단
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </Layout>
       <Footer />
     </>

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -25,6 +25,7 @@ export interface FeedDetail extends FeedBase {
   ownerName: string | null;
   isOwnerCertified: boolean;
   isSubscribed: boolean;
+  isBlocked: boolean;
 }
 
 export interface InfiniteScrollResponse<T> {

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -27,7 +27,7 @@ export interface SidebarItem {
   id: string;
 }
 
-export type ProfileTab = "mypage" | "rss" | "settings";
+export type ProfileTab = "mypage" | "rss" | "blocks" | "settings";
 
 export interface UserProfile {
   userName: string;
@@ -36,6 +36,14 @@ export interface UserProfile {
   maxStreak: number;
   currentStreak: number;
   totalViews: number;
+  isBlocked: boolean;
+}
+
+export interface BlockedUser {
+  userId: number;
+  userName: string;
+  profileImage: string | null;
+  blockedAt: string;
 }
 
 export interface ProfileActivity {

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -46,6 +46,13 @@ export interface BlockedUser {
   blockedAt: string;
 }
 
+export interface BlockedRss {
+  rssId: number;
+  name: string;
+  blogPlatform: string;
+  blockedAt: string;
+}
+
 export interface ProfileActivity {
   dailyActivities: DailyActivity[];
 }
@@ -138,6 +145,7 @@ export interface RssInfo {
   isOwner: boolean;
   lastPublishedAt: string | null;
   owner: RssOwner | null;
+  isBlocked: boolean;
 }
 
 export interface OwnedRssFeedItem extends RssFeedItem {

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -180,6 +180,20 @@ CREATE TABLE `likes` (
   CONSTRAINT `FK_85b0dbd1e7836d0f8cdc38fe830` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+-- denamu.blocks definition
+
+CREATE TABLE `blocks` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `blocker_id` int NOT NULL,
+  `blocked_id` int NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `IDX_806f6a5d38d031cdd868fd5e37` (`blocker_id`,`blocked_id`),
+  KEY `FK_8aa6c887bed61ad10829450f2f0` (`blocked_id`),
+  CONSTRAINT `FK_74f530c6fbffc357047b263818d` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_8aa6c887bed61ad10829450f2f0` FOREIGN KEY (`blocked_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
 -- denamu.subscription definition
 
 CREATE TABLE `subscription` (

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -194,6 +194,20 @@ CREATE TABLE `blocks` (
   CONSTRAINT `FK_8aa6c887bed61ad10829450f2f0` FOREIGN KEY (`blocked_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+-- denamu.rss_blocks definition
+
+CREATE TABLE `rss_blocks` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `blocker_id` int NOT NULL,
+  `blocked_rss_id` int NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `IDX_db6b27acdc83264d33a75a0a47` (`blocker_id`,`blocked_rss_id`),
+  KEY `FK_e73dfdcbc10b6c48b749886d9b5` (`blocked_rss_id`),
+  CONSTRAINT `FK_d7a0693b47b13a59bd72133c5ba` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_e73dfdcbc10b6c48b749886d9b5` FOREIGN KEY (`blocked_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
 -- denamu.subscription definition
 
 CREATE TABLE `subscription` (

--- a/server/.prettierrc.js
+++ b/server/.prettierrc.js
@@ -13,6 +13,7 @@ module.exports = {
     '<THIRD_PARTY_MODULES>',
     '^@activity/(.*)?$',
     '^@admin/(.*)?$',
+    '^@block/(.*)?$',
     '^@chat/(.*)?$',
     '^@comment/(.*)?$',
     '^@common/(.*)?$',

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,6 +11,8 @@ import { ActivityModule } from '@activity/module/activity.module';
 
 import { AdminModule } from '@admin/module/admin.module';
 
+import { BlockModule } from '@block/module/block.module';
+
 import { ChatModule } from '@chat/module/chat.module';
 
 import { CommentModule } from '@comment/module/comment.module';
@@ -89,6 +91,7 @@ const exists = !!chosen && fs.existsSync(chosen);
     StatisticModule,
     CommentModule,
     LikeModule,
+    BlockModule,
     SubscribeModule,
     FileModule,
     RabbitMQModule,

--- a/server/src/block/api-docs/createBlock.api-docs.ts
+++ b/server/src/block/api-docs/createBlock.api-docs.ts
@@ -1,0 +1,28 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiConflictDoc,
+  ApiCreatedDoc,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiCreateBlock() {
+  return applyDecorators(
+    ApiOperation({ summary: '사용자 차단 등록 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'userId',
+      type: Number,
+      description: '차단할 사용자 ID',
+      example: 1,
+    }),
+    ApiCreatedDoc('사용자 차단 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했거나 자기 자신을 차단한 경우'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('해당 ID의 사용자가 존재하지 않는 경우'),
+    ApiConflictDoc('이미 차단한 사용자인 경우'),
+  );
+}

--- a/server/src/block/api-docs/createRssBlock.api-docs.ts
+++ b/server/src/block/api-docs/createRssBlock.api-docs.ts
@@ -1,0 +1,28 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiConflictDoc,
+  ApiCreatedDoc,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiCreateRssBlock() {
+  return applyDecorators(
+    ApiOperation({ summary: 'RSS 차단 등록 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'rssId',
+      type: Number,
+      description: '차단할 RSS ID',
+      example: 1,
+    }),
+    ApiCreatedDoc('RSS 차단 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패한 경우'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('해당 ID의 RSS가 존재하지 않는 경우'),
+    ApiConflictDoc('이미 차단한 RSS인 경우'),
+  );
+}

--- a/server/src/block/api-docs/deleteBlock.api-docs.ts
+++ b/server/src/block/api-docs/deleteBlock.api-docs.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiDeleteBlock() {
+  return applyDecorators(
+    ApiOperation({ summary: '사용자 차단 해제 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'userId',
+      type: Number,
+      description: '차단 해제할 사용자 ID',
+      example: 1,
+    }),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('차단하지 않은 사용자인 경우'),
+  );
+}

--- a/server/src/block/api-docs/deleteRssBlock.api-docs.ts
+++ b/server/src/block/api-docs/deleteRssBlock.api-docs.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiDeleteRssBlock() {
+  return applyDecorators(
+    ApiOperation({ summary: 'RSS 차단 해제 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'rssId',
+      type: Number,
+      description: '차단 해제할 RSS ID',
+      example: 1,
+    }),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('차단하지 않은 RSS인 경우'),
+  );
+}

--- a/server/src/block/api-docs/getBlockedRss.api-docs.ts
+++ b/server/src/block/api-docs/getBlockedRss.api-docs.ts
@@ -1,0 +1,18 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiDataResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+import { GetBlockedRssResponseDto } from '@block/dto/response/getBlockedRss.dto';
+
+export function ApiGetBlockedRss() {
+  return applyDecorators(
+    ApiOperation({ summary: '차단한 RSS 목록 조회 API' }),
+    ApiBearerAuth(),
+    ApiDataResponse(GetBlockedRssResponseDto, true, 'RSS 차단 목록 조회 성공'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/block/api-docs/getBlockedUsers.api-docs.ts
+++ b/server/src/block/api-docs/getBlockedUsers.api-docs.ts
@@ -1,0 +1,18 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiDataResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+import { GetBlockedUsersResponseDto } from '@block/dto/response/getBlockedUsers.dto';
+
+export function ApiGetBlockedUsers() {
+  return applyDecorators(
+    ApiOperation({ summary: '차단한 사용자 목록 조회 API' }),
+    ApiBearerAuth(),
+    ApiDataResponse(GetBlockedUsersResponseDto, true, '차단 목록 조회 성공'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/block/controller/block.controller.ts
+++ b/server/src/block/controller/block.controller.ts
@@ -15,9 +15,13 @@ import { JwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
 
 import { ApiCreateBlock } from '@block/api-docs/createBlock.api-docs';
+import { ApiCreateRssBlock } from '@block/api-docs/createRssBlock.api-docs';
 import { ApiDeleteBlock } from '@block/api-docs/deleteBlock.api-docs';
+import { ApiDeleteRssBlock } from '@block/api-docs/deleteRssBlock.api-docs';
+import { ApiGetBlockedRss } from '@block/api-docs/getBlockedRss.api-docs';
 import { ApiGetBlockedUsers } from '@block/api-docs/getBlockedUsers.api-docs';
 import { ManageBlockRequestDto } from '@block/dto/request/manageBlock.dto';
+import { ManageRssBlockRequestDto } from '@block/dto/request/manageRssBlock.dto';
 import { BlockService } from '@block/service/block.service';
 
 @ApiTags('Block')
@@ -34,6 +38,41 @@ export class BlockController {
       '차단 목록 조회를 성공했습니다.',
       await this.blockService.getBlockedUsers(user),
     );
+  }
+
+  @ApiGetBlockedRss()
+  @Get('/rss')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.OK)
+  async getBlockedRssList(@CurrentUser() user: Payload) {
+    return ApiResponse.responseWithData(
+      'RSS 차단 목록 조회를 성공했습니다.',
+      await this.blockService.getBlockedRssList(user),
+    );
+  }
+
+  @ApiCreateRssBlock()
+  @Post('/rss/:rssId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async createRssBlock(
+    @CurrentUser() user: Payload,
+    @Param() rssBlockDto: ManageRssBlockRequestDto,
+  ) {
+    await this.blockService.createRssBlock(user, rssBlockDto);
+    return ApiResponse.responseWithNoContent('RSS 차단을 성공했습니다.');
+  }
+
+  @ApiDeleteRssBlock()
+  @Delete('/rss/:rssId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.OK)
+  async deleteRssBlock(
+    @CurrentUser() user: Payload,
+    @Param() rssBlockDto: ManageRssBlockRequestDto,
+  ) {
+    await this.blockService.deleteRssBlock(user, rssBlockDto);
+    return ApiResponse.responseWithNoContent('RSS 차단 해제를 성공했습니다.');
   }
 
   @ApiCreateBlock()

--- a/server/src/block/controller/block.controller.ts
+++ b/server/src/block/controller/block.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { CurrentUser } from '@common/decorator';
+import { JwtGuard, Payload } from '@common/guard/jwt.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiCreateBlock } from '@block/api-docs/createBlock.api-docs';
+import { ApiDeleteBlock } from '@block/api-docs/deleteBlock.api-docs';
+import { ApiGetBlockedUsers } from '@block/api-docs/getBlockedUsers.api-docs';
+import { ManageBlockRequestDto } from '@block/dto/request/manageBlock.dto';
+import { BlockService } from '@block/service/block.service';
+
+@ApiTags('Block')
+@Controller('blocks')
+export class BlockController {
+  constructor(private readonly blockService: BlockService) {}
+
+  @ApiGetBlockedUsers()
+  @Get()
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.OK)
+  async getBlockedUsers(@CurrentUser() user: Payload) {
+    return ApiResponse.responseWithData(
+      '차단 목록 조회를 성공했습니다.',
+      await this.blockService.getBlockedUsers(user),
+    );
+  }
+
+  @ApiCreateBlock()
+  @Post('/:userId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async createBlock(
+    @CurrentUser() user: Payload,
+    @Param() blockDto: ManageBlockRequestDto,
+  ) {
+    await this.blockService.create(user, blockDto);
+    return ApiResponse.responseWithNoContent('사용자 차단을 성공했습니다.');
+  }
+
+  @ApiDeleteBlock()
+  @Delete('/:userId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.OK)
+  async deleteBlock(
+    @CurrentUser() user: Payload,
+    @Param() blockDto: ManageBlockRequestDto,
+  ) {
+    await this.blockService.delete(user, blockDto);
+    return ApiResponse.responseWithNoContent('사용자 차단 해제를 성공했습니다.');
+  }
+}

--- a/server/src/block/dto/request/manageBlock.dto.ts
+++ b/server/src/block/dto/request/manageBlock.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class ManageBlockRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '차단 또는 차단 해제할 사용자 ID 입력',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: '사용자 ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  userId: number;
+
+  constructor(partial: Partial<ManageBlockRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/block/dto/request/manageRssBlock.dto.ts
+++ b/server/src/block/dto/request/manageRssBlock.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class ManageRssBlockRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '차단 또는 차단 해제할 RSS ID 입력',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: 'RSS ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  rssId: number;
+
+  constructor(partial: Partial<ManageRssBlockRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/block/dto/response/getBlockedRss.dto.ts
+++ b/server/src/block/dto/response/getBlockedRss.dto.ts
@@ -1,0 +1,45 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { RssBlock } from '@block/entity/rssBlock.entity';
+
+export class GetBlockedRssResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: '차단된 RSS(rss_accept) ID',
+  })
+  rssId: number;
+
+  @ApiProperty({
+    example: 'seok3765.log',
+    description: '차단된 RSS 블로그 이름',
+  })
+  name: string;
+
+  @ApiProperty({
+    example: 'velog',
+    description: '차단된 RSS 블로그 플랫폼 종류',
+  })
+  blogPlatform: string;
+
+  @ApiProperty({
+    example: '2025-08-16T12:00:00.000Z',
+    description: '차단 일시',
+  })
+  blockedAt: Date;
+
+  constructor(partial: Partial<GetBlockedRssResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDtoArray(rssBlocks: RssBlock[]) {
+    return rssBlocks.map(
+      (rssBlock) =>
+        new GetBlockedRssResponseDto({
+          rssId: rssBlock.blockedRss.id,
+          name: rssBlock.blockedRss.name,
+          blogPlatform: rssBlock.blockedRss.blogPlatform,
+          blockedAt: rssBlock.createdAt,
+        }),
+    );
+  }
+}

--- a/server/src/block/dto/response/getBlockedUsers.dto.ts
+++ b/server/src/block/dto/response/getBlockedUsers.dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Block } from '@block/entity/block.entity';
+
+export class GetBlockedUsersResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: '차단된 사용자 ID',
+  })
+  userId: number;
+
+  @ApiProperty({
+    example: '김개발',
+    description: '차단된 사용자 이름',
+  })
+  userName: string;
+
+  @ApiProperty({
+    example: 'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+    description: '차단된 사용자 프로필 이미지 URL (미설정 시 null)',
+    nullable: true,
+  })
+  profileImage: string | null;
+
+  @ApiProperty({
+    example: '2025-08-16T12:00:00.000Z',
+    description: '차단 일시',
+  })
+  blockedAt: Date;
+
+  constructor(partial: Partial<GetBlockedUsersResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDtoArray(blocks: Block[]) {
+    return blocks.map(
+      (block) =>
+        new GetBlockedUsersResponseDto({
+          userId: block.blocked.id,
+          userName: block.blocked.userName,
+          profileImage: block.blocked.profileImage ?? null,
+          blockedAt: block.createdAt,
+        }),
+    );
+  }
+}

--- a/server/src/block/entity/block.entity.ts
+++ b/server/src/block/entity/block.entity.ts
@@ -1,0 +1,45 @@
+import {
+  BaseEntity,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+import { User } from '@user/entity/user.entity';
+
+@Entity({ name: 'blocks' })
+@Unique(['blocker', 'blocked'])
+export class Block extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user) => user.id, {
+    nullable: false,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'blocker_id',
+  })
+  blocker: User;
+
+  @ManyToOne(() => User, (user) => user.id, {
+    nullable: false,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'blocked_id',
+  })
+  blocked: User;
+
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'datetime',
+    nullable: false,
+  })
+  createdAt: Date;
+}

--- a/server/src/block/entity/rssBlock.entity.ts
+++ b/server/src/block/entity/rssBlock.entity.ts
@@ -1,0 +1,47 @@
+import {
+  BaseEntity,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+
+import { User } from '@user/entity/user.entity';
+
+@Entity({ name: 'rss_blocks' })
+@Unique(['blocker', 'blockedRss'])
+export class RssBlock extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, (user) => user.id, {
+    nullable: false,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'blocker_id',
+  })
+  blocker: User;
+
+  @ManyToOne(() => RssAccept, (rssAccept) => rssAccept.id, {
+    nullable: false,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({
+    name: 'blocked_rss_id',
+  })
+  blockedRss: RssAccept;
+
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'datetime',
+    nullable: false,
+  })
+  createdAt: Date;
+}

--- a/server/src/block/module/block.module.ts
+++ b/server/src/block/module/block.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+
+import { JwtAuthModule } from '@common/auth/jwt.module';
+
+import { BlockController } from '@block/controller/block.controller';
+import { BlockRepository } from '@block/repository/block.repository';
+import { BlockService } from '@block/service/block.service';
+
+import { UserModule } from '@user/module/user.module';
+
+@Module({
+  imports: [JwtAuthModule, UserModule],
+  controllers: [BlockController],
+  providers: [BlockService, BlockRepository],
+  exports: [],
+})
+export class BlockModule {}

--- a/server/src/block/module/block.module.ts
+++ b/server/src/block/module/block.module.ts
@@ -4,14 +4,22 @@ import { JwtAuthModule } from '@common/auth/jwt.module';
 
 import { BlockController } from '@block/controller/block.controller';
 import { BlockRepository } from '@block/repository/block.repository';
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 import { BlockService } from '@block/service/block.service';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { UserModule } from '@user/module/user.module';
 
 @Module({
   imports: [JwtAuthModule, UserModule],
   controllers: [BlockController],
-  providers: [BlockService, BlockRepository],
+  providers: [
+    BlockService,
+    BlockRepository,
+    RssBlockRepository,
+    RssAcceptRepository,
+  ],
   exports: [],
 })
 export class BlockModule {}

--- a/server/src/block/repository/block.repository.ts
+++ b/server/src/block/repository/block.repository.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+
+import { DataSource, Repository } from 'typeorm';
+
+import { Block } from '@block/entity/block.entity';
+
+@Injectable()
+export class BlockRepository extends Repository<Block> {
+  constructor(private dataSource: DataSource) {
+    super(Block, dataSource.createEntityManager());
+  }
+
+  async getBlockedUsers(blockerId: number) {
+    return await this.createQueryBuilder('block')
+      .innerJoin('block.blocked', 'blocked')
+      .select(['block.id', 'block.createdAt'])
+      .addSelect(['blocked.id', 'blocked.userName', 'blocked.profileImage'])
+      .where('block.blocker_id = :blockerId', { blockerId })
+      .orderBy('block.id', 'DESC')
+      .getMany();
+  }
+}

--- a/server/src/block/repository/rssBlock.repository.ts
+++ b/server/src/block/repository/rssBlock.repository.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+
+import { DataSource, Repository } from 'typeorm';
+
+import { RssBlock } from '@block/entity/rssBlock.entity';
+
+@Injectable()
+export class RssBlockRepository extends Repository<RssBlock> {
+  constructor(private dataSource: DataSource) {
+    super(RssBlock, dataSource.createEntityManager());
+  }
+
+  async getBlockedRssList(blockerId: number) {
+    return await this.createQueryBuilder('rssBlock')
+      .innerJoin('rssBlock.blockedRss', 'blockedRss')
+      .select(['rssBlock.id', 'rssBlock.createdAt'])
+      .addSelect(['blockedRss.id', 'blockedRss.name', 'blockedRss.blogPlatform'])
+      .where('rssBlock.blocker_id = :blockerId', { blockerId })
+      .orderBy('rssBlock.id', 'DESC')
+      .getMany();
+  }
+
+  async getBlockedRssIds(blockerId: number) {
+    const rssBlocks = await this.createQueryBuilder('rssBlock')
+      .select('rssBlock.blocked_rss_id', 'blockedRssId')
+      .where('rssBlock.blocker_id = :blockerId', { blockerId })
+      .getRawMany<{ blockedRssId: number }>();
+    return rssBlocks.map((rssBlock) => rssBlock.blockedRssId);
+  }
+
+  async existsByBlockerAndRss(blockerId: number, rssId: number) {
+    const count = await this.createQueryBuilder('rssBlock')
+      .where('rssBlock.blocker_id = :blockerId', { blockerId })
+      .andWhere('rssBlock.blocked_rss_id = :rssId', { rssId })
+      .getCount();
+    return count > 0;
+  }
+}

--- a/server/src/block/service/block.service.ts
+++ b/server/src/block/service/block.service.ts
@@ -1,0 +1,59 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { Payload } from '@common/guard/jwt.guard';
+
+import { ManageBlockRequestDto } from '@block/dto/request/manageBlock.dto';
+import { GetBlockedUsersResponseDto } from '@block/dto/response/getBlockedUsers.dto';
+import { BlockRepository } from '@block/repository/block.repository';
+
+import { UserService } from '@user/service/user.service';
+
+@Injectable()
+export class BlockService {
+  constructor(
+    private readonly blockRepository: BlockRepository,
+    private readonly userService: UserService,
+  ) {}
+
+  async create(userInformation: Payload, blockDto: ManageBlockRequestDto) {
+    if (userInformation.id === blockDto.userId) {
+      throw new BadRequestException('자기 자신을 차단할 수 없습니다.');
+    }
+    await this.userService.getUser(blockDto.userId);
+
+    try {
+      await this.blockRepository.insert({
+        blocker: { id: userInformation.id },
+        blocked: { id: blockDto.userId },
+      });
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ER_DUP_ENTRY') {
+        throw new ConflictException('이미 차단한 사용자입니다.');
+      }
+      throw error;
+    }
+  }
+
+  async delete(userInformation: Payload, blockDto: ManageBlockRequestDto) {
+    const result = await this.blockRepository.delete({
+      blocker: { id: userInformation.id },
+      blocked: { id: blockDto.userId },
+    });
+
+    if (!result.affected) {
+      throw new NotFoundException('차단하지 않은 사용자입니다.');
+    }
+  }
+
+  async getBlockedUsers(userInformation: Payload) {
+    const blocks = await this.blockRepository.getBlockedUsers(
+      userInformation.id,
+    );
+    return GetBlockedUsersResponseDto.toResponseDtoArray(blocks);
+  }
+}

--- a/server/src/block/service/block.service.ts
+++ b/server/src/block/service/block.service.ts
@@ -8,8 +8,13 @@ import {
 import { Payload } from '@common/guard/jwt.guard';
 
 import { ManageBlockRequestDto } from '@block/dto/request/manageBlock.dto';
+import { ManageRssBlockRequestDto } from '@block/dto/request/manageRssBlock.dto';
+import { GetBlockedRssResponseDto } from '@block/dto/response/getBlockedRss.dto';
 import { GetBlockedUsersResponseDto } from '@block/dto/response/getBlockedUsers.dto';
 import { BlockRepository } from '@block/repository/block.repository';
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { UserService } from '@user/service/user.service';
 
@@ -17,6 +22,8 @@ import { UserService } from '@user/service/user.service';
 export class BlockService {
   constructor(
     private readonly blockRepository: BlockRepository,
+    private readonly rssBlockRepository: RssBlockRepository,
+    private readonly rssAcceptRepository: RssAcceptRepository,
     private readonly userService: UserService,
   ) {}
 
@@ -55,5 +62,51 @@ export class BlockService {
       userInformation.id,
     );
     return GetBlockedUsersResponseDto.toResponseDtoArray(blocks);
+  }
+
+  async createRssBlock(
+    userInformation: Payload,
+    rssBlockDto: ManageRssBlockRequestDto,
+  ) {
+    const rssAccept = await this.rssAcceptRepository.findOne({
+      where: { id: rssBlockDto.rssId },
+      select: { id: true },
+    });
+    if (!rssAccept) {
+      throw new NotFoundException('존재하지 않는 RSS입니다.');
+    }
+
+    try {
+      await this.rssBlockRepository.insert({
+        blocker: { id: userInformation.id },
+        blockedRss: { id: rssBlockDto.rssId },
+      });
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ER_DUP_ENTRY') {
+        throw new ConflictException('이미 차단한 RSS입니다.');
+      }
+      throw error;
+    }
+  }
+
+  async deleteRssBlock(
+    userInformation: Payload,
+    rssBlockDto: ManageRssBlockRequestDto,
+  ) {
+    const result = await this.rssBlockRepository.delete({
+      blocker: { id: userInformation.id },
+      blockedRss: { id: rssBlockDto.rssId },
+    });
+
+    if (!result.affected) {
+      throw new NotFoundException('차단하지 않은 RSS입니다.');
+    }
+  }
+
+  async getBlockedRssList(userInformation: Payload) {
+    const rssBlocks = await this.rssBlockRepository.getBlockedRssList(
+      userInformation.id,
+    );
+    return GetBlockedRssResponseDto.toResponseDtoArray(rssBlocks);
   }
 }

--- a/server/src/comment/controller/comment.controller.ts
+++ b/server/src/comment/controller/comment.controller.ts
@@ -23,7 +23,7 @@ import { UpdateCommentRequestDto } from '@comment/dto/request/updateComment.dto'
 import { CommentService } from '@comment/service/comment.service';
 
 import { CurrentUser } from '@common/decorator';
-import { JwtGuard, Payload } from '@common/guard/jwt.guard';
+import { JwtGuard, OptionalJwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
 
 @ApiTags('Comment')
@@ -34,10 +34,14 @@ export class CommentController {
   @ApiGetComment()
   @Get()
   @HttpCode(HttpStatus.OK)
-  async getComment(@Param() feedDto: GetCommentRequestDto) {
+  @UseGuards(OptionalJwtGuard)
+  async getComment(
+    @CurrentUser() user: Payload | null,
+    @Param() feedDto: GetCommentRequestDto,
+  ) {
     return ApiResponse.responseWithData(
       '댓글 조회를 성공했습니다.',
-      await this.commentService.get(feedDto),
+      await this.commentService.get(feedDto, user),
     );
   }
 

--- a/server/src/comment/repository/comment.repository.ts
+++ b/server/src/comment/repository/comment.repository.ts
@@ -10,13 +10,26 @@ export class CommentRepository extends Repository<Comment> {
     super(Comment, dataSource.createEntityManager());
   }
 
-  async getCommentInformation(feedId: number) {
-    return await this.createQueryBuilder('comment')
+  async getCommentInformation(feedId: number, blockerId?: number) {
+    const query = this.createQueryBuilder('comment')
       .innerJoin('comment.user', 'user')
       .select(['comment', 'comment.date', 'user'])
       .where('comment.feed_id = :feedId', { feedId })
-      .orderBy('comment.date', 'ASC')
-      .getMany();
+      .orderBy('comment.date', 'ASC');
+
+    if (blockerId) {
+      query
+        .leftJoin('comment.parent', 'parent')
+        .andWhere(
+          'comment.user_id NOT IN (SELECT block.blocked_id FROM blocks block WHERE block.blocker_id = :blockerId)',
+          { blockerId },
+        )
+        .andWhere(
+          '(comment.parent_id IS NULL OR parent.user_id NOT IN (SELECT block.blocked_id FROM blocks block WHERE block.blocker_id = :blockerId))',
+        );
+    }
+
+    return await query.getMany();
   }
 
   async getCommentsByUser(userId: number, lastId: number, limit: number) {

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -78,11 +78,12 @@ export class CommentService {
     return commentObj;
   }
 
-  async get(commentDto: GetCommentRequestDto) {
+  async get(commentDto: GetCommentRequestDto, requester: Payload | null = null) {
     await this.feedService.getPublicFeed(commentDto.feedId);
 
     const comments = await this.commentRepository.getCommentInformation(
       commentDto.feedId,
+      requester?.id,
     );
     return GetCommentResponseDto.toResponseDtoArray(comments);
   }

--- a/server/src/common/database/migration/1781500000000-AddUserBlock.ts
+++ b/server/src/common/database/migration/1781500000000-AddUserBlock.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddUserBlock1781500000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE `blocks` (' +
+        '`id` int NOT NULL AUTO_INCREMENT, ' +
+        '`created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), ' +
+        '`blocker_id` int NOT NULL, ' +
+        '`blocked_id` int NOT NULL, ' +
+        'PRIMARY KEY (`id`), ' +
+        'UNIQUE KEY `IDX_806f6a5d38d031cdd868fd5e37` (`blocker_id`,`blocked_id`), ' +
+        'KEY `FK_8aa6c887bed61ad10829450f2f0` (`blocked_id`), ' +
+        'CONSTRAINT `FK_74f530c6fbffc357047b263818d` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, ' +
+        'CONSTRAINT `FK_8aa6c887bed61ad10829450f2f0` FOREIGN KEY (`blocked_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE' +
+        ');',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `blocks`;');
+  }
+}

--- a/server/src/common/database/migration/1781600000000-AddRssBlock.ts
+++ b/server/src/common/database/migration/1781600000000-AddRssBlock.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddRssBlock1781600000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE `rss_blocks` (' +
+        '`id` int NOT NULL AUTO_INCREMENT, ' +
+        '`created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), ' +
+        '`blocker_id` int NOT NULL, ' +
+        '`blocked_rss_id` int NOT NULL, ' +
+        'PRIMARY KEY (`id`), ' +
+        'UNIQUE KEY `IDX_db6b27acdc83264d33a75a0a47` (`blocker_id`,`blocked_rss_id`), ' +
+        'KEY `FK_e73dfdcbc10b6c48b749886d9b5` (`blocked_rss_id`), ' +
+        'CONSTRAINT `FK_d7a0693b47b13a59bd72133c5ba` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, ' +
+        'CONSTRAINT `FK_e73dfdcbc10b6c48b749886d9b5` FOREIGN KEY (`blocked_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE' +
+        ');',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `rss_blocks`;');
+  }
+}

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -51,12 +51,17 @@ export class FeedController {
   @ApiReadFeedPagination()
   @Get()
   @HttpCode(HttpStatus.OK)
+  @UseGuards(OptionalJwtGuard)
   async readFeedPagination(
     @Query() feedPaginationQueryDto: ReadFeedPaginationRequestDto,
+    @CurrentUser() user: Payload | null,
   ) {
     return ApiResponse.responseWithData(
       '피드 조회 완료',
-      await this.feedService.readFeedPagination(feedPaginationQueryDto),
+      await this.feedService.readFeedPagination(
+        feedPaginationQueryDto,
+        user?.id,
+      ),
     );
   }
 
@@ -94,10 +99,14 @@ export class FeedController {
   @ApiSearchFeedList()
   @Get('search')
   @HttpCode(HttpStatus.OK)
-  async searchFeedList(@Query() searchFeedQueryDto: SearchFeedRequestDto) {
+  @UseGuards(OptionalJwtGuard)
+  async searchFeedList(
+    @Query() searchFeedQueryDto: SearchFeedRequestDto,
+    @CurrentUser() user: Payload | null,
+  ) {
     return ApiResponse.responseWithData(
       '검색 결과 조회 완료',
-      await this.feedService.searchFeedList(searchFeedQueryDto),
+      await this.feedService.searchFeedList(searchFeedQueryDto, user?.id),
     );
   }
 

--- a/server/src/feed/dto/response/getFeedDetail.ts
+++ b/server/src/feed/dto/response/getFeedDetail.ts
@@ -107,6 +107,12 @@ export class GetFeedDetailResponseDto {
   })
   isSubscribed: boolean;
 
+  @ApiProperty({
+    example: false,
+    description: '요청자가 해당 게시글의 RSS를 차단했는지 여부 (비로그인 시 false)',
+  })
+  isBlocked: boolean;
+
   constructor(partial: Partial<GetFeedDetailResponseDto>) {
     Object.assign(this, partial);
   }
@@ -116,6 +122,7 @@ export class GetFeedDetailResponseDto {
     isOwner = false,
     blogMeta: { id: number; userName: string; userId: number | null } | null = null,
     isSubscribed = false,
+    isBlocked = false,
   ) {
     return new GetFeedDetailResponseDto({
       id: feed.feedId,
@@ -135,6 +142,7 @@ export class GetFeedDetailResponseDto {
       ownerName: blogMeta?.userName ?? null,
       isOwnerCertified: blogMeta?.userId != null,
       isSubscribed,
+      isBlocked,
     });
   }
 }

--- a/server/src/feed/module/feed.module.ts
+++ b/server/src/feed/module/feed.module.ts
@@ -4,6 +4,8 @@ import { ActivityModule } from '@activity/module/activity.module';
 
 import { JwtAuthModule } from '@common/auth/jwt.module';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { FeedController } from '@feed/controller/feed.controller';
 import { FeedViewedListener } from '@feed/listener/feed-viewed.listener';
 import {
@@ -27,6 +29,7 @@ import { UserModule } from '@user/module/user.module';
     FeedScheduler,
     FeedViewedListener,
     SubscriptionRepository,
+    RssBlockRepository,
   ],
   exports: [FeedRepository, FeedService],
 })

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -17,6 +17,7 @@ export class FeedRepository extends Repository<Feed> {
     limit: number,
     type: SearchType,
     offset: number,
+    blockerId?: number,
   ) {
     const queryBuilder = this.createQueryBuilder('feed')
       .innerJoinAndSelect('feed.blog', 'rss_accept')
@@ -27,6 +28,13 @@ export class FeedRepository extends Repository<Feed> {
       .addOrderBy('feed.createdAt', 'DESC')
       .skip(offset)
       .take(limit);
+
+    if (blockerId) {
+      queryBuilder.andWhere(
+        'feed.blog_id NOT IN (SELECT rss_block.blocked_rss_id FROM rss_blocks rss_block WHERE rss_block.blocker_id = :blockerId)',
+        { blockerId },
+      );
+    }
 
     return queryBuilder.getManyAndCount();
   }
@@ -246,6 +254,7 @@ export class FeedViewRepository extends Repository<FeedView> {
 
   async findFeedPagination(
     feedPaginationQueryDto: ReadFeedPaginationRequestDto,
+    blockerId?: number,
   ) {
     const { lastId, limit, tags } = feedPaginationQueryDto;
 
@@ -278,6 +287,13 @@ export class FeedViewRepository extends Repository<FeedView> {
           }),
         );
       }
+    }
+
+    if (blockerId) {
+      query.andWhere(
+        'id NOT IN (SELECT f.id FROM feed f INNER JOIN rss_blocks rss_block ON rss_block.blocked_rss_id = f.blog_id WHERE rss_block.blocker_id = :blockerId)',
+        { blockerId },
+      );
     }
 
     query.orderBy('order_id', 'DESC').take(limit + 1);

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -12,6 +12,8 @@ import { cookieConfig } from '@common/cookie/cookie.config';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 import { AI_RETRY_LOCK_TTL_SECONDS } from '@feed/constant/feed.constant';
@@ -53,6 +55,7 @@ export class FeedService {
     private readonly feedViewRepository: FeedViewRepository,
     private readonly redisService: RedisService,
     private readonly subscriptionRepository: SubscriptionRepository,
+    private readonly rssBlockRepository: RssBlockRepository,
   ) {}
 
   async getFeed(feedId: number) {
@@ -116,9 +119,11 @@ export class FeedService {
 
   async readFeedPagination(
     feedPaginationQueryDto: ReadFeedPaginationRequestDto,
+    blockerId?: number,
   ) {
     const feedList = await this.feedViewRepository.findFeedPagination(
       feedPaginationQueryDto,
+      blockerId,
     );
 
     const hasMore = this.existNextFeed(feedList, feedPaginationQueryDto.limit);
@@ -173,7 +178,10 @@ export class FeedService {
     );
   }
 
-  async searchFeedList(searchFeedQueryDto: SearchFeedRequestDto) {
+  async searchFeedList(
+    searchFeedQueryDto: SearchFeedRequestDto,
+    blockerId?: number,
+  ) {
     const { find, page, limit, type } = searchFeedQueryDto;
     const offset = (page - 1) * limit;
 
@@ -182,6 +190,7 @@ export class FeedService {
       limit,
       type,
       offset,
+      blockerId,
     );
 
     const feeds = SearchFeedResult.toResultDtoArray(searchResult);
@@ -328,11 +337,20 @@ export class FeedService {
       isSubscribed = !!subscription;
     }
 
+    let isBlocked = false;
+    if (userId && blogMeta) {
+      isBlocked = await this.rssBlockRepository.existsByBlockerAndRss(
+        userId,
+        blogMeta.id,
+      );
+    }
+
     return GetFeedDetailResponseDto.toResponseDto(
       feed,
       isOwner,
       blogMeta,
       isSubscribed,
+      isBlocked,
     );
   }
 
@@ -341,10 +359,15 @@ export class FeedService {
     feedPaginationQueryDto: ReadFeedPaginationRequestDto,
   ) {
     const limit = feedPaginationQueryDto.limit ?? 12;
-    const blogIds =
-      await this.subscriptionRepository.getSubscribedBlogIds(userId);
+    const [blogIds, blockedRssIds] = await Promise.all([
+      this.subscriptionRepository.getSubscribedBlogIds(userId),
+      this.rssBlockRepository.getBlockedRssIds(userId),
+    ]);
+    const visibleBlogIds = blogIds.filter(
+      (blogId) => !blockedRssIds.includes(blogId),
+    );
     const feeds = await this.feedRepository.getSubscriptionFeeds(
-      blogIds,
+      visibleBlogIds,
       feedPaginationQueryDto.lastId ?? 0,
       limit,
     );

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -258,12 +258,13 @@ export class RssController {
   }
 
   @ApiGetRecentRss()
+  @UseGuards(OptionalJwtGuard)
   @Get('recent')
   @HttpCode(HttpStatus.OK)
-  async getRecentRss() {
+  async getRecentRss(@CurrentUser() viewer: Payload | null) {
     return ApiResponse.responseWithData(
       '최근 발행 RSS 목록 조회를 처리했습니다.',
-      await this.rssService.getRecentRss(),
+      await this.rssService.getRecentRss(viewer?.id),
     );
   }
 

--- a/server/src/rss/dto/response/getRssInfo.dto.ts
+++ b/server/src/rss/dto/response/getRssInfo.dto.ts
@@ -92,6 +92,12 @@ export class GetRssInfoResponseDto {
   })
   owner: RssOwnerDto | null;
 
+  @ApiProperty({
+    example: false,
+    description: '요청자가 해당 RSS를 차단했는지 여부 (비로그인 시 false)',
+  })
+  isBlocked: boolean;
+
   constructor(partial: Partial<GetRssInfoResponseDto>) {
     Object.assign(this, partial);
   }
@@ -103,6 +109,7 @@ export class GetRssInfoResponseDto {
     isSubscribed: boolean,
     isOwner: boolean,
     lastPublishedAt: Date | null,
+    isBlocked = false,
   ) {
     const owner = rssAccept.user
       ? {
@@ -124,6 +131,7 @@ export class GetRssInfoResponseDto {
       isOwner,
       lastPublishedAt,
       owner,
+      isBlocked,
     });
   }
 }

--- a/server/src/rss/module/rss.module.ts
+++ b/server/src/rss/module/rss.module.ts
@@ -5,6 +5,8 @@ import { NotifierModule } from '@common/notification/notifier.module';
 
 import { AdminModule } from '@admin/module/admin.module';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
@@ -27,6 +29,7 @@ import { RssService } from '@rss/service/rss.service';
     RssRejectRepository,
     FeedRepository,
     SubscriptionRepository,
+    RssBlockRepository,
   ],
   exports: [RssAcceptRepository],
 })

--- a/server/src/rss/repository/rss.repository.ts
+++ b/server/src/rss/repository/rss.repository.ts
@@ -33,13 +33,22 @@ export class RssAcceptRepository extends Repository<RssAccept> {
       .getRawMany();
   }
 
-  findRecentlyPublished(limit: number) {
-    return this.createQueryBuilder('rss')
+  findRecentlyPublished(limit: number, blockerId?: number) {
+    const query = this.createQueryBuilder('rss')
       .innerJoin(
         'feed',
         'feed',
         'feed.blog_id = rss.id AND feed.is_public = 1',
-      )
+      );
+
+    if (blockerId) {
+      query.where(
+        'rss.id NOT IN (SELECT rss_block.blocked_rss_id FROM rss_blocks rss_block WHERE rss_block.blocker_id = :blockerId)',
+        { blockerId },
+      );
+    }
+
+    return query
       .select('rss.id', 'id')
       .addSelect('rss.name', 'name')
       .addSelect('rss.blog_platform', 'blogPlatform')

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -10,7 +10,14 @@ import * as uuid from 'uuid';
 import axios from 'axios';
 import { DataSource, IsNull } from 'typeorm';
 
+import {
+  DailyActivityDto,
+  ReadActivityResponseDto,
+} from '@activity/dto/response/readActivity.dto';
+
 import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 
 import { EmailProducer } from '@common/email/email.producer';
 import { Payload } from '@common/guard/jwt.guard';
@@ -19,17 +26,19 @@ import { NotifierRegistry } from '@common/notification/notifier-registry';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
+import { FeedRepository } from '@feed/repository/feed.repository';
+
 import { DeleteCertificateRssRequestDto } from '@rss/dto/request/deleteCertificateRss.dto';
 import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
+import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dto';
+import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
-import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dto';
-import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
 import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
 import { GetOwnedRssFeedsResponseDto } from '@rss/dto/response/getOwnedRssFeeds.dto';
-import { GetRssFeedsResponseDto } from '@rss/dto/response/getRssFeeds.dto';
 import { GetRecentRssResponseDto } from '@rss/dto/response/getRecentRss.dto';
+import { GetRssFeedsResponseDto } from '@rss/dto/response/getRssFeeds.dto';
 import { GetRssInfoResponseDto } from '@rss/dto/response/getRssInfo.dto';
 import { PreviewRssCertificationResponseDto } from '@rss/dto/response/previewRssCertification.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
@@ -41,13 +50,6 @@ import {
   RssRejectRepository,
   RssRepository,
 } from '@rss/repository/rss.repository';
-
-import {
-  DailyActivityDto,
-  ReadActivityResponseDto,
-} from '@activity/dto/response/readActivity.dto';
-
-import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
@@ -73,6 +75,7 @@ export class RssService {
     private readonly adminRepository: AdminRepository,
     private readonly notifierRegistry: NotifierRegistry,
     private readonly logger: WinstonLoggerService,
+    private readonly rssBlockRepository: RssBlockRepository,
   ) {}
 
   async createRss(rssRegisterBodyDto: RegisterRssRequestDto) {
@@ -306,11 +309,14 @@ export class RssService {
     }
   }
 
-  async getRecentRss() {
+  async getRecentRss(viewerId?: number) {
     const recentRssList = await this.rssAcceptRepository.findRecentlyPublished(
       RssService.RECENT_RSS_LIMIT,
+      viewerId,
     );
-    return recentRssList.map((row) => GetRecentRssResponseDto.toResponseDto(row));
+    return recentRssList.map((row) =>
+      GetRecentRssResponseDto.toResponseDto(row),
+    );
   }
 
   async getRssInfo(rssId: number, viewerId?: number) {
@@ -331,10 +337,15 @@ export class RssService {
       ]);
 
     let isSubscribed = false;
+    let isBlocked = false;
     if (viewerId) {
       const viewerBlogIds =
         await this.subscriptionRepository.getSubscribedBlogIds(viewerId);
       isSubscribed = viewerBlogIds.includes(rssId);
+      isBlocked = await this.rssBlockRepository.existsByBlockerAndRss(
+        viewerId,
+        rssId,
+      );
     }
 
     const isOwner = viewerId != null && rssAccept.userId === viewerId;
@@ -346,6 +357,7 @@ export class RssService {
       isSubscribed,
       isOwner,
       lastPublishedAt,
+      isBlocked,
     );
   }
 
@@ -551,7 +563,10 @@ export class RssService {
       throw new ForbiddenException('본인이 인증한 RSS가 아닙니다.');
     }
 
-    await this.rssAcceptRepository.update({ id: rssAcceptId }, { userId: null });
+    await this.rssAcceptRepository.update(
+      { id: rssAcceptId },
+      { userId: null },
+    );
   }
 
   private async assertRssOwnership(rssAcceptId: number, userId: number) {

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -95,20 +95,28 @@ export class UserController {
   @ApiSearchUser()
   @Get('/search')
   @HttpCode(HttpStatus.OK)
-  async searchUser(@Query() searchUserQueryDto: SearchUserRequestDto) {
+  @UseGuards(OptionalJwtGuard)
+  async searchUser(
+    @CurrentUser() user: Payload | null,
+    @Query() searchUserQueryDto: SearchUserRequestDto,
+  ) {
     return ApiResponse.responseWithData(
       '유저 검색 결과 조회 완료',
-      await this.userService.searchUserList(searchUserQueryDto),
+      await this.userService.searchUserList(searchUserQueryDto, user),
     );
   }
 
   @ApiGetUserProfile()
   @Get('/:id/profile')
   @HttpCode(HttpStatus.OK)
-  async getUserProfile(@Param() paramDto: GetUserProfileParamRequestDto) {
+  @UseGuards(OptionalJwtGuard)
+  async getUserProfile(
+    @CurrentUser() user: Payload | null,
+    @Param() paramDto: GetUserProfileParamRequestDto,
+  ) {
     return ApiResponse.responseWithData(
       '프로필 조회가 성공적으로 처리되었습니다.',
-      await this.userService.getUserProfile(paramDto.id),
+      await this.userService.getUserProfile(paramDto.id, user),
     );
   }
 

--- a/server/src/user/dto/response/getUserProfile.dto.ts
+++ b/server/src/user/dto/response/getUserProfile.dto.ts
@@ -41,11 +41,17 @@ export class GetUserProfileResponseDto {
   })
   totalViews: number;
 
+  @ApiProperty({
+    example: false,
+    description: '요청자가 해당 사용자를 차단했는지 여부 (비로그인 시 false)',
+  })
+  isBlocked: boolean;
+
   constructor(partial: Partial<GetUserProfileResponseDto>) {
     Object.assign(this, partial);
   }
 
-  static toResponseDto(user: User) {
+  static toResponseDto(user: User, isBlocked = false) {
     return new GetUserProfileResponseDto({
       userName: user.userName,
       profileImage: user.profileImage ?? null,
@@ -53,6 +59,7 @@ export class GetUserProfileResponseDto {
       maxStreak: user.maxStreak,
       currentStreak: user.currentStreak,
       totalViews: user.totalViews,
+      isBlocked,
     });
   }
 }

--- a/server/src/user/repository/user.repository.ts
+++ b/server/src/user/repository/user.repository.ts
@@ -2,6 +2,8 @@ import { Injectable } from '@nestjs/common';
 
 import { DataSource, Repository } from 'typeorm';
 
+import { Block } from '@block/entity/block.entity';
+
 import { User } from '@user/entity/user.entity';
 
 @Injectable()
@@ -10,17 +12,39 @@ export class UserRepository extends Repository<User> {
     super(User, dataSource.createEntityManager());
   }
 
-  async searchUserList(find: string, limit: number, offset: number) {
+  async searchUserList(
+    find: string,
+    limit: number,
+    offset: number,
+    blockerId?: number,
+  ) {
     const escaped = find.replace(/[\\%_]/g, (char) => `\\${char}`);
 
-    return this.createQueryBuilder('user')
+    const query = this.createQueryBuilder('user')
       .where('user.userName LIKE :pattern', { pattern: `%${escaped}%` })
       .orderBy('user.userName = :find', 'DESC')
       .addOrderBy('user.userName LIKE :prefix', 'DESC')
       .addOrderBy('user.userName', 'ASC')
       .setParameters({ find, prefix: `${escaped}%` })
       .skip(offset)
-      .take(limit)
-      .getManyAndCount();
+      .take(limit);
+
+    if (blockerId) {
+      query.andWhere(
+        'user.id NOT IN (SELECT block.blocked_id FROM blocks block WHERE block.blocker_id = :blockerId)',
+        { blockerId },
+      );
+    }
+
+    return query.getManyAndCount();
+  }
+
+  async isUserBlocked(blockerId: number, blockedId: number) {
+    return await this.manager.exists(Block, {
+      where: {
+        blocker: { id: blockerId },
+        blocked: { id: blockedId },
+      },
+    });
   }
 }

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -70,12 +70,19 @@ export class UserService {
     return user;
   }
 
-  async getUserProfile(userId: number) {
+  async getUserProfile(userId: number, requester: Payload | null = null) {
     const user = await this.getUser(userId);
-    return GetUserProfileResponseDto.toResponseDto(user);
+    const isBlocked =
+      requester && requester.id !== userId
+        ? await this.userRepository.isUserBlocked(requester.id, userId)
+        : false;
+    return GetUserProfileResponseDto.toResponseDto(user, isBlocked);
   }
 
-  async searchUserList(searchUserQueryDto: SearchUserRequestDto) {
+  async searchUserList(
+    searchUserQueryDto: SearchUserRequestDto,
+    requester: Payload | null = null,
+  ) {
     const { find, page, limit } = searchUserQueryDto;
     const offset = (page - 1) * limit;
 
@@ -83,6 +90,7 @@ export class UserService {
       find,
       limit,
       offset,
+      requester?.id,
     );
 
     const users = SearchUserResult.toResultDtoArray(searchResult);

--- a/server/test/block/dto/manageBlock.dto.spec.ts
+++ b/server/test/block/dto/manageBlock.dto.spec.ts
@@ -1,0 +1,59 @@
+import { validate } from 'class-validator';
+
+import { ManageBlockRequestDto } from '@block/dto/request/manageBlock.dto';
+
+describe(`${ManageBlockRequestDto.name} Test`, () => {
+  let dto: ManageBlockRequestDto;
+
+  beforeEach(() => {
+    dto = new ManageBlockRequestDto({
+      userId: 1,
+    });
+  });
+
+  it('사용자 ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('userId', () => {
+    it('사용자 ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('사용자 ID가 정수가 아니고 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('사용자 ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.userId = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/block/dto/manageRssBlock.dto.spec.ts
+++ b/server/test/block/dto/manageRssBlock.dto.spec.ts
@@ -1,0 +1,59 @@
+import { validate } from 'class-validator';
+
+import { ManageRssBlockRequestDto } from '@block/dto/request/manageRssBlock.dto';
+
+describe(`${ManageRssBlockRequestDto.name} Test`, () => {
+  let dto: ManageRssBlockRequestDto;
+
+  beforeEach(() => {
+    dto = new ManageRssBlockRequestDto({
+      rssId: 1,
+    });
+  });
+
+  it('RSS ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('rssId', () => {
+    it('RSS ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.rssId = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('RSS ID가 정수가 아니고 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.rssId = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('RSS ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.rssId = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/block/e2e/create.e2e-spec.ts
+++ b/server/test/block/e2e/create.e2e-spec.ts
@@ -1,0 +1,117 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { BlockRepository } from '@block/repository/block.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/blocks';
+
+describe(`POST ${BASE_URL}/:userId E2E Test`, () => {
+  let agent: TestAgent;
+  let blockRepository: BlockRepository;
+  let userRepository: UserRepository;
+  let blocker: User;
+  let target: User;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    blockRepository = testApp.get(BlockRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    [blocker, target] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      userRepository.save(UserFixture.createUserFixture()),
+    ]);
+    accessToken = createAccessToken(blocker);
+  });
+
+  it('[401] 로그인이 되어 있지 않을 경우 차단 등록을 실패한다.', async () => {
+    // Http when
+    const response = await agent.post(`${BASE_URL}/${target.id}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+
+    // DB when
+    const savedBlock = await blockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blocked: { id: target.id },
+    });
+
+    // DB then
+    expect(savedBlock).toBeNull();
+  });
+
+  it('[400] 자기 자신을 차단할 경우 차단 등록을 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${blocker.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+  });
+
+  it('[404] 차단 대상 유저가 존재하지 않을 경우 차단 등록을 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${Number.MAX_SAFE_INTEGER}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[409] 이미 차단한 유저를 다시 차단할 경우 실패한다.', async () => {
+    // given
+    await blockRepository.save({
+      blocker: { id: blocker.id },
+      blocked: { id: target.id },
+    });
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${target.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+    expect(data).toBeUndefined();
+  });
+
+  it('[201] 유저 차단 등록을 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${target.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB when
+    const savedBlock = await blockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blocked: { id: target.id },
+    });
+
+    // DB then
+    expect(savedBlock).not.toBeNull();
+  });
+});

--- a/server/test/block/e2e/delete.e2e-spec.ts
+++ b/server/test/block/e2e/delete.e2e-spec.ts
@@ -1,0 +1,127 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { BlockRepository } from '@block/repository/block.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/blocks';
+
+describe(`DELETE ${BASE_URL}/:userId E2E Test`, () => {
+  let agent: TestAgent;
+  let blockRepository: BlockRepository;
+  let userRepository: UserRepository;
+  let blocker: User;
+  let target: User;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    blockRepository = testApp.get(BlockRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    [blocker, target] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      userRepository.save(UserFixture.createUserFixture()),
+    ]);
+    accessToken = createAccessToken(blocker);
+  });
+
+  it('[401] 로그인이 되어 있지 않을 경우 차단 해제를 실패한다.', async () => {
+    // given
+    await blockRepository.save({
+      blocker: { id: blocker.id },
+      blocked: { id: target.id },
+    });
+
+    // Http when
+    const response = await agent.delete(`${BASE_URL}/${target.id}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+
+    // DB when
+    const savedBlock = await blockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blocked: { id: target.id },
+    });
+
+    // DB then
+    expect(savedBlock).not.toBeNull();
+  });
+
+  it('[404] 차단하지 않은 유저를 해제할 경우 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${target.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 유저 차단 해제를 성공한다.', async () => {
+    // given
+    await blockRepository.save({
+      blocker: { id: blocker.id },
+      blocked: { id: target.id },
+    });
+
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${target.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB when
+    const savedBlock = await blockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blocked: { id: target.id },
+    });
+
+    // DB then
+    expect(savedBlock).toBeNull();
+  });
+
+  it('[200] 차단 해제는 본인의 차단만 제거하고 다른 유저의 차단은 유지한다.', async () => {
+    // given - 다른 유저도 같은 대상을 차단한 상태
+    const otherBlocker = await userRepository.save(
+      UserFixture.createUserFixture(),
+    );
+    await blockRepository.save([
+      { blocker: { id: blocker.id }, blocked: { id: target.id } },
+      { blocker: { id: otherBlocker.id }, blocked: { id: target.id } },
+    ]);
+
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${target.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB when
+    const otherBlock = await blockRepository.findOneBy({
+      blocker: { id: otherBlocker.id },
+      blocked: { id: target.id },
+    });
+
+    // DB then
+    expect(otherBlock).not.toBeNull();
+  });
+});

--- a/server/test/block/e2e/get.e2e-spec.ts
+++ b/server/test/block/e2e/get.e2e-spec.ts
@@ -1,0 +1,114 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { BlockRepository } from '@block/repository/block.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/blocks';
+
+describe(`GET ${BASE_URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let blockRepository: BlockRepository;
+  let userRepository: UserRepository;
+  let blocker: User;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    blockRepository = testApp.get(BlockRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    blocker = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    accessToken = createAccessToken(blocker);
+  });
+
+  it('[401] 로그인이 되어 있지 않을 경우 차단 목록 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(BASE_URL);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 차단한 유저가 없으면 빈 배열을 반환한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(BASE_URL)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toStrictEqual([]);
+  });
+
+  it('[200] 본인이 차단한 유저 목록만 최신순으로 반환한다.', async () => {
+    // given - 본인이 2명 차단, 다른 유저가 1명 차단
+    const [targetA, targetB, otherBlocker, otherTarget] = await Promise.all([
+      userRepository.save(
+        UserFixture.createUserFixture({ userName: '차단대상A' }),
+      ),
+      userRepository.save(
+        UserFixture.createUserFixture({
+          userName: '차단대상B',
+          profileImage:
+            'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+        }),
+      ),
+      userRepository.save(UserFixture.createUserFixture()),
+      userRepository.save(UserFixture.createUserFixture()),
+    ]);
+    await blockRepository.save({
+      blocker: { id: blocker.id },
+      blocked: { id: targetA.id },
+    });
+    await blockRepository.save({
+      blocker: { id: blocker.id },
+      blocked: { id: targetB.id },
+    });
+    await blockRepository.save({
+      blocker: { id: otherBlocker.id },
+      blocked: { id: otherTarget.id },
+    });
+
+    // Http when
+    const response = await agent
+      .get(BASE_URL)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body as {
+      data: {
+        userId: number;
+        userName: string;
+        profileImage: string | null;
+        blockedAt: string;
+      }[];
+    };
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toHaveLength(2);
+    expect(data.map((item) => item.userId)).toStrictEqual([
+      targetB.id,
+      targetA.id,
+    ]);
+    expect(data[0]).toMatchObject({
+      userId: targetB.id,
+      userName: targetB.userName,
+      profileImage: targetB.profileImage,
+    });
+    expect(data[0].blockedAt).toBeDefined();
+  });
+});

--- a/server/test/block/e2e/rss-create.e2e-spec.ts
+++ b/server/test/block/e2e/rss-create.e2e-spec.ts
@@ -1,0 +1,111 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/blocks/rss';
+
+describe(`POST ${BASE_URL}/:rssId E2E Test`, () => {
+  let agent: TestAgent;
+  let rssBlockRepository: RssBlockRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let blocker: User;
+  let targetRss: RssAccept;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssBlockRepository = testApp.get(RssBlockRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    [blocker, targetRss] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
+    ]);
+    accessToken = createAccessToken(blocker);
+  });
+
+  it('[401] 로그인이 되어 있지 않을 경우 RSS 차단 등록을 실패한다.', async () => {
+    // Http when
+    const response = await agent.post(`${BASE_URL}/${targetRss.id}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+
+    // DB when
+    const savedRssBlock = await rssBlockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // DB then
+    expect(savedRssBlock).toBeNull();
+  });
+
+  it('[404] 차단 대상 RSS가 존재하지 않을 경우 RSS 차단 등록을 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${Number.MAX_SAFE_INTEGER}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[409] 이미 차단한 RSS를 다시 차단할 경우 실패한다.', async () => {
+    // given
+    await rssBlockRepository.save({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${targetRss.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+    expect(data).toBeUndefined();
+  });
+
+  it('[201] RSS 차단 등록을 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${targetRss.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB when
+    const savedRssBlock = await rssBlockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // DB then
+    expect(savedRssBlock).not.toBeNull();
+  });
+});

--- a/server/test/block/e2e/rss-delete.e2e-spec.ts
+++ b/server/test/block/e2e/rss-delete.e2e-spec.ts
@@ -1,0 +1,137 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/blocks/rss';
+
+describe(`DELETE ${BASE_URL}/:rssId E2E Test`, () => {
+  let agent: TestAgent;
+  let rssBlockRepository: RssBlockRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let blocker: User;
+  let targetRss: RssAccept;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssBlockRepository = testApp.get(RssBlockRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    [blocker, targetRss] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
+    ]);
+    accessToken = createAccessToken(blocker);
+  });
+
+  it('[401] 로그인이 되어 있지 않을 경우 RSS 차단 해제를 실패한다.', async () => {
+    // given
+    await rssBlockRepository.save({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // Http when
+    const response = await agent.delete(`${BASE_URL}/${targetRss.id}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+
+    // DB when
+    const savedRssBlock = await rssBlockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // DB then
+    expect(savedRssBlock).not.toBeNull();
+  });
+
+  it('[404] 차단하지 않은 RSS를 해제할 경우 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${targetRss.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] RSS 차단 해제를 성공한다.', async () => {
+    // given
+    await rssBlockRepository.save({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${targetRss.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB when
+    const savedRssBlock = await rssBlockRepository.findOneBy({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // DB then
+    expect(savedRssBlock).toBeNull();
+  });
+
+  it('[200] 차단 해제는 본인의 차단만 제거하고 다른 유저의 차단은 유지한다.', async () => {
+    // given
+    const otherBlocker = await userRepository.save(
+      UserFixture.createUserFixture(),
+    );
+    await rssBlockRepository.save({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+    await rssBlockRepository.save({
+      blocker: { id: otherBlocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // Http when
+    const response = await agent
+      .delete(`${BASE_URL}/${targetRss.id}`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+
+    // DB when
+    const otherRssBlock = await rssBlockRepository.findOneBy({
+      blocker: { id: otherBlocker.id },
+      blockedRss: { id: targetRss.id },
+    });
+
+    // DB then
+    expect(otherRssBlock).not.toBeNull();
+  });
+});

--- a/server/test/block/e2e/rss-get.e2e-spec.ts
+++ b/server/test/block/e2e/rss-get.e2e-spec.ts
@@ -1,0 +1,114 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/blocks/rss';
+
+describe(`GET ${BASE_URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let rssBlockRepository: RssBlockRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let blocker: User;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssBlockRepository = testApp.get(RssBlockRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    blocker = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    accessToken = createAccessToken(blocker);
+  });
+
+  it('[401] 로그인이 되어 있지 않을 경우 RSS 차단 목록 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(BASE_URL);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 차단한 RSS가 없으면 빈 배열을 반환한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(BASE_URL)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toStrictEqual([]);
+  });
+
+  it('[200] 본인이 차단한 RSS 목록만 최신순으로 반환한다.', async () => {
+    // given - 본인이 2개 차단, 다른 유저가 1개 차단
+    const [targetRssA, targetRssB, otherTargetRss, otherBlocker] =
+      await Promise.all([
+        rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
+        rssAcceptRepository.save(
+          RssAcceptFixture.createRssAcceptFixture({ blogPlatform: 'velog' }),
+        ),
+        rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture()),
+        userRepository.save(UserFixture.createUserFixture()),
+      ]);
+    await rssBlockRepository.save({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRssA.id },
+    });
+    await rssBlockRepository.save({
+      blocker: { id: blocker.id },
+      blockedRss: { id: targetRssB.id },
+    });
+    await rssBlockRepository.save({
+      blocker: { id: otherBlocker.id },
+      blockedRss: { id: otherTargetRss.id },
+    });
+
+    // Http when
+    const response = await agent
+      .get(BASE_URL)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body as {
+      data: {
+        rssId: number;
+        name: string;
+        blogPlatform: string;
+        blockedAt: string;
+      }[];
+    };
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toHaveLength(2);
+    expect(data.map((item) => item.rssId)).toStrictEqual([
+      targetRssB.id,
+      targetRssA.id,
+    ]);
+    expect(data[0]).toMatchObject({
+      rssId: targetRssB.id,
+      name: targetRssB.name,
+      blogPlatform: targetRssB.blogPlatform,
+    });
+    expect(data[0].blockedAt).toBeDefined();
+  });
+});

--- a/server/test/block/unit/block.service.unit.spec.ts
+++ b/server/test/block/unit/block.service.unit.spec.ts
@@ -1,0 +1,161 @@
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { Payload } from '@common/guard/jwt.guard';
+
+import { GetBlockedUsersResponseDto } from '@block/dto/response/getBlockedUsers.dto';
+import { Block } from '@block/entity/block.entity';
+import { BlockRepository } from '@block/repository/block.repository';
+import { BlockService } from '@block/service/block.service';
+
+import { UserService } from '@user/service/user.service';
+
+describe(`${BlockService.name} Unit Test`, () => {
+  let blockService: BlockService;
+  let blockRepository: jest.Mocked<
+    Pick<BlockRepository, 'insert' | 'delete' | 'getBlockedUsers'>
+  >;
+  let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
+
+  const user: Payload = {
+    id: 1,
+    email: 'user@test.com',
+    userName: 'tester',
+    role: 'user',
+  };
+  const dto = { userId: 2 };
+
+  beforeEach(() => {
+    blockRepository = {
+      insert: jest.fn(),
+      delete: jest.fn(),
+      getBlockedUsers: jest.fn(),
+    };
+    userService = { getUser: jest.fn() };
+
+    blockService = new BlockService(
+      blockRepository as unknown as BlockRepository,
+      userService as unknown as UserService,
+    );
+  });
+
+  describe('create', () => {
+    it('자기 자신을 차단하면 BadRequestException을 던진다.', async () => {
+      // when & then
+      await expect(
+        blockService.create(user, { userId: user.id }),
+      ).rejects.toThrow(BadRequestException);
+      expect(blockRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('차단 대상 유저가 존재하지 않으면 NotFoundException을 던진다.', async () => {
+      // given
+      userService.getUser.mockRejectedValue(
+        new NotFoundException('존재하지 않는 유저입니다.'),
+      );
+
+      // when & then
+      await expect(blockService.create(user, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(blockRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('이미 차단한 유저면 ConflictException을 던진다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: dto.userId } as any);
+      blockRepository.insert.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
+
+      // when & then
+      await expect(blockService.create(user, dto)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('차단 등록에 성공한다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: dto.userId } as any);
+      blockRepository.insert.mockResolvedValue(undefined);
+
+      // when
+      await blockService.create(user, dto);
+
+      // then
+      expect(blockRepository.insert).toHaveBeenCalledWith({
+        blocker: { id: user.id },
+        blocked: { id: dto.userId },
+      });
+    });
+
+    it('중복 이외의 DB 오류는 그대로 전파한다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: dto.userId } as any);
+      const dbError = new Error('connection lost');
+      blockRepository.insert.mockRejectedValue(dbError);
+
+      // when & then
+      await expect(blockService.create(user, dto)).rejects.toThrow(dbError);
+    });
+  });
+
+  describe('delete', () => {
+    it('차단하지 않은 유저를 해제하면 NotFoundException을 던진다.', async () => {
+      // given
+      blockRepository.delete.mockResolvedValue({ affected: 0 } as any);
+
+      // when & then
+      await expect(blockService.delete(user, dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('차단 해제에 성공한다.', async () => {
+      // given
+      blockRepository.delete.mockResolvedValue({ affected: 1 } as any);
+
+      // when
+      await blockService.delete(user, dto);
+
+      // then
+      expect(blockRepository.delete).toHaveBeenCalledWith({
+        blocker: { id: user.id },
+        blocked: { id: dto.userId },
+      });
+    });
+  });
+
+  describe('getBlockedUsers', () => {
+    it('차단 목록을 응답 DTO 배열로 변환하여 반환한다.', async () => {
+      // given
+      const blocks = [
+        {
+          id: 1,
+          createdAt: new Date('2025-08-16T12:00:00.000Z'),
+          blocked: {
+            id: 2,
+            userName: '차단된유저',
+            profileImage: null,
+          },
+        },
+      ] as Block[];
+      blockRepository.getBlockedUsers.mockResolvedValue(blocks);
+
+      // when
+      const result = await blockService.getBlockedUsers(user);
+
+      // then
+      expect(blockRepository.getBlockedUsers).toHaveBeenCalledWith(user.id);
+      expect(result).toStrictEqual(
+        GetBlockedUsersResponseDto.toResponseDtoArray(blocks),
+      );
+      expect(result[0]).toMatchObject({
+        userId: 2,
+        userName: '차단된유저',
+        profileImage: null,
+      });
+    });
+  });
+});

--- a/server/test/block/unit/block.service.unit.spec.ts
+++ b/server/test/block/unit/block.service.unit.spec.ts
@@ -6,10 +6,15 @@ import {
 
 import { Payload } from '@common/guard/jwt.guard';
 
+import { GetBlockedRssResponseDto } from '@block/dto/response/getBlockedRss.dto';
 import { GetBlockedUsersResponseDto } from '@block/dto/response/getBlockedUsers.dto';
 import { Block } from '@block/entity/block.entity';
+import { RssBlock } from '@block/entity/rssBlock.entity';
 import { BlockRepository } from '@block/repository/block.repository';
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 import { BlockService } from '@block/service/block.service';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { UserService } from '@user/service/user.service';
 
@@ -18,6 +23,10 @@ describe(`${BlockService.name} Unit Test`, () => {
   let blockRepository: jest.Mocked<
     Pick<BlockRepository, 'insert' | 'delete' | 'getBlockedUsers'>
   >;
+  let rssBlockRepository: jest.Mocked<
+    Pick<RssBlockRepository, 'insert' | 'delete' | 'getBlockedRssList'>
+  >;
+  let rssAcceptRepository: jest.Mocked<Pick<RssAcceptRepository, 'findOne'>>;
   let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
 
   const user: Payload = {
@@ -34,10 +43,18 @@ describe(`${BlockService.name} Unit Test`, () => {
       delete: jest.fn(),
       getBlockedUsers: jest.fn(),
     };
+    rssBlockRepository = {
+      insert: jest.fn(),
+      delete: jest.fn(),
+      getBlockedRssList: jest.fn(),
+    };
+    rssAcceptRepository = { findOne: jest.fn() };
     userService = { getUser: jest.fn() };
 
     blockService = new BlockService(
       blockRepository as unknown as BlockRepository,
+      rssBlockRepository as unknown as RssBlockRepository,
+      rssAcceptRepository as unknown as RssAcceptRepository,
       userService as unknown as UserService,
     );
   });
@@ -155,6 +172,127 @@ describe(`${BlockService.name} Unit Test`, () => {
         userId: 2,
         userName: '차단된유저',
         profileImage: null,
+      });
+    });
+  });
+
+  describe('createRssBlock', () => {
+    const rssDto = { rssId: 5 };
+
+    it('차단 대상 RSS가 존재하지 않으면 NotFoundException을 던진다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(blockService.createRssBlock(user, rssDto)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(rssBlockRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('이미 차단한 RSS면 ConflictException을 던진다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: rssDto.rssId,
+      } as any);
+      rssBlockRepository.insert.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
+
+      // when & then
+      await expect(blockService.createRssBlock(user, rssDto)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('RSS 차단 등록에 성공한다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: rssDto.rssId,
+      } as any);
+      rssBlockRepository.insert.mockResolvedValue(undefined);
+
+      // when
+      await blockService.createRssBlock(user, rssDto);
+
+      // then
+      expect(rssBlockRepository.insert).toHaveBeenCalledWith({
+        blocker: { id: user.id },
+        blockedRss: { id: rssDto.rssId },
+      });
+    });
+
+    it('중복 이외의 DB 오류는 그대로 전파한다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: rssDto.rssId,
+      } as any);
+      const dbError = new Error('connection lost');
+      rssBlockRepository.insert.mockRejectedValue(dbError);
+
+      // when & then
+      await expect(blockService.createRssBlock(user, rssDto)).rejects.toThrow(
+        dbError,
+      );
+    });
+  });
+
+  describe('deleteRssBlock', () => {
+    const rssDto = { rssId: 5 };
+
+    it('차단하지 않은 RSS를 해제하면 NotFoundException을 던진다.', async () => {
+      // given
+      rssBlockRepository.delete.mockResolvedValue({ affected: 0 } as any);
+
+      // when & then
+      await expect(blockService.deleteRssBlock(user, rssDto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('RSS 차단 해제에 성공한다.', async () => {
+      // given
+      rssBlockRepository.delete.mockResolvedValue({ affected: 1 } as any);
+
+      // when
+      await blockService.deleteRssBlock(user, rssDto);
+
+      // then
+      expect(rssBlockRepository.delete).toHaveBeenCalledWith({
+        blocker: { id: user.id },
+        blockedRss: { id: rssDto.rssId },
+      });
+    });
+  });
+
+  describe('getBlockedRssList', () => {
+    it('RSS 차단 목록을 응답 DTO 배열로 변환하여 반환한다.', async () => {
+      // given
+      const rssBlocks = [
+        {
+          id: 1,
+          createdAt: new Date('2025-08-16T12:00:00.000Z'),
+          blockedRss: {
+            id: 5,
+            name: '차단된블로그',
+            blogPlatform: 'velog',
+          },
+        },
+      ] as RssBlock[];
+      rssBlockRepository.getBlockedRssList.mockResolvedValue(rssBlocks);
+
+      // when
+      const result = await blockService.getBlockedRssList(user);
+
+      // then
+      expect(rssBlockRepository.getBlockedRssList).toHaveBeenCalledWith(
+        user.id,
+      );
+      expect(result).toStrictEqual(
+        GetBlockedRssResponseDto.toResponseDtoArray(rssBlocks),
+      );
+      expect(result[0]).toMatchObject({
+        rssId: 5,
+        name: '차단된블로그',
+        blogPlatform: 'velog',
       });
     });
   });

--- a/server/test/comment/e2e/get.e2e-spec.ts
+++ b/server/test/comment/e2e/get.e2e-spec.ts
@@ -3,6 +3,8 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { BlockRepository } from '@block/repository/block.repository';
+
 import { Comment } from '@comment/entity/comment.entity';
 import { CommentRepository } from '@comment/repository/comment.repository';
 
@@ -19,7 +21,7 @@ import { CommentFixture } from '@test/config/common/fixture/comment.fixture';
 import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
 import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
-import { testApp } from '@test/config/e2e/env/jest.setup';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
 const BASE_URL = '/api/feeds';
 
@@ -27,6 +29,7 @@ describe(`GET ${BASE_URL}/:feedId/comments E2E Test`, () => {
   let agent: TestAgent;
   let feed: Feed;
   let commentRepository: CommentRepository;
+  let blockRepository: BlockRepository;
   let userRepository: UserRepository;
   let rssAcceptRepository: RssAcceptRepository;
   let feedRepository: FeedRepository;
@@ -37,6 +40,7 @@ describe(`GET ${BASE_URL}/:feedId/comments E2E Test`, () => {
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     commentRepository = testApp.get(CommentRepository);
+    blockRepository = testApp.get(BlockRepository);
     userRepository = testApp.get(UserRepository);
     rssAcceptRepository = testApp.get(RssAcceptRepository);
     feedRepository = testApp.get(FeedRepository);
@@ -106,5 +110,116 @@ describe(`GET ${BASE_URL}/:feedId/comments E2E Test`, () => {
         },
       },
     ]);
+  });
+
+  it('[200] 차단한 사용자의 댓글은 조회 결과에서 제외된다.', async () => {
+    // given - viewer가 기존 댓글 작성자(user)를 차단한 상태
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await blockRepository.save({
+      blocker: { id: viewer.id },
+      blocked: { id: user.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // Http when
+    const response = await agent
+      .get(`${BASE_URL}/${feed.id}/comments`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toStrictEqual([]);
+  });
+
+  it('[200] 차단한 사용자가 작성한 부모 댓글은 대댓글까지 스레드 통째로 제외된다.', async () => {
+    // given - 차단된 user의 부모 댓글(comment)에 viewer가 아닌 유저의 대댓글 존재
+    const [viewer, replier] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      userRepository.save(UserFixture.createUserFixture()),
+    ]);
+    await commentRepository.save(
+      CommentFixture.createCommentFixture(feed, replier, {
+        parentId: comment.id,
+      }),
+    );
+    const normalComment = await commentRepository.save(
+      CommentFixture.createCommentFixture(feed, replier),
+    );
+    await blockRepository.save({
+      blocker: { id: viewer.id },
+      blocked: { id: user.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // Http when
+    const response = await agent
+      .get(`${BASE_URL}/${feed.id}/comments`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then - 차단 스레드는 사라지고 차단되지 않은 최상위 댓글만 남는다
+    const { data } = response.body as { data: { id: number }[] };
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.map((item) => item.id)).toStrictEqual([normalComment.id]);
+  });
+
+  it('[200] 차단하지 않은 부모 댓글의 대댓글 중 차단한 사용자의 대댓글만 제외된다.', async () => {
+    // given - replier의 부모 댓글에 user(차단 대상)와 replier의 대댓글이 달린 상태
+    const [viewer, replier] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      userRepository.save(UserFixture.createUserFixture()),
+    ]);
+    const parent = await commentRepository.save(
+      CommentFixture.createCommentFixture(feed, replier),
+    );
+    await commentRepository.save(
+      CommentFixture.createCommentFixture(feed, user, {
+        parentId: parent.id,
+      }),
+    );
+    const normalReply = await commentRepository.save(
+      CommentFixture.createCommentFixture(feed, replier, {
+        parentId: parent.id,
+      }),
+    );
+    await blockRepository.save({
+      blocker: { id: viewer.id },
+      blocked: { id: user.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // Http when
+    const response = await agent
+      .get(`${BASE_URL}/${feed.id}/comments`)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then - user의 최상위 댓글(comment)과 user의 대댓글만 제외된다
+    const { data } = response.body as { data: { id: number }[] };
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.map((item) => item.id).sort((a, b) => a - b)).toStrictEqual(
+      [parent.id, normalReply.id].sort((a, b) => a - b),
+    );
+  });
+
+  it('[200] 비로그인 사용자는 차단 필터 없이 모든 댓글을 조회한다.', async () => {
+    // given - 다른 유저가 user를 차단한 상태여도 비로그인 조회에는 영향이 없다
+    const otherUser = await userRepository.save(
+      UserFixture.createUserFixture(),
+    );
+    await blockRepository.save({
+      blocker: { id: otherUser.id },
+      blocked: { id: user.id },
+    });
+
+    // Http when
+    const response = await agent.get(`${BASE_URL}/${feed.id}/comments`);
+
+    // Http then
+    const { data } = response.body as { data: { id: number }[] };
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe(comment.id);
   });
 });

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -85,7 +85,10 @@ describe(`${CommentService.name} Unit Test`, () => {
 
       // then
       expect(feedService.getPublicFeed).toHaveBeenCalledWith(10);
-      expect(commentRepository.getCommentInformation).toHaveBeenCalledWith(10);
+      expect(commentRepository.getCommentInformation).toHaveBeenCalledWith(
+        10,
+        undefined,
+      );
       expect(result).toEqual(
         GetCommentResponseDto.toResponseDtoArray(comments),
       );

--- a/server/test/feed/e2e/detail.e2e-spec.ts
+++ b/server/test/feed/e2e/detail.e2e-spec.ts
@@ -8,6 +8,8 @@ import { ActivityRepository } from '@activity/repository/activity.repository';
 
 import { RedisService } from '@common/redis/redis.service';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
 import { Feed } from '@feed/entity/feed.entity';
 import { FeedRepository } from '@feed/repository/feed.repository';
@@ -104,6 +106,7 @@ describe(`GET ${URL}/{feedId} E2E Test`, () => {
       ownerName: feedList[0].blog.userName,
       isOwnerCertified: false,
       isSubscribed: false,
+      isBlocked: false,
     });
   });
 
@@ -137,6 +140,7 @@ describe(`GET ${URL}/{feedId} E2E Test`, () => {
       ownerName: feedList[1].blog.userName,
       isOwnerCertified: false,
       isSubscribed: false,
+      isBlocked: false,
     });
   });
 
@@ -166,8 +170,9 @@ describe(`GET ${URL}/{feedId} E2E Test`, () => {
         .set('Authorization', `Bearer ${accessToken}`);
 
       // Http then
+      const { data } = response.body as { data: { isOwner: boolean } };
       expect(response.status).toBe(HttpStatus.OK);
-      expect(response.body.data.isOwner).toBe(true);
+      expect(data.isOwner).toBe(true);
     });
 
     it('[200] RSS 소유자가 아닌 사용자가 조회할 경우 isOwner=false로 응답한다.', async () => {
@@ -180,8 +185,76 @@ describe(`GET ${URL}/{feedId} E2E Test`, () => {
         .set('Authorization', `Bearer ${accessToken}`);
 
       // Http then
+      const { data } = response.body as { data: { isOwner: boolean } };
       expect(response.status).toBe(HttpStatus.OK);
-      expect(response.body.data.isOwner).toBe(false);
+      expect(data.isOwner).toBe(false);
+    });
+  });
+
+  describe('isBlocked 필드', () => {
+    let user: User;
+    let userRepository: UserRepository;
+    let rssBlockRepository: RssBlockRepository;
+
+    beforeAll(() => {
+      userRepository = testApp.get(UserRepository);
+      rssBlockRepository = testApp.get(RssBlockRepository);
+    });
+
+    beforeEach(async () => {
+      user = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+    });
+
+    it('[200] 차단한 RSS의 게시글을 조회할 경우 isBlocked=true로 응답한다.', async () => {
+      // given
+      await rssBlockRepository.save({
+        blocker: { id: user.id },
+        blockedRss: { id: rssAccept.id },
+      });
+      const accessToken = createAccessToken(user);
+
+      // Http when
+      const response = await agent
+        .get(`${URL}/${feedList[0].id}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      const { data } = response.body as { data: { isBlocked: boolean } };
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(data.isBlocked).toBe(true);
+    });
+
+    it('[200] 차단하지 않은 RSS의 게시글을 조회할 경우 isBlocked=false로 응답한다.', async () => {
+      // given
+      const accessToken = createAccessToken(user);
+
+      // Http when
+      const response = await agent
+        .get(`${URL}/${feedList[0].id}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      const { data } = response.body as { data: { isBlocked: boolean } };
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(data.isBlocked).toBe(false);
+    });
+
+    it('[200] 비로그인으로 조회할 경우 isBlocked=false로 응답한다.', async () => {
+      // given
+      await rssBlockRepository.save({
+        blocker: { id: user.id },
+        blockedRss: { id: rssAccept.id },
+      });
+
+      // Http when
+      const response = await agent.get(`${URL}/${feedList[0].id}`);
+
+      // Http then
+      const { data } = response.body as { data: { isBlocked: boolean } };
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(data.isBlocked).toBe(false);
     });
   });
 

--- a/server/test/feed/e2e/pagination.e2e-spec.ts
+++ b/server/test/feed/e2e/pagination.e2e-spec.ts
@@ -3,6 +3,8 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
 import { Feed } from '@feed/entity/feed.entity';
 import { FeedRepository } from '@feed/repository/feed.repository';
@@ -10,9 +12,12 @@ import { FeedRepository } from '@feed/repository/feed.repository';
 import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
+import { UserRepository } from '@user/repository/user.repository';
+
 import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
 import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
-import { testApp } from '@test/config/e2e/env/jest.setup';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = '/api/feeds';
 
@@ -175,6 +180,76 @@ describe(`GET ${URL}?limit={}&lastId={} E2E Test`, () => {
       result: [],
       lastId: 0,
       hasMore: false,
+    });
+  });
+
+  describe('차단 RSS 필터', () => {
+    let userRepository: UserRepository;
+    let rssBlockRepository: RssBlockRepository;
+
+    beforeAll(() => {
+      userRepository = testApp.get(UserRepository);
+      rssBlockRepository = testApp.get(RssBlockRepository);
+    });
+
+    it('[200] 로그인한 사용자가 차단한 RSS의 게시글은 피드 목록에서 제외된다.', async () => {
+      // given - 차단된 RSS의 게시글 1개 추가
+      const blockedRss = await rssAcceptRepository.save(
+        RssAcceptFixture.createRssAcceptFixture(),
+      );
+      const blockedFeed = await feedRepository.save(
+        FeedFixture.createFeedFixture(blockedRss),
+      );
+      const viewer = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+      await rssBlockRepository.save({
+        blocker: { id: viewer.id },
+        blockedRss: { id: blockedRss.id },
+      });
+      const accessToken = createAccessToken(viewer);
+
+      // Http when
+      const response = await agent
+        .get(URL)
+        .query({ limit: 20 })
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      const { data } = response.body as {
+        data: { result: { id: number }[] };
+      };
+      expect(response.status).toBe(HttpStatus.OK);
+      const ids = data.result.map((feed) => feed.id);
+      expect(ids).not.toContain(blockedFeed.id);
+      expect(ids).toHaveLength(feedList.length);
+    });
+
+    it('[200] 비로그인 사용자에게는 차단 여부와 관계없이 모든 게시글이 제공된다.', async () => {
+      // given
+      const blockedRss = await rssAcceptRepository.save(
+        RssAcceptFixture.createRssAcceptFixture(),
+      );
+      const blockedFeed = await feedRepository.save(
+        FeedFixture.createFeedFixture(blockedRss),
+      );
+      const viewer = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+      await rssBlockRepository.save({
+        blocker: { id: viewer.id },
+        blockedRss: { id: blockedRss.id },
+      });
+
+      // Http when
+      const response = await agent.get(URL).query({ limit: 20 });
+
+      // Http then
+      const { data } = response.body as {
+        data: { result: { id: number }[] };
+      };
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(data.result.map((feed) => feed.id)).toContain(blockedFeed.id);
     });
   });
 });

--- a/server/test/feed/e2e/search.e2e-spec.ts
+++ b/server/test/feed/e2e/search.e2e-spec.ts
@@ -13,9 +13,14 @@ import { FeedRepository } from '@feed/repository/feed.repository';
 import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { UserRepository } from '@user/repository/user.repository';
+
 import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
 import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
-import { testApp } from '@test/config/e2e/env/jest.setup';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = '/api/feeds/search';
 
@@ -98,6 +103,83 @@ describe(`GET ${URL}?type={}&find={} E2E Test`, () => {
       result: [],
       totalPages: 0,
       limit: 4,
+    });
+  });
+
+  describe('차단 RSS 필터', () => {
+    let userRepository: UserRepository;
+    let rssBlockRepository: RssBlockRepository;
+
+    beforeAll(() => {
+      userRepository = testApp.get(UserRepository);
+      rssBlockRepository = testApp.get(RssBlockRepository);
+    });
+
+    it('[200] 로그인한 사용자가 차단한 RSS의 게시글은 검색 결과에서 제외된다.', async () => {
+      // given - 동일 검색어의 차단 RSS 게시글 1개 추가
+      const blockedRss = await rssAcceptRepository.save(
+        RssAcceptFixture.createRssAcceptFixture(),
+      );
+      const blockedFeed = await feedRepository.save(
+        FeedFixture.createFeedFixture(blockedRss, { title: 'search-data99' }),
+      );
+      const viewer = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+      await rssBlockRepository.save({
+        blocker: { id: viewer.id },
+        blockedRss: { id: blockedRss.id },
+      });
+      const accessToken = createAccessToken(viewer);
+      const requestDto = new SearchFeedRequestDto({
+        type: SearchType.TITLE,
+        find: 'search-data',
+      });
+
+      // Http when
+      const response = await agent
+        .get(URL)
+        .query(requestDto)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      const { data } = response.body as {
+        data: { totalCount: number; result: { id: number }[] };
+      };
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(data.totalCount).toBe(feedList.length);
+      expect(data.result.map((feed) => feed.id)).not.toContain(blockedFeed.id);
+    });
+
+    it('[200] 비로그인 사용자에게는 차단 여부와 관계없이 검색 결과가 제공된다.', async () => {
+      // given
+      const blockedRss = await rssAcceptRepository.save(
+        RssAcceptFixture.createRssAcceptFixture(),
+      );
+      const blockedFeed = await feedRepository.save(
+        FeedFixture.createFeedFixture(blockedRss, { title: 'search-data99' }),
+      );
+      const viewer = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+      await rssBlockRepository.save({
+        blocker: { id: viewer.id },
+        blockedRss: { id: blockedRss.id },
+      });
+      const requestDto = new SearchFeedRequestDto({
+        type: SearchType.TITLE,
+        find: 'search-data99',
+      });
+
+      // Http when
+      const response = await agent.get(URL).query(requestDto);
+
+      // Http then
+      const { data } = response.body as {
+        data: { result: { id: number }[] };
+      };
+      expect(response.status).toBe(HttpStatus.OK);
+      expect(data.result.map((feed) => feed.id)).toContain(blockedFeed.id);
     });
   });
 });

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -16,6 +16,8 @@ import {
 } from '@feed/repository/feed.repository';
 import { FeedService } from '@feed/service/feed.service';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 jest.mock('axios');
@@ -40,6 +42,9 @@ describe(`${FeedService.name} Unit Test`, () => {
   >;
   let subscriptionRepository: jest.Mocked<
     Pick<SubscriptionRepository, 'findOneBy' | 'getSubscribedBlogIds'>
+  >;
+  let rssBlockRepository: jest.Mocked<
+    Pick<RssBlockRepository, 'existsByBlockerAndRss'>
   >;
   let redisService: jest.Mocked<
     Pick<
@@ -88,11 +93,16 @@ describe(`${FeedService.name} Unit Test`, () => {
       getSubscribedBlogIds: jest.fn().mockResolvedValue([]),
     };
 
+    rssBlockRepository = {
+      existsByBlockerAndRss: jest.fn().mockResolvedValue(false),
+    };
+
     feedService = new FeedService(
       feedRepository as unknown as FeedRepository,
       feedViewRepository as unknown as FeedViewRepository,
       redisService as unknown as RedisService,
       subscriptionRepository as unknown as SubscriptionRepository,
+      rssBlockRepository as unknown as RssBlockRepository,
     );
   });
 
@@ -306,6 +316,7 @@ describe(`${FeedService.name} Unit Test`, () => {
         10,
         'title',
         10, // offset = (2-1)*10
+        undefined,
       );
       expect(result.totalCount).toBe(25);
       expect(result.totalPages).toBe(3); // ceil(25/10)

--- a/server/test/rss/e2e/get-info.e2e-spec.ts
+++ b/server/test/rss/e2e/get-info.e2e-spec.ts
@@ -3,6 +3,8 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { GetRssInfoResponseDto } from '@rss/dto/response/getRssInfo.dto';
@@ -134,5 +136,46 @@ describe(`GET /api/rss/:rssId E2E Test`, () => {
     const { data }: { data: GetRssInfoResponseDto } = response.body;
     expect(data.isSubscribed).toBe(true);
     expect(data.subscriberCount).toBe(1);
+  });
+
+  it('[200] 차단한 사용자가 조회하면 isBlocked=true를 반환한다.', async () => {
+    // given
+    const rssBlockRepository = testApp.get(RssBlockRepository);
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const rssAccept: RssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    await rssBlockRepository.save({
+      blocker: { id: viewer.id },
+      blockedRss: { id: rssAccept.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // when
+    const response = await agent
+      .get(makeURL(rssAccept.id))
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRssInfoResponseDto } = response.body;
+    expect(data.isBlocked).toBe(true);
+  });
+
+  it('[200] 차단하지 않았거나 비로그인으로 조회하면 isBlocked=false를 반환한다.', async () => {
+    // given
+    const rssAccept: RssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+
+    // when - 비로그인
+    const response = await agent.get(makeURL(rssAccept.id));
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRssInfoResponseDto } = response.body;
+    expect(data.isBlocked).toBe(false);
   });
 });

--- a/server/test/rss/e2e/recent.e2e-spec.ts
+++ b/server/test/rss/e2e/recent.e2e-spec.ts
@@ -3,14 +3,19 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { GetRecentRssResponseDto } from '@rss/dto/response/getRecentRss.dto';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
+import { UserRepository } from '@user/repository/user.repository';
+
 import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
 import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
-import { testApp } from '@test/config/e2e/env/jest.setup';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = '/api/rss/recent';
 
@@ -123,5 +128,61 @@ describe(`GET ${URL} E2E Test`, () => {
     expect(response.status).toBe(HttpStatus.OK);
     const { data }: { data: GetRecentRssResponseDto[] } = response.body;
     expect(data.length).toBe(10);
+  });
+
+  it('[200] 로그인한 사용자가 차단한 RSS는 목록에서 제외된다.', async () => {
+    // given
+    const userRepository = testApp.get(UserRepository);
+    const rssBlockRepository = testApp.get(RssBlockRepository);
+    const { rssAccept: blockedRss } = await createRssWithFeed(
+      new Date('2025-12-10'),
+    );
+    const { rssAccept: normalRss } = await createRssWithFeed(
+      new Date('2025-12-01'),
+    );
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await rssBlockRepository.save({
+      blocker: { id: viewer.id },
+      blockedRss: { id: blockedRss.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // when
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRecentRssResponseDto[] } = response.body;
+    const ids = data.map((rss) => rss.id);
+    expect(ids).not.toContain(blockedRss.id);
+    expect(ids).toContain(normalRss.id);
+  });
+
+  it('[200] 비로그인 사용자에게는 차단 여부와 관계없이 모든 RSS가 제공된다.', async () => {
+    // given
+    const userRepository = testApp.get(UserRepository);
+    const rssBlockRepository = testApp.get(RssBlockRepository);
+    const { rssAccept: blockedRss } = await createRssWithFeed(
+      new Date('2025-12-10'),
+    );
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await rssBlockRepository.save({
+      blocker: { id: viewer.id },
+      blockedRss: { id: blockedRss.id },
+    });
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: GetRecentRssResponseDto[] } = response.body;
+    expect(data.map((rss) => rss.id)).toContain(blockedRss.id);
   });
 });

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -31,6 +31,8 @@ import {
 } from '@rss/repository/rss.repository';
 import { RssService } from '@rss/service/rss.service';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
@@ -77,6 +79,9 @@ describe(`${RssService.name} Unit Test`, () => {
   let adminRepository: jest.Mocked<Pick<AdminRepository, 'find'>>;
   let notifierRegistry: jest.Mocked<Pick<NotifierRegistry, 'sendAlert'>>;
   let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
+  let rssBlockRepository: jest.Mocked<
+    Pick<RssBlockRepository, 'existsByBlockerAndRss'>
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -125,6 +130,9 @@ describe(`${RssService.name} Unit Test`, () => {
     adminRepository = { find: jest.fn().mockResolvedValue([]) };
     notifierRegistry = { sendAlert: jest.fn() };
     logger = { error: jest.fn() };
+    rssBlockRepository = {
+      existsByBlockerAndRss: jest.fn().mockResolvedValue(false),
+    };
 
     rssService = new RssService(
       rssRepository as unknown as RssRepository,
@@ -138,6 +146,7 @@ describe(`${RssService.name} Unit Test`, () => {
       adminRepository as unknown as AdminRepository,
       notifierRegistry as unknown as NotifierRegistry,
       logger as unknown as WinstonLoggerService,
+      rssBlockRepository as unknown as RssBlockRepository,
     );
   });
 
@@ -714,6 +723,7 @@ describe(`${RssService.name} Unit Test`, () => {
       // then
       expect(rssAcceptRepository.findRecentlyPublished).toHaveBeenCalledWith(
         10,
+        undefined,
       );
       expect(result).toEqual([
         {

--- a/server/test/subscribe/e2e/feed.e2e-spec.ts
+++ b/server/test/subscribe/e2e/feed.e2e-spec.ts
@@ -3,7 +3,8 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
-import { Feed } from '@feed/entity/feed.entity';
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { RssAccept } from '@rss/entity/rss.entity';
@@ -24,6 +25,14 @@ import { UserFixture } from '@test/config/common/fixture/user.fixture';
 import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = '/api/feeds/subscriptions';
+
+type SubscriptionFeedBody = {
+  data: {
+    result: { id: number; author: string; tag: string[] }[];
+    hasMore: boolean;
+    lastId: number;
+  };
+};
 
 describe(`GET ${URL} E2E Test`, () => {
   let agent: TestAgent;
@@ -48,7 +57,9 @@ describe(`GET ${URL} E2E Test`, () => {
   });
 
   beforeEach(async () => {
-    user = await userRepository.save(await UserFixture.createUserCryptFixture());
+    user = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
     accessToken = createAccessToken(user);
 
     subscribedBlog = await rssAcceptRepository.save(
@@ -71,9 +82,10 @@ describe(`GET ${URL} E2E Test`, () => {
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data.result).toEqual([]);
-    expect(response.body.data.hasMore).toBe(false);
-    expect(response.body.data.lastId).toBe(0);
+    const { data } = response.body as SubscriptionFeedBody;
+    expect(data.result).toEqual([]);
+    expect(data.hasMore).toBe(false);
+    expect(data.lastId).toBe(0);
   });
 
   it('[200] 구독한 블로그의 공개 게시글만 반환하고 비공개·미구독 블로그는 제외한다.', async () => {
@@ -102,14 +114,12 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { result } = response.body.data;
+    const { result } = (response.body as SubscriptionFeedBody).data;
     expect(result).toHaveLength(2);
-    expect(
-      result.every((feed: { author: string }) => feed.author === subscribedBlog.name),
-    ).toBe(true);
-    const taggedResult = result.find(
-      (feed: { tag: string[] }) => feed.tag.length > 0,
+    expect(result.every((feed) => feed.author === subscribedBlog.name)).toBe(
+      true,
     );
+    const taggedResult = result.find((feed) => feed.tag.length > 0);
     expect(taggedResult.tag).toContain(tag.name);
   });
 
@@ -128,24 +138,54 @@ describe(`GET ${URL} E2E Test`, () => {
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(firstPage.status).toBe(HttpStatus.OK);
-    expect(firstPage.body.data.result).toHaveLength(2);
-    expect(firstPage.body.data.hasMore).toBe(true);
+    const firstPageData = (firstPage.body as SubscriptionFeedBody).data;
+    expect(firstPageData.result).toHaveLength(2);
+    expect(firstPageData.hasMore).toBe(true);
 
     // 다음 페이지
     const secondPage = await agent
       .get(URL)
-      .query({ limit: 2, lastId: firstPage.body.data.lastId })
+      .query({ limit: 2, lastId: firstPageData.lastId })
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(secondPage.status).toBe(HttpStatus.OK);
-    expect(secondPage.body.data.result).toHaveLength(1);
-    expect(secondPage.body.data.hasMore).toBe(false);
+    const secondPageData = (secondPage.body as SubscriptionFeedBody).data;
+    expect(secondPageData.result).toHaveLength(1);
+    expect(secondPageData.hasMore).toBe(false);
     // 전체 3개 ID가 중복 없이 반환되었는지
     const ids = [
-      ...firstPage.body.data.result.map((f: { id: number }) => f.id),
-      ...secondPage.body.data.result.map((f: { id: number }) => f.id),
+      ...firstPageData.result.map((f) => f.id),
+      ...secondPageData.result.map((f) => f.id),
     ];
     expect(new Set(ids).size).toBe(3);
     expect(ids.sort()).toEqual(feeds.map((f) => f.id).sort());
+  });
+
+  it('[200] 구독 중이어도 차단한 RSS의 게시글은 구독 피드에서 제외된다.', async () => {
+    // given - 두 블로그 모두 구독, 한 블로그는 차단
+    const rssBlockRepository = testApp.get(RssBlockRepository);
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(subscribedBlog, { isPublic: true }),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(otherBlog, { isPublic: true }),
+    );
+    await subscriptionRepository.insert({ user, rssAccept: subscribedBlog });
+    await subscriptionRepository.insert({ user, rssAccept: otherBlog });
+    await rssBlockRepository.save({
+      blocker: { id: user.id },
+      blockedRss: { id: otherBlog.id },
+    });
+
+    // when
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { result } = (response.body as SubscriptionFeedBody).data;
+    expect(result).toHaveLength(1);
+    expect(result[0].author).toBe(subscribedBlog.name);
   });
 });

--- a/server/test/user/e2e/get-profile.e2e-spec.ts
+++ b/server/test/user/e2e/get-profile.e2e-spec.ts
@@ -1,24 +1,28 @@
 import { HttpStatus } from '@nestjs/common';
 
+import { BlockRepository } from '@block/repository/block.repository';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { GetUserProfileResponseDto } from '@user/dto/response/getUserProfile.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
-import { testApp } from '@test/config/e2e/env/jest.setup';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = (id: number | string) => `/api/users/${id}/profile`;
 
 describe(`GET /api/users/:id/profile E2E Test`, () => {
   let agent: TestAgent;
   let userRepository: UserRepository;
+  let blockRepository: BlockRepository;
   let user: User;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     userRepository = testApp.get(UserRepository);
+    blockRepository = testApp.get(BlockRepository);
   });
 
   beforeEach(async () => {
@@ -49,6 +53,7 @@ describe(`GET /api/users/:id/profile E2E Test`, () => {
       maxStreak: user.maxStreak,
       currentStreak: user.currentStreak,
       totalViews: user.totalViews,
+      isBlocked: false,
     });
   });
 
@@ -75,7 +80,52 @@ describe(`GET /api/users/:id/profile E2E Test`, () => {
       maxStreak: minimalUser.maxStreak,
       currentStreak: minimalUser.currentStreak,
       totalViews: minimalUser.totalViews,
+      isBlocked: false,
     });
+  });
+
+  it('[200] 차단한 유저의 프로필을 조회하면 isBlocked가 true로 반환된다.', async () => {
+    // given
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await blockRepository.save({
+      blocker: { id: viewer.id },
+      blocked: { id: user.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // Http when
+    const response = await agent
+      .get(URL(user.id))
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data }: { data: GetUserProfileResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.isBlocked).toBe(true);
+  });
+
+  it('[200] 차단당한 유저가 차단한 유저의 프로필을 조회하면 isBlocked가 false로 반환된다.', async () => {
+    // given - 차단은 단방향이므로 반대 방향 조회에는 영향이 없다
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await blockRepository.save({
+      blocker: { id: user.id },
+      blocked: { id: viewer.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // Http when
+    const response = await agent
+      .get(URL(user.id))
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // Http then
+    const { data }: { data: GetUserProfileResponseDto } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.isBlocked).toBe(false);
   });
 
   it('[404] 존재하지 않는 유저를 조회하면 실패한다.', async () => {

--- a/server/test/user/e2e/search.e2e-spec.ts
+++ b/server/test/user/e2e/search.e2e-spec.ts
@@ -3,21 +3,34 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { BlockRepository } from '@block/repository/block.repository';
+
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
-import { testApp } from '@test/config/e2e/env/jest.setup';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = '/api/users/search';
+
+type SearchResponseBody = {
+  data: {
+    totalCount: number;
+    totalPages: number;
+    limit: number;
+    result: { id: number; userName: string; profileImage: string | null }[];
+  };
+};
 
 describe(`GET ${URL}?find={} E2E Test`, () => {
   let agent: TestAgent;
   let userRepository: UserRepository;
+  let blockRepository: BlockRepository;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     userRepository = testApp.get(UserRepository);
+    blockRepository = testApp.get(BlockRepository);
   });
 
   const saveUser = (userName: string, overwrites: Partial<User> = {}) =>
@@ -37,12 +50,12 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
     const response = await agent.get(URL).query({ find: '김' });
 
     // then
-    const { data } = response.body;
+    const { data } = response.body as SearchResponseBody;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data.totalCount).toBe(4);
     expect(data.totalPages).toBe(1);
     expect(data.limit).toBe(5);
-    expect(data.result.map((user: { id: number }) => user.id)).toStrictEqual([
+    expect(data.result.map((user) => user.id)).toStrictEqual([
       exact.id,
       prefixA.id,
       prefixB.id,
@@ -61,7 +74,7 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
     const response = await agent.get(URL).query({ find: '프로필유저' });
 
     // then
-    const { data } = response.body;
+    const { data } = response.body as SearchResponseBody;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data.result).toStrictEqual([
       {
@@ -80,7 +93,7 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
     const response = await agent.get(URL).query({ find: '이미지없음' });
 
     // then
-    const { data } = response.body;
+    const { data } = response.body as SearchResponseBody;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data.result[0]).toStrictEqual({
       id: user.id,
@@ -98,7 +111,7 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
     const response = await agent.get(URL).query({ find: 'a%b' });
 
     // then
-    const { data } = response.body;
+    const { data } = response.body as SearchResponseBody;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data.totalCount).toBe(1);
     expect(data.result[0].id).toBe(literal.id);
@@ -132,15 +145,62 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
     const response = await agent.get(URL).query({ find: '김', page: 2, limit: 2 });
 
     // then
-    const { data } = response.body;
+    const { data } = response.body as SearchResponseBody;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data.totalCount).toBe(6);
     expect(data.totalPages).toBe(3);
     expect(data.limit).toBe(2);
-    expect(data.result.map((user: { id: number }) => user.id)).toStrictEqual([
+    expect(data.result.map((user) => user.id)).toStrictEqual([
       users[2].id,
       users[3].id,
     ]);
+  });
+
+  it('[200] 로그인 사용자의 검색 결과에서 차단한 유저를 제외하고 totalCount에도 반영한다.', async () => {
+    // given
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    const blocked = await saveUser('김차단');
+    const visible = await saveUser('김공개');
+    await blockRepository.save({
+      blocker: { id: viewer.id },
+      blocked: { id: blocked.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // when
+    const response = await agent
+      .get(URL)
+      .query({ find: '김' })
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // then
+    const { data } = response.body as SearchResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.totalCount).toBe(1);
+    expect(data.result.map((user) => user.id)).toStrictEqual([visible.id]);
+  });
+
+  it('[200] 비로그인 사용자의 검색 결과에는 차단 필터가 적용되지 않는다.', async () => {
+    // given - 다른 유저가 차단했더라도 비로그인 검색에는 영향이 없다
+    const otherUser = await userRepository.save(
+      UserFixture.createUserFixture(),
+    );
+    const blocked = await saveUser('김차단');
+    await blockRepository.save({
+      blocker: { id: otherUser.id },
+      blocked: { id: blocked.id },
+    });
+
+    // when
+    const response = await agent.get(URL).query({ find: '김차단' });
+
+    // then
+    const { data } = response.body as SearchResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.totalCount).toBe(1);
+    expect(data.result[0].id).toBe(blocked.id);
   });
 
   it('[400] 검색어(find)가 없으면 검증에 실패한다.', async () => {

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -194,7 +194,12 @@ describe(`${UserService.name} Unit Test`, () => {
       );
 
       // then
-      expect(userRepository.searchUserList).toHaveBeenCalledWith('김', 4, 8);
+      expect(userRepository.searchUserList).toHaveBeenCalledWith(
+        '김',
+        4,
+        8,
+        undefined,
+      );
     });
 
     it('검색 결과가 없으면 빈 배열과 0건을 반환한다.', async () => {

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -20,6 +20,7 @@
     "paths": {
       "@activity/*": ["./src/activity/*"],
       "@admin/*": ["./src/admin/*"],
+      "@block/*": ["./src/block/*"],
       "@chat/*": ["./src/chat/*"],
       "@comment/*": ["./src/comment/*"],
       "@common/*": ["./src/common/*"],


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #791

### 사용자·RSS 차단 도메인 구현

- 기존에 없던 차단(block) 도메인을 신설했습니다. `block` / `rss_block` 두 엔티티로 **사용자 차단**과 **RSS 차단**을 분리해 관리합니다.
- 차단 시 단순 조회 제한을 넘어, 차단한 대상의 콘텐츠가 서비스 전반(피드 목록/검색/상세, 최신 RSS, 댓글, 프로필)에서 노출되지 않도록 각 조회 쿼리에 필터를 반영했습니다.
- `blocker`/`blocked` 유니크 제약으로 중복 차단을 DB 레벨에서 차단하고, `ER_DUP_ENTRY`를 `ConflictException(이미 차단한 ...)`으로 변환해 멱등성을 보장합니다.
- 유저 차단 모달에서 대상이 소유한 인증 RSS 목록을 함께 노출하고, 토글로 선택한 RSS를 유저 차단과 동시에 차단할 수 있게 했습니다. (기본값 OFF — 유저 차단만으로 RSS가 함께 차단되는 사고 방지)

### trending·short polling 게시글은 왜 서버 차단이 아닌 프론트 필터인가

- trending 게시글은 **Redis에 집계된 전역 랭킹**을 SSE로 브로드캐스트하는 구조입니다. 모든 구독자에게 동일한 페이로드를 push하기 때문에, **요청자(viewer)별 차단 컨텍스트를 서버가 알 수 없습니다.**
- short polling 게시글도 Redis에 캐싱된 데이터를 제공하는 방식이기에 DB에 접근하는 순간 Redis의 캐싱 이점이 저하되게 됩니다.
- 여기에 사용자별 차단 필터를 서버에서 적용하려면 Redis 집계 결과를 viewer마다 재가공해야 하는데, 이는 SSE 브로드캐스트의 전역성·성능 이점을 무너뜨립니다.
- 따라서 trending / SSE 수신 게시글은 **서버에서 block을 제공하지 않고**, 클라이언트가 `useBlockedRss`로 받은 차단 RSS 목록을 기준으로 `author` 기반 필터링을 수행합니다. (`useTrendingPosts`)
- 반대로 일반 피드/검색/상세/최신 RSS 등 **요청자 인증 컨텍스트가 있는 HTTP 조회**는 모두 서버에서 차단 필터를 적용합니다.

# 📋 작업 내용

**Backend**
- `block` 도메인 신설: 사용자/RSS 차단 등록·해제·조회 API + 엔티티 2종 + 마이그레이션 2종
- 피드 목록/검색/상세, 최신 RSS, RSS 정보, 댓글, 유저 검색/프로필 조회에 차단 필터 반영
- E2E/유닛 테스트 작성 (차단 CRUD, 각 조회 필터 반영 검증)

**Frontend**
- 차단 API 서비스 + `useBlock` 훅 (유저/RSS 차단·해제·조회)
- 마이페이지 차단 관리 탭 (유저/RSS 차단 목록 + 해제)
- 프로필 차단 모달: 소유 인증 RSS 목록 카드 UI + 개별/전체 토글로 함께 차단
- 게시글 상세·RSS 페이지 차단 표기, trending 게시글 프론트 필터링
- Vitest / Storybook 테스트·픽스처 작성

# 📷 스크린 샷(선택 사항)

<img width="991" height="806" alt="image" src="https://github.com/user-attachments/assets/34c0ddc1-85ad-4b9a-b56b-3b34ab95ca4d" />
<img width="1522" height="816" alt="image" src="https://github.com/user-attachments/assets/64ecf7ce-1a06-4dd0-a75e-c81072f87631" />
<img width="1269" height="416" alt="image" src="https://github.com/user-attachments/assets/3a55fb9e-d19f-4381-9ace-2164fa241d18" />
<img width="939" height="396" alt="image" src="https://github.com/user-attachments/assets/eb00799d-18a7-42af-8f1a-42271a90777b" />
<img width="630" height="337" alt="image" src="https://github.com/user-attachments/assets/104e29f4-2b12-44bf-81df-5f4c18949871" />