### PR TITLE
✨ feat: 댓글 알림 기능 추가

### DIFF
--- a/client/src/__tests__/components/common/Card/PostDetail.test.tsx
+++ b/client/src/__tests__/components/common/Card/PostDetail.test.tsx
@@ -15,6 +15,7 @@ vi.mock("lucide-react", () => lucideProxy());
 vi.mock("react-router-dom", () => ({
   useParams: () => params,
   useNavigate: () => mockNavigate,
+  useLocation: () => ({ state: null }),
 }));
 
 vi.mock("@/hooks/queries/usePostDetail", () => ({

--- a/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
@@ -138,4 +138,51 @@ describe("PostComment", () => {
 
     expect(screen.queryByRole("button", { name: "댓글 더보기" })).not.toBeInTheDocument();
   });
+
+  it("highlightCommentId로 지정된 댓글로 스크롤 이동한다", () => {
+    comments = [makeComment(1), makeComment(2)];
+    render(<PostComment feedId={10} highlightCommentId={2} />);
+
+    const target = document.getElementById("comment-2");
+    expect(target).not.toBeNull();
+    expect(target?.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+  });
+
+  it("댓글이 마운트 이후(react-query 로딩 완료 후) 도착해도 스크롤 이동한다", () => {
+    comments = [];
+    const { rerender } = render(<PostComment feedId={10} highlightCommentId={2} />);
+
+    expect(document.getElementById("comment-2")).toBeNull();
+
+    comments = [makeComment(1), makeComment(2)];
+    rerender(<PostComment feedId={10} highlightCommentId={2} />);
+
+    const target = document.getElementById("comment-2");
+    expect(target).not.toBeNull();
+    expect(target?.scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "center" });
+  });
+
+  it("highlightCommentId 댓글이 초기 노출 범위(3개) 밖이면 자동으로 '더보기'를 펼친다", () => {
+    // makeComment는 날짜 오름차순(id 1이 가장 오래됨)이고 목록은 최신순 정렬이라
+    // id 1(가장 오래된 루트)이 4개 중 노출 범위(3개) 밖으로 밀려난다.
+    comments = [makeComment(1), makeComment(2), makeComment(3), makeComment(4)];
+    render(<PostComment feedId={10} highlightCommentId={1} />);
+
+    expect(screen.queryByRole("button", { name: "댓글 더보기" })).not.toBeInTheDocument();
+    expect(document.getElementById("comment-1")).not.toBeNull();
+  });
+
+  it("highlightCommentId가 대댓글이면 그 부모 위치 기준으로 노출 범위를 펼친다", () => {
+    comments = [
+      makeComment(1),
+      makeComment(2),
+      makeComment(3),
+      makeComment(4),
+      makeComment(5, { parentId: 1, comment: "대댓글" }),
+    ];
+    render(<PostComment feedId={10} highlightCommentId={5} />);
+
+    expect(screen.queryByRole("button", { name: "댓글 더보기" })).not.toBeInTheDocument();
+    expect(document.getElementById("comment-5")).not.toBeNull();
+  });
 });

--- a/client/src/__tests__/components/common/NotificationBell.test.tsx
+++ b/client/src/__tests__/components/common/NotificationBell.test.tsx
@@ -47,6 +47,8 @@ const makeItem = (overrides: Partial<NotificationItem> = {}): NotificationItem =
   feed: { id: 10, title: "테스트 게시글", path: "https://example.com/10" },
   actor: { userName: "liker", profileImage: null },
   otherCount: 0,
+  commentPreview: null,
+  commentId: null,
   ...overrides,
 });
 
@@ -94,7 +96,39 @@ describe("NotificationBell", () => {
     expect(item).toHaveTextContent("liker님이 테스트 게시글에 좋아요를 표시했습니다.");
 
     const bolded = item.querySelectorAll(".font-semibold");
-    expect(Array.from(bolded).map((el) => el.textContent)).toEqual(["liker", "테스트 게시글", "좋아요를 표시했습니다"]);
+    expect(Array.from(bolded).map((el) => el.textContent)).toEqual(["liker", "테스트 게시글", "좋아요"]);
+  });
+
+  it("댓글 알림 메시지를 템플릿에 맞게 표시한다", () => {
+    listState = {
+      data: [makeItem({ type: "COMMENT", actor: { userName: "commenter", profileImage: null } })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("commenter님이 테스트 게시글에 댓글을 남겼습니다.");
+
+    const bolded = item.querySelectorAll(".font-semibold");
+    expect(Array.from(bolded).map((el) => el.textContent)).toEqual(["commenter", "테스트 게시글", "댓글"]);
+  });
+
+  it("댓글 알림에는 댓글 내용 일부를 인용부호로 표시한다", () => {
+    listState = {
+      data: [makeItem({ type: "COMMENT", commentPreview: "내용 좋네요" })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("“내용 좋네요”");
+  });
+
+  it("좋아요 알림에는 댓글 내용을 표시하지 않는다", () => {
+    listState = { data: [makeItem({ commentPreview: "무시되어야 함" })], isLoading: false };
+    render(<NotificationBell />);
+
+    expect(screen.queryByText("“무시되어야 함”")).not.toBeInTheDocument();
   });
 
   it("다른 좋아요가 더 있으면 '외 N명' 문구를 표시한다", () => {
@@ -112,7 +146,9 @@ describe("NotificationBell", () => {
     fireEvent.click(screen.getByTestId("notification-item"));
 
     expect(markRead).toHaveBeenCalledWith(5);
-    expect(mockNavigate).toHaveBeenCalledWith("/10", { state: { backgroundLocation: { pathname: "/" } } });
+    expect(mockNavigate).toHaveBeenCalledWith("/10", {
+      state: { backgroundLocation: { pathname: "/" }, highlightCommentId: null },
+    });
   });
 
   it("이미 읽은 알림을 클릭하면 읽음 처리를 다시 호출하지 않는다", () => {
@@ -122,6 +158,22 @@ describe("NotificationBell", () => {
     fireEvent.click(screen.getByTestId("notification-item"));
 
     expect(markRead).not.toHaveBeenCalled();
-    expect(mockNavigate).toHaveBeenCalledWith("/10", { state: { backgroundLocation: { pathname: "/" } } });
+    expect(mockNavigate).toHaveBeenCalledWith("/10", {
+      state: { backgroundLocation: { pathname: "/" }, highlightCommentId: null },
+    });
+  });
+
+  it("댓글 알림을 클릭하면 해당 댓글 ID를 하이라이트 상태로 함께 넘긴다", () => {
+    listState = {
+      data: [makeItem({ id: 5, type: "COMMENT", commentId: 77 })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    fireEvent.click(screen.getByTestId("notification-item"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/10", {
+      state: { backgroundLocation: { pathname: "/" }, highlightCommentId: 77 },
+    });
   });
 });

--- a/client/src/__tests__/pages/PostDetailPage.test.tsx
+++ b/client/src/__tests__/pages/PostDetailPage.test.tsx
@@ -17,6 +17,7 @@ vi.mock("lucide-react", async () => {
 
 vi.mock("react-router-dom", () => ({
   useParams: () => params,
+  useLocation: () => ({ state: null }),
 }));
 
 vi.mock("@/hooks/queries/usePostDetail", () => ({

--- a/client/src/api/services/notifications.ts
+++ b/client/src/api/services/notifications.ts
@@ -3,7 +3,7 @@ import { NOTIFICATION } from "@/constants/endpoints";
 import { axiosInstance } from "@/api/instance";
 import { ApiData } from "@/types/api";
 
-export type NotificationType = "LIKE";
+export type NotificationType = "LIKE" | "COMMENT";
 
 export type NotificationItem = {
   id: number;
@@ -20,6 +20,8 @@ export type NotificationItem = {
     profileImage: string | null;
   };
   otherCount: number;
+  commentPreview: string | null;
+  commentId: number | null;
 };
 
 type GetUnreadCountResponse = ApiData<{ count: number }>;

--- a/client/src/components/common/Card/PostDetail.tsx
+++ b/client/src/components/common/Card/PostDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState, useCallback } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { X } from "lucide-react";
 
@@ -17,6 +17,9 @@ import { usePostDetail } from "@/hooks/queries/usePostDetail";
 export default function PostDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  const highlightCommentId = (location.state as { highlightCommentId?: number | null } | null)
+    ?.highlightCommentId;
   const modalRef = useRef<HTMLDivElement>(null);
   const { data } = usePostDetail(Number(id));
   const scrollbarWidth = useScrollbarAdjustment();
@@ -69,7 +72,7 @@ export default function PostDetail() {
         ) : (
           <div className="mt-5 flex flex-col gap-2 px-10 ">
             <PostHeader data={data.data} />
-            <PostContent post={data.data} />
+            <PostContent post={data.data} highlightCommentId={highlightCommentId} />
           </div>
         )}
       </div>

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Flag, MoreVertical } from "lucide-react";
 
@@ -31,6 +31,7 @@ interface PostCommentProps {
   feedId: number;
   isFeedOwner?: boolean;
   isAdmin?: boolean;
+  highlightCommentId?: number | null;
 }
 
 interface CommentItemProps {
@@ -50,7 +51,12 @@ interface CommentItemProps {
 
 const INITIAL_VISIBLE = 3;
 
-export default function PostComment({ feedId, isFeedOwner = false, isAdmin = false }: PostCommentProps) {
+export default function PostComment({
+  feedId,
+  isFeedOwner = false,
+  isAdmin = false,
+  highlightCommentId = null,
+}: PostCommentProps) {
   const { id: userId, userName } = useAuthStore((state) => state.userInfo);
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
@@ -151,6 +157,25 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
     .sort((a, b) => Number(new Date(b.date)) - Number(new Date(a.date)));
   const visibleRoots = showAll ? roots : roots.slice(0, INITIAL_VISIBLE);
 
+  useEffect(() => {
+    if (!highlightCommentId) return;
+    const target = comments.find((comment) => comment.id === highlightCommentId);
+    if (!target) return;
+    const rootId = target.parentId ?? target.id;
+    const rootIndex = roots.findIndex((root) => root.id === rootId);
+    if (rootIndex >= INITIAL_VISIBLE) setShowAll(true);
+  }, [highlightCommentId, comments]);
+
+  const scrolledToRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!highlightCommentId || scrolledToRef.current === highlightCommentId) return;
+    const target = document.getElementById(`comment-${highlightCommentId}`);
+    if (!target) return;
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    scrolledToRef.current = highlightCommentId;
+  }, [highlightCommentId, comments, showAll]);
+
   return (
     <div className="w-full space-y-6">
       {/* 댓글 입력 영역 */}
@@ -192,7 +217,13 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
       {/* 댓글 목록 */}
       <ul className="space-y-4">
         {visibleRoots.map((root) => (
-          <li key={root.id} className="border-b border-gray-100 pb-4">
+          <li
+            key={root.id}
+            id={`comment-${root.id}`}
+            className={`border-b border-gray-100 pb-4 transition-colors ${
+              root.id === highlightCommentId ? "-m-2 rounded-md bg-yellow-50 p-2 ring-2 ring-yellow-300" : ""
+            }`}
+          >
             <CommentItem
               comment={root}
               canEdit={canEditComment(root)}
@@ -211,7 +242,15 @@ export default function PostComment({ feedId, isFeedOwner = false, isAdmin = fal
             {(repliesByParent[root.id] ?? []).length > 0 && (
               <ul className="mt-3 ml-11 space-y-3 border-l-2 border-gray-100 pl-4">
                 {repliesByParent[root.id].map((reply) => (
-                  <li key={reply.id}>
+                  <li
+                    key={reply.id}
+                    id={`comment-${reply.id}`}
+                    className={`transition-colors ${
+                      reply.id === highlightCommentId
+                        ? "-m-2 rounded-md bg-yellow-50 p-2 ring-2 ring-yellow-300"
+                        : ""
+                    }`}
+                  >
                     <CommentItem
                       comment={reply}
                       canEdit={canEditComment(reply)}

--- a/client/src/components/common/Card/detail/PostContent.tsx
+++ b/client/src/components/common/Card/detail/PostContent.tsx
@@ -12,9 +12,10 @@ import { FeedDetail } from "@/types/post";
 
 interface PostContentProps {
   post: FeedDetail;
+  highlightCommentId?: number | null;
 }
 
-export const PostContent = React.memo(({ post }: PostContentProps) => {
+export const PostContent = React.memo(({ post, highlightCommentId }: PostContentProps) => {
   const summary = post.summary;
   const markdownString = (summary ?? "").replace(/\\n/g, "\n").replace(/\\r/g, "\r");
   const isMobile = useMediaStore((state) => state.isMobile);
@@ -56,7 +57,7 @@ export const PostContent = React.memo(({ post }: PostContentProps) => {
         <LikeButton post={post} />
         <ShareButton post={post} />
       </div>
-      <PostComment feedId={post.id} isFeedOwner={post.isOwner} />
+      <PostComment feedId={post.id} isFeedOwner={post.isOwner} highlightCommentId={highlightCommentId} />
     </div>
   );
 });

--- a/client/src/components/common/NotificationBell.stories.tsx
+++ b/client/src/components/common/NotificationBell.stories.tsx
@@ -1,10 +1,11 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, userEvent, within } from "storybook/test";
-
 import { NotificationBell } from "@/components/common/NotificationBell";
+
 import { NOTIFICATION } from "@/constants/endpoints";
+
 import { mockApi, ok } from "@/__storybook__/mockApi";
 import { useAuthStore } from "@/store/useAuthStore";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, within } from "storybook/test";
 
 const unreadItem = {
   id: 1,
@@ -14,6 +15,8 @@ const unreadItem = {
   feed: { id: 10, title: "Storybook으로 알림 미리보기", path: "https://example.com/10" },
   actor: { userName: "댓글러", profileImage: null },
   otherCount: 0,
+  commentPreview: null,
+  commentId: null,
 };
 
 const readItem = {
@@ -24,6 +27,8 @@ const readItem = {
   feed: { id: 11, title: "이미 읽은 알림 예시", path: "https://example.com/11" },
   actor: { userName: "먼저읽음", profileImage: null },
   otherCount: 0,
+  commentPreview: null,
+  commentId: null,
 };
 
 const multipleLikersItem = {
@@ -34,6 +39,32 @@ const multipleLikersItem = {
   feed: { id: 12, title: "여러 명이 좋아요한 게시글", path: "https://example.com/12" },
   actor: { userName: "최신좋아요러", profileImage: null },
   otherCount: 3,
+  commentPreview: null,
+  commentId: null,
+};
+
+const commentItem = {
+  id: 4,
+  type: "COMMENT",
+  isRead: false,
+  updatedAt: "2026-07-27T00:00:00.000Z",
+  feed: { id: 13, title: "댓글이 달린 게시글", path: "https://example.com/13" },
+  actor: { userName: "댓글러", profileImage: null },
+  otherCount: 0,
+  commentPreview: "저도 이 방법으로 해결했어요, 감사합니다!",
+  commentId: 101,
+};
+
+const multipleCommentersItem = {
+  id: 5,
+  type: "COMMENT",
+  isRead: false,
+  updatedAt: "2026-07-27T00:00:00.000Z",
+  feed: { id: 14, title: "여러 명이 댓글단 게시글", path: "https://example.com/14" },
+  actor: { userName: "최신댓글러", profileImage: null },
+  otherCount: 2,
+  commentPreview: "저도 같은 문제 있었는데 이 글 보고 해결했습니다",
+  commentId: 102,
 };
 
 const meta = {
@@ -98,6 +129,39 @@ export const WithMultipleLikers: Story = {
     await userEvent.click(canvas.getByRole("button", { name: "알림" }));
     const item = await body.findByTestId("notification-item");
     await expect(item).toHaveTextContent("최신좋아요러님 외 3명이 여러 명이 좋아요한 게시글에 좋아요를 표시했습니다.");
+  },
+};
+
+export const WithComment: Story = {
+  name: "댓글 알림",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [commentItem] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    const item = await body.findByTestId("notification-item");
+    await expect(item).toHaveTextContent("댓글러님이 댓글이 달린 게시글에 댓글을 남겼습니다.");
+    await expect(item).toHaveTextContent("저도 이 방법으로 해결했어요, 감사합니다!");
+  },
+};
+
+export const WithMultipleCommenters: Story = {
+  name: "여러 명이 댓글",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [multipleCommentersItem] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    const item = await body.findByTestId("notification-item");
+    await expect(item).toHaveTextContent("최신댓글러님 외 2명이 여러 명이 댓글단 게시글에 댓글을 남겼습니다.");
   },
 };
 

--- a/client/src/components/common/NotificationBell.tsx
+++ b/client/src/components/common/NotificationBell.tsx
@@ -20,20 +20,19 @@ import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/store/useAuthStore";
 
 const buildMessage = (item: NotificationItem) => {
-  switch (item.type) {
-    case "LIKE":
-    default: {
-      const actorSuffix = item.otherCount > 0 ? `님 외 ${item.otherCount}명이 ` : "님이 ";
-      return (
-        <>
-          <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
-          {actorSuffix}
-          <span className="font-semibold">{item.feed.title}</span>에{" "}
-          <span className="font-semibold">좋아요를 표시했습니다</span>.
-        </>
-      );
-    }
-  }
+  const actorSuffix = item.otherCount > 0 ? `님 외 ${item.otherCount}명이 ` : "님이 ";
+  const [actionBold, actionRest] =
+    item.type === "COMMENT" ? ["댓글", "을 남겼습니다"] : ["좋아요", "를 표시했습니다"];
+
+  return (
+    <>
+      <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
+      {actorSuffix}
+      <span className="font-semibold">{item.feed.title}</span>에{" "}
+      <span className="font-semibold">{actionBold}</span>
+      {actionRest}.
+    </>
+  );
 };
 
 export const NotificationBell = () => {
@@ -51,7 +50,10 @@ export const NotificationBell = () => {
   const handleItemClick = (item: NotificationItem) => {
     if (!item.isRead) markRead(item.id);
     setOpen(false);
-    navigate(`/${item.feed.id}`, { state: { backgroundLocation: location } });
+    const highlightCommentId = item.type === "COMMENT" ? item.commentId : null;
+    navigate(`/${item.feed.id}`, {
+      state: { backgroundLocation: location, highlightCommentId },
+    });
   };
 
   return (
@@ -97,6 +99,11 @@ export const NotificationBell = () => {
                 </Avatar>
                 <div className="min-w-0 flex-1">
                   <p className="line-clamp-2">{buildMessage(item)}</p>
+                  {item.type === "COMMENT" && item.commentPreview && (
+                    <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                      &ldquo;{item.commentPreview}&rdquo;
+                    </p>
+                  )}
                   <p className="mt-1 text-xs text-muted-foreground">{new Date(item.updatedAt).toLocaleString()}</p>
                 </div>
                 {!item.isRead && <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-primary" />}

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 
 import { BlockedFeedNotice } from "@/components/common/Card/detail/BlockedFeedNotice";
 import { PostContent } from "@/components/common/Card/detail/PostContent";
@@ -14,6 +14,9 @@ import { usePostDetail } from "@/hooks/queries/usePostDetail";
 
 export default function PostDetailPage() {
   const { id } = useParams();
+  const location = useLocation();
+  const highlightCommentId = (location.state as { highlightCommentId?: number | null } | null)
+    ?.highlightCommentId;
 
   const numericId = Number(id);
   const increment = useIncrementViewByPostId(numericId);
@@ -49,7 +52,7 @@ export default function PostDetailPage() {
       <Header />
       <div className="mt-5 px-10 md:px-40 flex flex-col gap-2 max-w-7xl mx-auto">
         <PostHeader data={data.data} />
-        <PostContent post={data.data} />
+        <PostContent post={data.data} highlightCommentId={highlightCommentId} />
       </div>
     </div>
   );

--- a/server/src/comment/event/comment-created.event.ts
+++ b/server/src/comment/event/comment-created.event.ts
@@ -1,0 +1,6 @@
+export class CommentCreatedEvent {
+  constructor(
+    public readonly feedId: number,
+    public readonly commenterUserId: number,
+  ) {}
+}

--- a/server/src/comment/event/comment-deleted.event.ts
+++ b/server/src/comment/event/comment-deleted.event.ts
@@ -1,0 +1,3 @@
+export class CommentDeletedEvent {
+  constructor(public readonly feedId: number) {}
+}

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { DataSource } from 'typeorm';
 
@@ -15,6 +16,8 @@ import { UpdateCommentRequestDto } from '@comment/dto/request/updateComment.dto'
 import { GetCommentResponseDto } from '@comment/dto/response/getComment.dto';
 import { GetUserCommentsResponseDto } from '@comment/dto/response/getUserComments.dto';
 import { Comment } from '@comment/entity/comment.entity';
+import { CommentCreatedEvent } from '@comment/event/comment-created.event';
+import { CommentDeletedEvent } from '@comment/event/comment-deleted.event';
 import { CommentRepository } from '@comment/repository/comment.repository';
 
 import { Payload } from '@common/guard/jwt.guard';
@@ -30,6 +33,7 @@ export class CommentService {
     private readonly dataSource: DataSource,
     private readonly feedService: FeedService,
     private readonly userService: UserService,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   private async getValidatedComment(
@@ -78,7 +82,10 @@ export class CommentService {
     return commentObj;
   }
 
-  async get(commentDto: GetCommentRequestDto, requester: Payload | null = null) {
+  async get(
+    commentDto: GetCommentRequestDto,
+    requester: Payload | null = null,
+  ) {
     await this.feedService.getPublicFeed(commentDto.feedId);
 
     const comments = await this.commentRepository.getCommentInformation(
@@ -147,6 +154,11 @@ export class CommentService {
         parentId: commentDto.parentId ?? null,
       });
     });
+
+    this.eventEmitter.emit(
+      'comment.created',
+      new CommentCreatedEvent(feedId, userInformation.id),
+    );
   }
 
   async delete(userInformation: Payload, commentDto: CommentParamRequestDto) {
@@ -174,11 +186,17 @@ export class CommentService {
       await manager.save(feed);
       await manager.remove(comment);
     });
+
+    this.eventEmitter.emit(
+      'comment.deleted',
+      new CommentDeletedEvent(comment.feed.id),
+    );
   }
 
   async deleteByAdmin(commentId: number) {
     const comment = await this.commentRepository.findOne({
       where: { id: commentId },
+      relations: ['feed'],
     });
 
     if (!comment) {
@@ -188,6 +206,11 @@ export class CommentService {
     comment.isDeleted = true;
     comment.isAdminDeleted = true;
     await this.commentRepository.save(comment);
+
+    this.eventEmitter.emit(
+      'comment.deleted',
+      new CommentDeletedEvent(comment.feed.id),
+    );
   }
 
   async update(

--- a/server/src/notification/dto/response/getNotifications.dto.ts
+++ b/server/src/notification/dto/response/getNotifications.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 
 import { NotificationType } from '@notification/entity/notification.entity';
+import { toCommentPreview } from '@notification/util/commentPreview.util';
 
 type NotificationRawRow = {
   id: number;
@@ -12,24 +13,37 @@ type NotificationRawRow = {
   feedPath: string;
   actorUserName: string | null;
   actorProfileImage: string | null;
-  otherLikersCount: string | number;
+  otherActorsCount: string | number;
+  commentContent: string | null;
+  commentId: number | null;
 };
 
 export class NotificationItemResult {
   @ApiProperty({ example: 1, description: '알림 ID' })
   id: number;
 
-  @ApiProperty({ example: 'LIKE', enum: NotificationType, description: '알림 종류' })
+  @ApiProperty({
+    example: 'LIKE',
+    enum: NotificationType,
+    description: '알림 종류',
+  })
   type: NotificationType;
 
   @ApiProperty({ example: false, description: '읽음 여부' })
   isRead: boolean;
 
-  @ApiProperty({ example: '2026-07-26T00:00:00.000Z', description: '알림 갱신 시각(표시 기준 시각)' })
+  @ApiProperty({
+    example: '2026-07-26T00:00:00.000Z',
+    description: '알림 갱신 시각(표시 기준 시각)',
+  })
   updatedAt: Date;
 
   @ApiProperty({
-    example: { id: 1, title: 'example title', path: 'https://example.com/feed' },
+    example: {
+      id: 1,
+      title: 'example title',
+      path: 'https://example.com/feed',
+    },
     description: '알림 대상 게시글 정보',
   })
   feed: {
@@ -40,7 +54,8 @@ export class NotificationItemResult {
 
   @ApiProperty({
     example: { userName: 'liker', profileImage: null },
-    description: '알림을 발생시킨 유저 정보(현재 최신 좋아요 사용자에서 파생)',
+    description:
+      '알림을 발생시킨 유저 정보(타입별 최신 행위자에서 파생: LIKE는 좋아요, COMMENT는 댓글)',
   })
   actor: {
     userName: string | null;
@@ -49,9 +64,25 @@ export class NotificationItemResult {
 
   @ApiProperty({
     example: 2,
-    description: '표시된 actor를 제외하고 이 게시글에 좋아요를 누른 다른 사람 수(수신자 본인 제외)',
+    description:
+      '표시된 actor를 제외하고 이 게시글에 좋아요/댓글을 남긴 다른 사람 수(수신자 본인 제외)',
   })
   otherCount: number;
+
+  @ApiProperty({
+    example: '이 글 정말 잘 읽었습니다...',
+    nullable: true,
+    description:
+      'COMMENT 타입일 때 최신 댓글 내용 일부(40자 초과 시 말줄임). LIKE는 항상 null',
+  })
+  commentPreview: string | null;
+
+  @ApiProperty({
+    example: 42,
+    nullable: true,
+    description: 'COMMENT 타입일 때 최신 댓글의 ID(하이라이트/이동용). LIKE는 항상 null',
+  })
+  commentId: number | null;
 
   private constructor(partial: Partial<NotificationItemResult>) {
     Object.assign(this, partial);
@@ -72,7 +103,9 @@ export class NotificationItemResult {
         userName: row.actorUserName,
         profileImage: row.actorProfileImage,
       },
-      otherCount: Math.max(0, Number(row.otherLikersCount) - 1),
+      otherCount: Math.max(0, Number(row.otherActorsCount) - 1),
+      commentPreview: toCommentPreview(row.commentContent),
+      commentId: row.commentId ?? null,
     });
   }
 

--- a/server/src/notification/entity/notification.entity.ts
+++ b/server/src/notification/entity/notification.entity.ts
@@ -17,6 +17,7 @@ import { User } from '@user/entity/user.entity';
 
 export enum NotificationType {
   LIKE = 'LIKE',
+  COMMENT = 'COMMENT',
 }
 
 @Entity({ name: 'notification' })

--- a/server/src/notification/listener/comment.listener.ts
+++ b/server/src/notification/listener/comment.listener.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { CommentCreatedEvent } from '@comment/event/comment-created.event';
+import { CommentDeletedEvent } from '@comment/event/comment-deleted.event';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { NotificationService } from '@notification/service/notification.service';
+
+@Injectable()
+export class CommentListener {
+  constructor(
+    private readonly feedRepository: FeedRepository,
+    private readonly notificationService: NotificationService,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  @OnEvent('comment.created')
+  async handleCommentCreated({ feedId, commenterUserId }: CommentCreatedEvent) {
+    try {
+      const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
+      if (!blogMeta?.userId) return;
+      if (blogMeta.userId === commenterUserId) return;
+
+      await this.notificationService.upsertCommentNotification(
+        blogMeta.userId,
+        feedId,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[CommentListener]: 댓글 알림 생성 중 오류 발생 (feedId: ${feedId}): ${error}`,
+      );
+    }
+  }
+
+  @OnEvent('comment.deleted')
+  async handleCommentDeleted({ feedId }: CommentDeletedEvent) {
+    try {
+      const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
+      if (!blogMeta?.userId) return;
+
+      await this.notificationService.removeCommentNotificationIfEmpty(
+        feedId,
+        blogMeta.userId,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[CommentListener]: 댓글 알림 삭제 중 오류 발생 (feedId: ${feedId}): ${error}`,
+      );
+    }
+  }
+}

--- a/server/src/notification/module/notification.module.ts
+++ b/server/src/notification/module/notification.module.ts
@@ -5,6 +5,7 @@ import { JwtAuthModule } from '@common/auth/jwt.module';
 import { FeedModule } from '@feed/module/feed.module';
 
 import { NotificationController } from '@notification/controller/notification.controller';
+import { CommentListener } from '@notification/listener/comment.listener';
 import { LikeListener } from '@notification/listener/like.listener';
 import { NotificationRepository } from '@notification/repository/notification.repository';
 import { NotificationScheduler } from '@notification/scheduler/notification.scheduler';
@@ -17,6 +18,7 @@ import { NotificationService } from '@notification/service/notification.service'
     NotificationService,
     NotificationRepository,
     LikeListener,
+    CommentListener,
     NotificationScheduler,
   ],
   exports: [],

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -33,15 +33,55 @@ export class NotificationRepository extends Repository<Notification> {
     await this.delete({ type: NotificationType.LIKE, feed: { id: feedId } });
   }
 
+  async upsertComment(recipientId: number, feedId: number) {
+    await this.createQueryBuilder()
+      .insert()
+      .into(Notification)
+      .values({
+        recipient: { id: recipientId } as User,
+        type: NotificationType.COMMENT,
+        feed: { id: feedId } as Feed,
+        isRead: false,
+      })
+      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'feed_id'])
+      .execute();
+  }
+
+  async deleteCommentNotification(feedId: number) {
+    await this.delete({ type: NotificationType.COMMENT, feed: { id: feedId } });
+  }
+
+  async hasActiveOtherComment(feedId: number, recipientId: number) {
+    const row = await this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)', 'count')
+      .from('comment', 'c')
+      .where('c.feed_id = :feedId', { feedId })
+      .andWhere('c.is_deleted = 0')
+      .andWhere('c.user_id != :recipientId', { recipientId })
+      .getRawOne<{ count: string }>();
+
+    return Number(row?.count ?? 0) > 0;
+  }
+
   async findByRecipient(recipientId: number, limit: number) {
     return this.createQueryBuilder('n')
       .innerJoin('n.feed', 'feed')
       .leftJoin(
         'likes',
         'latest_like',
-        'latest_like.id = (SELECT l2.id FROM likes l2 WHERE l2.feed_id = n.feed_id ORDER BY l2.like_date DESC LIMIT 1)',
+        "n.type = 'LIKE' AND latest_like.id = (SELECT l2.id FROM likes l2 WHERE l2.feed_id = n.feed_id ORDER BY l2.like_date DESC LIMIT 1)",
       )
-      .leftJoin('user', 'actor', 'actor.id = latest_like.user_id')
+      .leftJoin(
+        'comment',
+        'latest_comment',
+        "n.type = 'COMMENT' AND latest_comment.id = (SELECT c2.id FROM `comment` c2 WHERE c2.feed_id = n.feed_id AND c2.is_deleted = 0 AND c2.user_id != n.recipient_user_id ORDER BY c2.date DESC LIMIT 1)",
+      )
+      .leftJoin(
+        'user',
+        'actor',
+        'actor.id = COALESCE(latest_like.user_id, latest_comment.user_id)',
+      )
       .select('n.id', 'id')
       .addSelect('n.type', 'type')
       .addSelect('n.is_read', 'isRead')
@@ -51,9 +91,15 @@ export class NotificationRepository extends Repository<Notification> {
       .addSelect('feed.path', 'feedPath')
       .addSelect('actor.user_name', 'actorUserName')
       .addSelect('actor.profile_image', 'actorProfileImage')
+      .addSelect('latest_comment.comment', 'commentContent')
+      .addSelect('latest_comment.id', 'commentId')
       .addSelect(
-        '(SELECT COUNT(*) FROM likes l3 WHERE l3.feed_id = n.feed_id AND l3.user_id != n.recipient_user_id)',
-        'otherLikersCount',
+        `CASE n.type
+          WHEN 'LIKE' THEN (SELECT COUNT(*) FROM likes l3 WHERE l3.feed_id = n.feed_id AND l3.user_id != n.recipient_user_id)
+          WHEN 'COMMENT' THEN (SELECT COUNT(DISTINCT c3.user_id) FROM \`comment\` c3 WHERE c3.feed_id = n.feed_id AND c3.is_deleted = 0 AND c3.user_id != n.recipient_user_id)
+          ELSE 0
+        END`,
+        'otherActorsCount',
       )
       .where('n.recipient_user_id = :recipientId', { recipientId })
       .andWhere('n.updated_at >= :cutoff', { cutoff: getNotificationCutoffDate() })

--- a/server/src/notification/service/notification.service.ts
+++ b/server/src/notification/service/notification.service.ts
@@ -6,7 +6,9 @@ import { NotificationRepository } from '@notification/repository/notification.re
 
 @Injectable()
 export class NotificationService {
-  constructor(private readonly notificationRepository: NotificationRepository) {}
+  constructor(
+    private readonly notificationRepository: NotificationRepository,
+  ) {}
 
   async upsertLikeNotification(recipientId: number, feedId: number) {
     await this.notificationRepository.upsertLike(recipientId, feedId);
@@ -17,18 +19,38 @@ export class NotificationService {
     await this.notificationRepository.deleteLikeNotification(feedId);
   }
 
+  async upsertCommentNotification(recipientId: number, feedId: number) {
+    await this.notificationRepository.upsertComment(recipientId, feedId);
+  }
+
+  async removeCommentNotificationIfEmpty(feedId: number, recipientId: number) {
+    const hasOtherComment =
+      await this.notificationRepository.hasActiveOtherComment(
+        feedId,
+        recipientId,
+      );
+    if (hasOtherComment) return;
+    await this.notificationRepository.deleteCommentNotification(feedId);
+  }
+
   async getUnreadCount(userId: number) {
     const count = await this.notificationRepository.countUnread(userId);
     return GetUnreadCountResponseDto.toResponseDto(count);
   }
 
   async getNotifications(userId: number, limit: number) {
-    const rows = await this.notificationRepository.findByRecipient(userId, limit);
+    const rows = await this.notificationRepository.findByRecipient(
+      userId,
+      limit,
+    );
     return GetNotificationsResponseDto.toResponseDto(rows);
   }
 
   async markAsRead(notificationId: number, userId: number) {
-    const updated = await this.notificationRepository.markRead(notificationId, userId);
+    const updated = await this.notificationRepository.markRead(
+      notificationId,
+      userId,
+    );
     if (!updated) {
       throw new NotFoundException('존재하지 않거나 접근할 수 없는 알림입니다.');
     }

--- a/server/src/notification/util/commentPreview.util.ts
+++ b/server/src/notification/util/commentPreview.util.ts
@@ -1,0 +1,8 @@
+const COMMENT_PREVIEW_LENGTH = 40;
+
+export function toCommentPreview(content: string | null) {
+  if (!content) return null;
+  return content.length > COMMENT_PREVIEW_LENGTH
+    ? `${content.slice(0, COMMENT_PREVIEW_LENGTH)}...`
+    : content;
+}

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -3,12 +3,15 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { DataSource } from 'typeorm';
 
 import { GetCommentResponseDto } from '@comment/dto/response/getComment.dto';
 import { GetUserCommentsResponseDto } from '@comment/dto/response/getUserComments.dto';
 import { Comment } from '@comment/entity/comment.entity';
+import { CommentCreatedEvent } from '@comment/event/comment-created.event';
+import { CommentDeletedEvent } from '@comment/event/comment-deleted.event';
 import { CommentRepository } from '@comment/repository/comment.repository';
 import { CommentService } from '@comment/service/comment.service';
 
@@ -34,6 +37,7 @@ describe(`${CommentService.name} Unit Test`, () => {
   let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
   let manager: { save: jest.Mock; remove: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
+  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
 
   const user: Payload = {
     id: 1,
@@ -56,12 +60,14 @@ describe(`${CommentService.name} Unit Test`, () => {
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
     } as any;
+    eventEmitter = { emit: jest.fn() };
 
     commentService = new CommentService(
       commentRepository as unknown as CommentRepository,
       dataSource as unknown as DataSource,
       feedService as unknown as FeedService,
       userService as unknown as UserService,
+      eventEmitter as unknown as EventEmitter2,
     );
   });
 
@@ -196,6 +202,10 @@ describe(`${CommentService.name} Unit Test`, () => {
         user: { id: user.id },
         parentId: null,
       });
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.created',
+        new CommentCreatedEvent(10, user.id),
+      );
     });
 
     it('비공개 게시글이면 NotFoundException을 던지고 저장하지 않는다.', async () => {
@@ -209,6 +219,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         commentService.create(user, 10, { comment: 'x' }),
       ).rejects.toThrow(NotFoundException);
       expect(manager.save).not.toHaveBeenCalled();
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
 
     it('유효한 부모 댓글이 있으면 parentId를 포함해 답글을 저장한다.', async () => {
@@ -232,6 +243,10 @@ describe(`${CommentService.name} Unit Test`, () => {
         user: { id: user.id },
         parentId: 7,
       });
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.created',
+        new CommentCreatedEvent(10, user.id),
+      );
     });
 
     it('존재하지 않는 부모 댓글이면 NotFoundException을 던지고 저장하지 않는다.', async () => {
@@ -338,6 +353,10 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(feed.commentCount).toBe(2);
       expect(manager.save).toHaveBeenCalledWith(feed);
       expect(manager.remove).toHaveBeenCalledWith(comment);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.deleted',
+        new CommentDeletedEvent(10),
+      );
     });
 
     it('답글이 달린 최상위 댓글은 soft delete 처리하고 commentCount를 유지한다.', async () => {
@@ -361,6 +380,10 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(feed.commentCount).toBe(3);
       expect(manager.save).toHaveBeenCalledWith(comment);
       expect(manager.remove).not.toHaveBeenCalled();
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.deleted',
+        new CommentDeletedEvent(10),
+      );
     });
 
     it('답글(parentId 존재)은 replyCount 조회 없이 hard delete 한다.', async () => {
@@ -381,6 +404,10 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(commentRepository.count).not.toHaveBeenCalled();
       expect(feed.commentCount).toBe(2);
       expect(manager.remove).toHaveBeenCalledWith(comment);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.deleted',
+        new CommentDeletedEvent(10),
+      );
     });
 
     it('본인 댓글이 아니어도 RSS 소유자면 댓글 수를 감소시키고 댓글을 제거한다.', async () => {
@@ -396,6 +423,10 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(feed.commentCount).toBe(2);
       expect(manager.save).toHaveBeenCalledWith(feed);
       expect(manager.remove).toHaveBeenCalledWith(comment);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.deleted',
+        new CommentDeletedEvent(10),
+      );
     });
   });
 
@@ -417,6 +448,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         id: 5,
         isDeleted: false,
         isAdminDeleted: false,
+        feed: { id: 10 },
       } as Comment;
       commentRepository.findOne.mockResolvedValue(comment);
 
@@ -426,12 +458,17 @@ describe(`${CommentService.name} Unit Test`, () => {
       // then
       expect(commentRepository.findOne).toHaveBeenCalledWith({
         where: { id: 5 },
+        relations: ['feed'],
       });
       expect(comment.isDeleted).toBe(true);
       expect(comment.isAdminDeleted).toBe(true);
       expect(commentRepository.save).toHaveBeenCalledWith(comment);
       expect(commentRepository.count).not.toHaveBeenCalled();
       expect(dataSource.transaction).not.toHaveBeenCalled();
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.deleted',
+        new CommentDeletedEvent(10),
+      );
     });
   });
 

--- a/server/test/notification/unit/comment.listener.unit.spec.ts
+++ b/server/test/notification/unit/comment.listener.unit.spec.ts
@@ -1,0 +1,157 @@
+import { CommentCreatedEvent } from '@comment/event/comment-created.event';
+import { CommentDeletedEvent } from '@comment/event/comment-deleted.event';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { CommentListener } from '@notification/listener/comment.listener';
+import { NotificationService } from '@notification/service/notification.service';
+
+describe(`${CommentListener.name} Unit Test`, () => {
+  let commentListener: CommentListener;
+  let feedRepository: jest.Mocked<Pick<FeedRepository, 'getBlogMetaByFeedId'>>;
+  let notificationService: jest.Mocked<
+    Pick<
+      NotificationService,
+      'upsertCommentNotification' | 'removeCommentNotificationIfEmpty'
+    >
+  >;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
+
+  beforeEach(() => {
+    feedRepository = { getBlogMetaByFeedId: jest.fn() };
+    notificationService = {
+      upsertCommentNotification: jest.fn(),
+      removeCommentNotificationIfEmpty: jest.fn(),
+    };
+    logger = { error: jest.fn() };
+
+    commentListener = new CommentListener(
+      feedRepository as unknown as FeedRepository,
+      notificationService as unknown as NotificationService,
+      logger as unknown as WinstonLoggerService,
+    );
+  });
+
+  describe('handleCommentCreated', () => {
+    it('게시글 소유자가 없으면(RSS 미소유) 알림을 생성하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: null,
+      });
+
+      // when
+      await commentListener.handleCommentCreated(
+        new CommentCreatedEvent(10, 2),
+      );
+
+      // then
+      expect(
+        notificationService.upsertCommentNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('본인 게시글에 본인이 댓글을 달면(self-comment) 알림을 생성하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 2,
+      });
+
+      // when
+      await commentListener.handleCommentCreated(
+        new CommentCreatedEvent(10, 2),
+      );
+
+      // then
+      expect(
+        notificationService.upsertCommentNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('타인이 댓글을 달면 게시글 소유자에게 알림을 upsert한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentCreated(
+        new CommentCreatedEvent(10, 2),
+      );
+
+      // then
+      expect(
+        notificationService.upsertCommentNotification,
+      ).toHaveBeenCalledWith(99, 10);
+    });
+
+    it('처리 중 예외가 발생해도 던지지 않고 로깅한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockRejectedValue(
+        new Error('db down'),
+      );
+
+      // when & then
+      await expect(
+        commentListener.handleCommentCreated(new CommentCreatedEvent(10, 2)),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleCommentDeleted', () => {
+    it('게시글 소유자가 없으면(RSS 미소유) 아무 것도 하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: null,
+      });
+
+      // when
+      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10));
+
+      // then
+      expect(
+        notificationService.removeCommentNotificationIfEmpty,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('게시글 소유자 기준으로 남은 활성 댓글 여부를 위임한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10));
+
+      // then
+      expect(
+        notificationService.removeCommentNotificationIfEmpty,
+      ).toHaveBeenCalledWith(10, 99);
+    });
+
+    it('처리 중 예외가 발생해도 던지지 않고 로깅한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockRejectedValue(
+        new Error('db down'),
+      );
+
+      // when & then
+      await expect(
+        commentListener.handleCommentDeleted(new CommentDeletedEvent(10)),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/test/notification/unit/notification.service.unit.spec.ts
+++ b/server/test/notification/unit/notification.service.unit.spec.ts
@@ -10,6 +10,9 @@ describe(`${NotificationService.name} Unit Test`, () => {
       NotificationRepository,
       | 'upsertLike'
       | 'deleteLikeNotification'
+      | 'upsertComment'
+      | 'deleteCommentNotification'
+      | 'hasActiveOtherComment'
       | 'countUnread'
       | 'findByRecipient'
       | 'markRead'
@@ -21,6 +24,9 @@ describe(`${NotificationService.name} Unit Test`, () => {
     notificationRepository = {
       upsertLike: jest.fn(),
       deleteLikeNotification: jest.fn(),
+      upsertComment: jest.fn(),
+      deleteCommentNotification: jest.fn(),
+      hasActiveOtherComment: jest.fn(),
       countUnread: jest.fn(),
       findByRecipient: jest.fn(),
       markRead: jest.fn(),
@@ -48,7 +54,9 @@ describe(`${NotificationService.name} Unit Test`, () => {
       await notificationService.removeLikeNotificationIfEmpty(10, 1);
 
       // then
-      expect(notificationRepository.deleteLikeNotification).not.toHaveBeenCalled();
+      expect(
+        notificationRepository.deleteLikeNotification,
+      ).not.toHaveBeenCalled();
     });
 
     it('좋아요가 0개면 해당 게시글의 알림을 삭제한다.', async () => {
@@ -56,7 +64,51 @@ describe(`${NotificationService.name} Unit Test`, () => {
       await notificationService.removeLikeNotificationIfEmpty(10, 0);
 
       // then
-      expect(notificationRepository.deleteLikeNotification).toHaveBeenCalledWith(10);
+      expect(
+        notificationRepository.deleteLikeNotification,
+      ).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('upsertCommentNotification', () => {
+    it('recipientId, feedId로 upsertComment를 호출한다.', async () => {
+      // when
+      await notificationService.upsertCommentNotification(1, 10);
+
+      // then
+      expect(notificationRepository.upsertComment).toHaveBeenCalledWith(1, 10);
+    });
+  });
+
+  describe('removeCommentNotificationIfEmpty', () => {
+    it('본인 제외 활성 댓글이 남아있으면 알림을 삭제하지 않는다.', async () => {
+      // given
+      notificationRepository.hasActiveOtherComment.mockResolvedValue(true);
+
+      // when
+      await notificationService.removeCommentNotificationIfEmpty(10, 1);
+
+      // then
+      expect(notificationRepository.hasActiveOtherComment).toHaveBeenCalledWith(
+        10,
+        1,
+      );
+      expect(
+        notificationRepository.deleteCommentNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('본인 제외 활성 댓글이 없으면 해당 게시글의 알림을 삭제한다.', async () => {
+      // given
+      notificationRepository.hasActiveOtherComment.mockResolvedValue(false);
+
+      // when
+      await notificationService.removeCommentNotificationIfEmpty(10, 1);
+
+      // then
+      expect(
+        notificationRepository.deleteCommentNotification,
+      ).toHaveBeenCalledWith(10);
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #781

### 댓글 알림

- 본인이 인증한 RSS의 게시글에 댓글이 달렸을 때 알림이 오도록 구현. 기존 좋아요 알림(`notification` 도메인)과 동일하게 `(recipient, type, feed)` 단위로 집계하는 방식을 그대로 재사용해서 스키마 변경 없이(`NotificationType`에 `COMMENT` 문자열만 추가) 구현함.
- actor/댓글 미리보기/댓글 ID는 전부 저장하지 않고 매 조회 시 최신 댓글에서 derive함. 좋아요와 달리 댓글은 soft delete(답글 있는 최상위 댓글, 관리자 삭제)가 있어서 `feed.commentCount` 기준으로는 "알림을 지울지 말지" 판단이 부정확해질 수 있어, 활성 댓글 존재 여부를 별도 쿼리(`hasActiveOtherComment`)로 확인하도록 함.

### 댓글 하이라이트 + 이동

- 알림 클릭 시 게시글 이동뿐 아니라 해당 댓글로 스크롤 이동 + 하이라이트되도록 구현.
- 댓글 목록은 서버 페이지네이션이 없고 클라이언트에서 "더보기" 토글만 하므로, 하이라이트 대상이 초기 노출 범위 밖이면 자동으로 펼치도록 처리.
- react-query 비동기 로딩 타이밍 이슈(댓글 데이터 도착 전에 스크롤 시도되어 실패하는 버그)를 발견해 함께 수정.

# 📋 작업 내용

- `notification` 엔티티에 `COMMENT` 타입 추가(마이그레이션 불필요)
- `comment.service`에서 댓글 생성/삭제(soft/hard/관리자 삭제) 시 `comment.created`/`comment.deleted` 이벤트 emit
- `CommentListener` 추가: RSS 소유자에게 댓글 알림 upsert, self-comment 제외, 활성 댓글 없으면 알림 삭제
- `NotificationRepository.findByRecipient`를 LIKE/COMMENT 공용으로 일반화(actor derive 시 recipient 본인 댓글 제외)
- 알림 응답에 `commentPreview`(40자 말줄임), `commentId`(하이라이트/이동용) 추가
- 클라이언트 `NotificationBell`에 댓글 알림 문구/미리보기 표시, 클릭 시 `highlightCommentId` state와 함께 이동
- `PostComment`에서 하이라이트 대상 자동 펼침 + `scrollIntoView` + 하이라이트 스타일 적용
- 서버 unit(comment.service, comment.listener, notification.service), 클라이언트 컴포넌트 테스트, Storybook 스토리 추가

# 📷 스크린 샷(선택 사항)

<img width="401" height="202" alt="image" src="https://github.com/user-attachments/assets/330730ed-7606-4e12-8287-4f41de2f6b5d" />
<img width="893" height="574" alt="image" src="https://github.com/user-attachments/assets/2eecafe6-e8c7-4adb-bbc0-c3b7a8e08d74" />
