### PR TITLE
✨ feat: 유저, 댓글, 게시글, RSS 신고 기능 구현

### DIFF
--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -1,5 +1,3 @@
-// Shared mock data for Storybook stories.
-// Not part of the app bundle or test coverage scope (coverage targets components/** & hooks/**).
 import { FileText, Sparkles } from "lucide-react";
 
 import type { FeatureItem } from "@/types/about";
@@ -19,6 +17,7 @@ import type {
   User,
   UserProfile,
 } from "@/types/profile";
+import type { ReportItem } from "@/types/report";
 import type { AdminRssData, RecentRss } from "@/types/rss";
 import type { RssSearchResult, SearchResult, UserSearchResult } from "@/types/search";
 import type { SubscribedRss } from "@/types/subscription";
@@ -294,6 +293,49 @@ export const mockCommentItemsPage: CursorPage<CommentItem> = {
     },
   ],
   lastId: 2,
+  hasMore: false,
+};
+
+export const mockReportsPage: CursorPage<ReportItem> = {
+  result: [
+    {
+      id: 3,
+      targetType: "COMMENT",
+      targetId: 12,
+      targetLabel: "스팸성 광고 댓글입니다.",
+      reason: "SPAM",
+      detail: "같은 내용을 여러 게시글에 반복해서 남기고 있습니다.",
+      status: "PENDING",
+      reporter: { id: 1, userName: "제보자1" },
+      createdAt: "2026-06-25T09:00:00.000Z",
+      reviewedAt: null,
+    },
+    {
+      id: 2,
+      targetType: "RSS",
+      targetId: 5,
+      targetLabel: "차단된블로그",
+      reason: "COPYRIGHT",
+      detail: null,
+      status: "ACTIONED",
+      reporter: { id: 2, userName: "제보자2" },
+      createdAt: "2026-06-24T12:00:00.000Z",
+      reviewedAt: "2026-06-24T18:00:00.000Z",
+    },
+    {
+      id: 1,
+      targetType: "USER",
+      targetId: 7,
+      targetLabel: "스팸유저",
+      reason: "ABUSE",
+      detail: "댓글마다 욕설을 남깁니다.",
+      status: "REJECTED",
+      reporter: { id: 3, userName: "제보자3" },
+      createdAt: "2026-06-23T09:00:00.000Z",
+      reviewedAt: "2026-06-23T10:00:00.000Z",
+    },
+  ],
+  lastId: 1,
   hasMore: false,
 };
 

--- a/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
@@ -25,6 +25,9 @@ vi.mock("@/hooks/queries/useComments", () => ({
 }));
 
 vi.mock("@/hooks/queries/useProfile", () => ({ useUserProfile: () => ({ data: undefined }) }));
+vi.mock("@/hooks/queries/useReport", () => ({
+  useReportComment: () => ({ mutate: vi.fn(), isPending: false }),
+}));
 vi.mock("@/hooks/common/useNavigateToProfile", () => ({ useNavigateToProfile: () => vi.fn() }));
 vi.mock("@/utils/timeago", () => ({ timeAgo: () => "방금 전" }));
 vi.mock("@/components/auth/AuthSignInForm", () => ({ AuthSignInForm: () => <div data-testid="signin-form" /> }));

--- a/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
@@ -11,6 +11,10 @@ vi.mock("@/components/common/Card/detail/SubscribeButton", () => ({
   SubscribeButton: () => <button>구독</button>,
 }));
 
+vi.mock("@/hooks/queries/useReport", () => ({
+  useReportFeed: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
 const data = {
   id: 1,
   title: "상세 제목",

--- a/client/src/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/client/src/__tests__/components/profile/ProfileHeader.test.tsx
@@ -19,6 +19,9 @@ vi.mock("@/hooks/queries/useBlock.ts", () => ({
   useBlockRss: () => ({ mutateAsync: mockBlockRss }),
 }));
 vi.mock("@/hooks/queries/useProfile.ts", () => ({ useCertifiedRss: () => mockCertifiedRss() }));
+vi.mock("@/hooks/queries/useReport", () => ({
+  useReportUser: () => ({ mutate: vi.fn(), isPending: false }),
+}));
 
 describe("ProfileHeader", () => {
   beforeEach(() => {

--- a/client/src/__tests__/pages/RssPage.test.tsx
+++ b/client/src/__tests__/pages/RssPage.test.tsx
@@ -65,6 +65,10 @@ vi.mock("@/hooks/queries/useBlock.ts", () => ({
   useUnblockRss: () => ({ mutate: unblockRssMock, isPending: false }),
 }));
 
+vi.mock("@/hooks/queries/useReport", () => ({
+  useReportRss: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
 vi.mock("@/hooks/queries/useRssCertification.ts", () => ({
   useOwnedRssFeeds: () => ({
     data: { pages: [{ result: [] }] },

--- a/client/src/api/services/report.ts
+++ b/client/src/api/services/report.ts
@@ -1,0 +1,39 @@
+import { REPORT } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+
+import { ApiData, ApiMessage } from "@/types/api";
+import { CursorPage } from "@/types/profile";
+import { CreateReportPayload, ReportItem, ReportStatus, ReportTargetType } from "@/types/report";
+
+export const reportUser = async (userId: number, payload: CreateReportPayload): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(REPORT.USER(userId), payload);
+  return response.data;
+};
+
+export const reportRss = async (rssId: number, payload: CreateReportPayload): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(REPORT.RSS(rssId), payload);
+  return response.data;
+};
+
+export const reportComment = async (commentId: number, payload: CreateReportPayload): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(REPORT.COMMENT(commentId), payload);
+  return response.data;
+};
+
+export const reportFeed = async (feedId: number, payload: CreateReportPayload): Promise<ApiMessage> => {
+  const response = await axiosInstance.post<ApiMessage>(REPORT.FEED(feedId), payload);
+  return response.data;
+};
+
+export interface GetReportsParams {
+  status?: ReportStatus;
+  targetType?: ReportTargetType;
+  lastId?: number;
+  limit?: number;
+}
+
+export const getReports = async (params: GetReportsParams): Promise<CursorPage<ReportItem>> => {
+  const response = await axiosInstance.get<ApiData<CursorPage<ReportItem>>>(REPORT.ADMIN_LIST, { params });
+  return response.data.data;
+};

--- a/client/src/components/admin/layout/AdminHeader.tsx
+++ b/client/src/components/admin/layout/AdminHeader.tsx
@@ -19,7 +19,7 @@ export const AdminHeader = ({
   name,
 }: {
   setLogin: () => void;
-  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT") => void;
+  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT" | "REPORT") => void;
   name?: string;
 }) => {
   const handleLogout = () => {

--- a/client/src/components/admin/layout/AdminNavigationMenu.tsx
+++ b/client/src/components/admin/layout/AdminNavigationMenu.tsx
@@ -6,6 +6,7 @@ export const TAB_TYPES = {
   MEMBER: "MEMBER",
   POST: "POST",
   CHAT: "CHAT",
+  REPORT: "REPORT",
 } as const;
 
 type TabType = (typeof TAB_TYPES)[keyof typeof TAB_TYPES];
@@ -32,6 +33,11 @@ export const AdminNavigationMenu = ({ handleTap }: { handleTap: (tabType: TabTyp
         <NavigationMenuItem>
           <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("CHAT")}>
             채팅 관리
+          </Button>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("REPORT")}>
+            신고 관리
           </Button>
         </NavigationMenuItem>
       </NavigationMenuList>

--- a/client/src/components/admin/report/AdminReportTab.stories.tsx
+++ b/client/src/components/admin/report/AdminReportTab.stories.tsx
@@ -55,14 +55,14 @@ export const FilterByStatus: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    await expect(await canvas.findByText("제보자1")).toBeInTheDocument();
-    await expect(canvas.getByText("제보자2")).toBeInTheDocument();
-    await expect(canvas.getByText("제보자3")).toBeInTheDocument();
+    await expect(await canvas.findByText("제보자1", { exact: false })).toBeInTheDocument();
+    await expect(canvas.getByText("제보자2", { exact: false })).toBeInTheDocument();
+    await expect(canvas.getByText("제보자3", { exact: false })).toBeInTheDocument();
 
     await userEvent.click(canvas.getByRole("tab", { name: "미처리" }));
 
-    await waitFor(() => expect(canvas.getByText("제보자1")).toBeInTheDocument());
-    await expect(canvas.queryByText("제보자2")).not.toBeInTheDocument();
-    await expect(canvas.queryByText("제보자3")).not.toBeInTheDocument();
+    await waitFor(() => expect(canvas.getByText("제보자1", { exact: false })).toBeInTheDocument());
+    await expect(canvas.queryByText("제보자2", { exact: false })).not.toBeInTheDocument();
+    await expect(canvas.queryByText("제보자3", { exact: false })).not.toBeInTheDocument();
   },
 };

--- a/client/src/components/admin/report/AdminReportTab.stories.tsx
+++ b/client/src/components/admin/report/AdminReportTab.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import AdminReportTab from "@/components/admin/report/AdminReportTab";
+import { REPORT } from "@/constants/endpoints";
+import { mockReportsPage } from "@/__storybook__/fixtures";
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+import { ReportStatus } from "@/types/report";
+
+const meta = {
+  title: "admin/report/AdminReportTab",
+  component: AdminReportTab,
+} satisfies Meta<typeof AdminReportTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const setupFilterableReports = () => {
+  mockApi.onGet(REPORT.ADMIN_LIST).reply((config) => {
+    const status = config.params?.status as ReportStatus | undefined;
+    const filtered = status ? mockReportsPage.result.filter((report) => report.status === status) : mockReportsPage.result;
+    return ok({ result: filtered, lastId: filtered.at(-1)?.id ?? 0, hasMore: false });
+  });
+};
+
+export const WithData: Story = {
+  name: "신고 목록 있음",
+  beforeEach: setupFilterableReports,
+};
+
+export const Empty: Story = {
+  name: "신고 내역 없음",
+  beforeEach: () => {
+    mockApi.onGet(REPORT.ADMIN_LIST).reply(...ok({ result: [], lastId: 0, hasMore: false }));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(REPORT.ADMIN_LIST).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(REPORT.ADMIN_LIST).reply(...fail());
+  },
+};
+
+export const FilterByStatus: Story = {
+  name: "상태 필터 전환",
+  beforeEach: setupFilterableReports,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByText("제보자1")).toBeInTheDocument();
+    await expect(canvas.getByText("제보자2")).toBeInTheDocument();
+    await expect(canvas.getByText("제보자3")).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("tab", { name: "미처리" }));
+
+    await waitFor(() => expect(canvas.getByText("제보자1")).toBeInTheDocument());
+    await expect(canvas.queryByText("제보자2")).not.toBeInTheDocument();
+    await expect(canvas.queryByText("제보자3")).not.toBeInTheDocument();
+  },
+};

--- a/client/src/components/admin/report/AdminReportTab.tsx
+++ b/client/src/components/admin/report/AdminReportTab.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+import { getReports } from "@/api/services/report";
+import { REPORT_REASON_LABELS, REPORT_STATUS_LABELS, ReportItem, ReportStatus } from "@/types/report";
+
+type StatusFilter = ReportStatus | "ALL";
+
+const STATUS_FILTERS: { label: string; value: StatusFilter }[] = [
+  { label: "전체", value: "ALL" },
+  { label: "미처리", value: "PENDING" },
+  { label: "조치완료", value: "ACTIONED" },
+  { label: "반려", value: "REJECTED" },
+];
+
+const TARGET_TYPE_LABELS: Record<ReportItem["targetType"], string> = {
+  USER: "사용자",
+  RSS: "RSS",
+  COMMENT: "댓글",
+  FEED: "게시글",
+};
+
+const STATUS_BADGE_VARIANT: Record<ReportStatus, "default" | "secondary" | "outline"> = {
+  PENDING: "default",
+  ACTIONED: "secondary",
+  REJECTED: "outline",
+};
+
+const PAGE_SIZE = 10;
+
+export default function AdminReportTab() {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("ALL");
+
+  const { data, isLoading, isError, hasNextPage, fetchNextPage, isFetchingNextPage } = useInfiniteQuery({
+    queryKey: ["adminReports", statusFilter],
+    queryFn: ({ pageParam }: { pageParam: number | undefined }) =>
+      getReports({
+        lastId: pageParam,
+        limit: PAGE_SIZE,
+        status: statusFilter === "ALL" ? undefined : statusFilter,
+      }),
+    getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.lastId : undefined),
+    initialPageParam: undefined as number | undefined,
+  });
+
+  const reports = data?.pages.flatMap((page) => page.result) ?? [];
+
+  return (
+    <section className="flex flex-col gap-4 min-h-[300px]">
+      <Tabs value={statusFilter} onValueChange={(value) => setStatusFilter(value as StatusFilter)}>
+        <TabsList>
+          {STATUS_FILTERS.map((filter) => (
+            <TabsTrigger key={filter.value} value={filter.value}>
+              {filter.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
+
+      {isLoading ? (
+        <p className="py-12 text-center text-sm text-gray-400">불러오는 중...</p>
+      ) : isError ? (
+        <p className="py-12 text-center text-sm text-red-500">신고 목록을 불러오지 못했습니다.</p>
+      ) : reports.length === 0 ? (
+        <p className="py-12 text-center text-sm text-gray-400">신고 내역이 없습니다.</p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {reports.map((report) => (
+            <Card key={report.id}>
+              <CardContent className="flex flex-col gap-2 p-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">{TARGET_TYPE_LABELS[report.targetType]}</Badge>
+                  <Badge variant={STATUS_BADGE_VARIANT[report.status]}>{REPORT_STATUS_LABELS[report.status]}</Badge>
+                  <span className="text-sm font-medium">{REPORT_REASON_LABELS[report.reason]}</span>
+                  <span className="ml-auto text-xs text-gray-400">
+                    {new Date(report.createdAt).toLocaleString()}
+                  </span>
+                </div>
+
+                <p className="text-sm text-gray-700">
+                  대상: <span className="font-medium">{report.targetLabel ?? `(삭제된 대상 #${report.targetId})`}</span>
+                </p>
+                <p className="text-sm text-gray-500">
+                  신고자: {report.reporter.userName} (#{report.reporter.id})
+                </p>
+                {report.detail && <p className="text-sm text-gray-600 whitespace-pre-wrap">{report.detail}</p>}
+              </CardContent>
+            </Card>
+          ))}
+
+          {hasNextPage && (
+            <div className="text-center">
+              <Button variant="outline" size="sm" onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
+                {isFetchingNextPage ? "불러오는 중..." : "더 보기"}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/admin/report/AdminReportTab.tsx
+++ b/client/src/components/admin/report/AdminReportTab.tsx
@@ -8,7 +8,8 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { getReports } from "@/api/services/report";
-import { REPORT_REASON_LABELS, REPORT_STATUS_LABELS, ReportItem, ReportStatus } from "@/types/report";
+import { REPORT_REASON_LABELS, REPORT_STATUS_LABELS } from "@/constants/report";
+import { ReportItem, ReportStatus } from "@/types/report";
 
 type StatusFilter = ReportStatus | "ALL";
 

--- a/client/src/components/common/Card/PostDetail.tsx
+++ b/client/src/components/common/Card/PostDetail.tsx
@@ -50,6 +50,7 @@ export default function PostDetail() {
     <div
       ref={modalContainerRef}
       className="fixed inset-0 bg-black/50 flex justify-center items-start z-[999] overflow-y-auto py-10"
+      style={{ paddingRight: scrollbarWidth }}
       onClick={handleClickOutside}
     >
       <div ref={modalRef} className="bg-white rounded-md w-[90%] max-w-4xl h-auto relative">

--- a/client/src/components/common/Card/detail/PostComment.stories.tsx
+++ b/client/src/components/common/Card/detail/PostComment.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import PostComment from "@/components/common/Card/detail/PostComment";
-import { BLOG } from "@/constants/endpoints";
+import { BLOG, REPORT } from "@/constants/endpoints";
 import { mockApi, ok } from "@/__storybook__/mockApi";
+import { useAuthStore } from "@/store/useAuthStore";
 
 const mockComments = [
   {
@@ -32,6 +34,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const resetAuth = () => {
+  useAuthStore.setState({
+    isAuthenticated: false,
+    role: "guest",
+    userInfo: { id: null, email: null, userName: null },
+  });
+};
+
 export const Empty: Story = {
   name: "댓글 없음",
   beforeEach: () => {
@@ -49,5 +59,33 @@ export const WithComments: Story = {
     mockApi.onPost(BLOG.COMMENT.LIST(1)).reply(...ok(null));
     mockApi.onPatch(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
     mockApi.onDelete(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+  },
+};
+
+export const ReportFlow: Story = {
+  name: "댓글 신고하기 플로우 (로그인 방문자)",
+  beforeEach: () => {
+    useAuthStore.setState({
+      isInitialized: true,
+      isAuthenticated: true,
+      role: "user",
+      userInfo: { id: 1, email: "me@test.com", userName: "테스터" },
+    });
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok(mockComments));
+    mockApi.onPost(BLOG.COMMENT.LIST(1)).reply(...ok(null));
+    mockApi.onPost(REPORT.COMMENT(mockComments[0].id)).reply(...ok(null));
+    return resetAuth;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click((await canvas.findAllByRole("button", { name: "댓글 옵션" }))[0]);
+    await userEvent.click(await body.findByRole("menuitem", { name: "신고하기" }));
+    await userEvent.click(await body.findByRole("combobox"));
+    await userEvent.click(await body.findByRole("option", { name: "기타" }));
+    await userEvent.click(await body.findByRole("button", { name: "신고하기" }));
+
+    await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
   },
 };

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -291,6 +291,7 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
         title="댓글 신고"
         isPending={isReportPending}
         onSubmit={handleReportSubmit}
+        modal={false}
       />
     </div>
   );

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -1,10 +1,15 @@
 import { useState } from "react";
 
+import { Flag, MoreVertical } from "lucide-react";
+
 import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
 import CommentAction from "@/components/common/Card/detail/CommentAction";
+import { ReportDialog } from "@/components/common/ReportDialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 
+import { useCustomToast } from "@/hooks/common/useCustomToast";
 import { useNavigateToProfile } from "@/hooks/common/useNavigateToProfile";
 import {
   useComments,
@@ -14,11 +19,13 @@ import {
   useAdminDeleteComment,
 } from "@/hooks/queries/useComments";
 import { useUserProfile } from "@/hooks/queries/useProfile";
+import { useReportComment } from "@/hooks/queries/useReport";
 
 import { timeAgo } from "@/utils/timeago";
 
 import { useAuthStore } from "@/store/useAuthStore";
 import { FeedCommentType } from "@/types/post";
+import { CreateReportPayload } from "@/types/report";
 
 interface PostCommentProps {
   feedId: number;
@@ -30,6 +37,7 @@ interface CommentItemProps {
   comment: FeedCommentType;
   canEdit: boolean;
   canDelete: boolean;
+  canReport: boolean;
   canReply?: boolean;
   isReply?: boolean;
   modifyId: number | null;
@@ -37,6 +45,7 @@ interface CommentItemProps {
   onUpdate: (commentId: number, newComment: string) => void;
   onDelete: (commentId: number) => void;
   onReply: (rootId: number, mention?: string) => void;
+  onReport: (commentId: number) => void;
 }
 
 const INITIAL_VISIBLE = 3;
@@ -52,6 +61,8 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
   const { mutate: deleteCommentUser } = useDeleteComment(feedId);
   const { mutate: deleteCommentAdmin } = useAdminDeleteComment(feedId);
   const deleteComment = isAdmin ? deleteCommentAdmin : deleteCommentUser;
+  const { mutate: reportComment, isPending: isReportPending } = useReportComment();
+  const { toast } = useCustomToast();
 
   const [content, setContent] = useState("");
   const [modifyId, setModifyId] = useState<number | null>(null);
@@ -59,6 +70,7 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
   const [loginOpen, setLoginOpen] = useState(false);
   const [replyTo, setReplyTo] = useState<number | null>(null);
   const [replyContent, setReplyContent] = useState("");
+  const [reportCommentId, setReportCommentId] = useState<number | null>(null);
 
   const handleModify = (id: number | null) => setModifyId(id);
 
@@ -101,10 +113,28 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
     updateComment({ commentId, newComment: trimmed }, { onSuccess: () => setModifyId(null) });
   };
 
+  const handleReportSubmit = (payload: CreateReportPayload) => {
+    if (reportCommentId === null) return;
+    reportComment(
+      { commentId: reportCommentId, payload },
+      {
+        onSuccess: () => {
+          setReportCommentId(null);
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+        },
+        onError: () => {
+          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        },
+      }
+    );
+  };
+
   const canEditComment = (comment: FeedCommentType) =>
     !isAdmin && !comment.isDeleted && comment.user.id === userId;
   const canDeleteComment = (comment: FeedCommentType) =>
     !comment.isDeleted && (isAdmin || comment.user.id === userId || isFeedOwner);
+  const canReportComment = (comment: FeedCommentType) =>
+    !isAdmin && isAuthenticated && !comment.isDeleted && comment.user.id !== userId;
 
   const repliesByParent = comments.reduce<Record<number, FeedCommentType[]>>((acc, comment) => {
     if (comment.parentId !== null) {
@@ -167,12 +197,14 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
               comment={root}
               canEdit={canEditComment(root)}
               canDelete={canDeleteComment(root)}
+              canReport={canReportComment(root)}
               canReply={!isAdmin}
               modifyId={modifyId}
               handleModify={handleModify}
               onUpdate={handleUpdate}
               onDelete={deleteComment}
               onReply={handleReplyOpen}
+              onReport={setReportCommentId}
             />
 
             {/* 답글 목록 */}
@@ -184,6 +216,7 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
                       comment={reply}
                       canEdit={canEditComment(reply)}
                       canDelete={canDeleteComment(reply)}
+                      canReport={canReportComment(reply)}
                       canReply={!isAdmin}
                       isReply
                       modifyId={modifyId}
@@ -191,6 +224,7 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
                       onUpdate={handleUpdate}
                       onDelete={deleteComment}
                       onReply={() => handleReplyOpen(root.id, reply.user.userName)}
+                      onReport={setReportCommentId}
                     />
                   </li>
                 ))}
@@ -250,6 +284,14 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
           </DialogContent>
         </Dialog>
       </div>
+
+      <ReportDialog
+        open={reportCommentId !== null}
+        onOpenChange={(open) => !open && setReportCommentId(null)}
+        title="댓글 신고"
+        isPending={isReportPending}
+        onSubmit={handleReportSubmit}
+      />
     </div>
   );
 }
@@ -258,6 +300,7 @@ const CommentItem = ({
   comment,
   canEdit,
   canDelete,
+  canReport,
   canReply = true,
   isReply = false,
   modifyId,
@@ -265,6 +308,7 @@ const CommentItem = ({
   onUpdate,
   onDelete,
   onReply,
+  onReport,
 }: CommentItemProps) => {
   const [editContent, setEditContent] = useState(comment.comment);
   const isEditing = modifyId === comment.id;
@@ -297,14 +341,36 @@ const CommentItem = ({
               </p>
               <p className="text-sm text-gray-400">{timeAgo(comment.date)}</p>
             </div>
-            {(canEdit || canDelete) && !isEditing && (
-              <CommentAction
-                id={comment.id}
-                canEdit={canEdit}
-                canDelete={canDelete}
-                handleModify={handleModify}
-                onDelete={onDelete}
-              />
+            {!isEditing && (
+              <div className="flex items-center gap-1">
+                {(canEdit || canDelete) && (
+                  <CommentAction
+                    id={comment.id}
+                    canEdit={canEdit}
+                    canDelete={canDelete}
+                    handleModify={handleModify}
+                    onDelete={onDelete}
+                  />
+                )}
+                {canReport && (
+                  <DropdownMenu modal={false}>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        className="flex items-center justify-center w-6 h-6 text-gray-400 rounded hover:bg-gray-100"
+                        aria-label="댓글 옵션"
+                      >
+                        <MoreVertical className="w-4 h-4" />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="z-[1000]" onClick={(event) => event.stopPropagation()}>
+                      <DropdownMenuItem onClick={() => onReport(comment.id)}>
+                        <Flag className="w-4 h-4 mr-2" />
+                        신고하기
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </div>
             )}
           </div>
         </div>

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -291,7 +291,6 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
         title="댓글 신고"
         isPending={isReportPending}
         onSubmit={handleReportSubmit}
-        modal={false}
       />
     </div>
   );

--- a/client/src/components/common/Card/detail/PostHeader.stories.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { PostHeader } from "@/components/common/Card/detail/PostHeader";
+import { REPORT } from "@/constants/endpoints";
 import { mockFeedDetail } from "@/__storybook__/fixtures";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+import { useAuthStore } from "@/store/useAuthStore";
 
 const meta = {
   title: "common/Card/detail/PostHeader",
@@ -12,4 +16,38 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const resetAuth = () => {
+  useAuthStore.setState({
+    isAuthenticated: false,
+    role: "guest",
+    userInfo: { id: null, email: null, userName: null },
+  });
+};
+
 export const Default: Story = {};
+
+export const ReportFlow: Story = {
+  name: "신고하기 플로우 (로그인 방문자)",
+  beforeEach: () => {
+    useAuthStore.setState({
+      isInitialized: true,
+      isAuthenticated: true,
+      role: "user",
+      userInfo: { id: 1, email: "me@test.com", userName: "테스터" },
+    });
+    mockApi.onPost(REPORT.FEED(mockFeedDetail.id)).reply(...ok(null));
+    return resetAuth;
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole("button", { name: "더보기" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: "신고하기" }));
+    await userEvent.click(await body.findByRole("combobox"));
+    await userEvent.click(await body.findByRole("option", { name: "음란물/불건전한 콘텐츠" }));
+    await userEvent.click(await body.findByRole("button", { name: "신고하기" }));
+
+    await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
+  },
+};

--- a/client/src/components/common/Card/detail/PostHeader.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.tsx
@@ -1,21 +1,48 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 
-import { CheckCircle2 } from "lucide-react";
+import { CheckCircle2, Flag, MoreVertical } from "lucide-react";
 
 import PostAvatar from "@/components/common/Card/PostAvatar";
 import { SimpleTagList } from "@/components/common/Card/PostTag";
 import { SubscribeButton } from "@/components/common/Card/detail/SubscribeButton";
+import { ReportDialog } from "@/components/common/ReportDialog";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast";
+import { useReportFeed } from "@/hooks/queries/useReport";
 
 import { detailFormatDate } from "@/utils/date";
 
+import { useAuthStore } from "@/store/useAuthStore";
 import { FeedDetail } from "@/types/post";
+import { CreateReportPayload } from "@/types/report";
 
 interface PostHeaderProps {
   data: FeedDetail;
 }
 
 export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const { toast } = useCustomToast();
+  const { mutate: reportFeed, isPending: isReportPending } = useReportFeed();
+  const [showReportDialog, setShowReportDialog] = useState(false);
+
+  const handleReport = (payload: CreateReportPayload) => {
+    reportFeed(
+      { feedId: data.id, payload },
+      {
+        onSuccess: () => {
+          setShowReportDialog(false);
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+        },
+        onError: () => {
+          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        },
+      }
+    );
+  };
+
   const profileContent = (
     <>
       <PostAvatar
@@ -51,7 +78,27 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
 
   return (
     <div className="flex flex-col gap-2">
-      <h1 className="text-[2rem] font-bold">{data.title}</h1>
+      <div className="flex items-start justify-between gap-2">
+        <h1 className="text-[2rem] font-bold">{data.title}</h1>
+        {isAuthenticated && !data.isOwner && (
+          <DropdownMenu modal={false}>
+            <DropdownMenuTrigger asChild>
+              <button
+                className="flex items-center justify-center flex-shrink-0 w-8 h-8 mt-1 text-gray-500 transition-colors rounded-lg hover:bg-gray-100"
+                aria-label="더보기"
+              >
+                <MoreVertical className="w-5 h-5" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="z-[1000]" onClick={(event) => event.stopPropagation()}>
+              <DropdownMenuItem onClick={() => setShowReportDialog(true)}>
+                <Flag className="w-4 h-4 mr-2" />
+                신고하기
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+      </div>
       <span className="flex gap-2 items-center">
         {data.blogId != null ? (
           <Link
@@ -76,6 +123,14 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
       <span>
         <SimpleTagList tags={data.tag} />
       </span>
+
+      <ReportDialog
+        open={showReportDialog}
+        onOpenChange={setShowReportDialog}
+        title="게시글 신고"
+        isPending={isReportPending}
+        onSubmit={handleReport}
+      />
     </div>
   );
 });

--- a/client/src/components/common/Card/detail/PostHeader.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.tsx
@@ -130,6 +130,7 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
         title="게시글 신고"
         isPending={isReportPending}
         onSubmit={handleReport}
+        modal={false}
       />
     </div>
   );

--- a/client/src/components/common/Card/detail/PostHeader.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.tsx
@@ -130,7 +130,6 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
         title="게시글 신고"
         isPending={isReportPending}
         onSubmit={handleReport}
-        modal={false}
       />
     </div>
   );

--- a/client/src/components/common/ReportDialog.stories.tsx
+++ b/client/src/components/common/ReportDialog.stories.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+import { ReportDialog } from "@/components/common/ReportDialog";
+import { CreateReportPayload } from "@/types/report";
+
+const meta = {
+  title: "common/ReportDialog",
+  component: ReportDialog,
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    title: "게시글 신고",
+    isPending: false,
+    onSubmit: () => {},
+  },
+} satisfies Meta<typeof ReportDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    return <ReportDialog {...args} open={open} onOpenChange={setOpen} />;
+  },
+};
+
+export const Pending: Story = {
+  name: "제출 중",
+  args: { isPending: true },
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    return <ReportDialog {...args} open={open} onOpenChange={setOpen} />;
+  },
+};
+
+export const SubmitFlow: Story = {
+  name: "사유 선택 후 제출",
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    const [submitted, setSubmitted] = useState<CreateReportPayload | null>(null);
+    return (
+      <div>
+        <ReportDialog {...args} open={open} onOpenChange={setOpen} onSubmit={(payload) => setSubmitted(payload)} />
+        {submitted && <p data-testid="submitted-payload">{JSON.stringify(submitted)}</p>}
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+
+    await expect(await body.findByRole("button", { name: "신고하기" })).toBeDisabled();
+
+    await userEvent.click(await body.findByRole("combobox"));
+    await userEvent.click(await body.findByRole("option", { name: "스팸/광고" }));
+    await userEvent.type(await body.findByPlaceholderText("신고 사유에 대해 자세히 설명해주세요."), "반복 광고 댓글");
+    await userEvent.click(await body.findByRole("button", { name: "신고하기" }));
+
+    await waitFor(() => expect(canvas.getByTestId("submitted-payload")).toHaveTextContent("SPAM"));
+    await expect(canvas.getByTestId("submitted-payload")).toHaveTextContent("반복 광고 댓글");
+  },
+};
+
+export const Cancel: Story = {
+  name: "취소하면 닫힌다",
+  render: (args) => {
+    const [open, setOpen] = useState(true);
+    return <ReportDialog {...args} open={open} onOpenChange={setOpen} />;
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(await body.findByRole("button", { name: "취소" }));
+
+    await waitFor(() => expect(body.queryByRole("button", { name: "취소" })).not.toBeInTheDocument());
+  },
+};

--- a/client/src/components/common/ReportDialog.tsx
+++ b/client/src/components/common/ReportDialog.tsx
@@ -1,0 +1,88 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+import { CreateReportPayload, REPORT_REASON_LABELS, ReportReason } from "@/types/report";
+
+interface ReportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  isPending?: boolean;
+  onSubmit: (payload: CreateReportPayload) => void;
+}
+
+const REPORT_REASON_OPTIONS = Object.entries(REPORT_REASON_LABELS) as [ReportReason, string][];
+
+export function ReportDialog({ open, onOpenChange, title, isPending = false, onSubmit }: ReportDialogProps) {
+  const [reason, setReason] = useState<ReportReason | "">("");
+  const [detail, setDetail] = useState("");
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setReason("");
+      setDetail("");
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = () => {
+    if (!reason || isPending) return;
+    onSubmit({ reason, detail: detail.trim() || undefined });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="z-[1000]" onClick={(event) => event.stopPropagation()}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>신고 사유를 선택해주세요. 접수된 신고는 관리자가 검토합니다.</DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="report-reason">신고 사유</Label>
+            <Select value={reason || undefined} onValueChange={(value) => setReason(value as ReportReason)}>
+              <SelectTrigger id="report-reason">
+                <SelectValue placeholder="사유를 선택해주세요" />
+              </SelectTrigger>
+              <SelectContent className="z-[1001]">
+                {REPORT_REASON_OPTIONS.map(([value, label]) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="report-detail">상세 내용 (선택)</Label>
+            <Textarea
+              id="report-detail"
+              value={detail}
+              onChange={(event) => setDetail(event.target.value)}
+              placeholder="신고 사유에 대해 자세히 설명해주세요."
+              maxLength={500}
+              className="resize-none"
+            />
+            <span className="self-end text-xs text-muted-foreground">{detail.length}/500</span>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => handleOpenChange(false)}>
+            취소
+          </Button>
+          <Button onClick={handleSubmit} disabled={!reason || isPending} className="bg-red-600 hover:bg-red-700">
+            {isPending ? "신고 접수 중..." : "신고하기"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/common/ReportDialog.tsx
+++ b/client/src/components/common/ReportDialog.tsx
@@ -15,11 +15,23 @@ interface ReportDialogProps {
   title: string;
   isPending?: boolean;
   onSubmit: (payload: CreateReportPayload) => void;
+  /**
+   * 이미 자체적으로 스크롤을 잠그는 커스텀 모달(예: 게시글 detail 모달) 안에서 쓸 때는
+   * false로 넘겨서 Radix의 자체 scroll-lock과 중복되어 배경이 밀리는 현상을 막는다.
+   */
+  modal?: boolean;
 }
 
 const REPORT_REASON_OPTIONS = Object.entries(REPORT_REASON_LABELS) as [ReportReason, string][];
 
-export function ReportDialog({ open, onOpenChange, title, isPending = false, onSubmit }: ReportDialogProps) {
+export function ReportDialog({
+  open,
+  onOpenChange,
+  title,
+  isPending = false,
+  onSubmit,
+  modal = true,
+}: ReportDialogProps) {
   const [reason, setReason] = useState<ReportReason | "">("");
   const [detail, setDetail] = useState("");
 
@@ -37,7 +49,7 @@ export function ReportDialog({ open, onOpenChange, title, isPending = false, onS
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange} modal={modal}>
       <DialogContent className="z-[1000]" onClick={(event) => event.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
@@ -47,7 +59,7 @@ export function ReportDialog({ open, onOpenChange, title, isPending = false, onS
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Label htmlFor="report-reason">신고 사유</Label>
-            <Select value={reason || undefined} onValueChange={(value) => setReason(value as ReportReason)}>
+            <Select value={reason || undefined} onValueChange={(value) => setReason(value as ReportReason)} modal={modal}>
               <SelectTrigger id="report-reason">
                 <SelectValue placeholder="사유를 선택해주세요" />
               </SelectTrigger>

--- a/client/src/components/common/ReportDialog.tsx
+++ b/client/src/components/common/ReportDialog.tsx
@@ -23,19 +23,11 @@ interface ReportDialogProps {
   title: string;
   isPending?: boolean;
   onSubmit: (payload: CreateReportPayload) => void;
-  modal?: boolean;
 }
 
 const REPORT_REASON_OPTIONS = Object.entries(REPORT_REASON_LABELS) as [ReportReason, string][];
 
-export function ReportDialog({
-  open,
-  onOpenChange,
-  title,
-  isPending = false,
-  onSubmit,
-  modal = true,
-}: ReportDialogProps) {
+export function ReportDialog({ open, onOpenChange, title, isPending = false, onSubmit }: ReportDialogProps) {
   const [reason, setReason] = useState<ReportReason | "">("");
   const [detail, setDetail] = useState("");
 
@@ -53,53 +45,55 @@ export function ReportDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange} modal={modal}>
-      <DialogContent className="z-[1000]" onClick={(event) => event.stopPropagation()}>
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>신고 사유를 선택해주세요. 접수된 신고는 관리자가 검토합니다.</DialogDescription>
-        </DialogHeader>
+    <div onClick={(event) => event.stopPropagation()}>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent className="z-[1000]">
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>신고 사유를 선택해주세요. 접수된 신고는 관리자가 검토합니다.</DialogDescription>
+          </DialogHeader>
 
-        <div className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="report-reason">신고 사유</Label>
-            <Select value={reason || undefined} onValueChange={(value) => setReason(value as ReportReason)}>
-              <SelectTrigger id="report-reason">
-                <SelectValue placeholder="사유를 선택해주세요" />
-              </SelectTrigger>
-              <SelectContent className="z-[1001]">
-                {REPORT_REASON_OPTIONS.map(([value, label]) => (
-                  <SelectItem key={value} value={value}>
-                    {label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="report-reason">신고 사유</Label>
+              <Select value={reason || undefined} onValueChange={(value) => setReason(value as ReportReason)}>
+                <SelectTrigger id="report-reason">
+                  <SelectValue placeholder="사유를 선택해주세요" />
+                </SelectTrigger>
+                <SelectContent className="z-[1001]">
+                  {REPORT_REASON_OPTIONS.map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="report-detail">상세 내용 (선택)</Label>
+              <Textarea
+                id="report-detail"
+                value={detail}
+                onChange={(event) => setDetail(event.target.value)}
+                placeholder="신고 사유에 대해 자세히 설명해주세요."
+                maxLength={500}
+                className="resize-none"
+              />
+              <span className="self-end text-xs text-muted-foreground">{detail.length}/500</span>
+            </div>
           </div>
 
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="report-detail">상세 내용 (선택)</Label>
-            <Textarea
-              id="report-detail"
-              value={detail}
-              onChange={(event) => setDetail(event.target.value)}
-              placeholder="신고 사유에 대해 자세히 설명해주세요."
-              maxLength={500}
-              className="resize-none"
-            />
-            <span className="self-end text-xs text-muted-foreground">{detail.length}/500</span>
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
-            취소
-          </Button>
-          <Button onClick={handleSubmit} disabled={!reason || isPending} className="bg-red-600 hover:bg-red-700">
-            {isPending ? "신고 접수 중..." : "신고하기"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
+              취소
+            </Button>
+            <Button onClick={handleSubmit} disabled={!reason || isPending} className="bg-red-600 hover:bg-red-700">
+              {isPending ? "신고 접수 중..." : "신고하기"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }

--- a/client/src/components/common/ReportDialog.tsx
+++ b/client/src/components/common/ReportDialog.tsx
@@ -1,12 +1,20 @@
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
 import { REPORT_REASON_LABELS } from "@/constants/report";
+
 import { CreateReportPayload, ReportReason } from "@/types/report";
 
 interface ReportDialogProps {
@@ -15,10 +23,6 @@ interface ReportDialogProps {
   title: string;
   isPending?: boolean;
   onSubmit: (payload: CreateReportPayload) => void;
-  /**
-   * 이미 자체적으로 스크롤을 잠그는 커스텀 모달(예: 게시글 detail 모달) 안에서 쓸 때는
-   * false로 넘겨서 Radix의 자체 scroll-lock과 중복되어 배경이 밀리는 현상을 막는다.
-   */
   modal?: boolean;
 }
 
@@ -59,7 +63,7 @@ export function ReportDialog({
         <div className="flex flex-col gap-4">
           <div className="flex flex-col gap-2">
             <Label htmlFor="report-reason">신고 사유</Label>
-            <Select value={reason || undefined} onValueChange={(value) => setReason(value as ReportReason)} modal={modal}>
+            <Select value={reason || undefined} onValueChange={(value) => setReason(value as ReportReason)}>
               <SelectTrigger id="report-reason">
                 <SelectValue placeholder="사유를 선택해주세요" />
               </SelectTrigger>

--- a/client/src/components/common/ReportDialog.tsx
+++ b/client/src/components/common/ReportDialog.tsx
@@ -6,7 +6,8 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
-import { CreateReportPayload, REPORT_REASON_LABELS, ReportReason } from "@/types/report";
+import { REPORT_REASON_LABELS } from "@/constants/report";
+import { CreateReportPayload, ReportReason } from "@/types/report";
 
 interface ReportDialogProps {
   open: boolean;

--- a/client/src/components/profile/ProfileHeader.stories.tsx
+++ b/client/src/components/profile/ProfileHeader.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, waitFor, within } from "storybook/test";
 
 import { ProfileHeader } from "@/components/profile/ProfileHeader";
-import { BLOCK, PROFILE } from "@/constants/endpoints";
+import { BLOCK, PROFILE, REPORT } from "@/constants/endpoints";
 import { mockApi, ok } from "@/__storybook__/mockApi";
 
 const ownedRss = [
@@ -45,6 +45,27 @@ export const BlockFlow: Story = {
     await userEvent.click(body.getByRole("button", { name: "차단" }));
 
     await waitFor(() => expect(mockApi.history.post).toHaveLength(2));
+  },
+};
+
+export const ReportFlow: Story = {
+  name: "신고 플로우",
+  args: { email: "", blockableUserId: 2 },
+  beforeEach: () => {
+    mockApi.onGet(PROFILE.RSS(2)).reply(...ok(ownedRss));
+    mockApi.onPost(REPORT.USER(2)).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+
+    await userEvent.click(canvas.getByRole("button", { name: "더보기" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: "신고하기" }, { timeout: 5000 }));
+    await userEvent.click(await body.findByRole("combobox"));
+    await userEvent.click(await body.findByRole("option", { name: "욕설/혐오 표현" }));
+    await userEvent.click(await body.findByRole("button", { name: "신고하기" }));
+
+    await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
   },
 };
 

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 
-import { MoreVertical, Ban, FileText, Users } from "lucide-react";
+import { MoreVertical, Ban, FileText, Flag, Users } from "lucide-react";
 
+import { ReportDialog } from "@/components/common/ReportDialog";
 import { BlogPlatformBadge } from "@/components/profile/rss/BlogPlatformBadge.tsx";
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 import {
@@ -27,6 +28,9 @@ import { Switch } from "@/components/ui/switch.tsx";
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 import { useBlockRss, useBlockUser } from "@/hooks/queries/useBlock.ts";
 import { useCertifiedRss } from "@/hooks/queries/useProfile.ts";
+import { useReportUser } from "@/hooks/queries/useReport";
+
+import { CreateReportPayload } from "@/types/report";
 
 interface ProfileHeaderProps {
   name: string;
@@ -39,10 +43,12 @@ interface ProfileHeaderProps {
 export const ProfileHeader = ({ name, email, profileImage, introduction, blockableUserId }: ProfileHeaderProps) => {
   const initials = name ? name.substring(0, 2).toUpperCase() : "사용자";
   const [showBlockConfirm, setShowBlockConfirm] = useState(false);
+  const [showReportDialog, setShowReportDialog] = useState(false);
   const [selectedRssIds, setSelectedRssIds] = useState<Set<number>>(new Set());
   const { toast } = useCustomToast();
   const { mutateAsync: blockUser } = useBlockUser();
   const { mutateAsync: blockRss } = useBlockRss();
+  const { mutate: reportUser, isPending: isReportPending } = useReportUser();
   const { data: ownedRss = [] } = useCertifiedRss(blockableUserId ?? 0);
 
   const allSelected = ownedRss.length > 0 && ownedRss.every((rss) => selectedRssIds.has(rss.id));
@@ -88,6 +94,22 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
     }
   };
 
+  const handleReport = (payload: CreateReportPayload) => {
+    if (!blockableUserId) return;
+    reportUser(
+      { userId: blockableUserId, payload },
+      {
+        onSuccess: () => {
+          setShowReportDialog(false);
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+        },
+        onError: () => {
+          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        },
+      }
+    );
+  };
+
   return (
     <Card className="mb-8 overflow-hidden">
       <CardContent className="p-6">
@@ -114,6 +136,10 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => setShowReportDialog(true)}>
+                  <Flag className="w-4 h-4 mr-2" />
+                  신고하기
+                </DropdownMenuItem>
                 <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={() => setShowBlockConfirm(true)}>
                   <Ban className="w-4 h-4 mr-2" />
                   차단하기
@@ -190,6 +216,14 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <ReportDialog
+        open={showReportDialog}
+        onOpenChange={setShowReportDialog}
+        title={`${name} 유저 신고`}
+        isPending={isReportPending}
+        onSubmit={handleReport}
+      />
     </Card>
   );
 };

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -111,6 +111,14 @@ export const BLOCK = {
   RSS_MANAGE: (rssId: number) => `/api/blocks/rss/${rssId}`,
 };
 
+export const REPORT = {
+  USER: (userId: number) => `/api/reports/users/${userId}`,
+  RSS: (rssId: number) => `/api/reports/rss/${rssId}`,
+  COMMENT: (commentId: number) => `/api/reports/comments/${commentId}`,
+  FEED: (feedId: number) => `/api/reports/feeds/${feedId}`,
+  ADMIN_LIST: "/api/admins/reports",
+};
+
 export const FILE = {
   UPLOAD: "/api/files",
 };

--- a/client/src/constants/report.ts
+++ b/client/src/constants/report.ts
@@ -1,0 +1,16 @@
+import { ReportReason, ReportStatus } from "@/types/report";
+
+export const REPORT_REASON_LABELS: Record<ReportReason, string> = {
+  SPAM: "스팸/광고",
+  ABUSE: "욕설/혐오 표현",
+  ADULT: "음란물/불건전한 콘텐츠",
+  COPYRIGHT: "저작권 침해",
+  PRIVACY: "개인정보 노출",
+  ETC: "기타",
+};
+
+export const REPORT_STATUS_LABELS: Record<ReportStatus, string> = {
+  PENDING: "미처리",
+  ACTIONED: "조치완료",
+  REJECTED: "반려",
+};

--- a/client/src/hooks/common/useScrollbarAdjustment.ts
+++ b/client/src/hooks/common/useScrollbarAdjustment.ts
@@ -11,6 +11,7 @@ export const useScrollbarAdjustment = () => {
     document.querySelectorAll(".side-btn").forEach((btn) => {
       (btn as HTMLElement).style.transform = `translateX(-${width}px)`;
     });
+    document.documentElement.style.overflow = "hidden";
     document.body.style.overflow = "hidden";
 
     return () => {
@@ -18,6 +19,7 @@ export const useScrollbarAdjustment = () => {
       document.querySelectorAll(".side-btn").forEach((btn) => {
         (btn as HTMLElement).style.transform = "";
       });
+      document.documentElement.style.overflow = "";
       document.body.style.overflow = "auto";
     };
   }, []);

--- a/client/src/hooks/common/useScrollbarAdjustment.ts
+++ b/client/src/hooks/common/useScrollbarAdjustment.ts
@@ -11,6 +11,8 @@ export const useScrollbarAdjustment = () => {
     document.querySelectorAll(".side-btn").forEach((btn) => {
       (btn as HTMLElement).style.transform = `translateX(-${width}px)`;
     });
+    const fixedFooter = document.querySelector<HTMLElement>('[data-testid="scroll-aware-footer"]');
+    fixedFooter?.style.setProperty("padding-right", `${width}px`, "important");
     document.documentElement.style.overflow = "hidden";
     document.body.style.overflow = "hidden";
 
@@ -19,6 +21,7 @@ export const useScrollbarAdjustment = () => {
       document.querySelectorAll(".side-btn").forEach((btn) => {
         (btn as HTMLElement).style.transform = "";
       });
+      fixedFooter?.style.removeProperty("padding-right");
       document.documentElement.style.overflow = "";
       document.body.style.overflow = "auto";
     };

--- a/client/src/hooks/common/useScrollbarAdjustment.ts
+++ b/client/src/hooks/common/useScrollbarAdjustment.ts
@@ -7,7 +7,7 @@ export const useScrollbarAdjustment = () => {
     const width = window.innerWidth - document.documentElement.clientWidth;
     setScrollbarWidth(width);
 
-    document.body.style.paddingRight = `${width}px`;
+    document.body.style.setProperty("padding-right", `${width}px`, "important");
     document.querySelectorAll(".side-btn").forEach((btn) => {
       (btn as HTMLElement).style.transform = `translateX(-${width}px)`;
     });

--- a/client/src/hooks/queries/useReport.ts
+++ b/client/src/hooks/queries/useReport.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+
+import { GetReportsParams, getReports, reportComment, reportFeed, reportRss, reportUser } from "@/api/services/report";
+
+import { CreateReportPayload } from "@/types/report";
+
+export const useReportUser = () =>
+  useMutation({
+    mutationFn: ({ userId, payload }: { userId: number; payload: CreateReportPayload }) =>
+      reportUser(userId, payload),
+  });
+
+export const useReportRss = () =>
+  useMutation({
+    mutationFn: ({ rssId, payload }: { rssId: number; payload: CreateReportPayload }) => reportRss(rssId, payload),
+  });
+
+export const useReportComment = () =>
+  useMutation({
+    mutationFn: ({ commentId, payload }: { commentId: number; payload: CreateReportPayload }) =>
+      reportComment(commentId, payload),
+  });
+
+export const useReportFeed = () =>
+  useMutation({
+    mutationFn: ({ feedId, payload }: { feedId: number; payload: CreateReportPayload }) =>
+      reportFeed(feedId, payload),
+  });
+
+export const useReports = (params: GetReportsParams) =>
+  useQuery({
+    queryKey: ["adminReports", params],
+    queryFn: () => getReports(params),
+  });

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -8,6 +8,7 @@ import AdminMyPage from "@/components/admin/layout/AdminMyPage";
 import { AdminTabs } from "@/components/admin/layout/AdminTabs";
 import AdminLogin from "@/components/admin/login/AdminLoginModal";
 import AdminPostTab from "@/components/admin/post/AdminPostTab";
+import AdminReportTab from "@/components/admin/report/AdminReportTab";
 import AdminChatTab from "@/components/admin/chat/AdminChatTab";
 import { RssRequestSearchBar } from "@/components/admin/rss/RssSearchBar";
 
@@ -16,7 +17,7 @@ import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
 export default function Admin() {
   const [isLogin, setIsLogin] = useState<boolean>(false);
   const { status, isLoading, data } = useAdminCheck();
-  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT">("RSS");
+  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT" | "REPORT">("RSS");
 
   useEffect(() => {
     setIsLogin(status === "success");
@@ -39,6 +40,9 @@ export default function Admin() {
     }
     if (tap === "CHAT") {
       return <AdminChatTab />;
+    }
+    if (tap === "REPORT") {
+      return <AdminReportTab />;
     }
     return <AdminMember />;
   };

--- a/client/src/pages/RssPage.stories.tsx
+++ b/client/src/pages/RssPage.stories.tsx
@@ -1,12 +1,12 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, waitFor, within } from "storybook/test";
-
 import RssPage from "@/pages/RssPage";
-import { BLOCK, BLOG } from "@/constants/endpoints";
+
+import { BLOCK, BLOG, REPORT } from "@/constants/endpoints";
+
 import { mockApi, ok } from "@/__storybook__/mockApi";
 import { useAuthStore } from "@/store/useAuthStore";
-
 import { CursorPage, OwnedRssFeedItem, RssFeedItem, RssInfo } from "@/types/profile";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 
 const meta = {
   title: "pages/RssPage",
@@ -140,12 +140,35 @@ export const BlockFlow: Story = {
     const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(await body.findByRole("button", { name: "더보기" }));
     await userEvent.click(await body.findByRole("menuitem", { name: /차단하기/ }));
-    await expect(
-      await body.findByText("데나무 블로그 RSS를 차단하시겠습니까?")
-    ).toBeInTheDocument();
+    await expect(await body.findByText("데나무 블로그 RSS를 차단하시겠습니까?")).toBeInTheDocument();
     await userEvent.click(await body.findByRole("button", { name: "차단" }));
     await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
     await expect(await body.findByText("차단된 RSS입니다.")).toBeInTheDocument();
+  },
+};
+
+export const ReportFlow: Story = {
+  name: "신고하기 플로우 (로그인 방문자)",
+  beforeEach: () => {
+    useAuthStore.setState({
+      isInitialized: true,
+      isAuthenticated: true,
+      role: "user",
+      userInfo: { id: 1, email: "me@test.com", userName: "테스터" },
+    });
+    mockApi.onGet(BLOG.RSS.INFO(RSS_ID)).reply(...ok(baseRss));
+    mockApi.onPost(REPORT.RSS(RSS_ID)).reply(...ok(null));
+    setupFeeds();
+    return resetAuth;
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(await body.findByRole("button", { name: "더보기" }));
+    await userEvent.click(await body.findByRole("menuitem", { name: "신고하기" }));
+    await userEvent.click(await body.findByRole("combobox"));
+    await userEvent.click(await body.findByRole("option", { name: "저작권 침해" }));
+    await userEvent.click(await body.findByRole("button", { name: "신고하기" }));
+    await waitFor(() => expect(mockApi.history.post).toHaveLength(1));
   },
 };
 

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -1,11 +1,22 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
-import { Ban, CalendarClock, CheckCircle2, ExternalLink, FileText, MoreVertical, Pencil, Users } from "lucide-react";
+import {
+  Ban,
+  CalendarClock,
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  Flag,
+  MoreVertical,
+  Pencil,
+  Users,
+} from "lucide-react";
 
 import { Footer } from "@/components/about/Footer";
-import Layout from "@/components/layout/Layout";
 import { SubscribeButton } from "@/components/common/Card/detail/SubscribeButton.tsx";
+import { ReportDialog } from "@/components/common/ReportDialog";
+import Layout from "@/components/layout/Layout";
 import { ActivityGraph } from "@/components/profile/header/ui/ActivityGraph/ActivityGraph.tsx";
 import { BlogPlatformBadge } from "@/components/profile/rss/BlogPlatformBadge.tsx";
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
@@ -36,25 +47,19 @@ import NotFound from "@/pages/NotFound";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 import { useBlockRss, useUnblockRss } from "@/hooks/queries/useBlock.ts";
+import { useReportRss } from "@/hooks/queries/useReport";
 import { useOwnedRssFeeds, useSetFeedVisibility } from "@/hooks/queries/useRssCertification.ts";
-import {
-  useRssActivities,
-  useRssActivityYears,
-  useRssInfo,
-  useRssPageFeeds,
-} from "@/hooks/queries/useRssPage.ts";
+import { useRssActivities, useRssActivityYears, useRssInfo, useRssPageFeeds } from "@/hooks/queries/useRssPage.ts";
 
 import { formatDate } from "@/utils/date.ts";
 
 import { useAuthStore } from "@/store/useAuthStore";
 import { RssInfo } from "@/types/profile.ts";
+import { CreateReportPayload } from "@/types/report";
 
 const OwnerFeedManager = ({ rssId }: { rssId: number }) => {
   const { toast } = useCustomToast();
-  const { data, isLoading, isError, hasNextPage, fetchNextPage, isFetchingNextPage } = useOwnedRssFeeds(
-    rssId,
-    true
-  );
+  const { data, isLoading, isError, hasNextPage, fetchNextPage, isFetchingNextPage } = useOwnedRssFeeds(rssId, true);
   const visibilityMutation = useSetFeedVisibility(rssId, [
     ["rssInfo", rssId],
     ["rssPageFeeds", rssId],
@@ -139,7 +144,17 @@ const BlockedRssView = ({ rssId }: { rssId: number }) => {
   );
 };
 
-const RssHeader = ({ rss, onEdit, onBlock }: { rss: RssInfo; onEdit: () => void; onBlock?: () => void }) => (
+const RssHeader = ({
+  rss,
+  onEdit,
+  onBlock,
+  onReport,
+}: {
+  rss: RssInfo;
+  onEdit: () => void;
+  onBlock?: () => void;
+  onReport?: () => void;
+}) => (
   <Card className="mb-8">
     <CardContent className="p-6">
       <div className="flex items-start justify-between gap-4">
@@ -150,10 +165,7 @@ const RssHeader = ({ rss, onEdit, onBlock }: { rss: RssInfo; onEdit: () => void;
               <h1 className="text-2xl font-bold truncate">{rss.name}</h1>
               <BlogPlatformBadge platform={rss.blogPlatform} />
               {rss.owner && (
-                <span
-                  className="flex items-center gap-0.5 text-xs text-blue-500"
-                  title="RSS 소유 인증 블로그"
-                >
+                <span className="flex items-center gap-0.5 text-xs text-blue-500" title="RSS 소유 인증 블로그">
                   <CheckCircle2 className="w-4 h-4" />
                   인증된 RSS
                 </span>
@@ -199,13 +211,9 @@ const RssHeader = ({ rss, onEdit, onBlock }: { rss: RssInfo; onEdit: () => void;
               정보 수정
             </Button>
           ) : (
-            <SubscribeButton
-              rssId={rss.id}
-              isSubscribed={rss.isSubscribed}
-              invalidateKeys={[["rssInfo", rss.id]]}
-            />
+            <SubscribeButton rssId={rss.id} isSubscribed={rss.isSubscribed} invalidateKeys={[["rssInfo", rss.id]]} />
           )}
-          {onBlock && (
+          {(onBlock || onReport) && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -216,10 +224,18 @@ const RssHeader = ({ rss, onEdit, onBlock }: { rss: RssInfo; onEdit: () => void;
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={onBlock}>
-                  <Ban className="w-4 h-4 mr-2" />
-                  차단하기
-                </DropdownMenuItem>
+                {onReport && (
+                  <DropdownMenuItem onClick={onReport}>
+                    <Flag className="w-4 h-4 mr-2" />
+                    신고하기
+                  </DropdownMenuItem>
+                )}
+                {onBlock && (
+                  <DropdownMenuItem className="text-red-600 focus:text-red-600" onClick={onBlock}>
+                    <Ban className="w-4 h-4 mr-2" />
+                    차단하기
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           )}
@@ -260,10 +276,12 @@ export default function RssPage() {
   const [year, setYear] = useState(currentYear);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [showBlockConfirm, setShowBlockConfirm] = useState(false);
+  const [showReportDialog, setShowReportDialog] = useState(false);
 
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { toast } = useCustomToast();
   const { mutate: blockRss } = useBlockRss();
+  const { mutate: reportRss, isPending: isReportPending } = useReportRss();
 
   const { data: rss, isLoading, isError } = useRssInfo(numericId);
   const {
@@ -318,6 +336,21 @@ export default function RssPage() {
     setShowBlockConfirm(false);
   };
 
+  const handleReport = (payload: CreateReportPayload) => {
+    reportRss(
+      { rssId: rss.id, payload },
+      {
+        onSuccess: () => {
+          setShowReportDialog(false);
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+        },
+        onError: () => {
+          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        },
+      }
+    );
+  };
+
   const handleYearChange = (nextYear: number) => {
     setSelectedDate(null); // 다른 연도로 이동하면 선택한 잔디 칸이 사라지므로 필터 해제
     setYear(nextYear);
@@ -335,6 +368,7 @@ export default function RssPage() {
             rss={rss}
             onEdit={() => setEditOpen(true)}
             onBlock={isAuthenticated && !rss.isOwner ? () => setShowBlockConfirm(true) : undefined}
+            onReport={isAuthenticated && !rss.isOwner ? () => setShowReportDialog(true) : undefined}
           />
 
           {rss.owner && <OwnerProfileCard owner={rss.owner} />}
@@ -369,9 +403,7 @@ export default function RssPage() {
             <CardContent className="p-6">
               <h3 className="mb-4 text-lg font-semibold">
                 포스트
-                {selectedDate && (
-                  <span className="ml-2 text-sm font-normal text-gray-500">{selectedDate} 발행분</span>
-                )}
+                {selectedDate && <span className="ml-2 text-sm font-normal text-gray-500">{selectedDate} 발행분</span>}
               </h3>
               {feedsLoading && <p className="text-sm text-gray-400">포스트를 불러오는 중...</p>}
               {feedsError && <p className="text-sm text-red-500">포스트를 불러오지 못했습니다.</p>}
@@ -395,12 +427,7 @@ export default function RssPage() {
 
               {hasNextPage && (
                 <div className="mt-4 text-center">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => fetchNextPage()}
-                    disabled={isFetchingNextPage}
-                  >
+                  <Button variant="outline" size="sm" onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
                     {isFetchingNextPage ? "불러오는 중..." : "더 보기"}
                   </Button>
                 </div>
@@ -423,6 +450,14 @@ export default function RssPage() {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
+
+        <ReportDialog
+          open={showReportDialog}
+          onOpenChange={setShowReportDialog}
+          title={`${rss.name} RSS 신고`}
+          isPending={isReportPending}
+          onSubmit={handleReport}
+        />
       </Layout>
       <Footer />
     </>

--- a/client/src/types/report.ts
+++ b/client/src/types/report.ts
@@ -1,0 +1,43 @@
+export type ReportTargetType = "USER" | "RSS" | "COMMENT" | "FEED";
+
+export type ReportReason = "SPAM" | "ABUSE" | "ADULT" | "COPYRIGHT" | "PRIVACY" | "ETC";
+
+export type ReportStatus = "PENDING" | "ACTIONED" | "REJECTED";
+
+export const REPORT_REASON_LABELS: Record<ReportReason, string> = {
+  SPAM: "스팸/광고",
+  ABUSE: "욕설/혐오 표현",
+  ADULT: "음란물/불건전한 콘텐츠",
+  COPYRIGHT: "저작권 침해",
+  PRIVACY: "개인정보 노출",
+  ETC: "기타",
+};
+
+export const REPORT_STATUS_LABELS: Record<ReportStatus, string> = {
+  PENDING: "미처리",
+  ACTIONED: "조치완료",
+  REJECTED: "반려",
+};
+
+export interface CreateReportPayload {
+  reason: ReportReason;
+  detail?: string;
+}
+
+export interface ReportReporter {
+  id: number;
+  userName: string;
+}
+
+export interface ReportItem {
+  id: number;
+  targetType: ReportTargetType;
+  targetId: number;
+  targetLabel: string | null;
+  reason: ReportReason;
+  detail: string | null;
+  status: ReportStatus;
+  reporter: ReportReporter;
+  createdAt: string;
+  reviewedAt: string | null;
+}

--- a/client/src/types/report.ts
+++ b/client/src/types/report.ts
@@ -4,21 +4,6 @@ export type ReportReason = "SPAM" | "ABUSE" | "ADULT" | "COPYRIGHT" | "PRIVACY" 
 
 export type ReportStatus = "PENDING" | "ACTIONED" | "REJECTED";
 
-export const REPORT_REASON_LABELS: Record<ReportReason, string> = {
-  SPAM: "스팸/광고",
-  ABUSE: "욕설/혐오 표현",
-  ADULT: "음란물/불건전한 콘텐츠",
-  COPYRIGHT: "저작권 침해",
-  PRIVACY: "개인정보 노출",
-  ETC: "기타",
-};
-
-export const REPORT_STATUS_LABELS: Record<ReportStatus, string> = {
-  PENDING: "미처리",
-  ACTIONED: "조치완료",
-  REJECTED: "반려",
-};
-
 export interface CreateReportPayload {
   reason: ReportReason;
   detail?: string;

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -263,6 +263,35 @@ CREATE TABLE `provider` (
   CONSTRAINT `FK_d3d18186b602240b93c9f1621ea` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+-- denamu.report definition
+
+CREATE TABLE `report` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `target_type` varchar(20) NOT NULL,
+  `target_id` int NOT NULL,
+  `reason` varchar(20) NOT NULL,
+  `detail` text,
+  `status` varchar(20) NOT NULL DEFAULT 'PENDING',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `reviewed_at` datetime DEFAULT NULL,
+  `reporter_id` int NOT NULL,
+  `reported_user_id` int DEFAULT NULL,
+  `reported_rss_id` int DEFAULT NULL,
+  `reported_comment_id` int DEFAULT NULL,
+  `reported_feed_id` int DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `IDX_610f01b4829736eaac7acb4efb` (`reporter_id`,`target_type`,`target_id`),
+  KEY `FK_798954c041abe4b92a8f47d6638` (`reported_user_id`),
+  KEY `FK_a3396a7c98378e18ae4cb18b3a3` (`reported_rss_id`),
+  KEY `FK_12f75e00919ec73fa05c3986773` (`reported_comment_id`),
+  KEY `FK_1466885a174468bc1a94203b785` (`reported_feed_id`),
+  CONSTRAINT `FK_d41df66b60944992386ed47cf2e` FOREIGN KEY (`reporter_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_798954c041abe4b92a8f47d6638` FOREIGN KEY (`reported_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_a3396a7c98378e18ae4cb18b3a3` FOREIGN KEY (`reported_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_12f75e00919ec73fa05c3986773` FOREIGN KEY (`reported_comment_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_1466885a174468bc1a94203b785` FOREIGN KEY (`reported_feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
 -- denamu.admin insert data
 -- id: test1234@denamu.dev, password: test1234!
 -- id: test5678@denamu.dev, password: test1234!

--- a/server/.prettierrc.js
+++ b/server/.prettierrc.js
@@ -21,6 +21,7 @@ module.exports = {
     '^@file/(.*)?$',
     '^@health/(.*)?$',
     '^@like/(.*)?$',
+    '^@report/(.*)?$',
     '^@rss/(.*)?$',
     '^@statistic/(.*)?$',
     '^@subscribe/(.*)?$',

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -19,7 +19,6 @@ import { CommentModule } from '@comment/module/comment.module';
 
 import { loadDBSetting } from '@common/database/load.config';
 import { EmailModule } from '@common/email/email.module';
-import { HealthController } from '@health/health.controller';
 import { WinstonLoggerModule } from '@common/logger/logger.module';
 import { MetricsModule } from '@common/metrics/metrics.module';
 import { RabbitMQModule } from '@common/rabbitmq/rabbitmq.module';
@@ -29,7 +28,11 @@ import { FeedModule } from '@feed/module/feed.module';
 
 import { FileModule } from '@file/module/file.module';
 
+import { HealthController } from '@health/health.controller';
+
 import { LikeModule } from '@like/module/like.module';
+
+import { ReportModule } from '@report/module/report.module';
 
 import { RssModule } from '@rss/module/rss.module';
 
@@ -92,6 +95,7 @@ const exists = !!chosen && fs.existsSync(chosen);
     CommentModule,
     LikeModule,
     BlockModule,
+    ReportModule,
     SubscribeModule,
     FileModule,
     RabbitMQModule,

--- a/server/src/common/database/migration/1782000000000-CreateReport.ts
+++ b/server/src/common/database/migration/1782000000000-CreateReport.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateReport1782000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE `report` (' +
+        '`id` int NOT NULL AUTO_INCREMENT, ' +
+        '`target_type` varchar(20) NOT NULL, ' +
+        '`target_id` int NOT NULL, ' +
+        '`reason` varchar(20) NOT NULL, ' +
+        '`detail` text, ' +
+        "`status` varchar(20) NOT NULL DEFAULT 'PENDING', " +
+        '`created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), ' +
+        '`reviewed_at` datetime DEFAULT NULL, ' +
+        '`reporter_id` int NOT NULL, ' +
+        '`reported_user_id` int DEFAULT NULL, ' +
+        '`reported_rss_id` int DEFAULT NULL, ' +
+        '`reported_comment_id` int DEFAULT NULL, ' +
+        '`reported_feed_id` int DEFAULT NULL, ' +
+        'PRIMARY KEY (`id`), ' +
+        'UNIQUE KEY `IDX_610f01b4829736eaac7acb4efb` (`reporter_id`,`target_type`,`target_id`), ' +
+        'KEY `FK_798954c041abe4b92a8f47d6638` (`reported_user_id`), ' +
+        'KEY `FK_a3396a7c98378e18ae4cb18b3a3` (`reported_rss_id`), ' +
+        'KEY `FK_12f75e00919ec73fa05c3986773` (`reported_comment_id`), ' +
+        'KEY `FK_1466885a174468bc1a94203b785` (`reported_feed_id`), ' +
+        'CONSTRAINT `FK_d41df66b60944992386ed47cf2e` FOREIGN KEY (`reporter_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, ' +
+        'CONSTRAINT `FK_798954c041abe4b92a8f47d6638` FOREIGN KEY (`reported_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, ' +
+        'CONSTRAINT `FK_a3396a7c98378e18ae4cb18b3a3` FOREIGN KEY (`reported_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, ' +
+        'CONSTRAINT `FK_12f75e00919ec73fa05c3986773` FOREIGN KEY (`reported_comment_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, ' +
+        'CONSTRAINT `FK_1466885a174468bc1a94203b785` FOREIGN KEY (`reported_feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE' +
+        ');',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `report`;');
+  }
+}

--- a/server/src/report/api-docs/createReport.api-docs.ts
+++ b/server/src/report/api-docs/createReport.api-docs.ts
@@ -1,0 +1,88 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiConflictDoc,
+  ApiCreatedDoc,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+const CONFLICT_MESSAGE = '이미 신고한 대상입니다.';
+
+export function ApiCreateUserReport() {
+  return applyDecorators(
+    ApiOperation({ summary: '사용자 신고 등록 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'userId',
+      type: Number,
+      description: '신고할 사용자 ID',
+      example: 1,
+    }),
+    ApiCreatedDoc('사용자 신고 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했거나 자기 자신을 신고한 경우'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않는 사용자입니다.'),
+    ApiConflictDoc(CONFLICT_MESSAGE),
+  );
+}
+
+export function ApiCreateRssReport() {
+  return applyDecorators(
+    ApiOperation({ summary: 'RSS 신고 등록 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'rssId',
+      type: Number,
+      description: '신고할 RSS ID',
+      example: 1,
+    }),
+    ApiCreatedDoc('RSS 신고 성공'),
+    ApiBadRequestDoc(
+      '요청 데이터 검증에 실패했거나 본인 소유 RSS를 신고한 경우',
+    ),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않는 RSS입니다.'),
+    ApiConflictDoc(CONFLICT_MESSAGE),
+  );
+}
+
+export function ApiCreateCommentReport() {
+  return applyDecorators(
+    ApiOperation({ summary: '댓글 신고 등록 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'commentId',
+      type: Number,
+      description: '신고할 댓글 ID',
+      example: 1,
+    }),
+    ApiCreatedDoc('댓글 신고 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했거나 자신의 댓글을 신고한 경우'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않는 댓글입니다.'),
+    ApiConflictDoc(CONFLICT_MESSAGE),
+  );
+}
+
+export function ApiCreateFeedReport() {
+  return applyDecorators(
+    ApiOperation({ summary: '게시글 신고 등록 API' }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'feedId',
+      type: Number,
+      description: '신고할 게시글 ID',
+      example: 1,
+    }),
+    ApiCreatedDoc('게시글 신고 성공'),
+    ApiBadRequestDoc(
+      '요청 데이터 검증에 실패했거나 자신의 게시글을 신고한 경우',
+    ),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않는 게시글입니다.'),
+    ApiConflictDoc(CONFLICT_MESSAGE),
+  );
+}

--- a/server/src/report/api-docs/getReports.api-docs.ts
+++ b/server/src/report/api-docs/getReports.api-docs.ts
@@ -1,0 +1,20 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
+
+import { GetReportsResponseDto } from '@report/dto/response/getReports.dto';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiGetReports() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '관리자 신고 목록 조회 API' }),
+    ApiDataResponse(GetReportsResponseDto, false, '신고 목록 조회 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/report/constant/report.constant.ts
+++ b/server/src/report/constant/report.constant.ts
@@ -1,0 +1,21 @@
+export enum ReportTargetType {
+  USER = 'USER',
+  RSS = 'RSS',
+  COMMENT = 'COMMENT',
+  FEED = 'FEED',
+}
+
+export enum ReportReason {
+  SPAM = 'SPAM',
+  ABUSE = 'ABUSE',
+  ADULT = 'ADULT',
+  COPYRIGHT = 'COPYRIGHT',
+  PRIVACY = 'PRIVACY',
+  ETC = 'ETC',
+}
+
+export enum ReportStatus {
+  PENDING = 'PENDING',
+  ACTIONED = 'ACTIONED',
+  REJECTED = 'REJECTED',
+}

--- a/server/src/report/controller/adminReport.controller.ts
+++ b/server/src/report/controller/adminReport.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, HttpCode, HttpStatus, Query, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { AdminAuthGuard } from '@common/guard/session.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiGetReports } from '@report/api-docs/getReports.api-docs';
+import { GetReportsRequestDto } from '@report/dto/request/getReports.dto';
+import { ReportService } from '@report/service/report.service';
+
+@ApiTags('Admin')
+@Controller('admins/reports')
+export class AdminReportController {
+  constructor(private readonly reportService: ReportService) {}
+
+  @ApiGetReports()
+  @Get()
+  @UseGuards(AdminAuthGuard)
+  @HttpCode(HttpStatus.OK)
+  async getReports(@Query() queryDto: GetReportsRequestDto) {
+    return ApiResponse.responseWithData(
+      '신고 목록 조회를 성공했습니다.',
+      await this.reportService.getReports(queryDto),
+    );
+  }
+}

--- a/server/src/report/controller/report.controller.ts
+++ b/server/src/report/controller/report.controller.ts
@@ -1,0 +1,80 @@
+import { Body, Controller, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { CurrentUser } from '@common/decorator';
+import { JwtGuard, Payload } from '@common/guard/jwt.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ManageBlockRequestDto } from '@block/dto/request/manageBlock.dto';
+import { ManageRssBlockRequestDto } from '@block/dto/request/manageRssBlock.dto';
+
+import { CommentParamRequestDto } from '@comment/dto/request/commentParam.dto';
+
+import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
+
+import {
+  ApiCreateCommentReport,
+  ApiCreateFeedReport,
+  ApiCreateRssReport,
+  ApiCreateUserReport,
+} from '@report/api-docs/createReport.api-docs';
+import { CreateReportRequestDto } from '@report/dto/request/createReport.dto';
+import { ReportService } from '@report/service/report.service';
+
+@ApiTags('Report')
+@Controller('reports')
+export class ReportController {
+  constructor(private readonly reportService: ReportService) {}
+
+  @ApiCreateUserReport()
+  @Post('/users/:userId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async createUserReport(
+    @CurrentUser() user: Payload,
+    @Param() paramDto: ManageBlockRequestDto,
+    @Body() reportDto: CreateReportRequestDto,
+  ) {
+    await this.reportService.reportUser(user, paramDto.userId, reportDto);
+    return ApiResponse.responseWithNoContent('사용자 신고를 성공했습니다.');
+  }
+
+  @ApiCreateRssReport()
+  @Post('/rss/:rssId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async createRssReport(
+    @CurrentUser() user: Payload,
+    @Param() paramDto: ManageRssBlockRequestDto,
+    @Body() reportDto: CreateReportRequestDto,
+  ) {
+    await this.reportService.reportRss(user, paramDto.rssId, reportDto);
+    return ApiResponse.responseWithNoContent('RSS 신고를 성공했습니다.');
+  }
+
+  @ApiCreateCommentReport()
+  @Post('/comments/:commentId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async createCommentReport(
+    @CurrentUser() user: Payload,
+    @Param() paramDto: CommentParamRequestDto,
+    @Body() reportDto: CreateReportRequestDto,
+  ) {
+    await this.reportService.reportComment(user, paramDto.commentId, reportDto);
+    return ApiResponse.responseWithNoContent('댓글 신고를 성공했습니다.');
+  }
+
+  @ApiCreateFeedReport()
+  @Post('/feeds/:feedId')
+  @UseGuards(JwtGuard)
+  @HttpCode(HttpStatus.CREATED)
+  async createFeedReport(
+    @CurrentUser() user: Payload,
+    @Param() paramDto: ManageFeedRequestDto,
+    @Body() reportDto: CreateReportRequestDto,
+  ) {
+    await this.reportService.reportFeed(user, paramDto.feedId, reportDto);
+    return ApiResponse.responseWithNoContent('게시글 신고를 성공했습니다.');
+  }
+}

--- a/server/src/report/dto/request/createReport.dto.ts
+++ b/server/src/report/dto/request/createReport.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+import { IsEnum, IsOptional, IsString, MaxLength } from 'class-validator';
+
+import { ReportReason } from '@report/constant/report.constant';
+
+export class CreateReportRequestDto {
+  @ApiProperty({
+    description: '신고 사유',
+    enum: ReportReason,
+    example: ReportReason.SPAM,
+  })
+  @IsEnum(ReportReason, { message: '올바른 신고 사유를 선택해주세요.' })
+  reason: ReportReason;
+
+  @ApiPropertyOptional({
+    description: '신고 상세 내용',
+    example: '광고성 댓글을 반복해서 작성했습니다.',
+    maxLength: 500,
+  })
+  @IsOptional()
+  @IsString({ message: '문자열로 입력해주세요.' })
+  @MaxLength(500, { message: '상세 내용은 500자 이하로 입력해주세요.' })
+  detail?: string;
+
+  constructor(partial: Partial<CreateReportRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/report/dto/request/getReports.dto.ts
+++ b/server/src/report/dto/request/getReports.dto.ts
@@ -1,0 +1,48 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+
+import { ReportStatus, ReportTargetType } from '@report/constant/report.constant';
+
+export class GetReportsRequestDto {
+  @ApiPropertyOptional({
+    description: '조회할 처리 상태 (미입력 시 전체 조회)',
+    enum: ReportStatus,
+  })
+  @IsOptional()
+  @IsEnum(ReportStatus, { message: '올바른 처리 상태를 입력해주세요.' })
+  status?: ReportStatus;
+
+  @ApiPropertyOptional({
+    description: '조회할 신고 대상 타입 (미입력 시 전체 조회)',
+    enum: ReportTargetType,
+  })
+  @IsOptional()
+  @IsEnum(ReportTargetType, { message: '올바른 신고 대상 타입을 입력해주세요.' })
+  targetType?: ReportTargetType;
+
+  @ApiPropertyOptional({
+    example: 1,
+    description: '마지막으로 조회한 신고 ID (커서)',
+  })
+  @IsOptional()
+  @Min(1, { message: 'lastId 값은 1 이상이어야 합니다.' })
+  @IsInt({ message: '정수를 입력해주세요.' })
+  @Type(() => Number)
+  lastId?: number;
+
+  @ApiPropertyOptional({
+    example: 10,
+    description: '받아올 최대 신고 개수',
+  })
+  @IsOptional()
+  @Min(1, { message: 'limit 값은 1 이상이어야 합니다.' })
+  @IsInt({ message: '정수를 입력해주세요.' })
+  @Type(() => Number)
+  limit?: number = 10;
+
+  constructor(partial: Partial<GetReportsRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/report/dto/response/getReports.dto.ts
+++ b/server/src/report/dto/response/getReports.dto.ts
@@ -1,0 +1,122 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import {
+  ReportReason,
+  ReportStatus,
+  ReportTargetType,
+} from '@report/constant/report.constant';
+import { Report } from '@report/entity/report.entity';
+
+const resolveTargetLabel = (report: Report): string | null => {
+  switch (report.targetType) {
+    case ReportTargetType.USER:
+      return report.reportedUser?.userName ?? null;
+    case ReportTargetType.RSS:
+      return report.reportedRss?.name ?? null;
+    case ReportTargetType.COMMENT:
+      return report.reportedComment?.comment ?? null;
+    case ReportTargetType.FEED:
+      return report.reportedFeed?.title ?? null;
+    default:
+      return null;
+  }
+};
+
+export class ReportResult {
+  @ApiProperty({ example: 1, description: '신고 ID' })
+  id: number;
+
+  @ApiProperty({ enum: ReportTargetType, description: '신고 대상 타입' })
+  targetType: ReportTargetType;
+
+  @ApiProperty({ example: 1, description: '신고 대상 ID' })
+  targetId: number;
+
+  @ApiProperty({
+    example: '스팸 댓글입니다.',
+    description:
+      '신고 대상을 식별하기 위한 표시용 텍스트 (대상이 삭제된 경우 null)',
+    nullable: true,
+  })
+  targetLabel: string | null;
+
+  @ApiProperty({ enum: ReportReason, description: '신고 사유' })
+  reason: ReportReason;
+
+  @ApiProperty({ example: null, description: '신고 상세 내용', nullable: true })
+  detail: string | null;
+
+  @ApiProperty({ enum: ReportStatus, description: '처리 상태' })
+  status: ReportStatus;
+
+  @ApiProperty({
+    example: { id: 1, userName: '테스트 계정' },
+    description: '신고자 정보',
+  })
+  reporter: { id: number; userName: string };
+
+  @ApiProperty({
+    example: '2025-08-16T12:00:00.000Z',
+    description: '신고 접수 일시',
+  })
+  createdAt: Date;
+
+  @ApiProperty({
+    example: null,
+    description: '처리 일시 (미처리 시 null)',
+    nullable: true,
+  })
+  reviewedAt: Date | null;
+
+  private constructor(partial: Partial<ReportResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(report: Report) {
+    return new ReportResult({
+      id: report.id,
+      targetType: report.targetType,
+      targetId: report.targetId,
+      targetLabel: resolveTargetLabel(report),
+      reason: report.reason,
+      detail: report.detail,
+      status: report.status,
+      reporter: {
+        id: report.reporter.id,
+        userName: report.reporter.userName,
+      },
+      createdAt: report.createdAt,
+      reviewedAt: report.reviewedAt,
+    });
+  }
+
+  static toResultDtoArray(reports: Report[]) {
+    return reports.map((report) => this.toResultDto(report));
+  }
+}
+
+export class GetReportsResponseDto {
+  @ApiProperty({ type: [ReportResult], description: '신고 목록' })
+  result: ReportResult[];
+
+  @ApiProperty({
+    example: 1,
+    description: '마지막으로 조회한 신고 ID (다음 요청의 커서)',
+  })
+  lastId: number;
+
+  @ApiProperty({ example: true, description: '다음 페이지 존재 여부' })
+  hasMore: boolean;
+
+  constructor(partial: Partial<GetReportsResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(reports: Report[], lastId: number, hasMore: boolean) {
+    return new GetReportsResponseDto({
+      result: ReportResult.toResultDtoArray(reports),
+      lastId,
+      hasMore,
+    });
+  }
+}

--- a/server/src/report/entity/report.entity.ts
+++ b/server/src/report/entity/report.entity.ts
@@ -1,0 +1,88 @@
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+} from 'typeorm';
+
+import { ReportReason, ReportStatus, ReportTargetType } from '@report/constant/report.constant';
+
+import { Comment } from '@comment/entity/comment.entity';
+
+import { Feed } from '@feed/entity/feed.entity';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+
+import { User } from '@user/entity/user.entity';
+
+@Entity({ name: 'report' })
+@Unique(['reporter', 'targetType', 'targetId'])
+export class Report extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'target_type', length: 20, nullable: false })
+  targetType: ReportTargetType;
+
+  @Column({ name: 'target_id', type: 'int', nullable: false })
+  targetId: number;
+
+  @Column({ length: 20, nullable: false })
+  reason: ReportReason;
+
+  @Column({ type: 'text', nullable: true })
+  detail: string | null;
+
+  @Column({ length: 20, nullable: false, default: ReportStatus.PENDING })
+  status: ReportStatus;
+
+  @CreateDateColumn({ name: 'created_at', type: 'datetime', nullable: false })
+  createdAt: Date;
+
+  @Column({ name: 'reviewed_at', type: 'datetime', nullable: true })
+  reviewedAt: Date | null;
+
+  @ManyToOne(() => User, (user) => user.id, {
+    nullable: false,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'reporter_id' })
+  reporter: User;
+
+  @ManyToOne(() => User, (user) => user.id, {
+    nullable: true,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'reported_user_id' })
+  reportedUser: User | null;
+
+  @ManyToOne(() => RssAccept, (rssAccept) => rssAccept.id, {
+    nullable: true,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'reported_rss_id' })
+  reportedRss: RssAccept | null;
+
+  @ManyToOne(() => Comment, (comment) => comment.id, {
+    nullable: true,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'reported_comment_id' })
+  reportedComment: Comment | null;
+
+  @ManyToOne(() => Feed, (feed) => feed.id, {
+    nullable: true,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'reported_feed_id' })
+  reportedFeed: Feed | null;
+}

--- a/server/src/report/module/report.module.ts
+++ b/server/src/report/module/report.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+
+import { JwtAuthModule } from '@common/auth/jwt.module';
+
+import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { FeedModule } from '@feed/module/feed.module';
+
+import { AdminReportController } from '@report/controller/adminReport.controller';
+import { ReportController } from '@report/controller/report.controller';
+import { ReportRepository } from '@report/repository/report.repository';
+import { ReportService } from '@report/service/report.service';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { UserModule } from '@user/module/user.module';
+
+@Module({
+  imports: [JwtAuthModule, UserModule, FeedModule],
+  controllers: [ReportController, AdminReportController],
+  providers: [ReportService, ReportRepository, RssAcceptRepository, CommentRepository],
+  exports: [],
+})
+export class ReportModule {}

--- a/server/src/report/repository/report.repository.ts
+++ b/server/src/report/repository/report.repository.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@nestjs/common';
+
+import { DataSource, Repository } from 'typeorm';
+
+import { GetReportsRequestDto } from '@report/dto/request/getReports.dto';
+
+import { Report } from '@report/entity/report.entity';
+
+@Injectable()
+export class ReportRepository extends Repository<Report> {
+  constructor(private dataSource: DataSource) {
+    super(Report, dataSource.createEntityManager());
+  }
+
+  async getReports(queryDto: GetReportsRequestDto) {
+    const query = this.createQueryBuilder('report')
+      .innerJoin('report.reporter', 'reporter')
+      .leftJoin('report.reportedUser', 'reportedUser')
+      .leftJoin('report.reportedRss', 'reportedRss')
+      .leftJoin('report.reportedComment', 'reportedComment')
+      .leftJoin('report.reportedFeed', 'reportedFeed')
+      .select(['report', 'reporter.id', 'reporter.userName'])
+      .addSelect(['reportedUser.id', 'reportedUser.userName'])
+      .addSelect(['reportedRss.id', 'reportedRss.name'])
+      .addSelect(['reportedComment.id', 'reportedComment.comment'])
+      .addSelect(['reportedFeed.id', 'reportedFeed.title']);
+
+    if (queryDto.status) {
+      query.andWhere('report.status = :status', { status: queryDto.status });
+    }
+    if (queryDto.targetType) {
+      query.andWhere('report.target_type = :targetType', {
+        targetType: queryDto.targetType,
+      });
+    }
+    if (queryDto.lastId) {
+      query.andWhere('report.id < :lastId', { lastId: queryDto.lastId });
+    }
+
+    return await query
+      .orderBy('report.id', 'DESC')
+      .take((queryDto.limit ?? 10) + 1)
+      .getMany();
+  }
+}

--- a/server/src/report/service/report.service.ts
+++ b/server/src/report/service/report.service.ts
@@ -1,0 +1,158 @@
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+
+import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { Payload } from '@common/guard/jwt.guard';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { CreateReportRequestDto } from '@report/dto/request/createReport.dto';
+import { GetReportsRequestDto } from '@report/dto/request/getReports.dto';
+import { GetReportsResponseDto } from '@report/dto/response/getReports.dto';
+import { Report } from '@report/entity/report.entity';
+import { ReportRepository } from '@report/repository/report.repository';
+import { ReportTargetType } from '@report/constant/report.constant';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { UserService } from '@user/service/user.service';
+
+const DUPLICATE_MESSAGE = '이미 신고한 대상입니다.';
+
+@Injectable()
+export class ReportService {
+  constructor(
+    private readonly reportRepository: ReportRepository,
+    private readonly rssAcceptRepository: RssAcceptRepository,
+    private readonly commentRepository: CommentRepository,
+    private readonly feedRepository: FeedRepository,
+    private readonly userService: UserService,
+  ) {}
+
+  private async saveReport(report: QueryDeepPartialEntity<Report>) {
+    try {
+      await this.reportRepository.insert(report);
+    } catch (error) {
+      if ((error as { code?: string })?.code === 'ER_DUP_ENTRY') {
+        throw new ConflictException(DUPLICATE_MESSAGE);
+      }
+      throw error;
+    }
+  }
+
+  async reportUser(
+    userInformation: Payload,
+    targetUserId: number,
+    reportDto: CreateReportRequestDto,
+  ) {
+    if (userInformation.id === targetUserId) {
+      throw new BadRequestException('자기 자신을 신고할 수 없습니다.');
+    }
+    await this.userService.getUser(targetUserId);
+
+    await this.saveReport({
+      reporter: { id: userInformation.id },
+      targetType: ReportTargetType.USER,
+      targetId: targetUserId,
+      reportedUser: { id: targetUserId },
+      reason: reportDto.reason,
+      detail: reportDto.detail ?? null,
+    });
+  }
+
+  async reportRss(
+    userInformation: Payload,
+    targetRssId: number,
+    reportDto: CreateReportRequestDto,
+  ) {
+    const rssAccept = await this.rssAcceptRepository.findOne({
+      where: { id: targetRssId },
+      select: { id: true, userId: true },
+    });
+    if (!rssAccept) {
+      throw new NotFoundException('존재하지 않는 RSS입니다.');
+    }
+    if (rssAccept.userId === userInformation.id) {
+      throw new BadRequestException('본인 소유의 RSS는 신고할 수 없습니다.');
+    }
+
+    await this.saveReport({
+      reporter: { id: userInformation.id },
+      targetType: ReportTargetType.RSS,
+      targetId: targetRssId,
+      reportedRss: { id: targetRssId },
+      reason: reportDto.reason,
+      detail: reportDto.detail ?? null,
+    });
+  }
+
+  async reportComment(
+    userInformation: Payload,
+    targetCommentId: number,
+    reportDto: CreateReportRequestDto,
+  ) {
+    const comment = await this.commentRepository.findOne({
+      where: { id: targetCommentId },
+      relations: ['user'],
+    });
+    if (!comment) {
+      throw new NotFoundException('존재하지 않는 댓글입니다.');
+    }
+    if (comment.user.id === userInformation.id) {
+      throw new BadRequestException('자신의 댓글은 신고할 수 없습니다.');
+    }
+
+    await this.saveReport({
+      reporter: { id: userInformation.id },
+      targetType: ReportTargetType.COMMENT,
+      targetId: targetCommentId,
+      reportedComment: { id: targetCommentId },
+      reason: reportDto.reason,
+      detail: reportDto.detail ?? null,
+    });
+  }
+
+  async reportFeed(
+    userInformation: Payload,
+    targetFeedId: number,
+    reportDto: CreateReportRequestDto,
+  ) {
+    const feed = await this.feedRepository.findOne({
+      where: { id: targetFeedId, isPublic: true },
+      relations: ['blog'],
+    });
+    if (!feed) {
+      throw new NotFoundException('존재하지 않는 게시글입니다.');
+    }
+    if (feed.blog.userId === userInformation.id) {
+      throw new BadRequestException('자신의 게시글은 신고할 수 없습니다.');
+    }
+
+    await this.saveReport({
+      reporter: { id: userInformation.id },
+      targetType: ReportTargetType.FEED,
+      targetId: targetFeedId,
+      reportedFeed: { id: targetFeedId },
+      reason: reportDto.reason,
+      detail: reportDto.detail ?? null,
+    });
+  }
+
+  async getReports(queryDto: GetReportsRequestDto) {
+    const limit = queryDto.limit ?? 10;
+    const reports = await this.reportRepository.getReports(queryDto);
+
+    const hasMore = reports.length > limit;
+    if (hasMore) reports.pop();
+    const lastId = reports.length ? reports[reports.length - 1].id : 0;
+
+    return GetReportsResponseDto.toResponseDto(reports, lastId, hasMore);
+  }
+}

--- a/server/test/report/e2e/admin-get-reports.e2e-spec.ts
+++ b/server/test/report/e2e/admin-get-reports.e2e-spec.ts
@@ -1,0 +1,109 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { ReportReason, ReportStatus, ReportTargetType } from '@report/constant/report.constant';
+import { ReportRepository } from '@report/repository/report.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/admins/reports';
+
+describe(`GET ${BASE_URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let reportRepository: ReportRepository;
+  let userRepository: UserRepository;
+
+  const sessionKey = 'admin-report-get-session-key';
+  const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+
+  let reporter: User;
+  let target: User;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+    reportRepository = testApp.get(ReportRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    const admin = await adminRepository.save(await AdminFixture.createAdminCryptFixture());
+    await redisService.set(redisKeyMake(sessionKey), admin.email);
+
+    [reporter, target] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+    ]);
+  });
+
+  it('[401] 관리자 세션 쿠키가 없으면 신고 목록 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(BASE_URL);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[200] 신고 목록을 최신순으로 조회한다.', async () => {
+    // given
+    await reportRepository.insert({
+      reporter: { id: reporter.id },
+      targetType: ReportTargetType.USER,
+      targetId: target.id,
+      reportedUser: { id: target.id },
+      reason: ReportReason.ABUSE,
+    });
+
+    // Http when
+    const response = await agent.get(BASE_URL).set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data } = response.body as { data: { result: unknown[] } };
+    expect(data.result).toHaveLength(1);
+    expect(data.result[0]).toMatchObject({
+      targetType: ReportTargetType.USER,
+      targetId: target.id,
+      reason: ReportReason.ABUSE,
+      status: ReportStatus.PENDING,
+    });
+  });
+
+  it('[200] status 필터로 신고 목록을 조회한다.', async () => {
+    // given
+    await reportRepository.insert({
+      reporter: { id: reporter.id },
+      targetType: ReportTargetType.USER,
+      targetId: target.id,
+      reportedUser: { id: target.id },
+      reason: ReportReason.ABUSE,
+      status: ReportStatus.ACTIONED,
+    });
+
+    // Http when
+    const response = await agent
+      .get(BASE_URL)
+      .query({ status: ReportStatus.PENDING })
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data } = response.body as { data: { result: unknown[] } };
+    expect(data.result).toHaveLength(0);
+  });
+});

--- a/server/test/report/e2e/create-comment-report.e2e-spec.ts
+++ b/server/test/report/e2e/create-comment-report.e2e-spec.ts
@@ -1,0 +1,108 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Comment } from '@comment/entity/comment.entity';
+import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { ReportReason, ReportTargetType } from '@report/constant/report.constant';
+import { ReportRepository } from '@report/repository/report.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { CommentFixture } from '@test/config/common/fixture/comment.fixture';
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/reports/comments';
+
+describe(`POST ${BASE_URL}/:commentId E2E Test`, () => {
+  let agent: TestAgent;
+  let reportRepository: ReportRepository;
+  let commentRepository: CommentRepository;
+  let feedRepository: FeedRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let reporter: User;
+  let commentAuthor: User;
+  let feed: Feed;
+  let targetComment: Comment;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    reportRepository = testApp.get(ReportRepository);
+    commentRepository = testApp.get(CommentRepository);
+    feedRepository = testApp.get(FeedRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    const rssAccept: RssAccept = await rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture());
+    [reporter, commentAuthor] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+    ]);
+    feed = await feedRepository.save(FeedFixture.createFeedFixture(rssAccept));
+    targetComment = await commentRepository.save(CommentFixture.createCommentFixture(feed, commentAuthor));
+    accessToken = createAccessToken(reporter);
+  });
+
+  it('[404] 신고 대상 댓글이 존재하지 않을 경우 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${Number.MAX_SAFE_INTEGER}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[400] 자신의 댓글을 신고할 경우 실패한다.', async () => {
+    // given
+    const ownComment = await commentRepository.save(CommentFixture.createCommentFixture(feed, reporter));
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${ownComment.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[201] 댓글 신고 등록을 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${targetComment.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.ETC, detail: '부적절한 댓글입니다.' });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB when
+    const saved = await reportRepository.findOneBy({
+      reporter: { id: reporter.id },
+      targetType: ReportTargetType.COMMENT,
+      targetId: targetComment.id,
+    });
+
+    // DB then
+    expect(saved).not.toBeNull();
+    expect(saved.reason).toBe(ReportReason.ETC);
+  });
+});

--- a/server/test/report/e2e/create-feed-report.e2e-spec.ts
+++ b/server/test/report/e2e/create-feed-report.e2e-spec.ts
@@ -1,0 +1,99 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { ReportReason, ReportTargetType } from '@report/constant/report.constant';
+import { ReportRepository } from '@report/repository/report.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/reports/feeds';
+
+describe(`POST ${BASE_URL}/:feedId E2E Test`, () => {
+  let agent: TestAgent;
+  let reportRepository: ReportRepository;
+  let feedRepository: FeedRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let reporter: User;
+  let targetFeed: Feed;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    reportRepository = testApp.get(ReportRepository);
+    feedRepository = testApp.get(FeedRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    reporter = await userRepository.save(await UserFixture.createUserCryptFixture());
+    const rssAccept: RssAccept = await rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture());
+    targetFeed = await feedRepository.save(FeedFixture.createFeedFixture(rssAccept));
+    accessToken = createAccessToken(reporter);
+  });
+
+  it('[404] 신고 대상 게시글이 존재하지 않을 경우 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${Number.MAX_SAFE_INTEGER}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[400] 자신의 게시글을 신고할 경우 실패한다.', async () => {
+    // given
+    const ownedRss = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: reporter.id }),
+    );
+    const ownFeed = await feedRepository.save(FeedFixture.createFeedFixture(ownedRss));
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${ownFeed.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[201] 게시글 신고 등록을 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${targetFeed.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.ADULT });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB when
+    const saved = await reportRepository.findOneBy({
+      reporter: { id: reporter.id },
+      targetType: ReportTargetType.FEED,
+      targetId: targetFeed.id,
+    });
+
+    // DB then
+    expect(saved).not.toBeNull();
+    expect(saved.reason).toBe(ReportReason.ADULT);
+  });
+});

--- a/server/test/report/e2e/create-rss-report.e2e-spec.ts
+++ b/server/test/report/e2e/create-rss-report.e2e-spec.ts
@@ -1,0 +1,91 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { ReportReason, ReportTargetType } from '@report/constant/report.constant';
+import { ReportRepository } from '@report/repository/report.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/reports/rss';
+
+describe(`POST ${BASE_URL}/:rssId E2E Test`, () => {
+  let agent: TestAgent;
+  let reportRepository: ReportRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let userRepository: UserRepository;
+  let reporter: User;
+  let targetRss: RssAccept;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    reportRepository = testApp.get(ReportRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    reporter = await userRepository.save(await UserFixture.createUserCryptFixture());
+    targetRss = await rssAcceptRepository.save(RssAcceptFixture.createRssAcceptFixture());
+    accessToken = createAccessToken(reporter);
+  });
+
+  it('[404] 신고 대상 RSS가 존재하지 않을 경우 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${Number.MAX_SAFE_INTEGER}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[400] 본인 소유의 RSS를 신고할 경우 실패한다.', async () => {
+    // given
+    const ownedRss = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: reporter.id }),
+    );
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${ownedRss.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[201] RSS 신고 등록을 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${targetRss.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.COPYRIGHT });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB when
+    const saved = await reportRepository.findOneBy({
+      reporter: { id: reporter.id },
+      targetType: ReportTargetType.RSS,
+      targetId: targetRss.id,
+    });
+
+    // DB then
+    expect(saved).not.toBeNull();
+    expect(saved.reason).toBe(ReportReason.COPYRIGHT);
+  });
+});

--- a/server/test/report/e2e/create-user-report.e2e-spec.ts
+++ b/server/test/report/e2e/create-user-report.e2e-spec.ts
@@ -1,0 +1,112 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { ReportReason, ReportStatus, ReportTargetType } from '@report/constant/report.constant';
+import { ReportRepository } from '@report/repository/report.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const BASE_URL = '/api/reports/users';
+
+describe(`POST ${BASE_URL}/:userId E2E Test`, () => {
+  let agent: TestAgent;
+  let reportRepository: ReportRepository;
+  let userRepository: UserRepository;
+  let reporter: User;
+  let target: User;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    reportRepository = testApp.get(ReportRepository);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    [reporter, target] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+    ]);
+    accessToken = createAccessToken(reporter);
+  });
+
+  it('[401] 로그인이 되어 있지 않을 경우 사용자 신고를 실패한다.', async () => {
+    // Http when
+    const response = await agent.post(`${BASE_URL}/${target.id}`).send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[400] 자기 자신을 신고할 경우 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${reporter.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[404] 신고 대상 사용자가 존재하지 않을 경우 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${Number.MAX_SAFE_INTEGER}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[409] 이미 신고한 사용자를 다시 신고할 경우 실패한다.', async () => {
+    // given
+    await reportRepository.insert({
+      reporter: { id: reporter.id },
+      targetType: ReportTargetType.USER,
+      targetId: target.id,
+      reportedUser: { id: target.id },
+      reason: ReportReason.SPAM,
+    });
+
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${target.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.SPAM });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CONFLICT);
+  });
+
+  it('[201] 사용자 신고 등록을 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(`${BASE_URL}/${target.id}`)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ reason: ReportReason.ABUSE, detail: '욕설을 사용했습니다.' });
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB when
+    const saved = await reportRepository.findOneBy({
+      reporter: { id: reporter.id },
+      targetType: ReportTargetType.USER,
+      targetId: target.id,
+    });
+
+    // DB then
+    expect(saved).not.toBeNull();
+    expect(saved.reason).toBe(ReportReason.ABUSE);
+    expect(saved.detail).toBe('욕설을 사용했습니다.');
+    expect(saved.status).toBe(ReportStatus.PENDING);
+  });
+});

--- a/server/test/report/unit/report.service.unit.spec.ts
+++ b/server/test/report/unit/report.service.unit.spec.ts
@@ -1,0 +1,206 @@
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+
+import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { Payload } from '@common/guard/jwt.guard';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { ReportReason, ReportTargetType } from '@report/constant/report.constant';
+import { ReportRepository } from '@report/repository/report.repository';
+import { ReportService } from '@report/service/report.service';
+
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { UserService } from '@user/service/user.service';
+
+describe(`${ReportService.name} Unit Test`, () => {
+  let reportService: ReportService;
+  let reportRepository: jest.Mocked<Pick<ReportRepository, 'insert' | 'getReports'>>;
+  let rssAcceptRepository: jest.Mocked<Pick<RssAcceptRepository, 'findOne'>>;
+  let commentRepository: jest.Mocked<Pick<CommentRepository, 'findOne'>>;
+  let feedRepository: jest.Mocked<Pick<FeedRepository, 'findOne'>>;
+  let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
+
+  const user: Payload = { id: 1, email: 'user@test.com', userName: 'tester', role: 'user' };
+  const reportDto = { reason: ReportReason.SPAM, detail: '광고성 내용입니다.' };
+
+  beforeEach(() => {
+    reportRepository = {
+      insert: jest.fn(),
+      getReports: jest.fn(),
+    };
+    rssAcceptRepository = { findOne: jest.fn() };
+    commentRepository = { findOne: jest.fn() };
+    feedRepository = { findOne: jest.fn() };
+    userService = { getUser: jest.fn() };
+
+    reportService = new ReportService(
+      reportRepository as unknown as ReportRepository,
+      rssAcceptRepository as unknown as RssAcceptRepository,
+      commentRepository as unknown as CommentRepository,
+      feedRepository as unknown as FeedRepository,
+      userService as unknown as UserService,
+    );
+  });
+
+  describe('reportUser', () => {
+    it('자기 자신을 신고하면 BadRequestException을 던진다.', async () => {
+      // when & then
+      await expect(reportService.reportUser(user, user.id, reportDto)).rejects.toThrow(BadRequestException);
+      expect(reportRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('신고 대상 유저가 존재하지 않으면 NotFoundException을 던진다.', async () => {
+      // given
+      userService.getUser.mockRejectedValue(new NotFoundException('존재하지 않는 유저입니다.'));
+
+      // when & then
+      await expect(reportService.reportUser(user, 2, reportDto)).rejects.toThrow(NotFoundException);
+      expect(reportRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('이미 신고한 유저면 ConflictException을 던진다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: 2 } as any);
+      reportRepository.insert.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
+
+      // when & then
+      await expect(reportService.reportUser(user, 2, reportDto)).rejects.toThrow(ConflictException);
+    });
+
+    it('사용자 신고 등록에 성공한다.', async () => {
+      // given
+      userService.getUser.mockResolvedValue({ id: 2 } as any);
+      reportRepository.insert.mockResolvedValue(undefined);
+
+      // when
+      await reportService.reportUser(user, 2, reportDto);
+
+      // then
+      expect(reportRepository.insert).toHaveBeenCalledWith({
+        reporter: { id: user.id },
+        targetType: ReportTargetType.USER,
+        targetId: 2,
+        reportedUser: { id: 2 },
+        reason: reportDto.reason,
+        detail: reportDto.detail,
+      });
+    });
+  });
+
+  describe('reportRss', () => {
+    it('신고 대상 RSS가 존재하지 않으면 NotFoundException을 던진다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(reportService.reportRss(user, 5, reportDto)).rejects.toThrow(NotFoundException);
+      expect(reportRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('본인 소유의 RSS를 신고하면 BadRequestException을 던진다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue({ id: 5, userId: user.id } as any);
+
+      // when & then
+      await expect(reportService.reportRss(user, 5, reportDto)).rejects.toThrow(BadRequestException);
+      expect(reportRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('RSS 신고 등록에 성공한다.', async () => {
+      // given
+      rssAcceptRepository.findOne.mockResolvedValue({ id: 5, userId: 99 } as any);
+      reportRepository.insert.mockResolvedValue(undefined);
+
+      // when
+      await reportService.reportRss(user, 5, reportDto);
+
+      // then
+      expect(reportRepository.insert).toHaveBeenCalledWith({
+        reporter: { id: user.id },
+        targetType: ReportTargetType.RSS,
+        targetId: 5,
+        reportedRss: { id: 5 },
+        reason: reportDto.reason,
+        detail: reportDto.detail,
+      });
+    });
+  });
+
+  describe('reportComment', () => {
+    it('신고 대상 댓글이 존재하지 않으면 NotFoundException을 던진다.', async () => {
+      // given
+      commentRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(reportService.reportComment(user, 10, reportDto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('자신의 댓글을 신고하면 BadRequestException을 던진다.', async () => {
+      // given
+      commentRepository.findOne.mockResolvedValue({ id: 10, user: { id: user.id } } as any);
+
+      // when & then
+      await expect(reportService.reportComment(user, 10, reportDto)).rejects.toThrow(BadRequestException);
+      expect(reportRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('댓글 신고 등록에 성공한다.', async () => {
+      // given
+      commentRepository.findOne.mockResolvedValue({ id: 10, user: { id: 99 } } as any);
+      reportRepository.insert.mockResolvedValue(undefined);
+
+      // when
+      await reportService.reportComment(user, 10, reportDto);
+
+      // then
+      expect(reportRepository.insert).toHaveBeenCalledWith({
+        reporter: { id: user.id },
+        targetType: ReportTargetType.COMMENT,
+        targetId: 10,
+        reportedComment: { id: 10 },
+        reason: reportDto.reason,
+        detail: reportDto.detail,
+      });
+    });
+  });
+
+  describe('reportFeed', () => {
+    it('신고 대상 게시글이 존재하지 않으면 NotFoundException을 던진다.', async () => {
+      // given
+      feedRepository.findOne.mockResolvedValue(null);
+
+      // when & then
+      await expect(reportService.reportFeed(user, 20, reportDto)).rejects.toThrow(NotFoundException);
+    });
+
+    it('자신의 게시글을 신고하면 BadRequestException을 던진다.', async () => {
+      // given
+      feedRepository.findOne.mockResolvedValue({ id: 20, blog: { userId: user.id } } as any);
+
+      // when & then
+      await expect(reportService.reportFeed(user, 20, reportDto)).rejects.toThrow(BadRequestException);
+      expect(reportRepository.insert).not.toHaveBeenCalled();
+    });
+
+    it('게시글 신고 등록에 성공한다.', async () => {
+      // given
+      feedRepository.findOne.mockResolvedValue({ id: 20, blog: { userId: 99 } } as any);
+      reportRepository.insert.mockResolvedValue(undefined);
+
+      // when
+      await reportService.reportFeed(user, 20, reportDto);
+
+      // then
+      expect(reportRepository.insert).toHaveBeenCalledWith({
+        reporter: { id: user.id },
+        targetType: ReportTargetType.FEED,
+        targetId: 20,
+        reportedFeed: { id: 20 },
+        reason: reportDto.reason,
+        detail: reportDto.detail,
+      });
+    });
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -28,6 +28,7 @@
       "@file/*": ["./src/file/*"],
       "@health/*": ["./src/health/*"],
       "@like/*": ["./src/like/*"],
+      "@report/*": ["./src/report/*"],
       "@rss/*": ["./src/rss/*"],
       "@statistic/*": ["./src/statistic/*"],
       "@subscribe/*": ["./src/subscribe/*"],


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #832 

### 신고 도메인 백엔드 구현

- 유저 / RSS / 댓글 / 게시글 4가지 대상을 하나의 `report` 테이블로 관리하도록 설계함. 대상 타입별로 테이블을 나누는 `block` 도메인 패턴 대신, `target_type` + 대상별 nullable FK 컬럼(reported_user_id 등) 조합을 선택함 — 관리자가 신고를 한 큐에서 최신순으로 조회해야 하는데, 테이블을 나누면 4-way UNION이 필요해지기 때문.
- 신고 중복 방지는 `(reporter_id, target_type, target_id)` unique 제약 + `ER_DUP_ENTRY` 캐치로 처리 (block 도메인과 동일 패턴).
- 자기 자신 / 본인 소유 RSS·게시글·댓글은 신고할 수 없도록 서비스 레벨에서 막음.

### 신고 UI 4곳 구현

- RSS 페이지, 유저 프로필: 기존 "차단하기" 드롭다운에 "신고하기" 항목 추가
- 댓글: 기존 수정/삭제 텍스트 버튼은 그대로 두고, 별도의 점 3개 메뉴로 신고하기 분리
- 게시글: detail 우측 상단에 점 3개 메뉴 추가
- 공용 `ReportDialog` 컴포넌트(사유 select + 상세 내용 500자 textarea)를 만들어 4곳에서 재사용

### 관리자 신고 조회 탭

- 처리(조치완료/반려) 기능은 이번 PR 범위에서 제외하고 조회 전용으로만 구현 — 처리 기능은 별도 브랜치에서 진행 예정.

### 게시글 detail 모달 안에서 발생한 렌더링 버그들

- detail 모달이 커스텀 scroll-lock(`document.body`/`documentElement` overflow 조작)을 직접 관리하는데, 그 안에서 Radix Dialog/DropdownMenu/Select가 기본값(`modal=true`)으로 각자 또 scroll-lock을 걸면서 배경이 밀리는 문제가 여러 겹으로 있었음.
  - 드롭다운/다이얼로그가 z-50(기본값)으로 렌더링되어 모달의 z-999 배경보다 뒤에 숨는 문제
  - 클릭이 React 트리를 타고 모달의 바깥-클릭 핸들러까지 버블링되어 모달이 통째로 닫히는 문제
  - Radix 컴포넌트가 중복으로 scroll-lock을 걸면서 배경 레이아웃이 열릴 때마다 조금씩 밀리는 문제
- `html { overflow-y: scroll }`이 고정되어 있어 `body.style.overflow = "hidden"`만으로는 실제 뷰포트 스크롤이 막히지 않는 것도 확인하고 `documentElement`에도 직접 overflow를 걸도록 수정함.

# 📋 작업 내용

- `server/src/report/*`: entity, migration, init.sql, DTO, service, controller(사용자용 4개 생성 엔드포인트 + 관리자 조회), api-docs
- `client/src/components/common/ReportDialog.tsx`: 공용 신고 다이얼로그 (재사용 모달 안에서는 `modal={false}`로 중복 scroll-lock 방지)
- `client/src/components/admin/report/AdminReportTab.tsx`: 관리자 신고 목록 조회(상태 필터 + 커서 페이지네이션)
- `RssPage.tsx`, `ProfileHeader.tsx`, `PostHeader.tsx`, `PostComment.tsx`: 신고 진입점 4곳
- `useScrollbarAdjustment.ts`, `PostDetail.tsx`: 모달 스크롤/레이아웃 시프트 버그 수정
- 서버 unit/e2e 테스트, Storybook 스토리(인터랙션 포함) 추가

# 📷 스크린 샷(선택 사항)
<img width="934" height="1223" alt="image" src="https://github.com/user-attachments/assets/86eeaa68-3fd8-4507-8be2-0ded36d787c3" />
<img width="2238" height="503" alt="image" src="https://github.com/user-attachments/assets/8dd83df9-b267-4298-86a6-7a13488c960c" />
