### PR TITLE
✨ feat: 좋아요 알림 기능 구현

### DIFF
--- a/client/src/__tests__/components/common/NotificationBell.test.tsx
+++ b/client/src/__tests__/components/common/NotificationBell.test.tsx
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+import { NotificationBell } from "@/components/common/NotificationBell.tsx";
+import { NotificationItem } from "@/api/services/notifications";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockNavigate = vi.fn();
+const markRead = vi.fn();
+
+let authState: { isAuthenticated: boolean };
+let listState: { data: NotificationItem[]; isLoading: boolean };
+let unreadCount: number;
+
+vi.mock("lucide-react", () => lucideProxy());
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ pathname: "/" }),
+}));
+
+vi.mock("@/store/useAuthStore", () => ({
+  useAuthStore: () => authState,
+}));
+
+vi.mock("@/hooks/queries/useNotifications", () => ({
+  useUnreadNotificationCount: () => ({ data: unreadCount }),
+  useNotificationList: () => listState,
+  useMarkNotificationRead: () => ({ mutate: markRead }),
+}));
+
+vi.mock("@/components/ui/popover", () => {
+  const passthrough = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  return { Popover: passthrough, PopoverTrigger: passthrough, PopoverContent: passthrough };
+});
+
+vi.mock("@/components/ui/scroll-area", () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const makeItem = (overrides: Partial<NotificationItem> = {}): NotificationItem => ({
+  id: 1,
+  type: "LIKE",
+  isRead: false,
+  updatedAt: "2026-07-26T00:00:00.000Z",
+  feed: { id: 10, title: "테스트 게시글", path: "https://example.com/10" },
+  actor: { userName: "liker", profileImage: null },
+  otherCount: 0,
+  ...overrides,
+});
+
+describe("NotificationBell", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState = { isAuthenticated: true };
+    listState = { data: [], isLoading: false };
+    unreadCount = 0;
+  });
+
+  it("비인증 상태에서는 아무 것도 렌더링하지 않는다", () => {
+    authState.isAuthenticated = false;
+    const { container } = render(<NotificationBell />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("읽지 않은 알림이 없으면 배지를 표시하지 않는다", () => {
+    unreadCount = 0;
+    render(<NotificationBell />);
+
+    expect(screen.queryByTestId("unread-badge")).not.toBeInTheDocument();
+  });
+
+  it("읽지 않은 알림 개수를 배지로 표시한다", () => {
+    unreadCount = 3;
+    render(<NotificationBell />);
+
+    expect(screen.getByTestId("unread-badge")).toHaveTextContent("3");
+  });
+
+  it("알림이 없으면 안내 문구를 표시한다", () => {
+    listState = { data: [], isLoading: false };
+    render(<NotificationBell />);
+
+    expect(screen.getByText("알림이 없습니다.")).toBeInTheDocument();
+  });
+
+  it("좋아요 알림 메시지를 템플릿에 맞게 표시하고, 유저명/게시글명/행위만 강조한다", () => {
+    listState = { data: [makeItem()], isLoading: false };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("liker님이 테스트 게시글에 좋아요를 표시했습니다.");
+
+    const bolded = item.querySelectorAll(".font-semibold");
+    expect(Array.from(bolded).map((el) => el.textContent)).toEqual(["liker", "테스트 게시글", "좋아요를 표시했습니다"]);
+  });
+
+  it("다른 좋아요가 더 있으면 '외 N명' 문구를 표시한다", () => {
+    listState = { data: [makeItem({ otherCount: 3 })], isLoading: false };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("liker님 외 3명이 테스트 게시글에 좋아요를 표시했습니다.");
+  });
+
+  it("읽지 않은 알림을 클릭하면 읽음 처리 후 게시글로 이동한다", () => {
+    listState = { data: [makeItem({ id: 5, isRead: false })], isLoading: false };
+    render(<NotificationBell />);
+
+    fireEvent.click(screen.getByTestId("notification-item"));
+
+    expect(markRead).toHaveBeenCalledWith(5);
+    expect(mockNavigate).toHaveBeenCalledWith("/10", { state: { backgroundLocation: { pathname: "/" } } });
+  });
+
+  it("이미 읽은 알림을 클릭하면 읽음 처리를 다시 호출하지 않는다", () => {
+    listState = { data: [makeItem({ id: 5, isRead: true })], isLoading: false };
+    render(<NotificationBell />);
+
+    fireEvent.click(screen.getByTestId("notification-item"));
+
+    expect(markRead).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/10", { state: { backgroundLocation: { pathname: "/" } } });
+  });
+});

--- a/client/src/__tests__/components/layout/navigation/DesktopNavigation.test.tsx
+++ b/client/src/__tests__/components/layout/navigation/DesktopNavigation.test.tsx
@@ -21,6 +21,10 @@ vi.mock("@/components/common/UserProfileMenu", () => ({
   UserProfileMenu: () => <div data-testid="user-profile-menu" />,
 }));
 
+vi.mock("@/components/common/NotificationBell", () => ({
+  NotificationBell: () => <div data-testid="notification-bell" />,
+}));
+
 vi.mock("@/components/layout/SideButton", () => ({ default: () => <div data-testid="side-button" /> }));
 
 vi.mock("@/components/search/SearchButton", () => ({

--- a/client/src/__tests__/pages/PrivacyPolicy.test.tsx
+++ b/client/src/__tests__/pages/PrivacyPolicy.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import PrivacyPolicy from "@/pages/PrivacyPolicy.tsx";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("lucide-react", async () => {
@@ -17,12 +18,16 @@ vi.mock("react-router-dom", async (importOriginal) => {
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-const renderPage = () =>
-  render(
-    <MemoryRouter>
-      <PrivacyPolicy />
-    </MemoryRouter>
+const renderPage = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <PrivacyPolicy />
+      </MemoryRouter>
+    </QueryClientProvider>
   );
+};
 
 describe("PrivacyPolicy", () => {
   it("제목과 시행일을 렌더링해야 한다", () => {

--- a/client/src/api/services/notifications.ts
+++ b/client/src/api/services/notifications.ts
@@ -1,0 +1,40 @@
+import { NOTIFICATION } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+import { ApiData } from "@/types/api";
+
+export type NotificationType = "LIKE";
+
+export type NotificationItem = {
+  id: number;
+  type: NotificationType;
+  isRead: boolean;
+  updatedAt: string;
+  feed: {
+    id: number;
+    title: string;
+    path: string;
+  };
+  actor: {
+    userName: string | null;
+    profileImage: string | null;
+  };
+  otherCount: number;
+};
+
+type GetUnreadCountResponse = ApiData<{ count: number }>;
+type GetNotificationsResponse = ApiData<{ result: NotificationItem[] }>;
+
+export const notifications = {
+  getUnreadCount: async (): Promise<number> => {
+    const response = await axiosInstance.get<GetUnreadCountResponse>(NOTIFICATION.UNREAD_COUNT);
+    return response.data.data.count;
+  },
+  getList: async (): Promise<NotificationItem[]> => {
+    const response = await axiosInstance.get<GetNotificationsResponse>(NOTIFICATION.LIST);
+    return response.data.data.result;
+  },
+  markRead: async (id: number): Promise<void> => {
+    await axiosInstance.patch(NOTIFICATION.READ(id));
+  },
+};

--- a/client/src/components/common/NotificationBell.stories.tsx
+++ b/client/src/components/common/NotificationBell.stories.tsx
@@ -60,8 +60,9 @@ export const Empty: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("button", { name: "알림" }));
-    await expect(await canvas.findByText("알림이 없습니다.")).toBeInTheDocument();
+    await expect(await body.findByText("알림이 없습니다.")).toBeInTheDocument();
   },
 };
 
@@ -74,10 +75,11 @@ export const WithUnread: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await expect(await canvas.findByTestId("unread-badge")).toHaveTextContent("1");
 
     await userEvent.click(canvas.getByRole("button", { name: "알림" }));
-    const items = await canvas.findAllByTestId("notification-item");
+    const items = await body.findAllByTestId("notification-item");
     await expect(items[0]).toHaveTextContent("댓글러님이 Storybook으로 알림 미리보기에 좋아요를 표시했습니다.");
     await expect(items[1]).toHaveTextContent("먼저읽음님이 이미 읽은 알림 예시에 좋아요를 표시했습니다.");
   },
@@ -92,8 +94,9 @@ export const WithMultipleLikers: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("button", { name: "알림" }));
-    const item = await canvas.findByTestId("notification-item");
+    const item = await body.findByTestId("notification-item");
     await expect(item).toHaveTextContent("최신좋아요러님 외 3명이 여러 명이 좋아요한 게시글에 좋아요를 표시했습니다.");
   },
 };
@@ -108,8 +111,9 @@ export const MarkAsRead: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
     await userEvent.click(canvas.getByRole("button", { name: "알림" }));
-    await userEvent.click(await canvas.findByTestId("notification-item"));
+    await userEvent.click(await body.findByTestId("notification-item"));
 
     await expect(mockApi.history.patch).toHaveLength(1);
     await expect(mockApi.history.patch[0].url).toBe(NOTIFICATION.READ(unreadItem.id));

--- a/client/src/components/common/NotificationBell.stories.tsx
+++ b/client/src/components/common/NotificationBell.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
+
+import { NotificationBell } from "@/components/common/NotificationBell";
+import { NOTIFICATION } from "@/constants/endpoints";
+import { mockApi, ok } from "@/__storybook__/mockApi";
+import { useAuthStore } from "@/store/useAuthStore";
+
+const unreadItem = {
+  id: 1,
+  type: "LIKE",
+  isRead: false,
+  updatedAt: "2026-07-26T00:00:00.000Z",
+  feed: { id: 10, title: "Storybook으로 알림 미리보기", path: "https://example.com/10" },
+  actor: { userName: "댓글러", profileImage: null },
+  otherCount: 0,
+};
+
+const readItem = {
+  id: 2,
+  type: "LIKE",
+  isRead: true,
+  updatedAt: "2026-07-25T00:00:00.000Z",
+  feed: { id: 11, title: "이미 읽은 알림 예시", path: "https://example.com/11" },
+  actor: { userName: "먼저읽음", profileImage: null },
+  otherCount: 0,
+};
+
+const multipleLikersItem = {
+  id: 3,
+  type: "LIKE",
+  isRead: false,
+  updatedAt: "2026-07-27T00:00:00.000Z",
+  feed: { id: 12, title: "여러 명이 좋아요한 게시글", path: "https://example.com/12" },
+  actor: { userName: "최신좋아요러", profileImage: null },
+  otherCount: 3,
+};
+
+const meta = {
+  title: "common/NotificationBell",
+  component: NotificationBell,
+} satisfies Meta<typeof NotificationBell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NotAuthenticated: Story = {
+  name: "비로그인",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: false, accessToken: null });
+  },
+};
+
+export const Empty: Story = {
+  name: "알림 없음",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 0 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    await expect(await canvas.findByText("알림이 없습니다.")).toBeInTheDocument();
+  },
+};
+
+export const WithUnread: Story = {
+  name: "읽지 않은 알림 표시",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [unreadItem, readItem] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByTestId("unread-badge")).toHaveTextContent("1");
+
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    const items = await canvas.findAllByTestId("notification-item");
+    await expect(items[0]).toHaveTextContent("댓글러님이 Storybook으로 알림 미리보기에 좋아요를 표시했습니다.");
+    await expect(items[1]).toHaveTextContent("먼저읽음님이 이미 읽은 알림 예시에 좋아요를 표시했습니다.");
+  },
+};
+
+export const WithMultipleLikers: Story = {
+  name: "여러 명이 좋아요",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [multipleLikersItem] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    const item = await canvas.findByTestId("notification-item");
+    await expect(item).toHaveTextContent("최신좋아요러님 외 3명이 여러 명이 좋아요한 게시글에 좋아요를 표시했습니다.");
+  },
+};
+
+export const MarkAsRead: Story = {
+  name: "알림 클릭 시 읽음 처리",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [unreadItem] }));
+    mockApi.onPatch(NOTIFICATION.READ(unreadItem.id)).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    await userEvent.click(await canvas.findByTestId("notification-item"));
+
+    await expect(mockApi.history.patch).toHaveLength(1);
+    await expect(mockApi.history.patch[0].url).toBe(NOTIFICATION.READ(unreadItem.id));
+  },
+};

--- a/client/src/components/common/NotificationBell.tsx
+++ b/client/src/components/common/NotificationBell.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+import { Bell } from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+
+import {
+  useMarkNotificationRead,
+  useNotificationList,
+  useUnreadNotificationCount,
+} from "@/hooks/queries/useNotifications";
+
+import { NotificationItem } from "@/api/services/notifications";
+import { cn } from "@/lib/utils";
+import { useAuthStore } from "@/store/useAuthStore";
+
+const buildMessage = (item: NotificationItem) => {
+  switch (item.type) {
+    case "LIKE":
+    default: {
+      const actorSuffix = item.otherCount > 0 ? `님 외 ${item.otherCount}명이 ` : "님이 ";
+      return (
+        <>
+          <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
+          {actorSuffix}
+          <span className="font-semibold">{item.feed.title}</span>에{" "}
+          <span className="font-semibold">좋아요를 표시했습니다</span>.
+        </>
+      );
+    }
+  }
+};
+
+export const NotificationBell = () => {
+  const [open, setOpen] = useState(false);
+  const { isAuthenticated } = useAuthStore();
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const { data: unreadCount = 0 } = useUnreadNotificationCount(isAuthenticated);
+  const { data: items = [], isLoading } = useNotificationList(isAuthenticated && open);
+  const { mutate: markRead } = useMarkNotificationRead();
+
+  if (!isAuthenticated) return null;
+
+  const handleItemClick = (item: NotificationItem) => {
+    if (!item.isRead) markRead(item.id);
+    setOpen(false);
+    navigate(`/${item.feed.id}`, { state: { backgroundLocation: location } });
+  };
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="알림" className="relative mx-1 rounded-full">
+          <Bell className="!h-5 !w-5" />
+          {unreadCount > 0 && (
+            <Badge
+              variant="destructive"
+              data-testid="unread-badge"
+              className="absolute -top-1 -right-1 h-4 min-w-4 justify-center rounded-full px-1 text-[10px] leading-none"
+            >
+              {unreadCount > 99 ? "99+" : unreadCount}
+            </Badge>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-96 p-0">
+        <div className="border-b px-4 py-3">
+          <p className="text-sm font-medium">알림</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">30일이 지난 알림은 그날 오전 4시에 자동으로 삭제돼요.</p>
+        </div>
+        <ScrollArea className="max-h-[30rem]">
+          {isLoading ? (
+            <p className="px-4 py-6 text-center text-sm text-muted-foreground">불러오는 중...</p>
+          ) : items.length === 0 ? (
+            <p className="px-4 py-6 text-center text-sm text-muted-foreground">알림이 없습니다.</p>
+          ) : (
+            items.map((item) => (
+              <button
+                key={item.id}
+                data-testid="notification-item"
+                onClick={() => handleItemClick(item)}
+                className={cn(
+                  "flex w-full items-start gap-3 border-b px-4 py-3 text-left text-sm transition-colors last:border-b-0 hover:bg-accent",
+                  item.isRead ? "bg-muted/60 text-muted-foreground" : "bg-primary/5"
+                )}
+              >
+                <Avatar className={cn("h-8 w-8 shrink-0", item.isRead && "grayscale")}>
+                  <AvatarImage src={item.actor.profileImage ?? undefined} />
+                  <AvatarFallback>{item.actor.userName?.slice(0, 2).toUpperCase() ?? "?"}</AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <p className="line-clamp-2">{buildMessage(item)}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">{new Date(item.updatedAt).toLocaleString()}</p>
+                </div>
+                {!item.isRead && <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />}
+              </button>
+            ))
+          )}
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
+  );
+};

--- a/client/src/components/layout/navigation/DesktopNavigation.tsx
+++ b/client/src/components/layout/navigation/DesktopNavigation.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 
+import { NotificationBell } from "@/components/common/NotificationBell";
 import { UserProfileMenu } from "@/components/common/UserProfileMenu";
 import SideButton from "@/components/layout/SideButton";
 import SearchButton from "@/components/search/SearchButton";
@@ -50,6 +51,9 @@ export default function DesktopNavigation({ toggleModal }: { toggleModal: (modal
               >
                 서비스 소개
               </NavigationMenuLink>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <NotificationBell />
             </NavigationMenuItem>
             <NavigationMenuItem>
               <UserProfileMenu />

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -115,6 +115,12 @@ export const FILE = {
   UPLOAD: "/api/files",
 };
 
+export const NOTIFICATION = {
+  UNREAD_COUNT: "/api/notifications/unread-count",
+  LIST: "/api/notifications",
+  READ: (id: number) => `/api/notifications/${id}/read`,
+};
+
 export const PROFILE = {
   PROFILE: (id: number) => `/api/users/${id}/profile`,
   UPDATE: "/api/users/profile",

--- a/client/src/hooks/queries/useNotifications.ts
+++ b/client/src/hooks/queries/useNotifications.ts
@@ -1,0 +1,35 @@
+import { notifications } from "@/api/services/notifications";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+const UNREAD_COUNT_KEY = ["notifications", "unread-count"];
+const LIST_KEY = ["notifications", "list"];
+const UNREAD_COUNT_POLL_MS = 60000;
+
+export const useUnreadNotificationCount = (enabled: boolean) => {
+  return useQuery({
+    queryKey: UNREAD_COUNT_KEY,
+    queryFn: notifications.getUnreadCount,
+    enabled,
+    refetchInterval: enabled ? UNREAD_COUNT_POLL_MS : false,
+  });
+};
+
+export const useNotificationList = (enabled: boolean) => {
+  return useQuery({
+    queryKey: LIST_KEY,
+    queryFn: notifications.getList,
+    enabled,
+  });
+};
+
+export const useMarkNotificationRead = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => notifications.markRead(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: UNREAD_COUNT_KEY });
+      queryClient.invalidateQueries({ queryKey: LIST_KEY });
+    },
+  });
+};

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -188,6 +188,24 @@ CREATE TABLE `likes` (
   CONSTRAINT `FK_85b0dbd1e7836d0f8cdc38fe830` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
+-- denamu.notification definition
+
+CREATE TABLE `notification` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `type` varchar(20) NOT NULL,
+  `is_read` tinyint NOT NULL DEFAULT '0',
+  `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+  `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `recipient_user_id` int NOT NULL,
+  `feed_id` int NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `IDX_632ea8b2f172248eccfb067bfc` (`recipient_user_id`,`type`,`feed_id`),
+  KEY `IDX_e13cf12d6a05407dbac647761c` (`updated_at`),
+  KEY `FK_916163bd318675ea0c33d517f82` (`feed_id`),
+  CONSTRAINT `FK_7d7f411e854516f615ba846c6a4` FOREIGN KEY (`recipient_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+);
+
 -- denamu.blocks definition
 
 CREATE TABLE `blocks` (

--- a/server/.prettierrc.js
+++ b/server/.prettierrc.js
@@ -21,6 +21,7 @@ module.exports = {
     '^@file/(.*)?$',
     '^@health/(.*)?$',
     '^@like/(.*)?$',
+    "^@notification/(.*)?$",
     '^@rss/(.*)?$',
     '^@statistic/(.*)?$',
     '^@subscribe/(.*)?$',

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -19,7 +19,6 @@ import { CommentModule } from '@comment/module/comment.module';
 
 import { loadDBSetting } from '@common/database/load.config';
 import { EmailModule } from '@common/email/email.module';
-import { HealthController } from '@health/health.controller';
 import { WinstonLoggerModule } from '@common/logger/logger.module';
 import { MetricsModule } from '@common/metrics/metrics.module';
 import { RabbitMQModule } from '@common/rabbitmq/rabbitmq.module';
@@ -29,7 +28,11 @@ import { FeedModule } from '@feed/module/feed.module';
 
 import { FileModule } from '@file/module/file.module';
 
+import { HealthController } from '@health/health.controller';
+
 import { LikeModule } from '@like/module/like.module';
+
+import { NotificationModule } from '@notification/module/notification.module';
 
 import { RssModule } from '@rss/module/rss.module';
 
@@ -91,6 +94,7 @@ const exists = !!chosen && fs.existsSync(chosen);
     StatisticModule,
     CommentModule,
     LikeModule,
+    NotificationModule,
     BlockModule,
     SubscribeModule,
     FileModule,

--- a/server/src/common/database/migration/1782000000000-AddNotification.ts
+++ b/server/src/common/database/migration/1782000000000-AddNotification.ts
@@ -1,0 +1,27 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNotification1782000000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'CREATE TABLE `notification` (' +
+        '`id` int NOT NULL AUTO_INCREMENT, ' +
+        '`type` varchar(20) NOT NULL, ' +
+        '`is_read` tinyint NOT NULL DEFAULT \'0\', ' +
+        '`created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), ' +
+        '`updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), ' +
+        '`recipient_user_id` int NOT NULL, ' +
+        '`feed_id` int NOT NULL, ' +
+        'PRIMARY KEY (`id`), ' +
+        'UNIQUE KEY `IDX_632ea8b2f172248eccfb067bfc` (`recipient_user_id`,`type`,`feed_id`), ' +
+        'KEY `IDX_e13cf12d6a05407dbac647761c` (`updated_at`), ' +
+        'KEY `FK_916163bd318675ea0c33d517f82` (`feed_id`), ' +
+        'CONSTRAINT `FK_7d7f411e854516f615ba846c6a4` FOREIGN KEY (`recipient_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE, ' +
+        'CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE' +
+        ');',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE `notification`;');
+  }
+}

--- a/server/src/like/event/like-created.event.ts
+++ b/server/src/like/event/like-created.event.ts
@@ -1,0 +1,6 @@
+export class LikeCreatedEvent {
+  constructor(
+    public readonly feedId: number,
+    public readonly likerUserId: number,
+  ) {}
+}

--- a/server/src/like/event/like-deleted.event.ts
+++ b/server/src/like/event/like-deleted.event.ts
@@ -1,0 +1,6 @@
+export class LikeDeletedEvent {
+  constructor(
+    public readonly feedId: number,
+    public readonly likerUserId: number,
+  ) {}
+}

--- a/server/src/like/service/like.service.ts
+++ b/server/src/like/service/like.service.ts
@@ -3,6 +3,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { DataSource } from 'typeorm';
 
@@ -15,6 +16,8 @@ import { ManageLikeRequestDto } from '@like/dto/request/manageLike.dto';
 import { GetLikeResponseDto } from '@like/dto/response/getLike.dto';
 import { GetUserLikesResponseDto } from '@like/dto/response/getUserLikes.dto';
 import { Like } from '@like/entity/like.entity';
+import { LikeCreatedEvent } from '@like/event/like-created.event';
+import { LikeDeletedEvent } from '@like/event/like-deleted.event';
 import { LikeRepository } from '@like/repository/like.repository';
 
 import { UserService } from '@user/service/user.service';
@@ -26,6 +29,7 @@ export class LikeService {
     private readonly feedService: FeedService,
     private readonly dataSource: DataSource,
     private readonly userService: UserService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   async getLikesByUser(userId: number, likeDto: GetUserLikesRequestDto) {
@@ -67,7 +71,9 @@ export class LikeService {
     feedLikeCreateDto: ManageLikeRequestDto,
   ) {
     await this.dataSource.transaction(async (manager) => {
-      const feed = await this.feedService.getPublicFeed(feedLikeCreateDto.feedId);
+      const feed = await this.feedService.getPublicFeed(
+        feedLikeCreateDto.feedId,
+      );
       const existing = await this.likeRepository.findOneBy({
         user: { id: userInformation.id },
         feed,
@@ -83,6 +89,11 @@ export class LikeService {
         feed: { id: feedLikeCreateDto.feedId },
       });
     });
+
+    this.eventEmitter.emit(
+      'like.created',
+      new LikeCreatedEvent(feedLikeCreateDto.feedId, userInformation.id),
+    );
   }
 
   async delete(
@@ -106,5 +117,10 @@ export class LikeService {
         feed: { id: feedLikeDeleteDto.feedId },
       });
     });
+
+    this.eventEmitter.emit(
+      'like.deleted',
+      new LikeDeletedEvent(feedLikeDeleteDto.feedId, userInformation.id),
+    );
   }
 }

--- a/server/src/notification/api-docs/getNotifications.api-docs.ts
+++ b/server/src/notification/api-docs/getNotifications.api-docs.ts
@@ -1,0 +1,15 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import { ApiBadRequestDoc, ApiDataResponse, ApiUnauthorizedDoc } from '@common/swagger/swagger.helper';
+import { GetNotificationsResponseDto } from '@notification/dto/response/getNotifications.dto';
+
+export function ApiGetNotifications() {
+  return applyDecorators(
+    ApiOperation({ summary: '알림 목록 조회 API (최근 30일, 최신순)' }),
+    ApiBearerAuth(),
+    ApiDataResponse(GetNotificationsResponseDto, false, '알림 목록 조회 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/notification/api-docs/getUnreadCount.api-docs.ts
+++ b/server/src/notification/api-docs/getUnreadCount.api-docs.ts
@@ -1,0 +1,14 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import { ApiDataResponse, ApiUnauthorizedDoc } from '@common/swagger/swagger.helper';
+import { GetUnreadCountResponseDto } from '@notification/dto/response/getUnreadCount.dto';
+
+export function ApiGetUnreadCount() {
+  return applyDecorators(
+    ApiOperation({ summary: '읽지 않은 알림 개수 조회 API' }),
+    ApiBearerAuth(),
+    ApiDataResponse(GetUnreadCountResponseDto, false, '읽지 않은 알림 개수 조회 성공'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/notification/api-docs/readNotification.api-docs.ts
+++ b/server/src/notification/api-docs/readNotification.api-docs.ts
@@ -1,0 +1,16 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiParam } from '@nestjs/swagger';
+
+import { ApiBadRequestDoc, ApiMessageResponse, ApiNotFoundDoc, ApiUnauthorizedDoc } from '@common/swagger/swagger.helper';
+
+export function ApiReadNotification() {
+  return applyDecorators(
+    ApiOperation({ summary: '알림 읽음 처리 API' }),
+    ApiBearerAuth(),
+    ApiParam({ name: 'notificationId', type: Number, description: '알림 ID', example: 1 }),
+    ApiMessageResponse('알림 읽음 처리 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+    ApiNotFoundDoc('존재하지 않거나 본인 소유가 아닌 알림인 경우'),
+  );
+}

--- a/server/src/notification/constant/notification.constant.ts
+++ b/server/src/notification/constant/notification.constant.ts
@@ -1,0 +1,7 @@
+export const NOTIFICATION_RETENTION_DAYS = 30;
+
+export function getNotificationCutoffDate(now: Date = new Date()): Date {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - NOTIFICATION_RETENTION_DAYS);
+  return cutoff;
+}

--- a/server/src/notification/controller/notification.controller.ts
+++ b/server/src/notification/controller/notification.controller.ts
@@ -1,0 +1,54 @@
+import { Controller, Get, HttpCode, HttpStatus, Param, Patch, Query, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { CurrentUser } from '@common/decorator';
+import { JwtGuard, Payload } from '@common/guard/jwt.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiGetNotifications } from '@notification/api-docs/getNotifications.api-docs';
+import { ApiGetUnreadCount } from '@notification/api-docs/getUnreadCount.api-docs';
+import { ApiReadNotification } from '@notification/api-docs/readNotification.api-docs';
+import { GetNotificationsRequestDto } from '@notification/dto/request/getNotifications.dto';
+import { ReadNotificationParamRequestDto } from '@notification/dto/request/readNotificationParam.dto';
+import { NotificationService } from '@notification/service/notification.service';
+
+@ApiTags('Notification')
+@Controller('notifications')
+@UseGuards(JwtGuard)
+export class NotificationController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @ApiGetUnreadCount()
+  @Get('unread-count')
+  @HttpCode(HttpStatus.OK)
+  async getUnreadCount(@CurrentUser() user: Payload) {
+    return ApiResponse.responseWithData(
+      '읽지 않은 알림 개수 조회를 성공했습니다.',
+      await this.notificationService.getUnreadCount(user.id),
+    );
+  }
+
+  @ApiGetNotifications()
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getNotifications(
+    @CurrentUser() user: Payload,
+    @Query() queryDto: GetNotificationsRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '알림 목록 조회를 성공했습니다.',
+      await this.notificationService.getNotifications(user.id, queryDto.limit ?? 20),
+    );
+  }
+
+  @ApiReadNotification()
+  @Patch(':notificationId/read')
+  @HttpCode(HttpStatus.OK)
+  async readNotification(
+    @CurrentUser() user: Payload,
+    @Param() paramDto: ReadNotificationParamRequestDto,
+  ) {
+    await this.notificationService.markAsRead(paramDto.notificationId, user.id);
+    return ApiResponse.responseWithNoContent('알림 읽음 처리를 성공했습니다.');
+  }
+}

--- a/server/src/notification/dto/request/getNotifications.dto.ts
+++ b/server/src/notification/dto/request/getNotifications.dto.ts
@@ -1,0 +1,23 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class GetNotificationsRequestDto {
+  @ApiPropertyOptional({
+    example: 20,
+    description: '받아올 최대 알림 개수',
+    required: false,
+  })
+  @IsOptional()
+  @Min(1, { message: 'limit 값은 1 이상이어야 합니다.' })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Type(() => Number)
+  limit?: number = 20;
+
+  constructor(partial: Partial<GetNotificationsRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/notification/dto/request/readNotificationParam.dto.ts
+++ b/server/src/notification/dto/request/readNotificationParam.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class ReadNotificationParamRequestDto {
+  @ApiProperty({
+    example: 1,
+    description: '읽음 처리할 알림 ID',
+  })
+  @IsInt({
+    message: '정수를 입력해주세요.',
+  })
+  @Min(1, { message: '알림 ID는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  notificationId: number;
+
+  constructor(partial: Partial<ReadNotificationParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/notification/dto/response/getNotifications.dto.ts
+++ b/server/src/notification/dto/response/getNotifications.dto.ts
@@ -1,0 +1,97 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { NotificationType } from '@notification/entity/notification.entity';
+
+type NotificationRawRow = {
+  id: number;
+  type: NotificationType;
+  isRead: number | boolean;
+  updatedAt: Date;
+  feedId: number;
+  feedTitle: string;
+  feedPath: string;
+  actorUserName: string | null;
+  actorProfileImage: string | null;
+  otherLikersCount: string | number;
+};
+
+export class NotificationItemResult {
+  @ApiProperty({ example: 1, description: '알림 ID' })
+  id: number;
+
+  @ApiProperty({ example: 'LIKE', enum: NotificationType, description: '알림 종류' })
+  type: NotificationType;
+
+  @ApiProperty({ example: false, description: '읽음 여부' })
+  isRead: boolean;
+
+  @ApiProperty({ example: '2026-07-26T00:00:00.000Z', description: '알림 갱신 시각(표시 기준 시각)' })
+  updatedAt: Date;
+
+  @ApiProperty({
+    example: { id: 1, title: 'example title', path: 'https://example.com/feed' },
+    description: '알림 대상 게시글 정보',
+  })
+  feed: {
+    id: number;
+    title: string;
+    path: string;
+  };
+
+  @ApiProperty({
+    example: { userName: 'liker', profileImage: null },
+    description: '알림을 발생시킨 유저 정보(현재 최신 좋아요 사용자에서 파생)',
+  })
+  actor: {
+    userName: string | null;
+    profileImage: string | null;
+  };
+
+  @ApiProperty({
+    example: 2,
+    description: '표시된 actor를 제외하고 이 게시글에 좋아요를 누른 다른 사람 수(수신자 본인 제외)',
+  })
+  otherCount: number;
+
+  private constructor(partial: Partial<NotificationItemResult>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(row: NotificationRawRow) {
+    return new NotificationItemResult({
+      id: row.id,
+      type: row.type,
+      isRead: !!row.isRead,
+      updatedAt: row.updatedAt,
+      feed: {
+        id: row.feedId,
+        title: row.feedTitle,
+        path: row.feedPath,
+      },
+      actor: {
+        userName: row.actorUserName,
+        profileImage: row.actorProfileImage,
+      },
+      otherCount: Math.max(0, Number(row.otherLikersCount) - 1),
+    });
+  }
+
+  static toResultDtoArray(rows: NotificationRawRow[]) {
+    return rows.map((row) => this.toResultDto(row));
+  }
+}
+
+export class GetNotificationsResponseDto {
+  @ApiProperty({ type: [NotificationItemResult], description: '알림 목록' })
+  result: NotificationItemResult[];
+
+  constructor(partial: Partial<GetNotificationsResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(rows: NotificationRawRow[]) {
+    return new GetNotificationsResponseDto({
+      result: NotificationItemResult.toResultDtoArray(rows),
+    });
+  }
+}

--- a/server/src/notification/dto/response/getUnreadCount.dto.ts
+++ b/server/src/notification/dto/response/getUnreadCount.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GetUnreadCountResponseDto {
+  @ApiProperty({ example: 3, description: '읽지 않은 알림 개수' })
+  count: number;
+
+  constructor(partial: Partial<GetUnreadCountResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(count: number) {
+    return new GetUnreadCountResponseDto({ count });
+  }
+}

--- a/server/src/notification/entity/notification.entity.ts
+++ b/server/src/notification/entity/notification.entity.ts
@@ -1,0 +1,60 @@
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  Unique,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { Feed } from '@feed/entity/feed.entity';
+
+import { User } from '@user/entity/user.entity';
+
+export enum NotificationType {
+  LIKE = 'LIKE',
+}
+
+@Entity({ name: 'notification' })
+@Unique(['recipient', 'type', 'feed'])
+export class Notification extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, {
+    nullable: false,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'recipient_user_id' })
+  recipient: User;
+
+  @Column({
+    name: 'type',
+    type: 'varchar',
+    length: 20,
+  })
+  type: NotificationType;
+
+  @ManyToOne(() => Feed, {
+    nullable: false,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'feed_id' })
+  feed: Feed;
+
+  @Column({ name: 'is_read', default: false })
+  isRead: boolean;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @Index()
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/server/src/notification/listener/like.listener.ts
+++ b/server/src/notification/listener/like.listener.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { LikeCreatedEvent } from '@like/event/like-created.event';
+import { LikeDeletedEvent } from '@like/event/like-deleted.event';
+
+import { NotificationService } from '@notification/service/notification.service';
+
+@Injectable()
+export class LikeListener {
+  constructor(
+    private readonly feedRepository: FeedRepository,
+    private readonly notificationService: NotificationService,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  @OnEvent('like.created')
+  async handleLikeCreated({ feedId, likerUserId }: LikeCreatedEvent) {
+    try {
+      const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
+      if (!blogMeta?.userId) return;
+      if (blogMeta.userId === likerUserId) return;
+
+      await this.notificationService.upsertLikeNotification(blogMeta.userId, feedId);
+    } catch (error) {
+      this.logger.error(
+        `[LikeListener]: 좋아요 알림 생성 중 오류 발생 (feedId: ${feedId}): ${error}`,
+      );
+    }
+  }
+
+  @OnEvent('like.deleted')
+  async handleLikeDeleted({ feedId }: LikeDeletedEvent) {
+    try {
+      const feed = await this.feedRepository.findOneBy({ id: feedId });
+      if (!feed) return;
+
+      await this.notificationService.removeLikeNotificationIfEmpty(feedId, feed.likeCount);
+    } catch (error) {
+      this.logger.error(
+        `[LikeListener]: 좋아요 알림 삭제 중 오류 발생 (feedId: ${feedId}): ${error}`,
+      );
+    }
+  }
+}

--- a/server/src/notification/module/notification.module.ts
+++ b/server/src/notification/module/notification.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+
+import { JwtAuthModule } from '@common/auth/jwt.module';
+
+import { FeedModule } from '@feed/module/feed.module';
+
+import { NotificationController } from '@notification/controller/notification.controller';
+import { LikeListener } from '@notification/listener/like.listener';
+import { NotificationRepository } from '@notification/repository/notification.repository';
+import { NotificationScheduler } from '@notification/scheduler/notification.scheduler';
+import { NotificationService } from '@notification/service/notification.service';
+
+@Module({
+  imports: [FeedModule, JwtAuthModule],
+  controllers: [NotificationController],
+  providers: [
+    NotificationService,
+    NotificationRepository,
+    LikeListener,
+    NotificationScheduler,
+  ],
+  exports: [],
+})
+export class NotificationModule {}

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+
+import { DataSource, LessThan, Repository } from 'typeorm';
+
+import { Feed } from '@feed/entity/feed.entity';
+
+import { Notification, NotificationType } from '@notification/entity/notification.entity';
+import { getNotificationCutoffDate } from '@notification/constant/notification.constant';
+
+import { User } from '@user/entity/user.entity';
+
+@Injectable()
+export class NotificationRepository extends Repository<Notification> {
+  constructor(private dataSource: DataSource) {
+    super(Notification, dataSource.createEntityManager());
+  }
+
+  async upsertLike(recipientId: number, feedId: number) {
+    await this.createQueryBuilder()
+      .insert()
+      .into(Notification)
+      .values({
+        recipient: { id: recipientId } as User,
+        type: NotificationType.LIKE,
+        feed: { id: feedId } as Feed,
+        isRead: false,
+      })
+      .orUpdate(['is_read'], ['recipient_user_id', 'type', 'feed_id'])
+      .execute();
+  }
+
+  async deleteLikeNotification(feedId: number) {
+    await this.delete({ type: NotificationType.LIKE, feed: { id: feedId } });
+  }
+
+  async findByRecipient(recipientId: number, limit: number) {
+    return this.createQueryBuilder('n')
+      .innerJoin('n.feed', 'feed')
+      .leftJoin(
+        'likes',
+        'latest_like',
+        'latest_like.id = (SELECT l2.id FROM likes l2 WHERE l2.feed_id = n.feed_id ORDER BY l2.like_date DESC LIMIT 1)',
+      )
+      .leftJoin('user', 'actor', 'actor.id = latest_like.user_id')
+      .select('n.id', 'id')
+      .addSelect('n.type', 'type')
+      .addSelect('n.is_read', 'isRead')
+      .addSelect('n.updated_at', 'updatedAt')
+      .addSelect('feed.id', 'feedId')
+      .addSelect('feed.title', 'feedTitle')
+      .addSelect('feed.path', 'feedPath')
+      .addSelect('actor.user_name', 'actorUserName')
+      .addSelect('actor.profile_image', 'actorProfileImage')
+      .addSelect(
+        '(SELECT COUNT(*) FROM likes l3 WHERE l3.feed_id = n.feed_id AND l3.user_id != n.recipient_user_id)',
+        'otherLikersCount',
+      )
+      .where('n.recipient_user_id = :recipientId', { recipientId })
+      .andWhere('n.updated_at >= :cutoff', { cutoff: getNotificationCutoffDate() })
+      .orderBy('n.updated_at', 'DESC')
+      .limit(limit)
+      .getRawMany();
+  }
+
+  async countUnread(recipientId: number) {
+    return this.createQueryBuilder('n')
+      .where('n.recipient_user_id = :recipientId', { recipientId })
+      .andWhere('n.is_read = 0')
+      .andWhere('n.updated_at >= :cutoff', { cutoff: getNotificationCutoffDate() })
+      .getCount();
+  }
+
+  async markRead(id: number, recipientId: number) {
+    const result = await this.createQueryBuilder()
+      .update(Notification)
+      .set({ isRead: true })
+      .where('id = :id', { id })
+      .andWhere('recipient_user_id = :recipientId', { recipientId })
+      .execute();
+
+    return (result.affected ?? 0) > 0;
+  }
+
+  async deleteExpired() {
+    return this.delete({ updatedAt: LessThan(getNotificationCutoffDate()) });
+  }
+}

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -25,7 +25,7 @@ export class NotificationRepository extends Repository<Notification> {
         feed: { id: feedId } as Feed,
         isRead: false,
       })
-      .orUpdate(['is_read'], ['recipient_user_id', 'type', 'feed_id'])
+      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'feed_id'])
       .execute();
   }
 

--- a/server/src/notification/scheduler/notification.scheduler.ts
+++ b/server/src/notification/scheduler/notification.scheduler.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { NotificationService } from '@notification/service/notification.service';
+
+@Injectable()
+export class NotificationScheduler {
+  constructor(
+    private readonly notificationService: NotificationService,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_4AM)
+  async removeExpiredNotifications() {
+    try {
+      await this.notificationService.deleteExpired();
+      this.logger.log('[NotificationScheduler]: 만료된 알림 삭제 완료.');
+    } catch (error) {
+      this.logger.error(
+        `[NotificationScheduler]: 만료 알림 삭제 중 오류 발생: ${error}`,
+      );
+    }
+  }
+}

--- a/server/src/notification/service/notification.service.ts
+++ b/server/src/notification/service/notification.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+
+import { GetNotificationsResponseDto } from '@notification/dto/response/getNotifications.dto';
+import { GetUnreadCountResponseDto } from '@notification/dto/response/getUnreadCount.dto';
+import { NotificationRepository } from '@notification/repository/notification.repository';
+
+@Injectable()
+export class NotificationService {
+  constructor(private readonly notificationRepository: NotificationRepository) {}
+
+  async upsertLikeNotification(recipientId: number, feedId: number) {
+    await this.notificationRepository.upsertLike(recipientId, feedId);
+  }
+
+  async removeLikeNotificationIfEmpty(feedId: number, likeCount: number) {
+    if (likeCount > 0) return;
+    await this.notificationRepository.deleteLikeNotification(feedId);
+  }
+
+  async getUnreadCount(userId: number) {
+    const count = await this.notificationRepository.countUnread(userId);
+    return GetUnreadCountResponseDto.toResponseDto(count);
+  }
+
+  async getNotifications(userId: number, limit: number) {
+    const rows = await this.notificationRepository.findByRecipient(userId, limit);
+    return GetNotificationsResponseDto.toResponseDto(rows);
+  }
+
+  async markAsRead(notificationId: number, userId: number) {
+    const updated = await this.notificationRepository.markRead(notificationId, userId);
+    if (!updated) {
+      throw new NotFoundException('존재하지 않거나 접근할 수 없는 알림입니다.');
+    }
+  }
+
+  async deleteExpired() {
+    await this.notificationRepository.deleteExpired();
+  }
+}

--- a/server/test/like/unit/like.service.unit.spec.ts
+++ b/server/test/like/unit/like.service.unit.spec.ts
@@ -1,4 +1,5 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { DataSource } from 'typeorm';
 
@@ -23,6 +24,7 @@ describe(`${LikeService.name} Unit Test`, () => {
   let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
   let manager: { save: jest.Mock; delete: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
 
   const user: Payload = {
     id: 1,
@@ -40,12 +42,14 @@ describe(`${LikeService.name} Unit Test`, () => {
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
     } as any;
+    eventEmitter = { emit: jest.fn() };
 
     likeService = new LikeService(
       likeRepository as unknown as LikeRepository,
       feedService as unknown as FeedService,
       dataSource as unknown as DataSource,
       userService as unknown as UserService,
+      eventEmitter as unknown as EventEmitter2,
     );
   });
 
@@ -116,6 +120,10 @@ describe(`${LikeService.name} Unit Test`, () => {
         user: { id: user.id },
         feed: { id: dto.feedId },
       });
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'like.created',
+        expect.objectContaining({ feedId: dto.feedId, likerUserId: user.id }),
+      );
     });
   });
 
@@ -148,6 +156,10 @@ describe(`${LikeService.name} Unit Test`, () => {
         user: { id: user.id },
         feed: { id: dto.feedId },
       });
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'like.deleted',
+        expect.objectContaining({ feedId: dto.feedId, likerUserId: user.id }),
+      );
     });
   });
 

--- a/server/test/notification/dto/getNotifications.dto.spec.ts
+++ b/server/test/notification/dto/getNotifications.dto.spec.ts
@@ -1,0 +1,58 @@
+import { validate } from 'class-validator';
+
+import { GetNotificationsRequestDto } from '@notification/dto/request/getNotifications.dto';
+
+describe(`${GetNotificationsRequestDto.name} Test`, () => {
+  let dto: GetNotificationsRequestDto;
+
+  beforeEach(() => {
+    dto = new GetNotificationsRequestDto({
+      limit: 20,
+    });
+  });
+
+  it('limit이 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('limit은 선택값이므로 없어도 유효성 검사에 성공한다.', async () => {
+    // given
+    dto = new GetNotificationsRequestDto({});
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('limit', () => {
+    it('정수가 아니면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 1.5;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('1 미만이면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/notification/dto/readNotificationParam.dto.spec.ts
+++ b/server/test/notification/dto/readNotificationParam.dto.spec.ts
@@ -1,0 +1,59 @@
+import { validate } from 'class-validator';
+
+import { ReadNotificationParamRequestDto } from '@notification/dto/request/readNotificationParam.dto';
+
+describe(`${ReadNotificationParamRequestDto.name} Test`, () => {
+  let dto: ReadNotificationParamRequestDto;
+
+  beforeEach(() => {
+    dto = new ReadNotificationParamRequestDto({
+      notificationId: 1,
+    });
+  });
+
+  it('알림 ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('notificationId', () => {
+    it('알림 ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.notificationId = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('알림 ID가 정수가 아니고 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.notificationId = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('알림 ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.notificationId = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/notification/e2e/notification.e2e-spec.ts
+++ b/server/test/notification/e2e/notification.e2e-spec.ts
@@ -1,0 +1,228 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { GetNotificationsResponseDto } from '@notification/dto/response/getNotifications.dto';
+import { GetUnreadCountResponseDto } from '@notification/dto/response/getUnreadCount.dto';
+import { NotificationRepository } from '@notification/repository/notification.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const NOTIFICATION_URL = '/api/notifications';
+
+async function waitFor<T>(
+  check: () => Promise<T>,
+  isDone: (value: T) => boolean,
+  timeoutMs = 3000,
+  intervalMs = 50,
+): Promise<T> {
+  const start = Date.now();
+  let last: T;
+  do {
+    last = await check();
+    if (isDone(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  } while (Date.now() - start < timeoutMs);
+  return last;
+}
+
+describe(`${NOTIFICATION_URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let userRepository: UserRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+  let notificationRepository: NotificationRepository;
+  let owner: User;
+  let liker: User;
+  let rssAccept: RssAccept;
+  let feed: Feed;
+  let ownerToken: string;
+  let likerToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    userRepository = testApp.get(UserRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+    notificationRepository = testApp.get(NotificationRepository);
+  });
+
+  beforeEach(async () => {
+    owner = await userRepository.save(await UserFixture.createUserCryptFixture());
+    liker = await userRepository.save(await UserFixture.createUserCryptFixture());
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ user: owner }),
+    );
+    feed = await feedRepository.save(FeedFixture.createFeedFixture(rssAccept));
+    ownerToken = createAccessToken({ id: owner.id });
+    likerToken = createAccessToken({ id: liker.id });
+  });
+
+  const likeFeed = (token: string) =>
+    agent.post(`/api/feeds/${feed.id}/likes`).set('Authorization', `Bearer ${token}`);
+
+  const unlikeFeed = (token: string) =>
+    agent.delete(`/api/feeds/${feed.id}/likes`).set('Authorization', `Bearer ${token}`);
+
+  const getUnreadCount = async (token: string) => {
+    const response = await agent
+      .get(`${NOTIFICATION_URL}/unread-count`)
+      .set('Authorization', `Bearer ${token}`);
+    const { data } = response.body;
+    return data as GetUnreadCountResponseDto;
+  };
+
+  const getNotifications = async (token: string) => {
+    const response = await agent
+      .get(NOTIFICATION_URL)
+      .set('Authorization', `Bearer ${token}`);
+    const { data } = response.body;
+    return data as GetNotificationsResponseDto;
+  };
+
+  it('[401] 인증되지 않은 요청은 읽지 않은 알림 개수 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(`${NOTIFICATION_URL}/unread-count`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+  });
+
+  it('[200] 본인 게시글에 본인이 좋아요를 누르면(self-like) 알림이 생성되지 않는다.', async () => {
+    // Http when
+    await likeFeed(ownerToken).expect(HttpStatus.CREATED);
+
+    // then - self-like는 즉시 반영되므로 폴링 없이 바로 확인 가능
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const count = await getUnreadCount(ownerToken);
+    expect(count.count).toBe(0);
+  });
+
+  it('[200] 타인이 좋아요를 누르면 게시글 소유자에게 알림이 생성된다.', async () => {
+    // Http when
+    await likeFeed(likerToken).expect(HttpStatus.CREATED);
+
+    // then
+    const count = await waitFor(
+      () => getUnreadCount(ownerToken),
+      (result) => result.count > 0,
+    );
+    expect(count.count).toBe(1);
+
+    const notifications = await getNotifications(ownerToken);
+    expect(notifications.result).toHaveLength(1);
+    const item = notifications.result[0];
+    expect(item.type).toBe('LIKE');
+    expect(item.isRead).toBe(false);
+    expect(item.feed).toStrictEqual({ id: feed.id, title: feed.title, path: feed.path });
+    expect(item.actor.userName).toBe(liker.userName);
+    expect(item.otherCount).toBe(0);
+  });
+
+  it('[200] 여러 명이 좋아요를 누르면 최신 좋아요 사용자 외 나머지 인원 수가 otherCount로 표시된다.', async () => {
+    // given
+    const secondLiker = await userRepository.save(await UserFixture.createUserCryptFixture());
+    const secondLikerToken = createAccessToken({ id: secondLiker.id });
+
+    // Http when
+    await likeFeed(likerToken).expect(HttpStatus.CREATED);
+    await waitFor(
+      () => getUnreadCount(ownerToken),
+      (result) => result.count > 0,
+    );
+    await likeFeed(secondLikerToken).expect(HttpStatus.CREATED);
+
+    // then
+    const notifications = await waitFor(
+      () => getNotifications(ownerToken),
+      (result) => result.result[0]?.actor.userName === secondLiker.userName,
+    );
+    const item = notifications.result[0];
+    expect(item.actor.userName).toBe(secondLiker.userName);
+    expect(item.otherCount).toBe(1);
+  });
+
+  it('[200] 좋아요를 누른 사람은 알림을 받지 않는다(수신자는 게시글 소유자).', async () => {
+    // Http when
+    await likeFeed(likerToken).expect(HttpStatus.CREATED);
+    await waitFor(
+      () => getUnreadCount(ownerToken),
+      (result) => result.count > 0,
+    );
+
+    // then
+    const likerCount = await getUnreadCount(likerToken);
+    expect(likerCount.count).toBe(0);
+  });
+
+  it('[200] 알림을 읽음 처리하면 읽지 않은 알림 개수가 감소한다.', async () => {
+    // given
+    await likeFeed(likerToken).expect(HttpStatus.CREATED);
+    await waitFor(
+      () => getUnreadCount(ownerToken),
+      (result) => result.count > 0,
+    );
+    const notifications = await getNotifications(ownerToken);
+    const notificationId = notifications.result[0].id;
+
+    // Http when
+    const response = await agent
+      .patch(`${NOTIFICATION_URL}/${notificationId}/read`)
+      .set('Authorization', `Bearer ${ownerToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.OK);
+    const count = await getUnreadCount(ownerToken);
+    expect(count.count).toBe(0);
+  });
+
+  it('[404] 본인 소유가 아닌 알림을 읽음 처리하면 실패한다.', async () => {
+    // given
+    await likeFeed(likerToken).expect(HttpStatus.CREATED);
+    const notifications = await waitFor(
+      () => getNotifications(ownerToken),
+      (result) => result.result.length > 0,
+    );
+    const notificationId = notifications.result[0].id;
+
+    // Http when
+    const response = await agent
+      .patch(`${NOTIFICATION_URL}/${notificationId}/read`)
+      .set('Authorization', `Bearer ${likerToken}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[200] 좋아요를 취소해 좋아요 수가 0이 되면 알림도 삭제된다.', async () => {
+    // given
+    await likeFeed(likerToken).expect(HttpStatus.CREATED);
+    await waitFor(
+      () => getUnreadCount(ownerToken),
+      (result) => result.count > 0,
+    );
+
+    // Http when
+    await unlikeFeed(likerToken).expect(HttpStatus.OK);
+
+    // then
+    const remaining = await waitFor(
+      () => notificationRepository.findOneBy({ feed: { id: feed.id } } as any),
+      (result) => result === null,
+    );
+    expect(remaining).toBeNull();
+  });
+});

--- a/server/test/notification/unit/like.listener.unit.spec.ts
+++ b/server/test/notification/unit/like.listener.unit.spec.ts
@@ -1,0 +1,132 @@
+import { LikeListener } from '@notification/listener/like.listener';
+import { NotificationService } from '@notification/service/notification.service';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { LikeCreatedEvent } from '@like/event/like-created.event';
+import { LikeDeletedEvent } from '@like/event/like-deleted.event';
+
+describe(`${LikeListener.name} Unit Test`, () => {
+  let likeListener: LikeListener;
+  let feedRepository: jest.Mocked<
+    Pick<FeedRepository, 'getBlogMetaByFeedId' | 'findOneBy'>
+  >;
+  let notificationService: jest.Mocked<
+    Pick<
+      NotificationService,
+      'upsertLikeNotification' | 'removeLikeNotificationIfEmpty'
+    >
+  >;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
+
+  beforeEach(() => {
+    feedRepository = { getBlogMetaByFeedId: jest.fn(), findOneBy: jest.fn() };
+    notificationService = {
+      upsertLikeNotification: jest.fn(),
+      removeLikeNotificationIfEmpty: jest.fn(),
+    };
+    logger = { error: jest.fn() };
+
+    likeListener = new LikeListener(
+      feedRepository as unknown as FeedRepository,
+      notificationService as unknown as NotificationService,
+      logger as unknown as WinstonLoggerService,
+    );
+  });
+
+  describe('handleLikeCreated', () => {
+    it('게시글 소유자가 없으면(RSS 미소유) 알림을 생성하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: null,
+      });
+
+      // when
+      await likeListener.handleLikeCreated(new LikeCreatedEvent(10, 2));
+
+      // then
+      expect(notificationService.upsertLikeNotification).not.toHaveBeenCalled();
+    });
+
+    it('본인 게시글에 본인이 좋아요를 누르면(self-like) 알림을 생성하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 2,
+      });
+
+      // when
+      await likeListener.handleLikeCreated(new LikeCreatedEvent(10, 2));
+
+      // then
+      expect(notificationService.upsertLikeNotification).not.toHaveBeenCalled();
+    });
+
+    it('타인이 좋아요를 누르면 게시글 소유자에게 알림을 upsert한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await likeListener.handleLikeCreated(new LikeCreatedEvent(10, 2));
+
+      // then
+      expect(notificationService.upsertLikeNotification).toHaveBeenCalledWith(
+        99,
+        10,
+      );
+    });
+
+    it('처리 중 예외가 발생해도 던지지 않고 로깅한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockRejectedValue(
+        new Error('db down'),
+      );
+
+      // when & then
+      await expect(
+        likeListener.handleLikeCreated(new LikeCreatedEvent(10, 2)),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleLikeDeleted', () => {
+    it('게시글이 존재하지 않으면 아무 것도 하지 않는다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue(null);
+
+      // when
+      await likeListener.handleLikeDeleted(new LikeDeletedEvent(10, 2));
+
+      // then
+      expect(
+        notificationService.removeLikeNotificationIfEmpty,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('게시글의 현재 좋아요 수 기준으로 알림 삭제 여부를 위임한다.', async () => {
+      // given
+      feedRepository.findOneBy.mockResolvedValue({
+        id: 10,
+        likeCount: 0,
+      } as any);
+
+      // when
+      await likeListener.handleLikeDeleted(new LikeDeletedEvent(10, 2));
+
+      // then
+      expect(
+        notificationService.removeLikeNotificationIfEmpty,
+      ).toHaveBeenCalledWith(10, 0);
+    });
+  });
+});

--- a/server/test/notification/unit/notification.service.unit.spec.ts
+++ b/server/test/notification/unit/notification.service.unit.spec.ts
@@ -1,0 +1,85 @@
+import { NotFoundException } from '@nestjs/common';
+
+import { NotificationRepository } from '@notification/repository/notification.repository';
+import { NotificationService } from '@notification/service/notification.service';
+
+describe(`${NotificationService.name} Unit Test`, () => {
+  let notificationService: NotificationService;
+  let notificationRepository: jest.Mocked<
+    Pick<
+      NotificationRepository,
+      | 'upsertLike'
+      | 'deleteLikeNotification'
+      | 'countUnread'
+      | 'findByRecipient'
+      | 'markRead'
+      | 'deleteExpired'
+    >
+  >;
+
+  beforeEach(() => {
+    notificationRepository = {
+      upsertLike: jest.fn(),
+      deleteLikeNotification: jest.fn(),
+      countUnread: jest.fn(),
+      findByRecipient: jest.fn(),
+      markRead: jest.fn(),
+      deleteExpired: jest.fn(),
+    };
+
+    notificationService = new NotificationService(
+      notificationRepository as unknown as NotificationRepository,
+    );
+  });
+
+  describe('upsertLikeNotification', () => {
+    it('recipientId, feedId로 upsertLike를 호출한다.', async () => {
+      // when
+      await notificationService.upsertLikeNotification(1, 10);
+
+      // then
+      expect(notificationRepository.upsertLike).toHaveBeenCalledWith(1, 10);
+    });
+  });
+
+  describe('removeLikeNotificationIfEmpty', () => {
+    it('좋아요가 남아있으면(likeCount > 0) 알림을 삭제하지 않는다.', async () => {
+      // when
+      await notificationService.removeLikeNotificationIfEmpty(10, 1);
+
+      // then
+      expect(notificationRepository.deleteLikeNotification).not.toHaveBeenCalled();
+    });
+
+    it('좋아요가 0개면 해당 게시글의 알림을 삭제한다.', async () => {
+      // when
+      await notificationService.removeLikeNotificationIfEmpty(10, 0);
+
+      // then
+      expect(notificationRepository.deleteLikeNotification).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('markAsRead', () => {
+    it('본인 소유가 아니거나 존재하지 않는 알림이면 NotFoundException을 던진다.', async () => {
+      // given
+      notificationRepository.markRead.mockResolvedValue(false);
+
+      // when & then
+      await expect(notificationService.markAsRead(1, 2)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('본인 소유 알림이면 읽음 처리를 성공한다.', async () => {
+      // given
+      notificationRepository.markRead.mockResolvedValue(true);
+
+      // when & then
+      await expect(
+        notificationService.markAsRead(1, 2),
+      ).resolves.toBeUndefined();
+      expect(notificationRepository.markRead).toHaveBeenCalledWith(1, 2);
+    });
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -28,6 +28,7 @@
       "@file/*": ["./src/file/*"],
       "@health/*": ["./src/health/*"],
       "@like/*": ["./src/like/*"],
+      "@notification/*": ["./src/notification/*"],
       "@rss/*": ["./src/rss/*"],
       "@statistic/*": ["./src/statistic/*"],
       "@subscribe/*": ["./src/subscribe/*"],


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #781

### Server 좋아요 알림 구현 방식

- 알림 도메인/API 구현
- RSS 소유 게시글에 좋아요가 발생했을 때 알림을 남기도록 `like.service`에서 이벤트(`LikeCreatedEvent`, `LikeDeletedEvent`)를 발행하고, `notification` 모듈의 리스너가 이를 수신해 알림을 생성/삭제하도록 구성
- 알림은 조회 시점에 파생 데이터를 조합하는 대신, 좋아요 발생 시점에 원자적으로 upsert하여 동시성 문제(중복 알림, race condition)를 방지
- 알림 목록 조회, 읽지 않은 알림 개수 조회, 알림 읽음 처리 API 및 30일 경과 알림 자동 삭제 스케줄러 구현

### 알림 UI 구현 방식

- 프론트엔드 알림 UI 구현
- 알림 여부를 확인하기 위한 short polling 방식 도입 (WebSocket 등 별도 인프라 없이 기존 스택으로 실시간성 확보)
- `NotificationBell` 컴포넌트와 알림 목록 UI, 관련 훅(`useNotifications`) 구현

# 📋 작업 내용

- `notification` 엔티티/마이그레이션 추가
- `notification.service`, `notification.repository`, `notification.controller` 구현
- 좋아요 생성/삭제 시 알림 생성/삭제하는 `like.listener` 구현
- 알림 30일 경과 삭제 스케줄러 구현
- 알림 조회 API 단위/e2e 테스트 작성
- 프론트엔드 알림 벨 UI 및 short polling 훅 구현

# 📷 스크린 샷(선택 사항)

<img width="390" height="299" alt="image" src="https://github.com/user-attachments/assets/22ea206c-0573-4e70-94f6-240290d3dbf8" />