### PR TITLE
✨ feat: RSS 페이지에서 원본 블로그 바로가기 버튼 구현

### DIFF
--- a/client/src/__tests__/pages/RssPage.test.tsx
+++ b/client/src/__tests__/pages/RssPage.test.tsx
@@ -94,6 +94,7 @@ const baseRss: RssInfo = {
   name: "데나무 블로그",
   userName: "작성자",
   rssUrl: "https://blog.test/rss",
+  blogUrl: "https://blog.test",
   blogPlatform: "velog",
   feedCount: 12,
   subscriberCount: 3,

--- a/client/src/pages/RssPage.stories.tsx
+++ b/client/src/pages/RssPage.stories.tsx
@@ -46,6 +46,7 @@ const baseRss: RssInfo = {
   name: "데나무 블로그",
   userName: "조민석",
   rssUrl: "https://v2.velog.io/rss/@denamu",
+  blogUrl: "https://velog.io/@denamu",
   blogPlatform: "velog",
   feedCount: 12,
   subscriberCount: 34,

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
-import { Ban, CalendarClock, CheckCircle2, FileText, MoreVertical, Pencil, Users } from "lucide-react";
+import { Ban, CalendarClock, CheckCircle2, ExternalLink, FileText, MoreVertical, Pencil, Users } from "lucide-react";
 
 import { Footer } from "@/components/about/Footer";
 import Layout from "@/components/layout/Layout";
@@ -184,6 +184,15 @@ const RssHeader = ({ rss, onEdit, onBlock }: { rss: RssInfo; onEdit: () => void;
           </div>
         </div>
         <div className="flex items-center flex-shrink-0 gap-1">
+          <Button
+            asChild
+            className="gap-1.5 rounded-full bg-[#FF870D] font-semibold text-white hover:bg-[#e6790b]"
+          >
+            <a href={rss.blogUrl} target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="w-4 h-4" />
+              블로그 가기
+            </a>
+          </Button>
           {rss.isOwner ? (
             <Button variant="outline" className="gap-1" onClick={onEdit}>
               <Pencil className="w-4 h-4" />

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -186,7 +186,7 @@ const RssHeader = ({ rss, onEdit, onBlock }: { rss: RssInfo; onEdit: () => void;
         <div className="flex items-center flex-shrink-0 gap-1">
           <Button
             asChild
-            className="gap-1.5 rounded-full bg-[#FF870D] font-semibold text-white hover:bg-[#e6790b]"
+            className="h-auto gap-1.5 rounded-full bg-[#FF870D] px-4 py-1.5 font-semibold text-white hover:bg-[#e6790b]"
           >
             <a href={rss.blogUrl} target="_blank" rel="noopener noreferrer">
               <ExternalLink className="w-4 h-4" />

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -140,6 +140,7 @@ export interface RssInfo {
   name: string;
   userName: string;
   rssUrl: string;
+  blogUrl: string;
   blogPlatform: string;
   feedCount: number;
   subscriberCount: number;

--- a/server/src/rss/dto/response/getRssInfo.dto.ts
+++ b/server/src/rss/dto/response/getRssInfo.dto.ts
@@ -49,6 +49,12 @@ export class GetRssInfoResponseDto {
   rssUrl: string;
 
   @ApiProperty({
+    example: 'https://seok3765.tistory.com',
+    description: '블로그 원본 URL',
+  })
+  blogUrl: string;
+
+  @ApiProperty({
     example: 'velog',
     description: 'RSS 블로그 플랫폼 종류',
   })
@@ -131,6 +137,7 @@ export class GetRssInfoResponseDto {
       name: rssAccept.name,
       userName: rssAccept.userName,
       rssUrl: rssAccept.rssUrl,
+      blogUrl: rssAccept.blogUrl,
       blogPlatform: rssAccept.blogPlatform,
       feedCount,
       subscriberCount,

--- a/server/test/rss/e2e/get-info.e2e-spec.ts
+++ b/server/test/rss/e2e/get-info.e2e-spec.ts
@@ -68,6 +68,7 @@ describe(`GET /api/rss/:rssId E2E Test`, () => {
     expect(data.isSubscribed).toBe(false);
     expect(data.feedCount).toBe(2);
     expect(data.lastPublishedAt).not.toBeNull();
+    expect(data.blogUrl).toBe(rssAccept.blogUrl);
     expect(data).not.toHaveProperty('email');
   });
 

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -1031,6 +1031,7 @@ describe(`${RssService.name} Unit Test`, () => {
         name: 'blog',
         userName: '작성자',
         rssUrl: 'https://blog.test/rss',
+        blogUrl: 'https://blog.test',
         blogPlatform: 'etc',
         userId: null,
         user: null,
@@ -1058,6 +1059,7 @@ describe(`${RssService.name} Unit Test`, () => {
       expect(result.feedCount).toBe(5);
       expect(result.subscriberCount).toBe(2);
       expect(result.lastPublishedAt).toBe(latest);
+      expect(result.blogUrl).toBe('https://blog.test');
     });
 
     it('소유자 있는 RSS는 owner 정보를 포함하고 viewer가 소유자면 isOwner=true.', async () => {


### PR DESCRIPTION
# 🔨 테스크

### 원본 블로그 바로가기 버튼 추가

-   RSS 상세 페이지에서 사용자가 원본 블로그로 바로 이동할 수 있는 버튼이 없어 불편함이 있었음
-   서버에서 RSS 정보 조회 시 `blogUrl` 필드를 함께 반환하도록 DTO를 수정하고, 클라이언트에서 이를 이용해 새 탭으로 원본 블로그를 열 수 있는 버튼을 구현함
-   바로가기 버튼과 구독 버튼의 크기가 시각적으로 어긋나 있어 일관되도록 스타일을 맞춤

# 📋 작업 내용

-   `server`: `GetRssInfoResponseDto`에 `blogUrl` 필드 추가 및 응답 매핑
-   `client`: `RssInfo` 타입에 `blogUrl` 추가
-   `client`: `RssPage`에 원본 블로그로 이동하는 "블로그 가기" 버튼 추가 (새 탭 오픈)
-   `client`: 바로가기 버튼과 구독 버튼 크기 일관화
-   관련 e2e/unit 테스트 케이스에 `blogUrl` 반영

# 📷 스크린 샷(선택 사항)
<img width="873" height="806" alt="image" src="https://github.com/user-attachments/assets/43fdc3de-aca7-4353-8069-a1119c9ce038" />
