### PR TITLE
📦 chore: pre-commit lint 훅 도입 및 기존 lint 오류 정리

### DIFF
--- a/client/src/__tests__/__mocks__/components/ui/Pagination.tsx
+++ b/client/src/__tests__/__mocks__/components/ui/Pagination.tsx
@@ -1,18 +1,28 @@
+import { ReactNode } from "react";
+
+type MockPaginationProps = {
+  className?: string;
+  onClick?: () => void;
+  children?: ReactNode;
+};
+
 export const mockPagination = {
-  Pagination: ({ className, children }: any) => <nav className={className}>{children}</nav>,
-  PaginationContent: ({ children }: any) => <ul>{children}</ul>,
-  PaginationItem: ({ children }: any) => <li>{children}</li>,
-  PaginationLink: ({ className, onClick, children }: any) => (
+  Pagination: ({ className, children }: MockPaginationProps) => (
+    <nav className={className}>{children}</nav>
+  ),
+  PaginationContent: ({ children }: MockPaginationProps) => <ul>{children}</ul>,
+  PaginationItem: ({ children }: MockPaginationProps) => <li>{children}</li>,
+  PaginationLink: ({ className, onClick, children }: MockPaginationProps) => (
     <button className={className} onClick={onClick}>
       {children}
     </button>
   ),
-  PaginationPrevious: ({ onClick, className }: any) => (
+  PaginationPrevious: ({ onClick, className }: MockPaginationProps) => (
     <button onClick={onClick} className={className}>
       Previous
     </button>
   ),
-  PaginationNext: ({ onClick, className }: any) => (
+  PaginationNext: ({ onClick, className }: MockPaginationProps) => (
     <button onClick={onClick} className={className}>
       Next
     </button>

--- a/client/src/api/instance.ts
+++ b/client/src/api/instance.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from "axios";
+import axios, { AxiosError, AxiosHeaders, InternalAxiosRequestConfig } from "axios";
 
 import { BASE_URL } from "@/constants/endpoints";
 import { useAuthStore } from "@/store/useAuthStore.ts";
@@ -28,17 +28,15 @@ axiosInstance.interceptors.request.use((config) => {
   return config;
 });
 
-type RetryConfig = {
+type RetryConfig = InternalAxiosRequestConfig & {
   _retry?: boolean;
   _skipRefresh?: boolean;
-  headers?: any;
-  [key: string]: any;
 };
 
 // 응답 인터셉터: 401이면 refresh 1회 후 재시도
 axiosInstance.interceptors.response.use((res) => res, async (error: AxiosError) => {
   const status = error.response?.status;
-  const originalRequest = (error.config ?? {}) as RetryConfig;
+  const originalRequest = error.config as RetryConfig | undefined;
 
   if (status !== 401 || !originalRequest) {
     return Promise.reject(error);
@@ -74,7 +72,7 @@ axiosInstance.interceptors.response.use((res) => res, async (error: AxiosError) 
       return Promise.reject(error);
     }
 
-    originalRequest.headers = originalRequest.headers ?? {};
+    originalRequest.headers = originalRequest.headers ?? new AxiosHeaders();
     originalRequest.headers.Authorization = `Bearer ${newToken}`;
     return axiosInstance.request(originalRequest);
   } catch (e) {

--- a/client/src/components/admin/layout/AdminTabs.tsx
+++ b/client/src/components/admin/layout/AdminTabs.tsx
@@ -103,27 +103,17 @@ export const AdminTabs = ({ setLogout }: { setLogout: () => void }) => {
       </div>
     );
 
-  const pendingRss: AdminRssData[] =
+  const filterBySearchParam = (rssList: AdminRssData[] = []): AdminRssData[] =>
     searchParam === ""
-      ? pendingData.data
-      : pendingData.data.filter(
+      ? rssList
+      : rssList.filter(
           (data: AdminRssData) =>
             data.name.includes(searchParam) || data.userName.includes(searchParam) || data.rssUrl.includes(searchParam)
         );
-  const acceptedRss: AdminRssData[] =
-    searchParam === ""
-      ? acceptedData.data
-      : acceptedData.data.filter(
-          (data: AdminRssData) =>
-            data.name.includes(searchParam) || data.userName.includes(searchParam) || data.rssUrl.includes(searchParam)
-        );
-  const rejectedRss: AdminRssData[] =
-    searchParam === ""
-      ? rejectedData.data
-      : rejectedData.data.filter(
-          (data: AdminRssData) =>
-            data.name.includes(searchParam) || data.userName.includes(searchParam) || data.rssUrl.includes(searchParam)
-        );
+
+  const pendingRss: AdminRssData[] = filterBySearchParam(pendingData?.data);
+  const acceptedRss: AdminRssData[] = filterBySearchParam(acceptedData?.data);
+  const rejectedRss: AdminRssData[] = filterBySearchParam(rejectedData?.data);
 
   return (
     <div>

--- a/client/src/components/common/Card/detail/ShareButton.tsx
+++ b/client/src/components/common/Card/detail/ShareButton.tsx
@@ -11,9 +11,24 @@ import { TOAST_MESSAGES } from "@/constants/messages.ts";
 import { useMediaStore } from "@/store/useMediaStore";
 import { FeedDetail } from "@/types/post";
 
+type KakaoSDK = {
+  init: (appKey: string) => void;
+  cleanup?: () => void;
+  Share: {
+    sendDefault: (settings: {
+      objectType: "feed";
+      content: {
+        title: string;
+        imageUrl: string;
+        link: { webUrl: string };
+      };
+    }) => void;
+  };
+};
+
 declare global {
   interface Window {
-    Kakao: any;
+    Kakao: KakaoSDK;
   }
 }
 type ButtonType = {

--- a/client/src/components/ui/chart.tsx
+++ b/client/src/components/ui/chart.tsx
@@ -67,7 +67,7 @@ ChartContainer.displayName = "Chart"
 
 const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
   const colorConfig = Object.entries(config).filter(
-    ([_, config]) => config.theme || config.color
+    ([, config]) => config.theme || config.color
   )
 
   if (!colorConfig.length) {

--- a/client/src/hooks/queries/useFetchRss.ts
+++ b/client/src/hooks/queries/useFetchRss.ts
@@ -1,7 +1,7 @@
 import { admin } from "@/api/services/admin/rss";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
-export const useFetchData = (queryKey: string, queryFn: () => Promise<any>) => {
+export const useFetchData = <TData,>(queryKey: string, queryFn: () => Promise<TData>) => {
   const queryClient = useQueryClient();
 
   const { data, isLoading, error } = useQuery({

--- a/client/src/hooks/queries/useRegisterRss.ts
+++ b/client/src/hooks/queries/useRegisterRss.ts
@@ -6,9 +6,9 @@ import { useMutation, UseMutationResult } from "@tanstack/react-query";
 
 export const useRegisterRss = (
   onSuccess: (data: RegisterResponse) => void,
-  onError: (error: AxiosError<unknown, any>) => void
-): UseMutationResult<RegisterResponse, AxiosError<unknown, any>, RegisterRss, unknown> => {
-  return useMutation<RegisterResponse, AxiosError<unknown, any>, RegisterRss>({
+  onError: (error: AxiosError<unknown>) => void
+): UseMutationResult<RegisterResponse, AxiosError<unknown>, RegisterRss, unknown> => {
+  return useMutation<RegisterResponse, AxiosError<unknown>, RegisterRss>({
     mutationFn: registerRss,
     onSuccess,
     onError,

--- a/client/src/hooks/queries/useRssActions.ts
+++ b/client/src/hooks/queries/useRssActions.ts
@@ -6,9 +6,9 @@ import { useMutation, UseMutationResult } from "@tanstack/react-query";
 
 export const useAdminAccept = (
   onSuccess: (data: AdminResponse) => void,
-  onError: (error: AxiosError<unknown, any>) => void
-): UseMutationResult<AdminResponse, AxiosError<unknown, any>, AdminRequest, unknown> => {
-  return useMutation<AdminResponse, AxiosError<unknown, any>, AdminRequest>({
+  onError: (error: AxiosError<unknown>) => void
+): UseMutationResult<AdminResponse, AxiosError<unknown>, AdminRequest, unknown> => {
+  return useMutation<AdminResponse, AxiosError<unknown>, AdminRequest>({
     mutationFn: async (data) => {
       const response = await admin.acceptRss(data);
       return response;
@@ -20,9 +20,9 @@ export const useAdminAccept = (
 
 export const useAdminReject = (
   onSuccess: (data: AdminResponse) => void,
-  onError: (error: AxiosError<unknown, any>) => void
-): UseMutationResult<AdminResponse, AxiosError<unknown, any>, AdminRequest, unknown> => {
-  return useMutation<AdminResponse, AxiosError<unknown, any>, AdminRequest>({
+  onError: (error: AxiosError<unknown>) => void
+): UseMutationResult<AdminResponse, AxiosError<unknown>, AdminRequest, unknown> => {
+  return useMutation<AdminResponse, AxiosError<unknown>, AdminRequest>({
     mutationFn: async (data) => {
       const response = await admin.rejectRss(data);
       return response;

--- a/client/src/hooks/queries/useSearch.ts
+++ b/client/src/hooks/queries/useSearch.ts
@@ -10,7 +10,7 @@ export const useSearch = ({ query, filter, page, pageSize }: SearchRequest) => {
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   const queryClient = useQueryClient();
   useEffect(() => {
-    const handler = debounce((newQuery) => {
+    const handler = debounce((newQuery: string) => {
       setDebouncedQuery(newQuery);
     }, 300);
 

--- a/client/src/hooks/queries/useUserSearch.ts
+++ b/client/src/hooks/queries/useUserSearch.ts
@@ -9,7 +9,7 @@ import { useQuery } from "@tanstack/react-query";
 export const useUserSearch = ({ query, page, pageSize }: UserSearchRequest) => {
   const [debouncedQuery, setDebouncedQuery] = useState(query);
   useEffect(() => {
-    const handler = debounce((newQuery) => {
+    const handler = debounce((newQuery: string) => {
       setDebouncedQuery(newQuery);
     }, 300);
 

--- a/client/src/utils/debounce.ts
+++ b/client/src/utils/debounce.ts
@@ -1,6 +1,9 @@
-export function debounce(func: (...args: any[]) => void, delay: number) {
+export function debounce<Args extends unknown[]>(
+  func: (...args: Args) => void,
+  delay: number,
+) {
   let timer: ReturnType<typeof setTimeout>;
-  const debounced = (...args: any[]) => {
+  const debounced = (...args: Args) => {
     clearTimeout(timer);
     timer = setTimeout(() => func(...args), delay);
   };

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,3 +1,6 @@
+import typography from "@tailwindcss/typography";
+import animate from "tailwindcss-animate";
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ["class"],
@@ -96,5 +99,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
+  plugins: [animate, typography],
 };

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,3 +1,23 @@
+pre-commit:
+    parallel: true
+    commands:
+        client:
+            root: client/
+            glob: '*.{ts,tsx,js,jsx}'
+            run: npx eslint {staged_files}
+        server:
+            root: server/
+            glob: '*.ts'
+            run: npx eslint {staged_files}
+        feed-crawler:
+            root: feed-crawler/
+            glob: '*.ts'
+            run: npx eslint {staged_files}
+        email-worker:
+            root: email-worker/
+            glob: '*.ts'
+            run: npx eslint {staged_files}
+
 commit-msg:
     parallel: true
     commands:

--- a/server/test/chat/e2e/adminChat.e2e-spec.ts
+++ b/server/test/chat/e2e/adminChat.e2e-spec.ts
@@ -11,6 +11,10 @@ import {
   ADMIN_DELETED_USERNAME,
 } from '@chat/constant/constant';
 import { RedisMessagePayload } from '@chat/constant/type';
+import {
+  AdminChatMessageDto,
+  AdminChatRoomDto,
+} from '@chat/dto/response/adminChat.dto';
 
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
@@ -86,10 +90,9 @@ describe('Admin Chat (/api/admins/chats) E2E Test', () => {
 
       // then
       expect(response.status).toBe(HttpStatus.OK);
-      expect(response.body.data).toHaveLength(3);
-      const room1 = response.body.data.find(
-        (r: { roomId: string }) => r.roomId === ROOM,
-      );
+      const { data }: { data: AdminChatRoomDto[] } = response.body;
+      expect(data).toHaveLength(3);
+      const room1 = data.find((r) => r.roomId === ROOM);
       expect(room1).toMatchObject({
         roomId: ROOM,
         roomName: '익명 채팅방 1',
@@ -134,10 +137,8 @@ describe('Admin Chat (/api/admins/chats) E2E Test', () => {
 
       // then
       expect(response.status).toBe(HttpStatus.OK);
-      expect(response.body.data.map((m: RedisMessagePayload) => m.message)).toStrictEqual([
-        'older',
-        'newer',
-      ]);
+      const { data }: { data: AdminChatMessageDto[] } = response.body;
+      expect(data.map((m) => m.message)).toStrictEqual(['older', 'newer']);
     });
 
     it('[200] 메시지가 없으면 빈 배열을 반환한다.', async () => {
@@ -146,7 +147,8 @@ describe('Admin Chat (/api/admins/chats) E2E Test', () => {
         .set('Cookie', `sessionId=${sessionKey}`);
 
       expect(response.status).toBe(HttpStatus.OK);
-      expect(response.body.data).toStrictEqual([]);
+      const { data }: { data: AdminChatMessageDto[] } = response.body;
+      expect(data).toStrictEqual([]);
     });
   });
 

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -6,11 +6,11 @@ import {
 
 import { DataSource } from 'typeorm';
 
-import { CommentService } from '@comment/service/comment.service';
 import { GetCommentResponseDto } from '@comment/dto/response/getComment.dto';
 import { GetUserCommentsResponseDto } from '@comment/dto/response/getUserComments.dto';
 import { Comment } from '@comment/entity/comment.entity';
 import { CommentRepository } from '@comment/repository/comment.repository';
+import { CommentService } from '@comment/service/comment.service';
 
 import { Payload } from '@common/guard/jwt.guard';
 
@@ -77,7 +77,10 @@ describe(`${CommentService.name} Unit Test`, () => {
           user: { id: 1, userName: 'tester', profileImage: null },
         },
       ] as any;
-      feedService.getPublicFeed.mockResolvedValue({ id: 10, isPublic: true } as any);
+      feedService.getPublicFeed.mockResolvedValue({
+        id: 10,
+        isPublic: true,
+      } as any);
       commentRepository.getCommentInformation.mockResolvedValue(comments);
 
       // when
@@ -198,13 +201,13 @@ describe(`${CommentService.name} Unit Test`, () => {
     it('비공개 게시글이면 NotFoundException을 던지고 저장하지 않는다.', async () => {
       // given - getPublicFeed가 비공개 게시글에 대해 404를 던진다.
       feedService.getPublicFeed.mockRejectedValue(
-        new NotFoundException('존재하지 않는 게시글입니다.')
+        new NotFoundException('존재하지 않는 게시글입니다.'),
       );
 
       // when & then
-      await expect(commentService.create(user, 10, { comment: 'x' })).rejects.toThrow(
-        NotFoundException
-      );
+      await expect(
+        commentService.create(user, 10, { comment: 'x' }),
+      ).rejects.toThrow(NotFoundException);
       expect(manager.save).not.toHaveBeenCalled();
     });
 
@@ -346,7 +349,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         isDeleted: false,
         user: { id: user.id },
         feed,
-      } as any;
+      } as Comment;
       commentRepository.findOne.mockResolvedValue(comment);
       commentRepository.count.mockResolvedValue(2);
 
@@ -414,8 +417,8 @@ describe(`${CommentService.name} Unit Test`, () => {
         id: 5,
         isDeleted: false,
         isAdminDeleted: false,
-      } as any;
-      commentRepository.findOne.mockResolvedValue(comment);
+      };
+      commentRepository.findOne.mockResolvedValue(comment as unknown as Comment);
 
       // when
       await commentService.deleteByAdmin(5);
@@ -455,7 +458,11 @@ describe(`${CommentService.name} Unit Test`, () => {
       // then
       expect(dto.comment).toBe('관리자에 의해 제거된 댓글입니다.');
       expect(dto.isDeleted).toBe(true);
-      expect(dto.user).toEqual({ id: 0, userName: '(알 수 없음)', profileImage: null });
+      expect(dto.user).toEqual({
+        id: 0,
+        userName: '(알 수 없음)',
+        profileImage: null,
+      });
     });
 
     it('일반 soft delete 댓글은 "삭제된 댓글입니다." placeholder로 변환한다.', () => {

--- a/server/test/feed/e2e/visibility.e2e-spec.ts
+++ b/server/test/feed/e2e/visibility.e2e-spec.ts
@@ -3,6 +3,8 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { GetFeedDetailResponseDto } from '@feed/dto/response/getFeedDetail';
+import { ReadFeedPaginationResponseDto } from '@feed/dto/response/readFeedPagination.dto';
 import { Feed } from '@feed/entity/feed.entity';
 import { FeedRepository } from '@feed/repository/feed.repository';
 
@@ -45,7 +47,8 @@ describe(`비공개 게시글 공개 노출 제외 E2E Test (feed_view 필터)`,
     const response = await agent.get(URL).query({ limit: 10 });
 
     expect(response.status).toBe(HttpStatus.OK);
-    const ids = response.body.data.result.map((f: { id: number }) => f.id);
+    const { data }: { data: ReadFeedPaginationResponseDto } = response.body;
+    const ids = data.result.map((f) => f.id);
     expect(ids).toContain(publicFeed.id);
     expect(ids).not.toContain(privateFeed.id);
   });
@@ -58,6 +61,7 @@ describe(`비공개 게시글 공개 노출 제외 E2E Test (feed_view 필터)`,
   it('[200] 공개 게시글 상세 조회는 정상 제공된다.', async () => {
     const response = await agent.get(`${URL}/${publicFeed.id}`);
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data.id).toBe(publicFeed.id);
+    const { data }: { data: GetFeedDetailResponseDto } = response.body;
+    expect(data.id).toBe(publicFeed.id);
   });
 });

--- a/server/test/like/e2e/get.e2e-spec.ts
+++ b/server/test/like/e2e/get.e2e-spec.ts
@@ -6,6 +6,7 @@ import TestAgent from 'supertest/lib/agent';
 import { Feed } from '@feed/entity/feed.entity';
 import { FeedRepository } from '@feed/repository/feed.repository';
 
+import { GetLikeResponseDto } from '@like/dto/response/getLike.dto';
 import { LikeRepository } from '@like/repository/like.repository';
 
 import { RssAccept } from '@rss/entity/rss.entity';
@@ -74,7 +75,8 @@ describe(`GET ${BASE_URL}/:feedId/likes E2E Test`, () => {
 
     // Http then
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
-    expect(response.body.data).toBeUndefined();
+    const { data }: { data: GetLikeResponseDto } = response.body;
+    expect(data).toBeUndefined();
   });
 
   it('[200] 로그인하지 않은 상황에서 게시글에 대한 좋아요 조회 요청을 받을 경우 좋아요 정보 제공을 성공한다.', async () => {

--- a/server/test/rss/e2e/certification/feeds.e2e-spec.ts
+++ b/server/test/rss/e2e/certification/feeds.e2e-spec.ts
@@ -6,6 +6,7 @@ import TestAgent from 'supertest/lib/agent';
 import { Feed } from '@feed/entity/feed.entity';
 import { FeedRepository } from '@feed/repository/feed.repository';
 
+import { GetOwnedRssFeedsResponseDto } from '@rss/dto/response/getOwnedRssFeeds.dto';
 import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
@@ -85,10 +86,9 @@ describe(`소유 RSS 게시글 관리 E2E Test`, () => {
         .set('Authorization', `Bearer ${accessToken}`);
 
       expect(response.status).toBe(HttpStatus.OK);
-      const { data } = response.body;
+      const { data }: { data: GetOwnedRssFeedsResponseDto } = response.body;
       expect(data.result).toHaveLength(3);
-      // id DESC → feeds[2], feeds[1](비공개), feeds[0]
-      expect(data.result.map((f: { id: number }) => f.id)).toStrictEqual([
+      expect(data.result.map((f) => f.id)).toStrictEqual([
         feeds[2].id,
         feeds[1].id,
         feeds[0].id,

--- a/server/test/subscribe/e2e/get.e2e-spec.ts
+++ b/server/test/subscribe/e2e/get.e2e-spec.ts
@@ -6,6 +6,8 @@ import TestAgent from 'supertest/lib/agent';
 import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
+import { SubscribedRssResponseDto } from '@subscribe/dto/response/getMySubscriptions.dto';
+import { GetSubscriptionResponseDto } from '@subscribe/dto/response/getSubscription.dto';
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 import { User } from '@user/entity/user.entity';
@@ -51,8 +53,9 @@ describe(`GET 구독 상태/목록 E2E Test`, () => {
     const response = await agent.get(makeStatusURL(rssAccept.id));
 
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data.isSubscribed).toBe(false);
-    expect(response.body.data.subscriberCount).toBe(1);
+    const { data }: { data: GetSubscriptionResponseDto } = response.body;
+    expect(data.isSubscribed).toBe(false);
+    expect(data.subscriberCount).toBe(1);
   });
 
   it('[200] 로그인 + 구독 상태면 isSubscribed=true 를 반환한다.', async () => {
@@ -63,8 +66,9 @@ describe(`GET 구독 상태/목록 E2E Test`, () => {
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data.isSubscribed).toBe(true);
-    expect(response.body.data.subscriberCount).toBe(1);
+    const { data }: { data: GetSubscriptionResponseDto } = response.body;
+    expect(data.isSubscribed).toBe(true);
+    expect(data.subscriberCount).toBe(1);
   });
 
   it('[200] 특정 사용자의 구독 목록을 반환한다.', async () => {
@@ -73,8 +77,9 @@ describe(`GET 구독 상태/목록 E2E Test`, () => {
     const response = await agent.get(makeUserSubsURL(user.id));
 
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data).toHaveLength(1);
-    expect(response.body.data[0].id).toBe(rssAccept.id);
+    const { data }: { data: SubscribedRssResponseDto[] } = response.body;
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe(rssAccept.id);
   });
 
   it('[200] 비로그인 상태에서도 타 사용자의 구독 목록을 조회할 수 있다.', async () => {
@@ -86,7 +91,8 @@ describe(`GET 구독 상태/목록 E2E Test`, () => {
     const response = await agent.get(makeUserSubsURL(other.id));
 
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data).toHaveLength(1);
-    expect(response.body.data[0].id).toBe(rssAccept.id);
+    const { data }: { data: SubscribedRssResponseDto[] } = response.body;
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe(rssAccept.id);
   });
 });

--- a/server/test/subscribe/e2e/subscribers.e2e-spec.ts
+++ b/server/test/subscribe/e2e/subscribers.e2e-spec.ts
@@ -6,6 +6,7 @@ import TestAgent from 'supertest/lib/agent';
 import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
+import { GetSubscribersResponseDto } from '@subscribe/dto/response/getSubscribers.dto';
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 import { User } from '@user/entity/user.entity';
@@ -85,9 +86,10 @@ describe(`GET /api/rss/:rssId/subscribers E2E Test`, () => {
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data.result).toHaveLength(1);
-    expect(response.body.data.result[0].id).toBe(subscription.id);
-    expect(response.body.data.hasMore).toBe(false);
+    const { data }: { data: GetSubscribersResponseDto } = response.body;
+    expect(data.result).toHaveLength(1);
+    expect(data.result[0].id).toBe(subscription.id);
+    expect(data.hasMore).toBe(false);
   });
 
   it('[200] limit 기반 커서 페이지네이션이 동작한다.', async () => {
@@ -102,23 +104,20 @@ describe(`GET /api/rss/:rssId/subscribers E2E Test`, () => {
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(page1.status).toBe(HttpStatus.OK);
-    expect(page1.body.data.result.map((r: { id: number }) => r.id)).toEqual([
-      third.id,
-      second.id,
-    ]);
-    expect(page1.body.data.hasMore).toBe(true);
-    expect(page1.body.data.lastId).toBe(second.id);
+    const { data: page1Data }: { data: GetSubscribersResponseDto } = page1.body;
+    expect(page1Data.result.map((r) => r.id)).toEqual([third.id, second.id]);
+    expect(page1Data.hasMore).toBe(true);
+    expect(page1Data.lastId).toBe(second.id);
 
     // 2페이지: 커서(lastId) 이후 남은 1개 + hasMore=false
     const page2 = await agent
       .get(makeURL(ownedRss.id))
-      .query({ limit: 2, lastId: page1.body.data.lastId })
+      .query({ limit: 2, lastId: page1Data.lastId })
       .set('Authorization', `Bearer ${accessToken}`);
 
     expect(page2.status).toBe(HttpStatus.OK);
-    expect(page2.body.data.result.map((r: { id: number }) => r.id)).toEqual([
-      first.id,
-    ]);
-    expect(page2.body.data.hasMore).toBe(false);
+    const { data: page2Data }: { data: GetSubscribersResponseDto } = page2.body;
+    expect(page2Data.result.map((r) => r.id)).toEqual([first.id]);
+    expect(page2Data.hasMore).toBe(false);
   });
 });

--- a/server/test/tag/e2e/get.e2e-spec.ts
+++ b/server/test/tag/e2e/get.e2e-spec.ts
@@ -3,6 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { ReadTagResponseDto } from '@tag/dto/response/readTag.dto';
 import { Category } from '@tag/entity/category.entity';
 import { Tag } from '@tag/entity/tag.entity';
 import { CategoryRepository } from '@tag/repository/category.repository';
@@ -46,7 +47,8 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data).toStrictEqual([
+    const { data }: { data: ReadTagResponseDto[] } = response.body;
+    expect(data).toStrictEqual([
       { category: 'FrontEnd', tags: ['Frontend', 'React'] },
       { category: 'BackEnd', tags: ['Backend'] },
     ]);
@@ -58,6 +60,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data).toStrictEqual([]);
+    const { data }: { data: ReadTagResponseDto[] } = response.body;
+    expect(data).toStrictEqual([]);
   });
 });

--- a/server/test/user/e2e/username-availability.e2e-spec.ts
+++ b/server/test/user/e2e/username-availability.e2e-spec.ts
@@ -3,6 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
+import { CheckUserNameDuplicationResponseDto } from '@user/dto/response/checkUserNameDuplication.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
@@ -35,7 +36,8 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // Http then
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data).toEqual({ exists: true });
+    const { data }: { data: CheckUserNameDuplicationResponseDto } = response.body;
+    expect(data).toEqual({ exists: true });
   });
 
   it('[200] 존재하지 않는 닉네임이면 exists=false를 반환한다.', async () => {
@@ -46,7 +48,8 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // Http then
     expect(response.status).toBe(HttpStatus.OK);
-    expect(response.body.data).toEqual({ exists: false });
+    const { data }: { data: CheckUserNameDuplicationResponseDto } = response.body;
+    expect(data).toEqual({ exists: false });
   });
 
   it('[400] 닉네임이 비어 있으면 유효성 검사에 실패한다.', async () => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 관련 이슈 없음

### lefthook pre-commit lint 훅 도입

기존에는 `commit-msg`(commitlint)만 훅으로 걸려 있어 lint를 통과하지 않은 코드도 커밋이 가능했습니다. CI에서만 걸러지다 보니 PR을 올린 뒤에야 lint 실패를 발견하는 흐름이었습니다.

`lefthook.yml`에 `pre-commit`을 추가해 커밋 시점에 lint를 돌리도록 했습니다. 고민한 점은 아래 두 가지입니다.

- **전체 lint를 매번 돌리면 느립니다.** 4개 서비스 전체 `eslint .`는 커밋마다 20초 이상 걸립니다. `root:` + `glob:` + `{staged_files}` 조합으로 **스테이징된 파일이 있는 서비스만** lint 하도록 스코프를 제한했습니다. 관련 없는 파일만 커밋할 경우 4개 command 전부 skip되어 0.1초 내에 끝납니다.
- **`npm run commit`(commitizen)과의 호환.** commitizen은 내부적으로 `git commit`을 호출하므로 pre-commit 훅이 그대로 발동합니다. 다만 프롬프트 입력 → lint 실행 순서라 lint 실패 시 입력한 메시지가 유실됩니다. 이 경우 `npx cz --retry`로 직전 답변을 재사용할 수 있습니다.

### 기존 lint 오류 정리 (server 35건 / client 24건)

훅을 추가하니 기존 부채 59건이 드러났습니다. rule을 끄는 대신 전부 타입을 지정하는 방향으로 해결했습니다.

- **server (`no-unsafe-member-access` 35건)** — 전부 e2e/unit 테스트의 `response.body` 접근입니다. supertest가 `body`를 `any`로 주기 때문에 발생합니다. 인라인 리터럴 타입 대신 **실제 response DTO**를 재사용했고, 기존 `getUserComments`/`getUserLikes`/`oauth/link` 스펙과 동일한 `const { data }: { data: XxxResponseDto } = response.body;` 컨벤션을 따랐습니다.
- **client (`no-explicit-any` 등 24건)** — `debounce`를 제네릭으로, `useFetchData`를 `<TData>`로, `instance.ts`의 `RetryConfig`를 `InternalAxiosRequestConfig` 교차 타입으로, Kakao SDK를 `KakaoSDK` 타입으로 정리했습니다.

`useFetchData`에 제네릭을 넣자 **`AdminTabs.tsx`의 잠재 버그가 드러났습니다.** react-query의 `data`는 로딩 중 `undefined`인데 `pendingData.data`로 직접 접근하고 있었고, 기존에는 `any`라 타입 체커가 이를 잡지 못했습니다. `filterBySearchParam` 헬퍼로 `?? []` 처리했습니다.

# 📋 작업 내용

**`lefthook.yml`**

- `pre-commit` 추가: client / server / feed-crawler / email-worker 4개 서비스, `root:` + `glob:` 기반 스테이징 파일 한정 lint

**server (10개 테스트 파일, 35건)**

- e2e 스펙의 `response.body` 접근을 response DTO로 교체
  - `GetSubscriptionResponseDto`, `SubscribedRssResponseDto[]`, `GetSubscribersResponseDto`, `CheckUserNameDuplicationResponseDto`, `GetLikeResponseDto`, `ReadFeedPaginationResponseDto`, `GetFeedDetailResponseDto`, `ReadTagResponseDto[]`, `GetOwnedRssFeedsResponseDto`, `AdminChatRoomDto[]`, `AdminChatMessageDto[]`

**client (12개 파일, 24건)**

- `debounce.ts`: `<Args extends unknown[]>` 제네릭화 → `useSearch` / `useUserSearch` 콜백 파라미터 타입 명시
- `useFetchRss.ts`: `<TData>` 제네릭화 → `AdminTabs.tsx`의 `undefined` 접근 버그 수정
- `api/instance.ts`: `RetryConfig`를 `InternalAxiosRequestConfig` 기반으로 변경, `error.config` undefined 가드 활성화
- `ShareButton.tsx`: `window.Kakao` → `KakaoSDK` 타입 선언
- `useRegisterRss` / `useRssActions`: `AxiosError<unknown, any>` → `AxiosError<unknown>` (라이브러리 기본값, 타입 동일)
- `chart.tsx`: 미사용 destructure 변수 제거
- `__mocks__/Pagination.tsx`: `MockPaginationProps` 타입 지정
- `tailwind.config.js`: `require()` → `import` (파일이 이미 ESM이라 rename 불필요)

## ✅ 검증

| 항목 | 결과 |
| --- | --- |
| `eslint .` × 4 서비스 | 0 |
| `tsc --noEmit` (client, server) | 0 |
| client vitest | 148 files / 531 tests pass |
| server `test:unit` | 14 suites / 284 tests pass |
| client `build:local` | 성공, 빌드된 CSS에 `animate-in` / `--tw-enter` / `.prose` 존재 확인 |
| `lefthook run pre-commit --force` | 4/4 통과 |