### PR TITLE
✨ feat: RSS 검색 기능 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@emotion/is-prop-valid": "^1.3.1",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-alert-dialog": "^1.1.2",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -1022,6 +1023,21 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/memoize": "^0.9.0"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
+      "integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@emotion/is-prop-valid": "^1.3.1",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -4,6 +4,7 @@ import { FileText, Sparkles } from "lucide-react";
 
 import type { FeatureItem } from "@/types/about";
 import type { DayInfo, WeekInfo } from "@/types/activity";
+import type { ChildAdmin } from "@/types/admin";
 import type { ChartPlatform, ChartType } from "@/types/chart";
 import type { AdminChatRoom, ChatType } from "@/types/chat";
 import type { FeedDetail, FeedList } from "@/types/post";
@@ -19,8 +20,7 @@ import type {
   UserProfile,
 } from "@/types/profile";
 import type { AdminRssData, RecentRss } from "@/types/rss";
-import type { SearchResult, UserSearchResult } from "@/types/search";
-import type { ChildAdmin } from "@/types/admin";
+import type { RssSearchResult, SearchResult, UserSearchResult } from "@/types/search";
 import type { SubscribedRss } from "@/types/subscription";
 
 export const mockFeedList: FeedList = {
@@ -133,6 +133,13 @@ export const mockUserSearchResult: UserSearchResult = {
   profileImage: "https://picsum.photos/seed/usearch/80/80",
 };
 
+export const mockRssSearchResult: RssSearchResult = {
+  id: 1,
+  name: "seok3765.log",
+  blogPlatform: "velog",
+  blogImage: "https://picsum.photos/seed/rsearch/80/80",
+};
+
 export const mockAdminRssList: AdminRssData[] = [
   {
     id: 1,
@@ -186,15 +193,7 @@ const makeDay = (day: number, count: number): DayInfo => {
 
 export const mockWeekInfo: WeekInfo = {
   weekNumber: 1,
-  days: [
-    makeDay(1, 0),
-    makeDay(2, 2),
-    makeDay(3, 5),
-    makeDay(4, 1),
-    makeDay(5, 8),
-    makeDay(6, 3),
-    makeDay(7, 0),
-  ],
+  days: [makeDay(1, 0), makeDay(2, 2), makeDay(3, 5), makeDay(4, 1), makeDay(5, 8), makeDay(6, 3), makeDay(7, 0)],
 };
 
 export const mockDayInfo: DayInfo = makeDay(5, 8);
@@ -259,9 +258,21 @@ export const mockActivityYears: number[] = [2026, 2025, 2024];
 
 export const mockLikedItemsPage: CursorPage<LikedItem> = {
   result: [
-    { id: 1, likeDate: "2026-06-25T09:00:00.000Z", feed: { id: 1, title: "Storybook으로 컴포넌트 문서화하기", path: "https://example.com/post/1" } },
-    { id: 2, likeDate: "2026-06-24T09:00:00.000Z", feed: { id: 2, title: "TypeScript 5.0 새로운 기능 살펴보기", path: "https://example.com/post/2" } },
-    { id: 3, likeDate: "2026-06-23T09:00:00.000Z", feed: { id: 3, title: "React Query v5 마이그레이션 가이드", path: "https://example.com/post/3" } },
+    {
+      id: 1,
+      likeDate: "2026-06-25T09:00:00.000Z",
+      feed: { id: 1, title: "Storybook으로 컴포넌트 문서화하기", path: "https://example.com/post/1" },
+    },
+    {
+      id: 2,
+      likeDate: "2026-06-24T09:00:00.000Z",
+      feed: { id: 2, title: "TypeScript 5.0 새로운 기능 살펴보기", path: "https://example.com/post/2" },
+    },
+    {
+      id: 3,
+      likeDate: "2026-06-23T09:00:00.000Z",
+      feed: { id: 3, title: "React Query v5 마이그레이션 가이드", path: "https://example.com/post/3" },
+    },
   ],
   lastId: 3,
   hasMore: false,
@@ -269,8 +280,18 @@ export const mockLikedItemsPage: CursorPage<LikedItem> = {
 
 export const mockCommentItemsPage: CursorPage<CommentItem> = {
   result: [
-    { id: 1, comment: "좋은 글 감사합니다!", date: "2026-06-25T09:00:00.000Z", feed: { id: 1, title: "Storybook으로 컴포넌트 문서화하기", path: "https://example.com/post/1" } },
-    { id: 2, comment: "정말 유익한 내용이네요. 특히 마이그레이션 가이드 부분이 도움이 많이 됐습니다.", date: "2026-06-24T09:00:00.000Z", feed: { id: 2, title: "TypeScript 5.0 새로운 기능 살펴보기", path: "https://example.com/post/2" } },
+    {
+      id: 1,
+      comment: "좋은 글 감사합니다!",
+      date: "2026-06-25T09:00:00.000Z",
+      feed: { id: 1, title: "Storybook으로 컴포넌트 문서화하기", path: "https://example.com/post/1" },
+    },
+    {
+      id: 2,
+      comment: "정말 유익한 내용이네요. 특히 마이그레이션 가이드 부분이 도움이 많이 됐습니다.",
+      date: "2026-06-24T09:00:00.000Z",
+      feed: { id: 2, title: "TypeScript 5.0 새로운 기능 살펴보기", path: "https://example.com/post/2" },
+    },
   ],
   lastId: 2,
   hasMore: false,
@@ -283,9 +304,27 @@ export const mockAdminChatRooms: AdminChatRoom[] = [
 ];
 
 export const mockAdminChatMessages: ChatType[] = [
-  { userName: "사용자1", timestamp: "2026-06-25T09:00:00.000Z", message: "안녕하세요!", userId: "user-1", messageId: "msg-1" },
-  { userName: "사용자2", timestamp: "2026-06-25T09:01:00.000Z", message: "반갑습니다. Storybook 설정 완료했나요?", userId: "user-2", messageId: "msg-2" },
-  { userName: "사용자1", timestamp: "2026-06-25T09:02:00.000Z", message: "네, 방금 완료했습니다!", userId: "user-1", messageId: "msg-3" },
+  {
+    userName: "사용자1",
+    timestamp: "2026-06-25T09:00:00.000Z",
+    message: "안녕하세요!",
+    userId: "user-1",
+    messageId: "msg-1",
+  },
+  {
+    userName: "사용자2",
+    timestamp: "2026-06-25T09:01:00.000Z",
+    message: "반갑습니다. Storybook 설정 완료했나요?",
+    userId: "user-2",
+    messageId: "msg-2",
+  },
+  {
+    userName: "사용자1",
+    timestamp: "2026-06-25T09:02:00.000Z",
+    message: "네, 방금 완료했습니다!",
+    userId: "user-1",
+    messageId: "msg-3",
+  },
 ];
 
 export const mockChildAdmins: ChildAdmin[] = [

--- a/client/src/__tests__/components/common/search/SearchResults/RssSearchResultItem.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/RssSearchResultItem.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+
+import RssSearchResultItem from "@/components/search/SearchResults/RssSearchResultItem";
+
+import { RssSearchResult } from "@/types/search.ts";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("@/components/search/SearchHigilight", () => ({
+  default: ({ text }: { text: string }) => <span>{text}</span>,
+}));
+
+vi.mock("@/store/useSearchStore", () => ({
+  useSearchStore: vi.fn(() => ({
+    searchParam: "denamu",
+  })),
+}));
+
+describe("RssSearchResultItem", () => {
+  const mockRss: RssSearchResult = {
+    id: 7,
+    name: "denamu.log",
+    blogPlatform: "velog",
+    blogImage: null,
+  };
+
+  it("RSS 이름이 렌더링되어야 한다", () => {
+    render(<RssSearchResultItem {...mockRss} onSelect={vi.fn()} />);
+
+    expect(screen.getByText(mockRss.name)).toBeInTheDocument();
+  });
+
+  it("클릭하면 해당 RSS id로 onSelect가 호출되어야 한다", () => {
+    const onSelect = vi.fn();
+    render(<RssSearchResultItem {...mockRss} onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    expect(onSelect).toHaveBeenCalledWith(mockRss.id);
+  });
+});

--- a/client/src/__tests__/components/common/search/SearchResults/RssSearchResultList.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/RssSearchResultList.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+import RssSearchResultList from "@/components/search/SearchResults/RssSearchResultList.tsx";
+
+import { render, screen } from "@testing-library/react";
+
+let searchParam: string;
+let queryState: { data: unknown; isLoading: boolean; error: unknown };
+
+vi.mock("lucide-react", () => lucideProxy());
+
+vi.mock("@/store/useSearchStore", () => ({ useSearchStore: () => ({ searchParam, page: 1 }) }));
+vi.mock("@/hooks/common/useNavigateToRss", () => ({ useNavigateToRss: () => vi.fn() }));
+vi.mock("@/hooks/queries/useRssSearch", () => ({ useRssSearch: () => queryState }));
+
+vi.mock("@/components/ui/command", () => {
+  const pass = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  return { CommandList: pass, CommandEmpty: pass, CommandGroup: ({ children, heading }: { children: React.ReactNode; heading: string }) => <div>{heading}{children}</div> };
+});
+
+vi.mock("@/components/search/searchPages/SearchPages", () => ({ default: () => <div data-testid="pages" /> }));
+vi.mock("@/components/search/SearchResults/RssSearchResultItem", () => ({
+  default: ({ name }: { name: string }) => <div data-testid="rss-item">{name}</div>,
+}));
+
+describe("RssSearchResultList", () => {
+  beforeEach(() => {
+    searchParam = "denamu";
+    queryState = { data: { data: { totalCount: 0, totalPages: 0, result: [] } }, isLoading: false, error: null };
+  });
+
+  it("로딩 중이면 로더를 표시해야 한다", () => {
+    queryState.isLoading = true;
+    render(<RssSearchResultList onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("lucide-Loader")).toBeInTheDocument();
+  });
+
+  it("에러면 에러 문구를 표시해야 한다", () => {
+    queryState.error = new Error("fail");
+    render(<RssSearchResultList onClose={vi.fn()} />);
+
+    expect(screen.getByText("에러발생")).toBeInTheDocument();
+  });
+
+  it("검색어가 없으면 안내 문구를 표시해야 한다", () => {
+    searchParam = "";
+    render(<RssSearchResultList onClose={vi.fn()} />);
+
+    expect(screen.getByText("검색어를 입력해주세요")).toBeInTheDocument();
+  });
+
+  it("결과가 없으면 빈 안내를 표시해야 한다", () => {
+    render(<RssSearchResultList onClose={vi.fn()} />);
+
+    expect(screen.getByText("검색결과가 없습니다")).toBeInTheDocument();
+  });
+
+  it("결과가 있으면 헤딩과 RSS 아이템을 렌더링해야 한다", () => {
+    queryState.data = {
+      data: {
+        totalCount: 2,
+        totalPages: 1,
+        result: [
+          { id: 1, name: "seok3765.log", blogPlatform: "velog", blogImage: null },
+          { id: 2, name: "denamu.log", blogPlatform: "tistory", blogImage: null },
+        ],
+      },
+    };
+    render(<RssSearchResultList onClose={vi.fn()} />);
+
+    expect(screen.getByText(/검색결과 \(총 2건\)/)).toBeInTheDocument();
+    expect(screen.getAllByTestId("rss-item")).toHaveLength(2);
+  });
+});

--- a/client/src/__tests__/hooks/queries/useRssSearch.test.tsx
+++ b/client/src/__tests__/hooks/queries/useRssSearch.test.tsx
@@ -1,0 +1,103 @@
+import type { ReactNode } from "react";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRssSearch } from "@/hooks/queries/useRssSearch";
+
+import { RssSearchResponse } from "@/types/search";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const getRssSearch = vi.fn();
+
+vi.mock("@/api/services/search", () => ({
+  getRssSearch: (...args: unknown[]) => getRssSearch(...args),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return wrapper;
+};
+
+const makeResponse = (result: RssSearchResponse["data"]["result"]): RssSearchResponse => ({
+  message: "",
+  data: { totalCount: result.length, result, totalPages: 1 },
+});
+
+describe("useRssSearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getRssSearch.mockResolvedValue(makeResponse([]));
+  });
+
+  it("검색어가 비어 있으면 API를 호출하지 않는다.", () => {
+    const wrapper = createWrapper();
+    renderHook(() => useRssSearch({ query: "", page: 1, pageSize: 5 }), { wrapper });
+
+    expect(getRssSearch).not.toHaveBeenCalled();
+  });
+
+  it("마운트 시 검색어가 있으면 즉시 API를 호출한다.", async () => {
+    const wrapper = createWrapper();
+    renderHook(() => useRssSearch({ query: "seok3765", page: 1, pageSize: 5 }), { wrapper });
+
+    await waitFor(() =>
+      expect(getRssSearch).toHaveBeenCalledWith({ query: "seok3765", page: 1, pageSize: 5 }),
+    );
+  });
+
+  it("검색어 변경은 300ms 디바운스된 후에만 API를 호출한다.", async () => {
+    const wrapper = createWrapper();
+    const { rerender } = renderHook(({ query }) => useRssSearch({ query, page: 1, pageSize: 5 }), {
+      wrapper,
+      initialProps: { query: "seok" },
+    });
+
+    await waitFor(() => expect(getRssSearch).toHaveBeenCalledTimes(1));
+
+    rerender({ query: "seok3765" });
+
+    // 디바운스 대기 중에는 추가 호출이 없어야 한다.
+    expect(getRssSearch).toHaveBeenCalledTimes(1);
+
+    await waitFor(
+      () => expect(getRssSearch).toHaveBeenLastCalledWith({ query: "seok3765", page: 1, pageSize: 5 }),
+      { timeout: 1000 },
+    );
+    expect(getRssSearch).toHaveBeenCalledTimes(2);
+  });
+
+  it("연속으로 검색어가 바뀌면 마지막 값으로만 호출한다.", async () => {
+    const wrapper = createWrapper();
+    const { rerender } = renderHook(({ query }) => useRssSearch({ query, page: 1, pageSize: 5 }), {
+      wrapper,
+      initialProps: { query: "s" },
+    });
+
+    await waitFor(() => expect(getRssSearch).toHaveBeenCalledTimes(1));
+
+    rerender({ query: "se" });
+    rerender({ query: "seo" });
+
+    await waitFor(
+      () => expect(getRssSearch).toHaveBeenLastCalledWith({ query: "seo", page: 1, pageSize: 5 }),
+      { timeout: 1000 },
+    );
+    expect(getRssSearch).toHaveBeenCalledTimes(2);
+  });
+
+  it("API 응답을 data로 반환한다.", async () => {
+    const response = makeResponse([{ id: 1, name: "seok3765.log", blogPlatform: "velog", blogImage: null }]);
+    getRssSearch.mockResolvedValue(response);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useRssSearch({ query: "seok3765", page: 1, pageSize: 5 }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.data).toEqual(response));
+  });
+});

--- a/client/src/api/services/search.ts
+++ b/client/src/api/services/search.ts
@@ -1,7 +1,14 @@
 import { SEARCH } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
-import { SearchRequest, SearchResponse, UserSearchRequest, UserSearchResponse } from "@/types/search";
+import {
+  RssSearchRequest,
+  RssSearchResponse,
+  SearchRequest,
+  SearchResponse,
+  UserSearchRequest,
+  UserSearchResponse,
+} from "@/types/search";
 
 export const getSearch = async (data: SearchRequest): Promise<SearchResponse> => {
   const response = await axiosInstance.get<SearchResponse>(SEARCH.GET_RESULT, {
@@ -17,6 +24,17 @@ export const getSearch = async (data: SearchRequest): Promise<SearchResponse> =>
 
 export const getUserSearch = async (data: UserSearchRequest): Promise<UserSearchResponse> => {
   const response = await axiosInstance.get<UserSearchResponse>(SEARCH.GET_USER_RESULT, {
+    params: {
+      find: data.query,
+      page: data.page,
+      limit: data.pageSize,
+    },
+  });
+  return response.data;
+};
+
+export const getRssSearch = async (data: RssSearchRequest): Promise<RssSearchResponse> => {
+  const response = await axiosInstance.get<RssSearchResponse>(SEARCH.GET_RSS_RESULT, {
     params: {
       find: data.query,
       page: data.page,

--- a/client/src/components/search/SearchModal.stories.tsx
+++ b/client/src/components/search/SearchModal.stories.tsx
@@ -3,7 +3,7 @@ import { expect, fn, userEvent, within } from "storybook/test";
 
 import SearchModal from "@/components/search/SearchModal";
 import { SEARCH } from "@/constants/endpoints";
-import { mockSearchResult, mockUserSearchResult } from "@/__storybook__/fixtures";
+import { mockRssSearchResult, mockSearchResult, mockUserSearchResult } from "@/__storybook__/fixtures";
 import { mockApi, ok } from "@/__storybook__/mockApi";
 
 const meta = {
@@ -13,6 +13,7 @@ const meta = {
   beforeEach: () => {
     mockApi.onGet(SEARCH.GET_RESULT).reply(...ok({ result: [mockSearchResult], totalCount: 1, totalPages: 1 }));
     mockApi.onGet(SEARCH.GET_USER_RESULT).reply(...ok([mockUserSearchResult]));
+    mockApi.onGet(SEARCH.GET_RSS_RESULT).reply(...ok({ result: [mockRssSearchResult], totalCount: 1, totalPages: 1 }));
   },
 } satisfies Meta<typeof SearchModal>;
 

--- a/client/src/components/search/SearchModal.tsx
+++ b/client/src/components/search/SearchModal.tsx
@@ -1,6 +1,7 @@
 import FilterButton from "@/components/search/SearchFilters/FilterButton";
 import SearchInput from "@/components/search/SearchHeader/SearchInput";
 import SearchModeTabs from "@/components/search/SearchModeTabs";
+import RssSearchResultList from "@/components/search/SearchResults/RssSearchResultList";
 import SearchResultList from "@/components/search/SearchResults/SearchResultList";
 import UserSearchResultList from "@/components/search/SearchResults/UserSearchResultList";
 import { Command, CommandSeparator } from "@/components/ui/command";
@@ -26,15 +27,15 @@ export default function SearchModal({ onClose }: { onClose: () => void }) {
         <CommandSeparator />
         <SearchModeTabs />
         <CommandSeparator />
-        {searchMode === "feed" ? (
+        {searchMode === "feed" && (
           <>
             <FilterButton />
             <CommandSeparator />
             <SearchResultList />
           </>
-        ) : (
-          <UserSearchResultList onClose={handleClose} />
         )}
+        {searchMode === "user" && <UserSearchResultList onClose={handleClose} />}
+        {searchMode === "rss" && <RssSearchResultList onClose={handleClose} />}
       </div>
     </Command>
   );

--- a/client/src/components/search/SearchModeTabs.tsx
+++ b/client/src/components/search/SearchModeTabs.tsx
@@ -1,4 +1,4 @@
-import { FileText, Users } from "lucide-react";
+import { FileText, Rss, Users } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -14,6 +14,7 @@ interface ModeOption {
 const modeOptions: ModeOption[] = [
   { label: "게시글", mode: "feed", icon: <FileText size={16} /> },
   { label: "유저", mode: "user", icon: <Users size={16} /> },
+  { label: "RSS", mode: "rss", icon: <Rss size={16} /> },
 ];
 
 export default function SearchModeTabs() {

--- a/client/src/components/search/SearchResults/RssSearchResultItem.stories.tsx
+++ b/client/src/components/search/SearchResults/RssSearchResultItem.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import RssSearchResultItem from "@/components/search/SearchResults/RssSearchResultItem";
+import { Command } from "@/components/ui/command";
+import { mockRssSearchResult } from "@/__storybook__/fixtures";
+
+const meta = {
+  title: "search/SearchResults/RssSearchResultItem",
+  component: RssSearchResultItem,
+  decorators: [
+    (Story) => (
+      <Command>
+        <Story />
+      </Command>
+    ),
+  ],
+  args: { ...mockRssSearchResult, onSelect: fn() },
+} satisfies Meta<typeof RssSearchResultItem>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchResults/RssSearchResultItem.tsx
+++ b/client/src/components/search/SearchResults/RssSearchResultItem.tsx
@@ -1,0 +1,31 @@
+import SearchHighlight from "@/components/search/SearchHigilight";
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
+import { CommandItem } from "@/components/ui/command";
+
+import { useSearchStore } from "@/store/useSearchStore";
+import { RssSearchResult } from "@/types/search";
+
+interface RssSearchResultItemProps extends RssSearchResult {
+  onSelect: (rssId: number) => void;
+}
+
+export default function RssSearchResultItem({ id, name, blogPlatform, blogImage, onSelect }: RssSearchResultItemProps) {
+  const { searchParam } = useSearchStore();
+
+  return (
+    <CommandItem className="p-0">
+      <button
+        type="button"
+        onClick={() => onSelect(id)}
+        className="flex items-center gap-3 w-full px-2 py-1.5 text-left cursor-pointer"
+      >
+        <div className="overflow-hidden bg-white border rounded-full w-9 h-9 shrink-0">
+          <PlatformIcon platform={blogPlatform} image={blogImage} className="object-cover w-full h-full" />
+        </div>
+        <p className="text-sm">
+          <SearchHighlight text={name} highlight={searchParam} />
+        </p>
+      </button>
+    </CommandItem>
+  );
+}

--- a/client/src/components/search/SearchResults/RssSearchResultList.stories.tsx
+++ b/client/src/components/search/SearchResults/RssSearchResultList.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
+
+import RssSearchResultList from "@/components/search/SearchResults/RssSearchResultList";
+import { Command } from "@/components/ui/command";
+
+const meta = {
+  title: "search/SearchResults/RssSearchResultList",
+  component: RssSearchResultList,
+  decorators: [
+    (Story) => (
+      <Command>
+        <Story />
+      </Command>
+    ),
+  ],
+  args: { onClose: fn() },
+} satisfies Meta<typeof RssSearchResultList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/client/src/components/search/SearchResults/RssSearchResultList.tsx
+++ b/client/src/components/search/SearchResults/RssSearchResultList.tsx
@@ -1,0 +1,63 @@
+import { Loader } from "lucide-react";
+
+import { CommandList, CommandEmpty, CommandGroup } from "@/components/ui/command";
+
+import { useNavigateToRss } from "@/hooks/common/useNavigateToRss";
+import { useRssSearch } from "@/hooks/queries/useRssSearch";
+
+import SearchPages from "../searchPages/SearchPages";
+import RssSearchResultItem from "./RssSearchResultItem";
+import { useSearchStore } from "@/store/useSearchStore";
+
+const RESULT_PER_PAGE = 5;
+const COMMANDCLASS = "flex h-[28rem] justify-center items-center";
+
+export default function RssSearchResultList({ onClose }: { onClose: () => void }) {
+  const { searchParam, page } = useSearchStore();
+  const navigateToRss = useNavigateToRss();
+  const { data, isLoading, error } = useRssSearch({
+    query: searchParam,
+    page,
+    pageSize: RESULT_PER_PAGE,
+  });
+
+  const totalItems = data?.data.totalCount ?? 0;
+  const totalPages = data?.data.totalPages ?? 0;
+  const results = data?.data.result || [];
+
+  const handleSelect = (rssId: number) => {
+    onClose();
+    navigateToRss(rssId);
+  };
+
+  const renderContent = {
+    noQuery: <CommandEmpty className={COMMANDCLASS}>검색어를 입력해주세요</CommandEmpty>,
+    loading: (
+      <CommandEmpty className={COMMANDCLASS}>
+        <Loader />
+      </CommandEmpty>
+    ),
+    searchEmpty: <CommandEmpty className={COMMANDCLASS}>검색결과가 없습니다</CommandEmpty>,
+    error: <div className={COMMANDCLASS}>에러발생</div>,
+    default: (
+      <CommandGroup heading={`검색결과 (총 ${totalItems}건)`} className="h-[28rem] relative">
+        <CommandList>
+          {results.map((result) => (
+            <RssSearchResultItem key={result.id} {...result} onSelect={handleSelect} />
+          ))}
+        </CommandList>
+        <SearchPages totalPages={totalPages} />
+      </CommandGroup>
+    ),
+  };
+
+  const getRenderKey = () => {
+    if (isLoading || !results) return "loading";
+    if (error) return "error";
+    if (searchParam.length === 0) return "noQuery";
+    if (results.length === 0) return "searchEmpty";
+    return "default";
+  };
+
+  return renderContent[getRenderKey()];
+}

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -80,6 +80,7 @@ export const CHART = {
 export const SEARCH = {
   GET_RESULT: "/api/feeds/search",
   GET_USER_RESULT: "/api/users/search",
+  GET_RSS_RESULT: "/api/rss/search",
 };
 
 export const USER = {

--- a/client/src/hooks/common/useNavigateToRss.ts
+++ b/client/src/hooks/common/useNavigateToRss.ts
@@ -1,0 +1,13 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+export const useNavigateToRss = () => {
+  const navigate = useNavigate();
+
+  return useCallback(
+    (rssId: number) => {
+      navigate(`/rss/${rssId}`);
+    },
+    [navigate]
+  );
+};

--- a/client/src/hooks/queries/useRssSearch.ts
+++ b/client/src/hooks/queries/useRssSearch.ts
@@ -1,0 +1,31 @@
+import { useState, useEffect } from "react";
+
+import { debounce } from "@/utils/debounce";
+
+import { getRssSearch } from "@/api/services/search";
+import { RssSearchRequest } from "@/types/search";
+import { useQuery } from "@tanstack/react-query";
+
+export const useRssSearch = ({ query, page, pageSize }: RssSearchRequest) => {
+  const [debouncedQuery, setDebouncedQuery] = useState(query);
+  useEffect(() => {
+    const handler = debounce((newQuery: string) => {
+      setDebouncedQuery(newQuery);
+    }, 300);
+
+    handler(query);
+
+    return () => {
+      if (handler.cancel) handler.cancel();
+    };
+  }, [query]);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["getRssSearch", debouncedQuery, page, pageSize],
+    queryFn: () => getRssSearch({ query: debouncedQuery, page, pageSize }),
+    enabled: debouncedQuery.trim().length > 0,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+  return { data, isLoading, error };
+};

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -30,7 +30,7 @@ export interface SearchRequest {
 }
 export type FilterType = "title" | "blogName" | "all";
 
-export type SearchMode = "feed" | "user";
+export type SearchMode = "feed" | "user" | "rss";
 
 export interface UserSearchResult {
   id: number;
@@ -47,6 +47,27 @@ export interface UserSearchData {
 export type UserSearchResponse = ApiData<UserSearchData>;
 
 export interface UserSearchRequest {
+  query: string;
+  page: number;
+  pageSize: number;
+}
+
+export interface RssSearchResult {
+  id: number;
+  name: string;
+  blogPlatform: string;
+  blogImage: string | null;
+}
+
+export interface RssSearchData {
+  totalCount: number;
+  result: RssSearchResult[];
+  totalPages: number;
+}
+
+export type RssSearchResponse = ApiData<RssSearchData>;
+
+export interface RssSearchRequest {
   query: string;
   page: number;
   pageSize: number;

--- a/server/src/rss/api-docs/searchRss.api-docs.ts
+++ b/server/src/rss/api-docs/searchRss.api-docs.ts
@@ -1,0 +1,42 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiQuery } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+} from '@common/swagger/swagger.helper';
+
+import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
+
+export function ApiSearchRss() {
+  return applyDecorators(
+    ApiOperation({
+      summary: 'RSS 블로그 이름 검색 API',
+      description:
+        '승인된 RSS(rss_accept) 중 블로그 이름으로 검색합니다. 결과는 id, 이름, 플랫폼, 프로필 이미지를 포함합니다.',
+    }),
+    ApiQuery({
+      name: 'find',
+      required: true,
+      type: String,
+      description: '검색할 RSS 블로그 이름',
+      example: 'seok3765',
+    }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      type: Number,
+      description: '페이지 번호',
+      example: 1,
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: '한 페이지에 보여줄 개수',
+      example: 5,
+    }),
+    ApiDataResponse(SearchRssResponseDto, false, 'RSS 검색 결과 조회 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -13,9 +13,11 @@ import {
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
 
+import { ReadActivityQueryRequestDto } from '@activity/dto/request/readActivity.dto';
+
 import { CurrentUser } from '@common/decorator';
-import { AdminAuthGuard } from '@common/guard/session.guard';
 import { JwtGuard, OptionalJwtGuard, Payload } from '@common/guard/jwt.guard';
+import { AdminAuthGuard } from '@common/guard/session.guard';
 import { ApiResponse } from '@common/response/common.response';
 
 import { ApiAcceptRss } from '@rss/api-docs/acceptRss.api-docs';
@@ -30,30 +32,30 @@ import { ApiGetRssActivities } from '@rss/api-docs/getRssActivities.api-docs';
 import { ApiGetRssActivityYears } from '@rss/api-docs/getRssActivityYears.api-docs';
 import { ApiGetRssFeeds } from '@rss/api-docs/getRssFeeds.api-docs';
 import { ApiGetRssInfo } from '@rss/api-docs/getRssInfo.api-docs';
-import { ApiSetFeedVisibility } from '@rss/api-docs/setFeedVisibility.api-docs';
 import { ApiPreviewRssCertification } from '@rss/api-docs/previewRssCertification.api-docs';
 import { ApiReadAllRss } from '@rss/api-docs/readAllRss.api-docs';
 import { ApiReadRssAcceptHistory } from '@rss/api-docs/readRssAcceptHistory.api-docs';
 import { ApiReadRssRejectHistory } from '@rss/api-docs/readRssRejectHistory.api-docs';
 import { ApiRejectRss } from '@rss/api-docs/rejectRss.api-docs';
+import { ApiSearchRss } from '@rss/api-docs/searchRss.api-docs';
+import { ApiSetFeedVisibility } from '@rss/api-docs/setFeedVisibility.api-docs';
 import { ApiUpdateRssCertification } from '@rss/api-docs/updateRssCertification.api-docs';
 import { ApiVerifyRssCertification } from '@rss/api-docs/verifyRssCertification.api-docs';
 import { CreateRssCertificationRequestDto } from '@rss/dto/request/createRssCertification.dto';
 import { DeleteCertificateRssRequestDto } from '@rss/dto/request/deleteCertificateRss.dto';
+import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { DeleteRssCertificationParamRequestDto } from '@rss/dto/request/deleteRssCertificationParam.dto';
 import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dto';
 import { GetOwnedRssFeedsParamRequestDto } from '@rss/dto/request/getOwnedRssFeedsParam.dto';
 import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
 import { GetRssInfoParamRequestDto } from '@rss/dto/request/getRssInfoParam.dto';
-
-import { ReadActivityQueryRequestDto } from '@activity/dto/request/readActivity.dto';
-import { SetFeedVisibilityRequestDto } from '@rss/dto/request/setFeedVisibility.dto';
-import { SetFeedVisibilityParamRequestDto } from '@rss/dto/request/setFeedVisibilityParam.dto';
-import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { PreviewRssCertificationRequestDto } from '@rss/dto/request/previewRssCertification.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
+import { SearchRssRequestDto } from '@rss/dto/request/searchRss.dto';
+import { SetFeedVisibilityRequestDto } from '@rss/dto/request/setFeedVisibility.dto';
+import { SetFeedVisibilityParamRequestDto } from '@rss/dto/request/setFeedVisibilityParam.dto';
 import { UpdateRssCertificationRequestDto } from '@rss/dto/request/updateRssCertification.dto';
 import { UpdateRssCertificationParamRequestDto } from '@rss/dto/request/updateRssCertificationParam.dto';
 import { VerifyRssCertificationRequestDto } from '@rss/dto/request/verifyRssCertification.dto';
@@ -197,7 +199,8 @@ export class RssController {
   @HttpCode(HttpStatus.OK)
   async updateRssCertification(
     @CurrentUser() user: Payload,
-    @Param() updateRssCertificationParamDto: UpdateRssCertificationParamRequestDto,
+    @Param()
+    updateRssCertificationParamDto: UpdateRssCertificationParamRequestDto,
     @Body() updateRssCertificationDto: UpdateRssCertificationRequestDto,
   ) {
     await this.rssService.updateRssCertification(
@@ -254,7 +257,9 @@ export class RssController {
       paramDto.feedId,
       bodyDto.isPublic,
     );
-    return ApiResponse.responseWithNoContent('게시글 공개 상태를 변경했습니다.');
+    return ApiResponse.responseWithNoContent(
+      '게시글 공개 상태를 변경했습니다.',
+    );
   }
 
   @ApiGetRecentRss()
@@ -265,6 +270,20 @@ export class RssController {
     return ApiResponse.responseWithData(
       '최근 발행 RSS 목록 조회를 처리했습니다.',
       await this.rssService.getRecentRss(viewer?.id),
+    );
+  }
+
+  @ApiSearchRss()
+  @UseGuards(OptionalJwtGuard)
+  @Get('search')
+  @HttpCode(HttpStatus.OK)
+  async searchRss(
+    @CurrentUser() viewer: Payload | null,
+    @Query() searchRssQueryDto: SearchRssRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      'RSS 검색 결과 조회 완료',
+      await this.rssService.searchRss(searchRssQueryDto, viewer?.id),
     );
   }
 

--- a/server/src/rss/dto/request/searchRss.dto.ts
+++ b/server/src/rss/dto/request/searchRss.dto.ts
@@ -1,0 +1,48 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+
+export class SearchRssRequestDto {
+  @ApiProperty({
+    example: 'seok3765',
+    description: '검색할 RSS 블로그 이름',
+  })
+  @IsNotEmpty({
+    message: '검색어를 입력해주세요.',
+  })
+  @IsString({
+    message: '문자열로 입력해주세요.',
+  })
+  find: string;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: '페이지 번호 입력',
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({
+    message: '페이지 번호는 정수입니다.',
+  })
+  @Min(1, { message: '페이지 번호는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    example: 5,
+    description: '받아올 RSS 최대 개수',
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({
+    message: '한 페이지에 보여줄 개수는 정수입니다.',
+  })
+  @Min(1, { message: '개수 제한은 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  limit?: number = 5;
+
+  constructor(partial: Partial<SearchRssRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/response/searchRss.dto.ts
+++ b/server/src/rss/dto/response/searchRss.dto.ts
@@ -1,0 +1,79 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+
+export class SearchRssResult {
+  @ApiProperty({ example: 1, description: 'RSS(rss_accept) ID' })
+  id: number;
+
+  @ApiProperty({ example: 'seok3765.log', description: 'RSS 블로그 이름' })
+  name: string;
+
+  @ApiProperty({ example: 'velog', description: 'RSS 블로그 플랫폼 종류' })
+  blogPlatform: string;
+
+  @ApiProperty({
+    example: 'https://example.com/profile.png',
+    description: 'RSS 채널 프로필 이미지 URL',
+    nullable: true,
+  })
+  blogImage: string | null;
+
+  private constructor(partial: Partial<SearchRssResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(rss: RssAccept) {
+    return new SearchRssResult({
+      id: rss.id,
+      name: rss.name,
+      blogPlatform: rss.blogPlatform,
+      blogImage: rss.blogImage ?? null,
+    });
+  }
+
+  static toResultDtoArray(rssList: RssAccept[]) {
+    return rssList.map((rss) => this.toResultDto(rss));
+  }
+}
+
+export class SearchRssResponseDto {
+  @ApiProperty({
+    example: 1,
+    description: '전체 RSS 개수',
+  })
+  totalCount: number;
+
+  @ApiProperty({ type: [SearchRssResult], description: '검색 결과 RSS' })
+  result: SearchRssResult[];
+
+  @ApiProperty({
+    example: 10,
+    description: '총 페이지 수',
+  })
+  totalPages: number;
+
+  @ApiProperty({
+    example: 5,
+    description: '한 페이지 최대 RSS 개수',
+  })
+  limit: number;
+
+  constructor(partial: Partial<SearchRssResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(
+    totalCount: number,
+    rssList: SearchRssResult[],
+    totalPages: number,
+    limit: number,
+  ) {
+    return new SearchRssResponseDto({
+      totalCount,
+      result: rssList,
+      totalPages,
+      limit,
+    });
+  }
+}

--- a/server/src/rss/repository/rss.repository.ts
+++ b/server/src/rss/repository/rss.repository.ts
@@ -33,6 +33,35 @@ export class RssAcceptRepository extends Repository<RssAccept> {
       .getRawMany();
   }
 
+  searchRssList(
+    find: string,
+    limit: number,
+    offset: number,
+    blockerId?: number,
+  ) {
+    const query = this.createQueryBuilder('rss_accept')
+      .addSelect(
+        'MATCH(rss_accept.name) AGAINST (:find IN NATURAL LANGUAGE MODE)',
+        'relevance',
+      )
+      .where(
+        'MATCH(rss_accept.name) AGAINST (:find IN NATURAL LANGUAGE MODE)',
+        { find },
+      )
+      .orderBy('relevance', 'DESC')
+      .skip(offset)
+      .take(limit);
+
+    if (blockerId) {
+      query.andWhere(
+        'rss_accept.id NOT IN (SELECT rss_block.blocked_rss_id FROM rss_blocks rss_block WHERE rss_block.blocker_id = :blockerId)',
+        { blockerId },
+      );
+    }
+
+    return query.getManyAndCount();
+  }
+
   findRecentlyPublished(limit: number, blockerId?: number) {
     const query = this.createQueryBuilder('rss')
       .innerJoin(

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -35,6 +35,7 @@ import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
+import { SearchRssRequestDto } from '@rss/dto/request/searchRss.dto';
 import { CreateRssCertificationResponseDto } from '@rss/dto/response/createRssCertification.dto';
 import { GetOwnedRssFeedsResponseDto } from '@rss/dto/response/getOwnedRssFeeds.dto';
 import { GetRecentRssResponseDto } from '@rss/dto/response/getRecentRss.dto';
@@ -44,6 +45,10 @@ import { PreviewRssCertificationResponseDto } from '@rss/dto/response/previewRss
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
 import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
 import { ReadRssRejectHistoryResponseDto } from '@rss/dto/response/readRssRejectHistory.dto';
+import {
+  SearchRssResponseDto,
+  SearchRssResult,
+} from '@rss/dto/response/searchRss.dto';
 import { Rss, RssAccept, RssReject } from '@rss/entity/rss.entity';
 import {
   RssAcceptRepository,
@@ -346,6 +351,29 @@ export class RssService {
     );
     return recentRssList.map((row) =>
       GetRecentRssResponseDto.toResponseDto(row),
+    );
+  }
+
+  async searchRss(searchRssQueryDto: SearchRssRequestDto, viewerId?: number) {
+    const { find, page, limit } = searchRssQueryDto;
+    const offset = (page - 1) * limit;
+
+    const [searchResult, totalCount] =
+      await this.rssAcceptRepository.searchRssList(
+        find,
+        limit,
+        offset,
+        viewerId,
+      );
+
+    const rssList = SearchRssResult.toResultDtoArray(searchResult);
+    const totalPages = Math.ceil(totalCount / limit);
+
+    return SearchRssResponseDto.toResponseDto(
+      totalCount,
+      rssList,
+      totalPages,
+      limit,
     );
   }
 

--- a/server/test/rss/dto/searchRss.dto.spec.ts
+++ b/server/test/rss/dto/searchRss.dto.spec.ts
@@ -1,0 +1,124 @@
+import { validate } from 'class-validator';
+
+import { SearchRssRequestDto } from '@rss/dto/request/searchRss.dto';
+
+describe(`${SearchRssRequestDto.name} Test`, () => {
+  let dto: SearchRssRequestDto;
+
+  beforeEach(() => {
+    dto = new SearchRssRequestDto({
+      find: 'seok3765',
+      page: 1,
+      limit: 5,
+    });
+  });
+
+  it('검색어가 있을 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('page와 limit을 생략해도 유효성 검사에 성공한다.', async () => {
+    // given
+    dto = new SearchRssRequestDto({ find: 'seok3765' });
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('find', () => {
+    it('검색어가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.find = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('검색어가 빈 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.find = '';
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isNotEmpty');
+    });
+
+    it('검색어가 문자열이 아닐 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.find = 1 as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+  });
+
+  describe('page', () => {
+    it('페이지 번호가 정수가 아닐 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 1.1;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('페이지 번호가 1 미만일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+
+  describe('limit', () => {
+    it('개수 제한이 정수가 아닐 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 1.1;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('개수 제한이 1 미만일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -24,6 +24,7 @@ import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
 import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
 import { ReadRssRejectHistoryResponseDto } from '@rss/dto/response/readRssRejectHistory.dto';
+import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
 import {
   RssAcceptRepository,
   RssRejectRepository,
@@ -44,7 +45,12 @@ describe(`${RssService.name} Unit Test`, () => {
   let rssAcceptRepository: jest.Mocked<
     Pick<
       RssAcceptRepository,
-      'findOne' | 'find' | 'delete' | 'update' | 'findRecentlyPublished'
+      | 'findOne'
+      | 'find'
+      | 'delete'
+      | 'update'
+      | 'findRecentlyPublished'
+      | 'searchRssList'
     >
   >;
   let rssRejectRepository: jest.Mocked<Pick<RssRejectRepository, 'find'>>;
@@ -97,6 +103,7 @@ describe(`${RssService.name} Unit Test`, () => {
       delete: jest.fn(),
       update: jest.fn().mockResolvedValue({ affected: 1 }),
       findRecentlyPublished: jest.fn().mockResolvedValue([]),
+      searchRssList: jest.fn().mockResolvedValue([[], 0]),
     };
     rssRejectRepository = { find: jest.fn() };
     feedRepository = {
@@ -913,6 +920,100 @@ describe(`${RssService.name} Unit Test`, () => {
 
       // then
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('searchRss', () => {
+    const makeRssAccept = (id: number, name: string) =>
+      ({
+        id,
+        name,
+        blogPlatform: 'velog',
+        blogImage: null,
+      }) as any;
+
+    it('page와 limit으로 offset을 계산해 저장소에 전달하고 응답 DTO로 변환한다.', async () => {
+      // given
+      const rssList = [makeRssAccept(1, 'seok3765.log')];
+      rssAcceptRepository.searchRssList.mockResolvedValue([rssList, 1]);
+
+      // when
+      const result = await rssService.searchRss({
+        find: 'seok3765',
+        page: 3,
+        limit: 5,
+      });
+
+      // then
+      expect(rssAcceptRepository.searchRssList).toHaveBeenCalledWith(
+        'seok3765',
+        5,
+        10,
+        undefined,
+      );
+      expect(result).toEqual(
+        SearchRssResponseDto.toResponseDto(
+          1,
+          [
+            {
+              id: 1,
+              name: 'seok3765.log',
+              blogPlatform: 'velog',
+              blogImage: null,
+            },
+          ],
+          1,
+          5,
+        ),
+      );
+    });
+
+    it('viewerId가 있으면 차단 필터링을 위해 저장소에 함께 전달한다.', async () => {
+      // given
+      rssAcceptRepository.searchRssList.mockResolvedValue([[], 0]);
+
+      // when
+      await rssService.searchRss({ find: 'seok3765', page: 1, limit: 5 }, 10);
+
+      // then
+      expect(rssAcceptRepository.searchRssList).toHaveBeenCalledWith(
+        'seok3765',
+        5,
+        0,
+        10,
+      );
+    });
+
+    it('전체 개수를 limit으로 나눠 totalPages를 올림 계산한다.', async () => {
+      // given
+      rssAcceptRepository.searchRssList.mockResolvedValue([[], 12]);
+
+      // when
+      const result = await rssService.searchRss({
+        find: 'seok3765',
+        page: 1,
+        limit: 5,
+      });
+
+      // then
+      expect(result.totalPages).toBe(3);
+    });
+
+    it('검색 결과가 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      rssAcceptRepository.searchRssList.mockResolvedValue([[], 0]);
+
+      // when
+      const result = await rssService.searchRss({
+        find: 'no-match',
+        page: 1,
+        limit: 5,
+      });
+
+      // then
+      expect(result.result).toEqual([]);
+      expect(result.totalCount).toBe(0);
+      expect(result.totalPages).toBe(0);
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #828 

### RSS 검색 기능

- 검색 모달에 RSS 검색 탭 추가 (블로그/RSS 통합 검색 모드 분리)
- 백엔드에 RSS 검색 API 구현 (`GET /rss/search`), DTO 유효성 검증 포함
- 검색 결과 클릭 시 원본 RSS로 이동하는 훅(`useNavigateToRss`) 구현

# 📋 작업 내용

- `server/src/rss`: 검색 controller/service/repository, request/response DTO, Swagger 문서 추가
- `client/src/components/search`: `RssSearchResultItem`, `RssSearchResultList` 컴포넌트 및 Storybook 추가
- `client/src/hooks/queries/useRssSearch.ts`: RSS 검색 쿼리 훅
- `client/src/api/services/search.ts`, `constants/endpoints.ts`, `types/search.ts`: RSS 검색 API 연동
- 서버 DTO/서비스 단위 테스트, 프론트엔드 컴포넌트/훅 테스트 작성

# 📷 스크린 샷(선택 사항)
<img width="1333" height="792" alt="image" src="https://github.com/user-attachments/assets/13bc71e0-53c3-4158-9f59-b23880fb7b22" />
