### PR TITLE
🐛 fix: 댓글 날짜 출력 방식 변경

### DIFF
--- a/client/src/utils/timeago.ts
+++ b/client/src/utils/timeago.ts
@@ -9,5 +9,10 @@ export function timeAgo(dateString: string) {
 
   if (diffMin < 60) return `${diffMin}분 전`;
   if (diffHour < 24) return `${diffHour}시간 전`;
-  return `${diffDay}일 전`;
+  if (diffDay < 7) return `${diffDay}일 전`;
+
+  const year = past.getFullYear();
+  const month = String(past.getMonth() + 1).padStart(2, "0");
+  const date = String(past.getDate()).padStart(2, "0");
+  return `${year}-${month}-${date}`;
 }


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연관된 이슈 없음

### 댓글 날짜 표시 방식 개선

- 기존에는 댓글 작성 시점과 무관하게 항상 상대 시간(`분 전`, `시간 전`, `일 전`)으로 표시되어, 오래된 댓글도 정확한 날짜를 알기 어려운 문제가 있었음
- 1주일 이내 댓글은 기존처럼 상대 시간(`x분 전`, `x시간 전`, `x일 전`)을 유지하고, 1주일 이상 지난 댓글은 `yyyy-mm-dd` 절대 날짜로 표시하도록 변경

# 📋 작업 내용

- `client/src/utils/timeago.ts`의 `timeAgo` 함수에 7일 기준 분기 추가
  - `diffDay < 7`: 기존 상대 시간 로직 유지
  - `diffDay >= 7`: `yyyy-mm-dd` 형식으로 변환하여 반환
