### PR TITLE
🧼 clean: 사용자 차단 도메인 네이밍 정리 및 API 경로 네임스페이스화

### DIFF
--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -104,8 +104,8 @@ export const OAUTH = {
 };
 
 export const BLOCK = {
-  LIST: "/api/blocks",
-  MANAGE: (userId: number) => `/api/blocks/${userId}`,
+  LIST: "/api/blocks/user",
+  MANAGE: (userId: number) => `/api/blocks/user/${userId}`,
   RSS_LIST: "/api/blocks/rss",
   RSS_MANAGE: (rssId: number) => `/api/blocks/rss/${rssId}`,
 };

--- a/server/src/block/api-docs/createUserBlock.api-docs.ts
+++ b/server/src/block/api-docs/createUserBlock.api-docs.ts
@@ -9,7 +9,7 @@ import {
   ApiUnauthorizedDoc,
 } from '@common/swagger/swagger.helper';
 
-export function ApiCreateBlock() {
+export function ApiCreateUserBlock() {
   return applyDecorators(
     ApiOperation({ summary: '사용자 차단 등록 API' }),
     ApiBearerAuth(),

--- a/server/src/block/api-docs/deleteUserBlock.api-docs.ts
+++ b/server/src/block/api-docs/deleteUserBlock.api-docs.ts
@@ -7,7 +7,7 @@ import {
   ApiUnauthorizedDoc,
 } from '@common/swagger/swagger.helper';
 
-export function ApiDeleteBlock() {
+export function ApiDeleteUserBlock() {
   return applyDecorators(
     ApiOperation({ summary: '사용자 차단 해제 API' }),
     ApiBearerAuth(),

--- a/server/src/block/controller/block.controller.ts
+++ b/server/src/block/controller/block.controller.ts
@@ -14,9 +14,9 @@ import { CurrentUser } from '@common/decorator';
 import { JwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
 
-import { ApiCreateBlock } from '@block/api-docs/createBlock.api-docs';
+import { ApiCreateUserBlock } from '@block/api-docs/createUserBlock.api-docs';
 import { ApiCreateRssBlock } from '@block/api-docs/createRssBlock.api-docs';
-import { ApiDeleteBlock } from '@block/api-docs/deleteBlock.api-docs';
+import { ApiDeleteUserBlock } from '@block/api-docs/deleteUserBlock.api-docs';
 import { ApiDeleteRssBlock } from '@block/api-docs/deleteRssBlock.api-docs';
 import { ApiGetBlockedRss } from '@block/api-docs/getBlockedRss.api-docs';
 import { ApiGetBlockedUsers } from '@block/api-docs/getBlockedUsers.api-docs';
@@ -75,7 +75,7 @@ export class BlockController {
     return ApiResponse.responseWithNoContent('RSS 차단 해제를 성공했습니다.');
   }
 
-  @ApiCreateBlock()
+  @ApiCreateUserBlock()
   @Post('/:userId')
   @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.CREATED)
@@ -87,7 +87,7 @@ export class BlockController {
     return ApiResponse.responseWithNoContent('사용자 차단을 성공했습니다.');
   }
 
-  @ApiDeleteBlock()
+  @ApiDeleteUserBlock()
   @Delete('/:userId')
   @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.OK)

--- a/server/src/block/controller/block.controller.ts
+++ b/server/src/block/controller/block.controller.ts
@@ -30,7 +30,7 @@ export class BlockController {
   constructor(private readonly blockService: BlockService) {}
 
   @ApiGetBlockedUsers()
-  @Get()
+  @Get('/user')
   @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.OK)
   async getBlockedUsers(@CurrentUser() user: Payload) {
@@ -76,7 +76,7 @@ export class BlockController {
   }
 
   @ApiCreateUserBlock()
-  @Post('/:userId')
+  @Post('/user/:userId')
   @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.CREATED)
   async createBlock(
@@ -88,7 +88,7 @@ export class BlockController {
   }
 
   @ApiDeleteUserBlock()
-  @Delete('/:userId')
+  @Delete('/user/:userId')
   @UseGuards(JwtGuard)
   @HttpCode(HttpStatus.OK)
   async deleteBlock(

--- a/server/src/block/dto/response/getBlockedUsers.dto.ts
+++ b/server/src/block/dto/response/getBlockedUsers.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { Block } from '@block/entity/block.entity';
+import { UserBlock } from '@block/entity/userBlock.entity';
 
 export class GetBlockedUsersResponseDto {
   @ApiProperty({
@@ -32,7 +32,7 @@ export class GetBlockedUsersResponseDto {
     Object.assign(this, partial);
   }
 
-  static toResponseDtoArray(blocks: Block[]) {
+  static toResponseDtoArray(blocks: UserBlock[]) {
     return blocks.map(
       (block) =>
         new GetBlockedUsersResponseDto({

--- a/server/src/block/entity/userBlock.entity.ts
+++ b/server/src/block/entity/userBlock.entity.ts
@@ -12,7 +12,7 @@ import { User } from '@user/entity/user.entity';
 
 @Entity({ name: 'blocks' })
 @Unique(['blocker', 'blocked'])
-export class Block extends BaseEntity {
+export class UserBlock extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/server/src/block/module/block.module.ts
+++ b/server/src/block/module/block.module.ts
@@ -1,11 +1,11 @@
 import { Module } from '@nestjs/common';
 
-import { JwtAuthModule } from '@common/auth/jwt.module';
-
 import { BlockController } from '@block/controller/block.controller';
-import { BlockRepository } from '@block/repository/block.repository';
 import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 import { BlockService } from '@block/service/block.service';
+
+import { JwtAuthModule } from '@common/auth/jwt.module';
 
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
@@ -16,7 +16,7 @@ import { UserModule } from '@user/module/user.module';
   controllers: [BlockController],
   providers: [
     BlockService,
-    BlockRepository,
+    UserBlockRepository,
     RssBlockRepository,
     RssAcceptRepository,
   ],

--- a/server/src/block/repository/userBlock.repository.ts
+++ b/server/src/block/repository/userBlock.repository.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@nestjs/common';
 
 import { DataSource, Repository } from 'typeorm';
 
-import { Block } from '@block/entity/block.entity';
+import { UserBlock } from '@block/entity/userBlock.entity';
 
 @Injectable()
-export class BlockRepository extends Repository<Block> {
+export class UserBlockRepository extends Repository<UserBlock> {
   constructor(private dataSource: DataSource) {
-    super(Block, dataSource.createEntityManager());
+    super(UserBlock, dataSource.createEntityManager());
   }
 
   async getBlockedUsers(blockerId: number) {

--- a/server/src/block/service/block.service.ts
+++ b/server/src/block/service/block.service.ts
@@ -5,14 +5,14 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 
-import { Payload } from '@common/guard/jwt.guard';
-
 import { ManageBlockRequestDto } from '@block/dto/request/manageBlock.dto';
 import { ManageRssBlockRequestDto } from '@block/dto/request/manageRssBlock.dto';
 import { GetBlockedRssResponseDto } from '@block/dto/response/getBlockedRss.dto';
 import { GetBlockedUsersResponseDto } from '@block/dto/response/getBlockedUsers.dto';
-import { BlockRepository } from '@block/repository/block.repository';
 import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
+
+import { Payload } from '@common/guard/jwt.guard';
 
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
@@ -21,7 +21,7 @@ import { UserService } from '@user/service/user.service';
 @Injectable()
 export class BlockService {
   constructor(
-    private readonly blockRepository: BlockRepository,
+    private readonly userBlockRepository: UserBlockRepository,
     private readonly rssBlockRepository: RssBlockRepository,
     private readonly rssAcceptRepository: RssAcceptRepository,
     private readonly userService: UserService,
@@ -34,7 +34,7 @@ export class BlockService {
     await this.userService.getUser(blockDto.userId);
 
     try {
-      await this.blockRepository.insert({
+      await this.userBlockRepository.insert({
         blocker: { id: userInformation.id },
         blocked: { id: blockDto.userId },
       });
@@ -47,7 +47,7 @@ export class BlockService {
   }
 
   async delete(userInformation: Payload, blockDto: ManageBlockRequestDto) {
-    const result = await this.blockRepository.delete({
+    const result = await this.userBlockRepository.delete({
       blocker: { id: userInformation.id },
       blocked: { id: blockDto.userId },
     });
@@ -58,7 +58,7 @@ export class BlockService {
   }
 
   async getBlockedUsers(userInformation: Payload) {
-    const blocks = await this.blockRepository.getBlockedUsers(
+    const blocks = await this.userBlockRepository.getBlockedUsers(
       userInformation.id,
     );
     return GetBlockedUsersResponseDto.toResponseDtoArray(blocks);

--- a/server/src/user/repository/user.repository.ts
+++ b/server/src/user/repository/user.repository.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 
 import { DataSource, Repository } from 'typeorm';
 
-import { Block } from '@block/entity/block.entity';
+import { UserBlock } from '@block/entity/userBlock.entity';
 
 import { User } from '@user/entity/user.entity';
 
@@ -40,7 +40,7 @@ export class UserRepository extends Repository<User> {
   }
 
   async isUserBlocked(blockerId: number, blockedId: number) {
-    return await this.manager.exists(Block, {
+    return await this.manager.exists(UserBlock, {
       where: {
         blocker: { id: blockerId },
         blocked: { id: blockedId },

--- a/server/test/block/e2e/user-create.e2e-spec.ts
+++ b/server/test/block/e2e/user-create.e2e-spec.ts
@@ -3,7 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
-import { BlockRepository } from '@block/repository/block.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
@@ -11,11 +11,11 @@ import { UserRepository } from '@user/repository/user.repository';
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
 import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
-const BASE_URL = '/api/blocks';
+const BASE_URL = '/api/blocks/user';
 
 describe(`POST ${BASE_URL}/:userId E2E Test`, () => {
   let agent: TestAgent;
-  let blockRepository: BlockRepository;
+  let blockRepository: UserBlockRepository;
   let userRepository: UserRepository;
   let blocker: User;
   let target: User;
@@ -23,7 +23,7 @@ describe(`POST ${BASE_URL}/:userId E2E Test`, () => {
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
-    blockRepository = testApp.get(BlockRepository);
+    blockRepository = testApp.get(UserBlockRepository);
     userRepository = testApp.get(UserRepository);
   });
 

--- a/server/test/block/e2e/user-delete.e2e-spec.ts
+++ b/server/test/block/e2e/user-delete.e2e-spec.ts
@@ -3,7 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
-import { BlockRepository } from '@block/repository/block.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
@@ -11,11 +11,11 @@ import { UserRepository } from '@user/repository/user.repository';
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
 import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
-const BASE_URL = '/api/blocks';
+const BASE_URL = '/api/blocks/user';
 
 describe(`DELETE ${BASE_URL}/:userId E2E Test`, () => {
   let agent: TestAgent;
-  let blockRepository: BlockRepository;
+  let blockRepository: UserBlockRepository;
   let userRepository: UserRepository;
   let blocker: User;
   let target: User;
@@ -23,7 +23,7 @@ describe(`DELETE ${BASE_URL}/:userId E2E Test`, () => {
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
-    blockRepository = testApp.get(BlockRepository);
+    blockRepository = testApp.get(UserBlockRepository);
     userRepository = testApp.get(UserRepository);
   });
 

--- a/server/test/block/e2e/user-get.e2e-spec.ts
+++ b/server/test/block/e2e/user-get.e2e-spec.ts
@@ -3,7 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
-import { BlockRepository } from '@block/repository/block.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
@@ -11,18 +11,18 @@ import { UserRepository } from '@user/repository/user.repository';
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
 import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
-const BASE_URL = '/api/blocks';
+const BASE_URL = '/api/blocks/user';
 
 describe(`GET ${BASE_URL} E2E Test`, () => {
   let agent: TestAgent;
-  let blockRepository: BlockRepository;
+  let blockRepository: UserBlockRepository;
   let userRepository: UserRepository;
   let blocker: User;
   let accessToken: string;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
-    blockRepository = testApp.get(BlockRepository);
+    blockRepository = testApp.get(UserBlockRepository);
     userRepository = testApp.get(UserRepository);
   });
 

--- a/server/test/block/unit/block.service.unit.spec.ts
+++ b/server/test/block/unit/block.service.unit.spec.ts
@@ -4,15 +4,15 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 
-import { Payload } from '@common/guard/jwt.guard';
-
 import { GetBlockedRssResponseDto } from '@block/dto/response/getBlockedRss.dto';
 import { GetBlockedUsersResponseDto } from '@block/dto/response/getBlockedUsers.dto';
-import { Block } from '@block/entity/block.entity';
 import { RssBlock } from '@block/entity/rssBlock.entity';
-import { BlockRepository } from '@block/repository/block.repository';
+import { UserBlock } from '@block/entity/userBlock.entity';
 import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 import { BlockService } from '@block/service/block.service';
+
+import { Payload } from '@common/guard/jwt.guard';
 
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
@@ -21,7 +21,7 @@ import { UserService } from '@user/service/user.service';
 describe(`${BlockService.name} Unit Test`, () => {
   let blockService: BlockService;
   let blockRepository: jest.Mocked<
-    Pick<BlockRepository, 'insert' | 'delete' | 'getBlockedUsers'>
+    Pick<UserBlockRepository, 'insert' | 'delete' | 'getBlockedUsers'>
   >;
   let rssBlockRepository: jest.Mocked<
     Pick<RssBlockRepository, 'insert' | 'delete' | 'getBlockedRssList'>
@@ -52,7 +52,7 @@ describe(`${BlockService.name} Unit Test`, () => {
     userService = { getUser: jest.fn() };
 
     blockService = new BlockService(
-      blockRepository as unknown as BlockRepository,
+      blockRepository as unknown as UserBlockRepository,
       rssBlockRepository as unknown as RssBlockRepository,
       rssAcceptRepository as unknown as RssAcceptRepository,
       userService as unknown as UserService,
@@ -157,7 +157,7 @@ describe(`${BlockService.name} Unit Test`, () => {
             profileImage: null,
           },
         },
-      ] as Block[];
+      ] as UserBlock[];
       blockRepository.getBlockedUsers.mockResolvedValue(blocks);
 
       // when

--- a/server/test/comment/e2e/get.e2e-spec.ts
+++ b/server/test/comment/e2e/get.e2e-spec.ts
@@ -3,7 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
-import { BlockRepository } from '@block/repository/block.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 
 import { Comment } from '@comment/entity/comment.entity';
 import { CommentRepository } from '@comment/repository/comment.repository';
@@ -29,7 +29,7 @@ describe(`GET ${BASE_URL}/:feedId/comments E2E Test`, () => {
   let agent: TestAgent;
   let feed: Feed;
   let commentRepository: CommentRepository;
-  let blockRepository: BlockRepository;
+  let blockRepository: UserBlockRepository;
   let userRepository: UserRepository;
   let rssAcceptRepository: RssAcceptRepository;
   let feedRepository: FeedRepository;
@@ -40,7 +40,7 @@ describe(`GET ${BASE_URL}/:feedId/comments E2E Test`, () => {
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     commentRepository = testApp.get(CommentRepository);
-    blockRepository = testApp.get(BlockRepository);
+    blockRepository = testApp.get(UserBlockRepository);
     userRepository = testApp.get(UserRepository);
     rssAcceptRepository = testApp.get(RssAcceptRepository);
     feedRepository = testApp.get(FeedRepository);

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -76,7 +76,7 @@ describe(`${CommentService.name} Unit Test`, () => {
           date: new Date('2025-01-01'),
           user: { id: 1, userName: 'tester', profileImage: null },
         },
-      ] as any;
+      ] as Comment[];
       feedService.getPublicFeed.mockResolvedValue({
         id: 10,
         isPublic: true,
@@ -105,7 +105,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         comment: `c${id}`,
         date: new Date('2025-01-01'),
         feed: { id, title: `t${id}`, path: `https://example.com/${id}` },
-      }) as any;
+      }) as Comment;
 
     it('존재하지 않는 유저면 NotFoundException을 던진다.', async () => {
       // given
@@ -371,7 +371,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         parentId: 1,
         user: { id: user.id },
         feed,
-      } as any;
+      } as Comment;
       commentRepository.findOne.mockResolvedValue(comment);
 
       // when
@@ -386,7 +386,7 @@ describe(`${CommentService.name} Unit Test`, () => {
     it('본인 댓글이 아니어도 RSS 소유자면 댓글 수를 감소시키고 댓글을 제거한다.', async () => {
       // given
       const feed = { id: 10, commentCount: 3, blog: { userId: user.id } };
-      const comment = { id: 5, user: { id: 999 }, feed } as any;
+      const comment = { id: 5, user: { id: 999 }, feed } as Comment;
       commentRepository.findOne.mockResolvedValue(comment);
 
       // when
@@ -417,8 +417,8 @@ describe(`${CommentService.name} Unit Test`, () => {
         id: 5,
         isDeleted: false,
         isAdminDeleted: false,
-      };
-      commentRepository.findOne.mockResolvedValue(comment as unknown as Comment);
+      } as Comment;
+      commentRepository.findOne.mockResolvedValue(comment);
 
       // when
       await commentService.deleteByAdmin(5);
@@ -450,7 +450,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         ...baseComment,
         isDeleted: true,
         isAdminDeleted: true,
-      } as any;
+      } as Comment;
 
       // when
       const dto = GetCommentResponseDto.toResponseDto(comment);
@@ -471,7 +471,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         ...baseComment,
         isDeleted: true,
         isAdminDeleted: false,
-      } as any;
+      } as Comment;
 
       // when
       const dto = GetCommentResponseDto.toResponseDto(comment);
@@ -486,7 +486,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         ...baseComment,
         isDeleted: false,
         isAdminDeleted: false,
-      } as any;
+      } as Comment;
 
       // when
       const dto = GetCommentResponseDto.toResponseDto(comment);
@@ -504,8 +504,8 @@ describe(`${CommentService.name} Unit Test`, () => {
         comment: '이전',
         user: { id: user.id },
         feed: { id: 10 },
-      };
-      commentRepository.findOne.mockResolvedValue(comment as any);
+      } as Comment;
+      commentRepository.findOne.mockResolvedValue(comment);
       const dto = { newComment: '수정됨' };
 
       // when

--- a/server/test/user/e2e/get-profile.e2e-spec.ts
+++ b/server/test/user/e2e/get-profile.e2e-spec.ts
@@ -1,8 +1,9 @@
 import { HttpStatus } from '@nestjs/common';
 
-import { BlockRepository } from '@block/repository/block.repository';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
+
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 
 import { GetUserProfileResponseDto } from '@user/dto/response/getUserProfile.dto';
 import { User } from '@user/entity/user.entity';
@@ -16,13 +17,13 @@ const URL = (id: number | string) => `/api/users/${id}/profile`;
 describe(`GET /api/users/:id/profile E2E Test`, () => {
   let agent: TestAgent;
   let userRepository: UserRepository;
-  let blockRepository: BlockRepository;
+  let blockRepository: UserBlockRepository;
   let user: User;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     userRepository = testApp.get(UserRepository);
-    blockRepository = testApp.get(BlockRepository);
+    blockRepository = testApp.get(UserBlockRepository);
   });
 
   beforeEach(async () => {

--- a/server/test/user/e2e/search.e2e-spec.ts
+++ b/server/test/user/e2e/search.e2e-spec.ts
@@ -3,7 +3,7 @@ import { HttpStatus } from '@nestjs/common';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
 
-import { BlockRepository } from '@block/repository/block.repository';
+import { UserBlockRepository } from '@block/repository/userBlock.repository';
 
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
@@ -25,12 +25,12 @@ type SearchResponseBody = {
 describe(`GET ${URL}?find={} E2E Test`, () => {
   let agent: TestAgent;
   let userRepository: UserRepository;
-  let blockRepository: BlockRepository;
+  let blockRepository: UserBlockRepository;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     userRepository = testApp.get(UserRepository);
-    blockRepository = testApp.get(BlockRepository);
+    blockRepository = testApp.get(UserBlockRepository);
   });
 
   const saveUser = (userName: string, overwrites: Partial<User> = {}) =>
@@ -142,7 +142,9 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
     );
 
     // when
-    const response = await agent.get(URL).query({ find: '김', page: 2, limit: 2 });
+    const response = await agent
+      .get(URL)
+      .query({ find: '김', page: 2, limit: 2 });
 
     // then
     const { data } = response.body as SearchResponseBody;


### PR DESCRIPTION
# 🔨 테스크

### API 경로 네임스페이스 정리

- 기존 차단 API는 사용자 차단만 루트(`/api/blocks`)를 점유하고, RSS 차단만 `/api/blocks/rss` 하위에 존재하는 비대칭 구조였습니다.
- 사용자 차단도 `/api/blocks/user` 하위로 이동시켜, `blocks` 아래 모든 리소스가 동일한 규칙으로 네임스페이스를 갖도록 맞췄습니다.
- 이제 bare `/api/blocks` 경로는 존재하지 않으며, 이후 차단 대상이 늘어나도 같은 패턴으로 확장 가능합니다.

| Method | Before | After |
| --- | --- | --- |
| GET | `/api/blocks` | `/api/blocks/user` |
| POST | `/api/blocks/:userId` | `/api/blocks/user/:userId` |
| DELETE | `/api/blocks/:userId` | `/api/blocks/user/:userId` |

### Block → UserBlock 네이밍 정리

- `Block` 이라는 이름이 RSS 차단(`RssBlock`)과 대비되어 "차단 전반"인지 "사용자 차단"인지 모호했습니다.
- 사용자 차단 관련 엔티티/레포지토리/Swagger 데코레이터를 `UserBlock` 접두사로 통일해 `RssBlock` 과 대칭을 맞췄습니다.
- 엔티티의 `@Entity({ name: 'blocks' })` 테이블명은 그대로 유지했습니다. **스키마 변경 및 마이그레이션 없습니다.**

### 호환성

- 클라이언트 엔드포인트 상수(`client/src/constants/endpoints.ts`)를 동일 PR에서 함께 수정했으므로 배포 단위 내 skew는 없습니다.
- `nginx/`, `feed-crawler/`, `email-worker/` 에서 `/api/blocks` 를 직접 참조하는 지점은 없음을 확인했습니다.

# 📋 작업 내용

- `Block` 엔티티 → `UserBlock` (`block.entity.ts` → `userBlock.entity.ts`)
- `BlockRepository` → `UserBlockRepository` (`block.repository.ts` → `userBlock.repository.ts`)
- `ApiCreateBlock` / `ApiDeleteBlock` → `ApiCreateUserBlock` / `ApiDeleteUserBlock` (파일명 동일 규칙 적용)
- `BlockController` 의 사용자 차단 라우트를 `/user` 하위로 이동
- 클라이언트 `BLOCK.LIST` / `BLOCK.MANAGE` 엔드포인트 경로 갱신
- 차단 E2E 테스트 파일명을 `user-create` / `user-delete` / `user-get` 으로 변경해 RSS 차단 테스트와 구분
- 댓글 테스트에서 `as any` 로 뭉개져 있던 부분을 `as Comment` 로 정정