### PR TITLE
🐛 fix: 게시글 모달 title과 모달 위치 안맞는 버그

### DIFF
--- a/client/src/components/common/Card/detail/FixedHeader.tsx
+++ b/client/src/components/common/Card/detail/FixedHeader.tsx
@@ -11,7 +11,7 @@ interface FixedHeaderProps {
 export const FixedHeader = React.memo(({ title, onClose, scrollbarWidth }: FixedHeaderProps) => (
   <div
     className="fixed top-0 left-1/2 w-[90%] max-w-4xl bg-gray-200 border-b flex justify-between items-center z-20"
-    style={{ transform: `translateX(calc(-50% - ${scrollbarWidth / 2}px))` }}
+    style={{ transform: `translateX(calc(-50% - ${scrollbarWidth}px))` }}
   >
     <h2 className="text-lg font-semibold truncate p-4">{title}</h2>
     <button onClick={onClose} className="p-4 hover:bg-gray-100 transition-colors" aria-label="Close modal">


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연결된 이슈 없음

### 모달 title 위치 불일치

- 게시글 상세 모달 스크롤 시 나타나는 FixedHeader(제목 고정 헤더)가 모달 카드 중심보다 오른쪽으로 밀려서 표시됨
- 원인: 모달 컨테이너는 자체 세로 스크롤바(overflow-y-auto)와 명시적 paddingRight(scrollbarWidth)로 두 번 폭이 줄어들어 카드 중심이 `W/2 - scrollbarWidth`인데, FixedHeader의 translateX 보정값은 `scrollbarWidth / 2`만 적용되어 있어 `scrollbarWidth / 2`만큼 어긋남

# 📋 작업 내용

- `FixedHeader.tsx`의 `translateX` 보정값을 `scrollbarWidth / 2`에서 `scrollbarWidth`로 수정

# 📷 스크린 샷(선택 사항)
<img width="929" height="348" alt="image" src="https://github.com/user-attachments/assets/cc0fefbb-c7b4-4c43-820b-5c078dd0acb2" />
<img width="907" height="212" alt="image" src="https://github.com/user-attachments/assets/cee56b26-c85e-4a24-8322-22eb4515797e" />
