### PR TITLE
✨ feat: RSS 구독 알림 기능 추가

### DIFF
--- a/client/src/__tests__/components/common/NotificationBell.test.tsx
+++ b/client/src/__tests__/components/common/NotificationBell.test.tsx
@@ -45,6 +45,7 @@ const makeItem = (overrides: Partial<NotificationItem> = {}): NotificationItem =
   isRead: false,
   updatedAt: "2026-07-26T00:00:00.000Z",
   feed: { id: 10, title: "테스트 게시글", path: "https://example.com/10" },
+  rss: null,
   actor: { userName: "liker", profileImage: null },
   otherCount: 0,
   commentPreview: null,
@@ -175,5 +176,29 @@ describe("NotificationBell", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/10", {
       state: { backgroundLocation: { pathname: "/" }, highlightCommentId: 77 },
     });
+  });
+
+  it("구독 알림 메시지를 템플릿에 맞게 표시한다", () => {
+    listState = {
+      data: [makeItem({ type: "SUBSCRIBE", feed: null, rss: { id: 7, name: "테스트 블로그" } })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("liker님이 테스트 블로그을(를) 구독했습니다.");
+  });
+
+  it("구독 알림을 클릭하면 해당 RSS 페이지로 이동한다", () => {
+    listState = {
+      data: [makeItem({ id: 6, type: "SUBSCRIBE", feed: null, rss: { id: 7, name: "테스트 블로그" } })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    fireEvent.click(screen.getByTestId("notification-item"));
+
+    expect(markRead).toHaveBeenCalledWith(6);
+    expect(mockNavigate).toHaveBeenCalledWith("/rss/7");
   });
 });

--- a/client/src/api/services/notifications.ts
+++ b/client/src/api/services/notifications.ts
@@ -3,7 +3,7 @@ import { NOTIFICATION } from "@/constants/endpoints";
 import { axiosInstance } from "@/api/instance";
 import { ApiData } from "@/types/api";
 
-export type NotificationType = "LIKE" | "COMMENT";
+export type NotificationType = "LIKE" | "COMMENT" | "SUBSCRIBE";
 
 export type NotificationItem = {
   id: number;
@@ -14,7 +14,11 @@ export type NotificationItem = {
     id: number;
     title: string;
     path: string;
-  };
+  } | null;
+  rss: {
+    id: number;
+    name: string;
+  } | null;
   actor: {
     userName: string | null;
     profileImage: string | null;

--- a/client/src/components/common/NotificationBell.stories.tsx
+++ b/client/src/components/common/NotificationBell.stories.tsx
@@ -67,6 +67,17 @@ const multipleCommentersItem = {
   commentId: 102,
 };
 
+const subscribeItem = {
+  id: 4,
+  type: "SUBSCRIBE",
+  isRead: false,
+  updatedAt: "2026-07-28T00:00:00.000Z",
+  feed: null,
+  rss: { id: 20, name: "denamu.log" },
+  actor: { userName: "새구독자", profileImage: null },
+  otherCount: 0,
+};
+
 const meta = {
   title: "common/NotificationBell",
   component: NotificationBell,
@@ -162,6 +173,22 @@ export const WithMultipleCommenters: Story = {
     await userEvent.click(canvas.getByRole("button", { name: "알림" }));
     const item = await body.findByTestId("notification-item");
     await expect(item).toHaveTextContent("최신댓글러님 외 2명이 여러 명이 댓글단 게시글에 댓글을 남겼습니다.");
+  },
+};
+
+export const WithSubscribe: Story = {
+  name: "구독 알림 표시",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [subscribeItem] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    const item = await body.findByTestId("notification-item");
+    await expect(item).toHaveTextContent("새구독자님이 denamu.log을(를) 구독했습니다.");
   },
 };
 

--- a/client/src/components/common/NotificationBell.tsx
+++ b/client/src/components/common/NotificationBell.tsx
@@ -21,18 +21,34 @@ import { useAuthStore } from "@/store/useAuthStore";
 
 const buildMessage = (item: NotificationItem) => {
   const actorSuffix = item.otherCount > 0 ? `님 외 ${item.otherCount}명이 ` : "님이 ";
-  const [actionBold, actionRest] =
-    item.type === "COMMENT" ? ["댓글", "을 남겼습니다"] : ["좋아요", "를 표시했습니다"];
 
-  return (
-    <>
-      <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
-      {actorSuffix}
-      <span className="font-semibold">{item.feed.title}</span>에{" "}
-      <span className="font-semibold">{actionBold}</span>
-      {actionRest}.
-    </>
-  );
+  switch (item.type) {
+    case "SUBSCRIBE":
+      return (
+        <>
+          <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
+          {actorSuffix}
+          <span className="font-semibold">{item.rss?.name}</span>을(를){" "}
+          <span className="font-semibold">구독했습니다</span>.
+        </>
+      );
+    case "COMMENT":
+    case "LIKE":
+    default: {
+      const [actionBold, actionRest] =
+        item.type === "COMMENT" ? ["댓글", "을 남겼습니다"] : ["좋아요", "를 표시했습니다"];
+
+      return (
+        <>
+          <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
+          {actorSuffix}
+          <span className="font-semibold">{item.feed?.title}</span>에{" "}
+          <span className="font-semibold">{actionBold}</span>
+          {actionRest}.
+        </>
+      );
+    }
+  }
 };
 
 export const NotificationBell = () => {
@@ -50,10 +66,17 @@ export const NotificationBell = () => {
   const handleItemClick = (item: NotificationItem) => {
     if (!item.isRead) markRead(item.id);
     setOpen(false);
-    const highlightCommentId = item.type === "COMMENT" ? item.commentId : null;
-    navigate(`/${item.feed.id}`, {
-      state: { backgroundLocation: location, highlightCommentId },
-    });
+
+    if (item.type === "SUBSCRIBE" && item.rss) {
+      navigate(`/rss/${item.rss.id}`);
+      return;
+    }
+    if (item.feed) {
+      const highlightCommentId = item.type === "COMMENT" ? item.commentId : null;
+      navigate(`/${item.feed.id}`, {
+        state: { backgroundLocation: location, highlightCommentId },
+      });
+    }
   };
 
   return (

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -203,13 +203,17 @@ CREATE TABLE `notification` (
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   `recipient_user_id` int NOT NULL,
-  `feed_id` int NOT NULL,
+  `feed_id` int NULL,
+  `rss_accept_id` int NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `IDX_632ea8b2f172248eccfb067bfc` (`recipient_user_id`,`type`,`feed_id`),
+  UNIQUE KEY `IDX_f87770358a4e011a7ab7f560f9` (`recipient_user_id`,`type`,`rss_accept_id`),
   KEY `IDX_e13cf12d6a05407dbac647761c` (`updated_at`),
   KEY `FK_916163bd318675ea0c33d517f82` (`feed_id`),
+  KEY `FK_70ba9f1bd291e6ad2a9e5c166a3` (`rss_accept_id`),
   CONSTRAINT `FK_7d7f411e854516f615ba846c6a4` FOREIGN KEY (`recipient_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_70ba9f1bd291e6ad2a9e5c166a3` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.blocks definition

--- a/server/src/common/database/migration/1782400000000-AddSubscribeNotification.ts
+++ b/server/src/common/database/migration/1782400000000-AddSubscribeNotification.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSubscribeNotification1782400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP FOREIGN KEY `FK_916163bd318675ea0c33d517f82`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` MODIFY `feed_id` int NULL;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD `rss_accept_id` int NULL;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD CONSTRAINT `FK_notification_rss_accept_id` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD UNIQUE INDEX `IDX_notification_recipient_type_rss_accept` (`recipient_user_id`,`type`,`rss_accept_id`);',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP INDEX `IDX_notification_recipient_type_rss_accept`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP FOREIGN KEY `FK_notification_rss_accept_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP COLUMN `rss_accept_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP FOREIGN KEY `FK_916163bd318675ea0c33d517f82`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` MODIFY `feed_id` int NOT NULL;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+  }
+}

--- a/server/src/notification/dto/response/getNotifications.dto.ts
+++ b/server/src/notification/dto/response/getNotifications.dto.ts
@@ -8,9 +8,11 @@ type NotificationRawRow = {
   type: NotificationType;
   isRead: number | boolean;
   updatedAt: Date;
-  feedId: number;
-  feedTitle: string;
-  feedPath: string;
+  feedId: number | null;
+  feedTitle: string | null;
+  feedPath: string | null;
+  rssId: number | null;
+  rssName: string | null;
   actorUserName: string | null;
   actorProfileImage: string | null;
   otherActorsCount: string | number;
@@ -45,17 +47,28 @@ export class NotificationItemResult {
       path: 'https://example.com/feed',
     },
     description: '알림 대상 게시글 정보',
+    nullable: true,
   })
   feed: {
     id: number;
     title: string;
     path: string;
-  };
+  } | null;
+
+  @ApiProperty({
+    example: { id: 1, name: 'seok3765.log' },
+    description: '알림 대상 RSS 정보(SUBSCRIBE 알림에만 존재)',
+    nullable: true,
+  })
+  rss: {
+    id: number;
+    name: string;
+  } | null;
 
   @ApiProperty({
     example: { userName: 'liker', profileImage: null },
     description:
-      '알림을 발생시킨 유저 정보(타입별 최신 행위자에서 파생: LIKE는 좋아요, COMMENT는 댓글)',
+      '알림을 발생시킨 유저 정보(타입별 최신 행위자에서 파생: LIKE는 좋아요, COMMENT는 댓글, SUBSCRIBE는 구독한 유저)',
   })
   actor: {
     userName: string | null;
@@ -65,7 +78,7 @@ export class NotificationItemResult {
   @ApiProperty({
     example: 2,
     description:
-      '표시된 actor를 제외하고 이 게시글에 좋아요/댓글을 남긴 다른 사람 수(수신자 본인 제외)',
+      '표시된 actor를 제외하고 이 게시글에 좋아요/댓글/구독을 한 다른 사람 수(수신자 본인 제외)',
   })
   otherCount: number;
 
@@ -94,11 +107,19 @@ export class NotificationItemResult {
       type: row.type,
       isRead: !!row.isRead,
       updatedAt: row.updatedAt,
-      feed: {
-        id: row.feedId,
-        title: row.feedTitle,
-        path: row.feedPath,
-      },
+      feed: row.feedId
+        ? {
+            id: row.feedId,
+            title: row.feedTitle,
+            path: row.feedPath,
+          }
+        : null,
+      rss: row.rssId
+        ? {
+            id: row.rssId,
+            name: row.rssName,
+          }
+        : null,
       actor: {
         userName: row.actorUserName,
         profileImage: row.actorProfileImage,

--- a/server/src/notification/dto/response/getNotifications.dto.ts
+++ b/server/src/notification/dto/response/getNotifications.dto.ts
@@ -46,7 +46,7 @@ export class NotificationItemResult {
       title: 'example title',
       path: 'https://example.com/feed',
     },
-    description: '알림 대상 게시글 정보',
+    description: '알림 대상 게시글 정보(LIKE/COMMENT 알림에 존재)',
     nullable: true,
   })
   feed: {

--- a/server/src/notification/entity/notification.entity.ts
+++ b/server/src/notification/entity/notification.entity.ts
@@ -13,15 +13,19 @@ import {
 
 import { Feed } from '@feed/entity/feed.entity';
 
+import { RssAccept } from '@rss/entity/rss.entity';
+
 import { User } from '@user/entity/user.entity';
 
 export enum NotificationType {
   LIKE = 'LIKE',
   COMMENT = 'COMMENT',
+  SUBSCRIBE = 'SUBSCRIBE',
 }
 
 @Entity({ name: 'notification' })
 @Unique(['recipient', 'type', 'feed'])
+@Unique(['recipient', 'type', 'rssAccept'])
 export class Notification extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -42,12 +46,20 @@ export class Notification extends BaseEntity {
   type: NotificationType;
 
   @ManyToOne(() => Feed, {
-    nullable: false,
+    nullable: true,
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
   @JoinColumn({ name: 'feed_id' })
-  feed: Feed;
+  feed: Feed | null;
+
+  @ManyToOne(() => RssAccept, {
+    nullable: true,
+    onUpdate: 'CASCADE',
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'rss_accept_id' })
+  rssAccept: RssAccept | null;
 
   @Column({ name: 'is_read', default: false })
   isRead: boolean;

--- a/server/src/notification/listener/subscription.listener.ts
+++ b/server/src/notification/listener/subscription.listener.ts
@@ -1,0 +1,54 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { NotificationService } from '@notification/service/notification.service';
+
+import { SubscriptionCreatedEvent } from '@subscribe/event/subscription-created.event';
+import { SubscriptionDeletedEvent } from '@subscribe/event/subscription-deleted.event';
+import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
+
+@Injectable()
+export class SubscriptionListener {
+  constructor(
+    private readonly subscriptionRepository: SubscriptionRepository,
+    private readonly notificationService: NotificationService,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  @OnEvent('subscription.created')
+  async handleSubscriptionCreated({
+    rssId,
+    ownerUserId,
+  }: SubscriptionCreatedEvent) {
+    try {
+      if (!ownerUserId) return;
+
+      await this.notificationService.upsertSubscribeNotification(
+        ownerUserId,
+        rssId,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[SubscriptionListener]: 구독 알림 생성 중 오류 발생 (rssId: ${rssId}): ${error}`,
+      );
+    }
+  }
+
+  @OnEvent('subscription.deleted')
+  async handleSubscriptionDeleted({ rssId }: SubscriptionDeletedEvent) {
+    try {
+      const subscriberCount =
+        await this.subscriptionRepository.countByBlogId(rssId);
+      await this.notificationService.removeSubscribeNotificationIfEmpty(
+        rssId,
+        subscriberCount,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[SubscriptionListener]: 구독 알림 삭제 중 오류 발생 (rssId: ${rssId}): ${error}`,
+      );
+    }
+  }
+}

--- a/server/src/notification/module/notification.module.ts
+++ b/server/src/notification/module/notification.module.ts
@@ -7,9 +7,12 @@ import { FeedModule } from '@feed/module/feed.module';
 import { NotificationController } from '@notification/controller/notification.controller';
 import { CommentListener } from '@notification/listener/comment.listener';
 import { LikeListener } from '@notification/listener/like.listener';
+import { SubscriptionListener } from '@notification/listener/subscription.listener';
 import { NotificationRepository } from '@notification/repository/notification.repository';
 import { NotificationScheduler } from '@notification/scheduler/notification.scheduler';
 import { NotificationService } from '@notification/service/notification.service';
+
+import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 @Module({
   imports: [FeedModule, JwtAuthModule],
@@ -19,6 +22,8 @@ import { NotificationService } from '@notification/service/notification.service'
     NotificationRepository,
     LikeListener,
     CommentListener,
+    SubscriptionListener,
+    SubscriptionRepository,
     NotificationScheduler,
   ],
   exports: [],

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -7,6 +7,8 @@ import { Feed } from '@feed/entity/feed.entity';
 import { Notification, NotificationType } from '@notification/entity/notification.entity';
 import { getNotificationCutoffDate } from '@notification/constant/notification.constant';
 
+import { RssAccept } from '@rss/entity/rss.entity';
+
 import { User } from '@user/entity/user.entity';
 
 @Injectable()
@@ -64,9 +66,28 @@ export class NotificationRepository extends Repository<Notification> {
     return Number(row?.count ?? 0) > 0;
   }
 
+  async upsertSubscribe(recipientId: number, rssAcceptId: number) {
+    await this.createQueryBuilder()
+      .insert()
+      .into(Notification)
+      .values({
+        recipient: { id: recipientId } as User,
+        type: NotificationType.SUBSCRIBE,
+        rssAccept: { id: rssAcceptId } as RssAccept,
+        isRead: false,
+      })
+      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'rss_accept_id'])
+      .execute();
+  }
+
+  async deleteSubscribeNotification(rssAcceptId: number) {
+    await this.delete({ type: NotificationType.SUBSCRIBE, rssAccept: { id: rssAcceptId } });
+  }
+
   async findByRecipient(recipientId: number, limit: number) {
     return this.createQueryBuilder('n')
-      .innerJoin('n.feed', 'feed')
+      .leftJoin('n.feed', 'feed')
+      .leftJoin('n.rssAccept', 'rss')
       .leftJoin(
         'likes',
         'latest_like',
@@ -78,10 +99,13 @@ export class NotificationRepository extends Repository<Notification> {
         "n.type = 'COMMENT' AND latest_comment.id = (SELECT c2.id FROM `comment` c2 WHERE c2.feed_id = n.feed_id AND c2.is_deleted = 0 AND c2.user_id != n.recipient_user_id ORDER BY c2.date DESC LIMIT 1)",
       )
       .leftJoin(
-        'user',
-        'actor',
-        'actor.id = COALESCE(latest_like.user_id, latest_comment.user_id)',
+        'subscription',
+        'latest_subscription',
+        'latest_subscription.id = (SELECT s2.id FROM subscription s2 WHERE s2.rss_accept_id = n.rss_accept_id ORDER BY s2.id DESC LIMIT 1)',
       )
+      .leftJoin('user', 'like_actor', 'like_actor.id = latest_like.user_id')
+      .leftJoin('user', 'comment_actor', 'comment_actor.id = latest_comment.user_id')
+      .leftJoin('user', 'subscribe_actor', 'subscribe_actor.id = latest_subscription.user_id')
       .select('n.id', 'id')
       .addSelect('n.type', 'type')
       .addSelect('n.is_read', 'isRead')
@@ -89,14 +113,23 @@ export class NotificationRepository extends Repository<Notification> {
       .addSelect('feed.id', 'feedId')
       .addSelect('feed.title', 'feedTitle')
       .addSelect('feed.path', 'feedPath')
-      .addSelect('actor.user_name', 'actorUserName')
-      .addSelect('actor.profile_image', 'actorProfileImage')
+      .addSelect('rss.id', 'rssId')
+      .addSelect('rss.name', 'rssName')
+      .addSelect(
+        'COALESCE(like_actor.user_name, comment_actor.user_name, subscribe_actor.user_name)',
+        'actorUserName',
+      )
+      .addSelect(
+        'COALESCE(like_actor.profile_image, comment_actor.profile_image, subscribe_actor.profile_image)',
+        'actorProfileImage',
+      )
       .addSelect('latest_comment.comment', 'commentContent')
       .addSelect('latest_comment.id', 'commentId')
       .addSelect(
         `CASE n.type
           WHEN 'LIKE' THEN (SELECT COUNT(*) FROM likes l3 WHERE l3.feed_id = n.feed_id AND l3.user_id != n.recipient_user_id)
           WHEN 'COMMENT' THEN (SELECT COUNT(DISTINCT c3.user_id) FROM \`comment\` c3 WHERE c3.feed_id = n.feed_id AND c3.is_deleted = 0 AND c3.user_id != n.recipient_user_id)
+          WHEN 'SUBSCRIBE' THEN (SELECT COUNT(*) FROM subscription s3 WHERE s3.rss_accept_id = n.rss_accept_id AND s3.user_id != n.recipient_user_id)
           ELSE 0
         END`,
         'otherActorsCount',

--- a/server/src/notification/service/notification.service.ts
+++ b/server/src/notification/service/notification.service.ts
@@ -33,6 +33,18 @@ export class NotificationService {
     await this.notificationRepository.deleteCommentNotification(feedId);
   }
 
+  async upsertSubscribeNotification(recipientId: number, rssAcceptId: number) {
+    await this.notificationRepository.upsertSubscribe(recipientId, rssAcceptId);
+  }
+
+  async removeSubscribeNotificationIfEmpty(
+    rssAcceptId: number,
+    subscriberCount: number,
+  ) {
+    if (subscriberCount > 0) return;
+    await this.notificationRepository.deleteSubscribeNotification(rssAcceptId);
+  }
+
   async getUnreadCount(userId: number) {
     const count = await this.notificationRepository.countUnread(userId);
     return GetUnreadCountResponseDto.toResponseDto(count);

--- a/server/src/subscribe/event/subscription-created.event.ts
+++ b/server/src/subscribe/event/subscription-created.event.ts
@@ -1,0 +1,7 @@
+export class SubscriptionCreatedEvent {
+  constructor(
+    public readonly rssId: number,
+    public readonly subscriberUserId: number,
+    public readonly ownerUserId: number | null,
+  ) {}
+}

--- a/server/src/subscribe/event/subscription-deleted.event.ts
+++ b/server/src/subscribe/event/subscription-deleted.event.ts
@@ -1,0 +1,6 @@
+export class SubscriptionDeletedEvent {
+  constructor(
+    public readonly rssId: number,
+    public readonly subscriberUserId: number,
+  ) {}
+}

--- a/server/src/subscribe/service/subscription.service.ts
+++ b/server/src/subscribe/service/subscription.service.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 
 import { In } from 'typeorm';
 
@@ -14,14 +15,16 @@ import { FeedRepository } from '@feed/repository/feed.repository';
 import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
+import { GetSubscribersRequestDto } from '@subscribe/dto/request/getSubscribers.dto';
+import { ManageSubscriptionRequestDto } from '@subscribe/dto/request/manageSubscription.dto';
 import {
   GetMySubscriptionsResponseDto,
   SubscribedRssResponseDto,
 } from '@subscribe/dto/response/getMySubscriptions.dto';
 import { GetSubscribersResponseDto } from '@subscribe/dto/response/getSubscribers.dto';
 import { GetSubscriptionResponseDto } from '@subscribe/dto/response/getSubscription.dto';
-import { ManageSubscriptionRequestDto } from '@subscribe/dto/request/manageSubscription.dto';
-import { GetSubscribersRequestDto } from '@subscribe/dto/request/getSubscribers.dto';
+import { SubscriptionCreatedEvent } from '@subscribe/event/subscription-created.event';
+import { SubscriptionDeletedEvent } from '@subscribe/event/subscription-deleted.event';
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 @Injectable()
@@ -30,6 +33,7 @@ export class SubscriptionService {
     private readonly subscriptionRepository: SubscriptionRepository,
     private readonly rssAcceptRepository: RssAcceptRepository,
     private readonly feedRepository: FeedRepository,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   private async getRssAccept(rssId: number): Promise<RssAccept> {
@@ -88,6 +92,11 @@ export class SubscriptionService {
       }
       throw error;
     }
+
+    this.eventEmitter.emit(
+      'subscription.created',
+      new SubscriptionCreatedEvent(rss.id, user.id, rss.userId),
+    );
   }
 
   async delete(user: Payload, dto: ManageSubscriptionRequestDto) {
@@ -105,6 +114,11 @@ export class SubscriptionService {
       user: { id: user.id },
       rssAccept: { id: rss.id },
     });
+
+    this.eventEmitter.emit(
+      'subscription.deleted',
+      new SubscriptionDeletedEvent(rss.id, user.id),
+    );
   }
 
   async getSubscribers(
@@ -132,7 +146,11 @@ export class SubscriptionService {
       ? subscribers[subscribers.length - 1].id
       : 0;
 
-    return GetSubscribersResponseDto.toResponseDto(subscribers, lastId, hasMore);
+    return GetSubscribersResponseDto.toResponseDto(
+      subscribers,
+      lastId,
+      hasMore,
+    );
   }
 
   async getUserSubscriptions(

--- a/server/test/notification/unit/notification.service.unit.spec.ts
+++ b/server/test/notification/unit/notification.service.unit.spec.ts
@@ -13,6 +13,8 @@ describe(`${NotificationService.name} Unit Test`, () => {
       | 'upsertComment'
       | 'deleteCommentNotification'
       | 'hasActiveOtherComment'
+      | 'upsertSubscribe'
+      | 'deleteSubscribeNotification'
       | 'countUnread'
       | 'findByRecipient'
       | 'markRead'
@@ -27,6 +29,8 @@ describe(`${NotificationService.name} Unit Test`, () => {
       upsertComment: jest.fn(),
       deleteCommentNotification: jest.fn(),
       hasActiveOtherComment: jest.fn(),
+      upsertSubscribe: jest.fn(),
+      deleteSubscribeNotification: jest.fn(),
       countUnread: jest.fn(),
       findByRecipient: jest.fn(),
       markRead: jest.fn(),
@@ -109,6 +113,34 @@ describe(`${NotificationService.name} Unit Test`, () => {
       expect(
         notificationRepository.deleteCommentNotification,
       ).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('upsertSubscribeNotification', () => {
+    it('recipientId, rssAcceptId로 upsertSubscribe를 호출한다.', async () => {
+      // when
+      await notificationService.upsertSubscribeNotification(1, 10);
+
+      // then
+      expect(notificationRepository.upsertSubscribe).toHaveBeenCalledWith(1, 10);
+    });
+  });
+
+  describe('removeSubscribeNotificationIfEmpty', () => {
+    it('구독자가 남아있으면(subscriberCount > 0) 알림을 삭제하지 않는다.', async () => {
+      // when
+      await notificationService.removeSubscribeNotificationIfEmpty(10, 1);
+
+      // then
+      expect(notificationRepository.deleteSubscribeNotification).not.toHaveBeenCalled();
+    });
+
+    it('구독자가 0명이면 해당 RSS의 알림을 삭제한다.', async () => {
+      // when
+      await notificationService.removeSubscribeNotificationIfEmpty(10, 0);
+
+      // then
+      expect(notificationRepository.deleteSubscribeNotification).toHaveBeenCalledWith(10);
     });
   });
 

--- a/server/test/notification/unit/subscription.listener.unit.spec.ts
+++ b/server/test/notification/unit/subscription.listener.unit.spec.ts
@@ -1,0 +1,86 @@
+import { SubscriptionListener } from '@notification/listener/subscription.listener';
+import { NotificationService } from '@notification/service/notification.service';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { SubscriptionCreatedEvent } from '@subscribe/event/subscription-created.event';
+import { SubscriptionDeletedEvent } from '@subscribe/event/subscription-deleted.event';
+import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
+
+describe(`${SubscriptionListener.name} Unit Test`, () => {
+  let subscriptionListener: SubscriptionListener;
+  let subscriptionRepository: jest.Mocked<Pick<SubscriptionRepository, 'countByBlogId'>>;
+  let notificationService: jest.Mocked<
+    Pick<
+      NotificationService,
+      'upsertSubscribeNotification' | 'removeSubscribeNotificationIfEmpty'
+    >
+  >;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
+
+  beforeEach(() => {
+    subscriptionRepository = { countByBlogId: jest.fn() };
+    notificationService = {
+      upsertSubscribeNotification: jest.fn(),
+      removeSubscribeNotificationIfEmpty: jest.fn(),
+    };
+    logger = { error: jest.fn() };
+
+    subscriptionListener = new SubscriptionListener(
+      subscriptionRepository as unknown as SubscriptionRepository,
+      notificationService as unknown as NotificationService,
+      logger as unknown as WinstonLoggerService,
+    );
+  });
+
+  describe('handleSubscriptionCreated', () => {
+    it('RSS 소유자가 없으면 알림을 생성하지 않는다.', async () => {
+      // when
+      await subscriptionListener.handleSubscriptionCreated(
+        new SubscriptionCreatedEvent(10, 2, null),
+      );
+
+      // then
+      expect(notificationService.upsertSubscribeNotification).not.toHaveBeenCalled();
+    });
+
+    it('RSS 소유자가 있으면 소유자에게 알림을 upsert한다.', async () => {
+      // when
+      await subscriptionListener.handleSubscriptionCreated(
+        new SubscriptionCreatedEvent(10, 2, 99),
+      );
+
+      // then
+      expect(notificationService.upsertSubscribeNotification).toHaveBeenCalledWith(99, 10);
+    });
+
+    it('처리 중 예외가 발생해도 던지지 않고 로깅한다.', async () => {
+      // given
+      notificationService.upsertSubscribeNotification.mockRejectedValue(new Error('db down'));
+
+      // when & then
+      await expect(
+        subscriptionListener.handleSubscriptionCreated(
+          new SubscriptionCreatedEvent(10, 2, 99),
+        ),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSubscriptionDeleted', () => {
+    it('현재 구독자 수 기준으로 알림 삭제 여부를 위임한다.', async () => {
+      // given
+      subscriptionRepository.countByBlogId.mockResolvedValue(0);
+
+      // when
+      await subscriptionListener.handleSubscriptionDeleted(
+        new SubscriptionDeletedEvent(10, 2),
+      );
+
+      // then
+      expect(subscriptionRepository.countByBlogId).toHaveBeenCalledWith(10);
+      expect(notificationService.removeSubscribeNotificationIfEmpty).toHaveBeenCalledWith(10, 0);
+    });
+  });
+});

--- a/server/test/subscribe/unit/subscription.service.unit.spec.ts
+++ b/server/test/subscribe/unit/subscription.service.unit.spec.ts
@@ -4,6 +4,8 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 
+import { EventEmitter2 } from '@nestjs/event-emitter';
+
 import { Payload } from '@common/guard/jwt.guard';
 
 import { FeedRepository } from '@feed/repository/feed.repository';
@@ -35,6 +37,7 @@ describe(`${SubscriptionService.name} Unit Test`, () => {
   >;
   let rssAcceptRepository: jest.Mocked<Pick<RssAcceptRepository, 'findOneBy' | 'find'>>;
   let feedRepository: jest.Mocked<Pick<FeedRepository, 'countPublicFeedsByBlogIds'>>;
+  let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
 
   const viewer: Payload = {
     id: 1,
@@ -59,11 +62,13 @@ describe(`${SubscriptionService.name} Unit Test`, () => {
     feedRepository = {
       countPublicFeedsByBlogIds: jest.fn().mockResolvedValue(new Map()),
     };
+    eventEmitter = { emit: jest.fn() };
 
     subscriptionService = new SubscriptionService(
       subscriptionRepository as unknown as SubscriptionRepository,
       rssAcceptRepository as unknown as RssAcceptRepository,
       feedRepository as unknown as FeedRepository,
+      eventEmitter as unknown as EventEmitter2,
     );
   });
 
@@ -158,6 +163,25 @@ describe(`${SubscriptionService.name} Unit Test`, () => {
         user: { id: viewer.id },
         rssAccept: { id: 10 },
       });
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'subscription.created',
+        expect.objectContaining({ rssId: 10, subscriberUserId: viewer.id, ownerUserId: 99 }),
+      );
+    });
+
+    it('소유자가 없는 RSS를 구독하면 ownerUserId가 null인 이벤트를 발행한다.', async () => {
+      // given
+      rssAcceptRepository.findOneBy.mockResolvedValue(makeRss({ userId: null }));
+      subscriptionRepository.findOneBy.mockResolvedValue(null);
+
+      // when
+      await subscriptionService.create(viewer, { rssId: 10 });
+
+      // then
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'subscription.created',
+        expect.objectContaining({ rssId: 10, subscriberUserId: viewer.id, ownerUserId: null }),
+      );
     });
 
     it('사전 조회를 통과해도 저장 시 unique 제약 위반(ER_DUP_ENTRY)이면 ConflictException으로 변환한다.', async () => {
@@ -170,6 +194,7 @@ describe(`${SubscriptionService.name} Unit Test`, () => {
       await expect(
         subscriptionService.create(viewer, { rssId: 10 }),
       ).rejects.toThrow(ConflictException);
+      expect(eventEmitter.emit).not.toHaveBeenCalled();
     });
   });
 
@@ -204,6 +229,10 @@ describe(`${SubscriptionService.name} Unit Test`, () => {
         user: { id: viewer.id },
         rssAccept: { id: 10 },
       });
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'subscription.deleted',
+        expect.objectContaining({ rssId: 10, subscriberUserId: viewer.id }),
+      );
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #781

### 구독 알림

- 본인이 등록한 RSS를 다른 유저가 구독했을 때 알림이 오도록 구현. 기존 좋아요 알림과 동일하게 `(recipient, type, 대상)` 단위로 집계하되, 구독은 게시글(feed)이 아닌 RSS 등록 건(rss_accept) 자체에 대한 알림이라 `feed_id`와 별개로 `rss_accept_id` FK를 신설함.
- `notification` 테이블의 `feed_id`를 nullable로 완화하고 `rss_accept_id` 컬럼 + `(recipient, type, rss_accept_id)` unique index를 추가하는 마이그레이션 작성.
- `SubscriptionService`에서 구독 생성/삭제 시 `subscription.created`/`subscription.deleted` 이벤트 emit, `SubscriptionListener`가 이를 받아 알림 upsert/삭제 처리(구독자가 전부 사라지면 알림 삭제).
- `NotificationRepository.findByRecipient`를 좋아요/구독 공용으로 확장(actor derive, otherActorsCount 합산 포함).
- 알림 응답에 `rss`(구독 알림용 RSS 정보) 필드 추가, `feed`는 nullable로 변경.
- 클라이언트 `NotificationBell`에 구독 알림 카드 UI 추가.
- 서버 unit(subscription.service, subscription.listener, notification.service), Storybook/컴포넌트 테스트 갱신.

# 📋 작업 내용

- `notification` 엔티티에 `rssAccept` 관계 추가, `NotificationType`에 `SUBSCRIBE` 추가
- `1782400000000-AddSubscribeNotification` 마이그레이션 추가(`feed_id` nullable화, `rss_accept_id` FK/unique index 추가)
- `SubscriptionCreatedEvent`/`SubscriptionDeletedEvent` 추가, `SubscriptionService`에서 이벤트 emit
- `SubscriptionListener` 추가: 구독 생성 시 알림 upsert, 구독자 0명 시 알림 삭제
- `NotificationRepository`/`NotificationService`에 구독 알림 upsert/삭제/조회 로직 추가
- `getNotifications.dto`에 `rss` 필드 추가, `feed`/`otherActorsCount` nullable/공용 필드로 정리
- 클라이언트 `NotificationBell` 구독 알림 카드 표시, API 응답 타입 갱신
- `init.sql`을 마이그레이션과 동일하게 갱신(fresh DB 부트스트랩 동기화)

# 📷 스크린 샷(선택 사항)

<img width="394" height="203" alt="image" src="https://github.com/user-attachments/assets/ca34bbbf-85fb-4366-9b2e-8614ba961c65" />