### PR TITLE
✨ feat: 댓글 답글 알림 기능 구현

### DIFF
--- a/client/src/__tests__/components/common/NotificationBell.test.tsx
+++ b/client/src/__tests__/components/common/NotificationBell.test.tsx
@@ -125,6 +125,45 @@ describe("NotificationBell", () => {
     expect(item).toHaveTextContent("“내용 좋네요”");
   });
 
+  it("답글 알림 메시지를 템플릿에 맞게 표시한다", () => {
+    listState = {
+      data: [makeItem({ type: "REPLY", actor: { userName: "replier", profileImage: null } })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("replier님이 테스트 게시글에 답글을 남겼습니다.");
+
+    const bolded = item.querySelectorAll(".font-semibold");
+    expect(Array.from(bolded).map((el) => el.textContent)).toEqual(["replier", "테스트 게시글", "답글"]);
+  });
+
+  it("답글 알림에는 답글 내용 일부를 인용부호로 표시한다", () => {
+    listState = {
+      data: [makeItem({ type: "REPLY", commentPreview: "저도 동의합니다" })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("“저도 동의합니다”");
+  });
+
+  it("답글 알림을 클릭하면 해당 답글 ID를 하이라이트 상태로 함께 넘긴다", () => {
+    listState = {
+      data: [makeItem({ id: 5, type: "REPLY", commentId: 88 })],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    fireEvent.click(screen.getByTestId("notification-item"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/10", {
+      state: { backgroundLocation: { pathname: "/" }, highlightCommentId: 88 },
+    });
+  });
+
   it("좋아요 알림에는 댓글 내용을 표시하지 않는다", () => {
     listState = { data: [makeItem({ commentPreview: "무시되어야 함" })], isLoading: false };
     render(<NotificationBell />);
@@ -187,6 +226,9 @@ describe("NotificationBell", () => {
 
     const item = screen.getByTestId("notification-item");
     expect(item).toHaveTextContent("liker님이 테스트 블로그을(를) 구독했습니다.");
+
+    const bolded = item.querySelectorAll(".font-semibold");
+    expect(Array.from(bolded).map((el) => el.textContent)).toEqual(["liker", "테스트 블로그", "구독"]);
   });
 
   it("구독 알림을 클릭하면 해당 RSS 페이지로 이동한다", () => {

--- a/client/src/api/services/notifications.ts
+++ b/client/src/api/services/notifications.ts
@@ -3,7 +3,7 @@ import { NOTIFICATION } from "@/constants/endpoints";
 import { axiosInstance } from "@/api/instance";
 import { ApiData } from "@/types/api";
 
-export type NotificationType = "LIKE" | "COMMENT" | "SUBSCRIBE";
+export type NotificationType = "LIKE" | "COMMENT" | "REPLY" | "SUBSCRIBE";
 
 export type NotificationItem = {
   id: number;

--- a/client/src/components/common/NotificationBell.stories.tsx
+++ b/client/src/components/common/NotificationBell.stories.tsx
@@ -67,6 +67,30 @@ const multipleCommentersItem = {
   commentId: 102,
 };
 
+const replyItem = {
+  id: 6,
+  type: "REPLY",
+  isRead: false,
+  updatedAt: "2026-07-28T00:00:00.000Z",
+  feed: { id: 15, title: "답글이 달린 댓글이 있는 게시글", path: "https://example.com/15" },
+  actor: { userName: "답글러", profileImage: null },
+  otherCount: 0,
+  commentPreview: "저도 답글로 남겨봅니다!",
+  commentId: 103,
+};
+
+const multipleRepliersItem = {
+  id: 7,
+  type: "REPLY",
+  isRead: false,
+  updatedAt: "2026-07-28T00:00:00.000Z",
+  feed: { id: 16, title: "답글이 여러 개 달린 댓글이 있는 게시글", path: "https://example.com/16" },
+  actor: { userName: "최신답글러", profileImage: null },
+  otherCount: 2,
+  commentPreview: "저도 같은 의견입니다",
+  commentId: 104,
+};
+
 const subscribeItem = {
   id: 4,
   type: "SUBSCRIBE",
@@ -173,6 +197,41 @@ export const WithMultipleCommenters: Story = {
     await userEvent.click(canvas.getByRole("button", { name: "알림" }));
     const item = await body.findByTestId("notification-item");
     await expect(item).toHaveTextContent("최신댓글러님 외 2명이 여러 명이 댓글단 게시글에 댓글을 남겼습니다.");
+  },
+};
+
+export const WithReply: Story = {
+  name: "답글 알림",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [replyItem] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    const item = await body.findByTestId("notification-item");
+    await expect(item).toHaveTextContent("답글러님이 답글이 달린 댓글이 있는 게시글에 답글을 남겼습니다.");
+    await expect(item).toHaveTextContent("저도 답글로 남겨봅니다!");
+  },
+};
+
+export const WithMultipleRepliers: Story = {
+  name: "여러 명이 답글",
+  beforeEach: () => {
+    useAuthStore.setState({ isAuthenticated: true, accessToken: "mock-token" });
+    mockApi.onGet(NOTIFICATION.UNREAD_COUNT).reply(...ok({ count: 1 }));
+    mockApi.onGet(NOTIFICATION.LIST).reply(...ok({ result: [multipleRepliersItem] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const body = within(canvasElement.ownerDocument.body);
+    await userEvent.click(canvas.getByRole("button", { name: "알림" }));
+    const item = await body.findByTestId("notification-item");
+    await expect(item).toHaveTextContent(
+      "최신답글러님 외 2명이 답글이 여러 개 달린 댓글이 있는 게시글에 답글을 남겼습니다.",
+    );
   },
 };
 

--- a/client/src/components/common/NotificationBell.tsx
+++ b/client/src/components/common/NotificationBell.tsx
@@ -19,36 +19,34 @@ import { NotificationItem } from "@/api/services/notifications";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/store/useAuthStore";
 
+const NOTIFICATION_MESSAGE_CONFIG: Record<
+  NotificationItem["type"],
+  { target: (item: NotificationItem) => string | null | undefined; connector: string; action: [string, string] }
+> = {
+  LIKE: { target: (item) => item.feed?.title, connector: "에", action: ["좋아요", "를 표시했습니다"] },
+  COMMENT: { target: (item) => item.feed?.title, connector: "에", action: ["댓글", "을 남겼습니다"] },
+  REPLY: { target: (item) => item.feed?.title, connector: "에", action: ["답글", "을 남겼습니다"] },
+  SUBSCRIBE: { target: (item) => item.rss?.name, connector: "을(를)", action: ["구독", "했습니다"] },
+};
+
 const buildMessage = (item: NotificationItem) => {
   const actorSuffix = item.otherCount > 0 ? `님 외 ${item.otherCount}명이 ` : "님이 ";
+  const {
+    target,
+    connector,
+    action: [actionBold, actionRest],
+  } = NOTIFICATION_MESSAGE_CONFIG[item.type];
 
-  switch (item.type) {
-    case "SUBSCRIBE":
-      return (
-        <>
-          <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
-          {actorSuffix}
-          <span className="font-semibold">{item.rss?.name}</span>을(를){" "}
-          <span className="font-semibold">구독했습니다</span>.
-        </>
-      );
-    case "COMMENT":
-    case "LIKE":
-    default: {
-      const [actionBold, actionRest] =
-        item.type === "COMMENT" ? ["댓글", "을 남겼습니다"] : ["좋아요", "를 표시했습니다"];
-
-      return (
-        <>
-          <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
-          {actorSuffix}
-          <span className="font-semibold">{item.feed?.title}</span>에{" "}
-          <span className="font-semibold">{actionBold}</span>
-          {actionRest}.
-        </>
-      );
-    }
-  }
+  return (
+    <>
+      <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
+      {actorSuffix}
+      <span className="font-semibold">{target(item)}</span>
+      {connector}{" "}
+      <span className="font-semibold">{actionBold}</span>
+      {actionRest}.
+    </>
+  );
 };
 
 export const NotificationBell = () => {
@@ -72,7 +70,8 @@ export const NotificationBell = () => {
       return;
     }
     if (item.feed) {
-      const highlightCommentId = item.type === "COMMENT" ? item.commentId : null;
+      const highlightCommentId =
+        item.type === "COMMENT" || item.type === "REPLY" ? item.commentId : null;
       navigate(`/${item.feed.id}`, {
         state: { backgroundLocation: location, highlightCommentId },
       });
@@ -122,7 +121,7 @@ export const NotificationBell = () => {
                 </Avatar>
                 <div className="min-w-0 flex-1">
                   <p className="line-clamp-2">{buildMessage(item)}</p>
-                  {item.type === "COMMENT" && item.commentPreview && (
+                  {(item.type === "COMMENT" || item.type === "REPLY") && item.commentPreview && (
                     <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
                       &ldquo;{item.commentPreview}&rdquo;
                     </p>

--- a/server/src/comment/event/comment-created.event.ts
+++ b/server/src/comment/event/comment-created.event.ts
@@ -2,5 +2,6 @@ export class CommentCreatedEvent {
   constructor(
     public readonly feedId: number,
     public readonly commenterUserId: number,
+    public readonly parentAuthorId: number | null,
   ) {}
 }

--- a/server/src/comment/event/comment-deleted.event.ts
+++ b/server/src/comment/event/comment-deleted.event.ts
@@ -1,3 +1,6 @@
 export class CommentDeletedEvent {
-  constructor(public readonly feedId: number) {}
+  constructor(
+    public readonly feedId: number,
+    public readonly parentAuthorId: number | null,
+  ) {}
 }

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -66,7 +66,7 @@ export class CommentService {
       where: {
         id: commentId,
       },
-      relations: ['user', 'feed', 'feed.blog'],
+      relations: ['user', 'feed', 'feed.blog', 'parent', 'parent.user'],
     });
 
     if (!commentObj) {
@@ -117,7 +117,7 @@ export class CommentService {
   private async validateParentComment(parentId: number, feedId: number) {
     const parent = await this.commentRepository.findOne({
       where: { id: parentId },
-      relations: ['feed'],
+      relations: ['feed', 'user'],
     });
 
     if (!parent) {
@@ -131,6 +131,8 @@ export class CommentService {
     if (parent.parentId !== null) {
       throw new BadRequestException('답글에는 답글을 달 수 없습니다.');
     }
+
+    return parent;
   }
 
   async create(
@@ -138,11 +140,17 @@ export class CommentService {
     feedId: number,
     commentDto: CreateCommentRequestDto,
   ) {
+    let parentAuthorId: number | null = null;
+
     await this.dataSource.transaction(async (manager) => {
       const feed = await this.feedService.getPublicFeed(feedId);
 
       if (commentDto.parentId) {
-        await this.validateParentComment(commentDto.parentId, feedId);
+        const parent = await this.validateParentComment(
+          commentDto.parentId,
+          feedId,
+        );
+        parentAuthorId = parent.user.id;
       }
 
       feed.commentCount++;
@@ -157,7 +165,7 @@ export class CommentService {
 
     this.eventEmitter.emit(
       'comment.created',
-      new CommentCreatedEvent(feedId, userInformation.id),
+      new CommentCreatedEvent(feedId, userInformation.id, parentAuthorId),
     );
   }
 
@@ -166,6 +174,8 @@ export class CommentService {
       userInformation,
       commentDto.commentId,
     );
+
+    const parentAuthorId = comment.parent?.user.id ?? null;
 
     const replyCount =
       comment.parentId === null
@@ -189,14 +199,14 @@ export class CommentService {
 
     this.eventEmitter.emit(
       'comment.deleted',
-      new CommentDeletedEvent(comment.feed.id),
+      new CommentDeletedEvent(comment.feed.id, parentAuthorId),
     );
   }
 
   async deleteByAdmin(commentId: number) {
     const comment = await this.commentRepository.findOne({
       where: { id: commentId },
-      relations: ['feed'],
+      relations: ['feed', 'parent', 'parent.user'],
     });
 
     if (!comment) {
@@ -209,7 +219,7 @@ export class CommentService {
 
     this.eventEmitter.emit(
       'comment.deleted',
-      new CommentDeletedEvent(comment.feed.id),
+      new CommentDeletedEvent(comment.feed.id, comment.parent?.user.id ?? null),
     );
   }
 

--- a/server/src/notification/dto/response/getNotifications.dto.ts
+++ b/server/src/notification/dto/response/getNotifications.dto.ts
@@ -68,7 +68,7 @@ export class NotificationItemResult {
   @ApiProperty({
     example: { userName: 'liker', profileImage: null },
     description:
-      '알림을 발생시킨 유저 정보(타입별 최신 행위자에서 파생: LIKE는 좋아요, COMMENT는 댓글, SUBSCRIBE는 구독한 유저)',
+      '알림을 발생시킨 유저 정보(타입별 최신 행위자에서 파생: LIKE는 좋아요, COMMENT는 댓글, REPLY는 답글, SUBSCRIBE는 구독한 유저)',
   })
   actor: {
     userName: string | null;
@@ -86,14 +86,15 @@ export class NotificationItemResult {
     example: '이 글 정말 잘 읽었습니다...',
     nullable: true,
     description:
-      'COMMENT 타입일 때 최신 댓글 내용 일부(40자 초과 시 말줄임). LIKE는 항상 null',
+      'COMMENT/REPLY 타입일 때 최신 댓글(답글) 내용 일부(40자 초과 시 말줄임). LIKE/SUBSCRIBE는 항상 null',
   })
   commentPreview: string | null;
 
   @ApiProperty({
     example: 42,
     nullable: true,
-    description: 'COMMENT 타입일 때 최신 댓글의 ID(하이라이트/이동용). LIKE는 항상 null',
+    description:
+      'COMMENT/REPLY 타입일 때 최신 댓글(답글)의 ID(하이라이트/이동용). LIKE/SUBSCRIBE는 항상 null',
   })
   commentId: number | null;
 

--- a/server/src/notification/entity/notification.entity.ts
+++ b/server/src/notification/entity/notification.entity.ts
@@ -20,6 +20,7 @@ import { User } from '@user/entity/user.entity';
 export enum NotificationType {
   LIKE = 'LIKE',
   COMMENT = 'COMMENT',
+  REPLY = 'REPLY',
   SUBSCRIBE = 'SUBSCRIBE',
 }
 

--- a/server/src/notification/listener/comment.listener.ts
+++ b/server/src/notification/listener/comment.listener.ts
@@ -19,37 +19,66 @@ export class CommentListener {
   ) {}
 
   @OnEvent('comment.created')
-  async handleCommentCreated({ feedId, commenterUserId }: CommentCreatedEvent) {
+  async handleCommentCreated({
+    feedId,
+    commenterUserId,
+    parentAuthorId,
+  }: CommentCreatedEvent) {
     try {
       const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
-      if (!blogMeta?.userId) return;
-      if (blogMeta.userId === commenterUserId) return;
-
-      await this.notificationService.upsertCommentNotification(
-        blogMeta.userId,
-        feedId,
-      );
+      if (blogMeta?.userId && blogMeta.userId !== commenterUserId) {
+        await this.notificationService.upsertCommentNotification(
+          blogMeta.userId,
+          feedId,
+        );
+      }
     } catch (error) {
       this.logger.error(
         `[CommentListener]: 댓글 알림 생성 중 오류 발생 (feedId: ${feedId}): ${error}`,
       );
     }
+
+    if (parentAuthorId !== null && parentAuthorId !== commenterUserId) {
+      try {
+        await this.notificationService.upsertReplyNotification(
+          parentAuthorId,
+          feedId,
+        );
+      } catch (error) {
+        this.logger.error(
+          `[CommentListener]: 답글 알림 생성 중 오류 발생 (feedId: ${feedId}): ${error}`,
+        );
+      }
+    }
   }
 
   @OnEvent('comment.deleted')
-  async handleCommentDeleted({ feedId }: CommentDeletedEvent) {
+  async handleCommentDeleted({ feedId, parentAuthorId }: CommentDeletedEvent) {
     try {
       const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
-      if (!blogMeta?.userId) return;
-
-      await this.notificationService.removeCommentNotificationIfEmpty(
-        feedId,
-        blogMeta.userId,
-      );
+      if (blogMeta?.userId) {
+        await this.notificationService.removeCommentNotificationIfEmpty(
+          feedId,
+          blogMeta.userId,
+        );
+      }
     } catch (error) {
       this.logger.error(
         `[CommentListener]: 댓글 알림 삭제 중 오류 발생 (feedId: ${feedId}): ${error}`,
       );
+    }
+
+    if (parentAuthorId !== null) {
+      try {
+        await this.notificationService.removeReplyNotificationIfEmpty(
+          feedId,
+          parentAuthorId,
+        );
+      } catch (error) {
+        this.logger.error(
+          `[CommentListener]: 답글 알림 삭제 중 오류 발생 (feedId: ${feedId}): ${error}`,
+        );
+      }
     }
   }
 }

--- a/server/src/notification/listener/comment.listener.ts
+++ b/server/src/notification/listener/comment.listener.ts
@@ -24,18 +24,20 @@ export class CommentListener {
     commenterUserId,
     parentAuthorId,
   }: CommentCreatedEvent) {
-    try {
-      const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
-      if (blogMeta?.userId && blogMeta.userId !== commenterUserId) {
-        await this.notificationService.upsertCommentNotification(
-          blogMeta.userId,
-          feedId,
+    if (parentAuthorId === null) {
+      try {
+        const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
+        if (blogMeta?.userId && blogMeta.userId !== commenterUserId) {
+          await this.notificationService.upsertCommentNotification(
+            blogMeta.userId,
+            feedId,
+          );
+        }
+      } catch (error) {
+        this.logger.error(
+          `[CommentListener]: 댓글 알림 생성 중 오류 발생 (feedId: ${feedId}): ${error}`,
         );
       }
-    } catch (error) {
-      this.logger.error(
-        `[CommentListener]: 댓글 알림 생성 중 오류 발생 (feedId: ${feedId}): ${error}`,
-      );
     }
 
     if (parentAuthorId !== null && parentAuthorId !== commenterUserId) {

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -66,6 +66,43 @@ export class NotificationRepository extends Repository<Notification> {
     return Number(row?.count ?? 0) > 0;
   }
 
+  async upsertReply(recipientId: number, feedId: number) {
+    await this.createQueryBuilder()
+      .insert()
+      .into(Notification)
+      .values({
+        recipient: { id: recipientId } as User,
+        type: NotificationType.REPLY,
+        feed: { id: feedId } as Feed,
+        isRead: false,
+      })
+      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'feed_id'])
+      .execute();
+  }
+
+  async deleteReplyNotification(feedId: number, recipientId: number) {
+    await this.delete({
+      type: NotificationType.REPLY,
+      feed: { id: feedId },
+      recipient: { id: recipientId } as User,
+    });
+  }
+
+  async hasActiveOtherReply(feedId: number, recipientId: number) {
+    const row = await this.dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)', 'count')
+      .from('comment', 'r')
+      .innerJoin('comment', 'p', 'p.id = r.parent_id')
+      .where('r.feed_id = :feedId', { feedId })
+      .andWhere('r.is_deleted = 0')
+      .andWhere('r.user_id != :recipientId', { recipientId })
+      .andWhere('p.user_id = :recipientId', { recipientId })
+      .getRawOne<{ count: string }>();
+
+    return Number(row?.count ?? 0) > 0;
+  }
+
   async upsertSubscribe(recipientId: number, rssAcceptId: number) {
     await this.createQueryBuilder()
       .insert()
@@ -99,12 +136,18 @@ export class NotificationRepository extends Repository<Notification> {
         "n.type = 'COMMENT' AND latest_comment.id = (SELECT c2.id FROM `comment` c2 WHERE c2.feed_id = n.feed_id AND c2.is_deleted = 0 AND c2.user_id != n.recipient_user_id ORDER BY c2.date DESC LIMIT 1)",
       )
       .leftJoin(
+        'comment',
+        'latest_reply',
+        "n.type = 'REPLY' AND latest_reply.id = (SELECT r2.id FROM `comment` r2 INNER JOIN `comment` p2 ON p2.id = r2.parent_id WHERE r2.feed_id = n.feed_id AND r2.is_deleted = 0 AND r2.user_id != n.recipient_user_id AND p2.user_id = n.recipient_user_id ORDER BY r2.date DESC LIMIT 1)",
+      )
+      .leftJoin(
         'subscription',
         'latest_subscription',
         'latest_subscription.id = (SELECT s2.id FROM subscription s2 WHERE s2.rss_accept_id = n.rss_accept_id ORDER BY s2.id DESC LIMIT 1)',
       )
       .leftJoin('user', 'like_actor', 'like_actor.id = latest_like.user_id')
       .leftJoin('user', 'comment_actor', 'comment_actor.id = latest_comment.user_id')
+      .leftJoin('user', 'reply_actor', 'reply_actor.id = latest_reply.user_id')
       .leftJoin('user', 'subscribe_actor', 'subscribe_actor.id = latest_subscription.user_id')
       .select('n.id', 'id')
       .addSelect('n.type', 'type')
@@ -116,19 +159,20 @@ export class NotificationRepository extends Repository<Notification> {
       .addSelect('rss.id', 'rssId')
       .addSelect('rss.name', 'rssName')
       .addSelect(
-        'COALESCE(like_actor.user_name, comment_actor.user_name, subscribe_actor.user_name)',
+        'COALESCE(like_actor.user_name, comment_actor.user_name, reply_actor.user_name, subscribe_actor.user_name)',
         'actorUserName',
       )
       .addSelect(
-        'COALESCE(like_actor.profile_image, comment_actor.profile_image, subscribe_actor.profile_image)',
+        'COALESCE(like_actor.profile_image, comment_actor.profile_image, reply_actor.profile_image, subscribe_actor.profile_image)',
         'actorProfileImage',
       )
-      .addSelect('latest_comment.comment', 'commentContent')
-      .addSelect('latest_comment.id', 'commentId')
+      .addSelect('COALESCE(latest_comment.comment, latest_reply.comment)', 'commentContent')
+      .addSelect('COALESCE(latest_comment.id, latest_reply.id)', 'commentId')
       .addSelect(
         `CASE n.type
           WHEN 'LIKE' THEN (SELECT COUNT(*) FROM likes l3 WHERE l3.feed_id = n.feed_id AND l3.user_id != n.recipient_user_id)
           WHEN 'COMMENT' THEN (SELECT COUNT(DISTINCT c3.user_id) FROM \`comment\` c3 WHERE c3.feed_id = n.feed_id AND c3.is_deleted = 0 AND c3.user_id != n.recipient_user_id)
+          WHEN 'REPLY' THEN (SELECT COUNT(DISTINCT r3.user_id) FROM \`comment\` r3 INNER JOIN \`comment\` p3 ON p3.id = r3.parent_id WHERE r3.feed_id = n.feed_id AND r3.is_deleted = 0 AND r3.user_id != n.recipient_user_id AND p3.user_id = n.recipient_user_id)
           WHEN 'SUBSCRIBE' THEN (SELECT COUNT(*) FROM subscription s3 WHERE s3.rss_accept_id = n.rss_accept_id AND s3.user_id != n.recipient_user_id)
           ELSE 0
         END`,

--- a/server/src/notification/service/notification.service.ts
+++ b/server/src/notification/service/notification.service.ts
@@ -33,6 +33,22 @@ export class NotificationService {
     await this.notificationRepository.deleteCommentNotification(feedId);
   }
 
+  async upsertReplyNotification(recipientId: number, feedId: number) {
+    await this.notificationRepository.upsertReply(recipientId, feedId);
+  }
+
+  async removeReplyNotificationIfEmpty(feedId: number, recipientId: number) {
+    const hasOtherReply = await this.notificationRepository.hasActiveOtherReply(
+      feedId,
+      recipientId,
+    );
+    if (hasOtherReply) return;
+    await this.notificationRepository.deleteReplyNotification(
+      feedId,
+      recipientId,
+    );
+  }
+
   async upsertSubscribeNotification(recipientId: number, rssAcceptId: number) {
     await this.notificationRepository.upsertSubscribe(recipientId, rssAcceptId);
   }

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -204,7 +204,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       });
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.created',
-        new CommentCreatedEvent(10, user.id),
+        new CommentCreatedEvent(10, user.id, null),
       );
     });
 
@@ -230,6 +230,7 @@ describe(`${CommentService.name} Unit Test`, () => {
         id: 7,
         parentId: null,
         feed: { id: 10 },
+        user: { id: 42 },
       } as any);
 
       // when
@@ -245,7 +246,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       });
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.created',
-        new CommentCreatedEvent(10, user.id),
+        new CommentCreatedEvent(10, user.id, 42),
       );
     });
 
@@ -355,7 +356,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).toHaveBeenCalledWith(comment);
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10),
+        new CommentDeletedEvent(10, null),
       );
     });
 
@@ -382,17 +383,18 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).not.toHaveBeenCalled();
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10),
+        new CommentDeletedEvent(10, null),
       );
     });
 
-    it('답글(parentId 존재)은 replyCount 조회 없이 hard delete 한다.', async () => {
+    it('답글(parentId 존재)은 replyCount 조회 없이 hard delete 하고, 원본 댓글 작성자를 parentAuthorId로 전달한다.', async () => {
       // given
       const feed = { id: 10, commentCount: 3, blog: { userId: 888 } };
       const comment = {
         id: 5,
         parentId: 1,
         user: { id: user.id },
+        parent: { user: { id: 42 } },
         feed,
       } as Comment;
       commentRepository.findOne.mockResolvedValue(comment);
@@ -406,7 +408,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).toHaveBeenCalledWith(comment);
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10),
+        new CommentDeletedEvent(10, 42),
       );
     });
 
@@ -425,7 +427,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).toHaveBeenCalledWith(comment);
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10),
+        new CommentDeletedEvent(10, null),
       );
     });
   });
@@ -458,7 +460,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       // then
       expect(commentRepository.findOne).toHaveBeenCalledWith({
         where: { id: 5 },
-        relations: ['feed'],
+        relations: ['feed', 'parent', 'parent.user'],
       });
       expect(comment.isDeleted).toBe(true);
       expect(comment.isAdminDeleted).toBe(true);
@@ -467,7 +469,28 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(dataSource.transaction).not.toHaveBeenCalled();
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10),
+        new CommentDeletedEvent(10, null),
+      );
+    });
+
+    it('답글을 관리자가 삭제하면 원본 댓글 작성자를 parentAuthorId로 전달한다.', async () => {
+      // given
+      const comment = {
+        id: 6,
+        isDeleted: false,
+        isAdminDeleted: false,
+        feed: { id: 10 },
+        parent: { user: { id: 42 } },
+      } as Comment;
+      commentRepository.findOne.mockResolvedValue(comment);
+
+      // when
+      await commentService.deleteByAdmin(6);
+
+      // then
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.deleted',
+        new CommentDeletedEvent(10, 42),
       );
     });
   });

--- a/server/test/notification/unit/comment.listener.unit.spec.ts
+++ b/server/test/notification/unit/comment.listener.unit.spec.ts
@@ -167,6 +167,29 @@ describe(`${CommentListener.name} Unit Test`, () => {
       ).toHaveBeenCalledWith(5, 10);
     });
 
+    it('내 게시글의 내 댓글에 답글이 달리면 답글 알림만 생성하고 댓글 알림은 생성하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentCreated(
+        new CommentCreatedEvent(10, 2, 99),
+      );
+
+      // then
+      expect(notificationService.upsertReplyNotification).toHaveBeenCalledWith(
+        99,
+        10,
+      );
+      expect(
+        notificationService.upsertCommentNotification,
+      ).not.toHaveBeenCalled();
+    });
+
     it('답글 알림 생성 중 예외가 발생해도 던지지 않고 로깅한다.', async () => {
       // given
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({

--- a/server/test/notification/unit/comment.listener.unit.spec.ts
+++ b/server/test/notification/unit/comment.listener.unit.spec.ts
@@ -14,7 +14,10 @@ describe(`${CommentListener.name} Unit Test`, () => {
   let notificationService: jest.Mocked<
     Pick<
       NotificationService,
-      'upsertCommentNotification' | 'removeCommentNotificationIfEmpty'
+      | 'upsertCommentNotification'
+      | 'removeCommentNotificationIfEmpty'
+      | 'upsertReplyNotification'
+      | 'removeReplyNotificationIfEmpty'
     >
   >;
   let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
@@ -24,6 +27,8 @@ describe(`${CommentListener.name} Unit Test`, () => {
     notificationService = {
       upsertCommentNotification: jest.fn(),
       removeCommentNotificationIfEmpty: jest.fn(),
+      upsertReplyNotification: jest.fn(),
+      removeReplyNotificationIfEmpty: jest.fn(),
     };
     logger = { error: jest.fn() };
 
@@ -45,7 +50,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when
       await commentListener.handleCommentCreated(
-        new CommentCreatedEvent(10, 2),
+        new CommentCreatedEvent(10, 2, null),
       );
 
       // then
@@ -64,7 +69,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when
       await commentListener.handleCommentCreated(
-        new CommentCreatedEvent(10, 2),
+        new CommentCreatedEvent(10, 2, null),
       );
 
       // then
@@ -83,7 +88,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when
       await commentListener.handleCommentCreated(
-        new CommentCreatedEvent(10, 2),
+        new CommentCreatedEvent(10, 2, null),
       );
 
       // then
@@ -100,7 +105,84 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        commentListener.handleCommentCreated(new CommentCreatedEvent(10, 2)),
+        commentListener.handleCommentCreated(new CommentCreatedEvent(10, 2, null)),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('부모 댓글이 없으면(top-level 댓글) 답글 알림을 생성하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentCreated(
+        new CommentCreatedEvent(10, 2, null),
+      );
+
+      // then
+      expect(
+        notificationService.upsertReplyNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('본인 댓글에 본인이 답글을 달면(self-reply) 답글 알림을 생성하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentCreated(
+        new CommentCreatedEvent(10, 2, 2),
+      );
+
+      // then
+      expect(
+        notificationService.upsertReplyNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('타인이 답글을 달면 원본 댓글 작성자에게 답글 알림을 upsert한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentCreated(
+        new CommentCreatedEvent(10, 2, 5),
+      );
+
+      // then
+      expect(
+        notificationService.upsertReplyNotification,
+      ).toHaveBeenCalledWith(5, 10);
+    });
+
+    it('답글 알림 생성 중 예외가 발생해도 던지지 않고 로깅한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+      notificationService.upsertReplyNotification.mockRejectedValue(
+        new Error('db down'),
+      );
+
+      // when & then
+      await expect(
+        commentListener.handleCommentCreated(
+          new CommentCreatedEvent(10, 2, 5),
+        ),
       ).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
     });
@@ -116,7 +198,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       });
 
       // when
-      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10));
+      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10, null));
 
       // then
       expect(
@@ -133,7 +215,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       });
 
       // when
-      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10));
+      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10, null));
 
       // then
       expect(
@@ -149,7 +231,65 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        commentListener.handleCommentDeleted(new CommentDeletedEvent(10)),
+        commentListener.handleCommentDeleted(new CommentDeletedEvent(10, null)),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('삭제된 댓글이 top-level이면(parentAuthorId 없음) 답글 알림 삭제를 위임하지 않는다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentDeleted(
+        new CommentDeletedEvent(10, null),
+      );
+
+      // then
+      expect(
+        notificationService.removeReplyNotificationIfEmpty,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('삭제된 댓글이 답글이면 원본 댓글 작성자 기준으로 남은 활성 답글 여부를 위임한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+
+      // when
+      await commentListener.handleCommentDeleted(
+        new CommentDeletedEvent(10, 5),
+      );
+
+      // then
+      expect(
+        notificationService.removeReplyNotificationIfEmpty,
+      ).toHaveBeenCalledWith(10, 5);
+    });
+
+    it('답글 알림 삭제 중 예외가 발생해도 던지지 않고 로깅한다.', async () => {
+      // given
+      feedRepository.getBlogMetaByFeedId.mockResolvedValue({
+        id: 1,
+        userName: 'blog',
+        userId: 99,
+      });
+      notificationService.removeReplyNotificationIfEmpty.mockRejectedValue(
+        new Error('db down'),
+      );
+
+      // when & then
+      await expect(
+        commentListener.handleCommentDeleted(
+          new CommentDeletedEvent(10, 5),
+        ),
       ).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
     });

--- a/server/test/notification/unit/notification.service.unit.spec.ts
+++ b/server/test/notification/unit/notification.service.unit.spec.ts
@@ -13,6 +13,9 @@ describe(`${NotificationService.name} Unit Test`, () => {
       | 'upsertComment'
       | 'deleteCommentNotification'
       | 'hasActiveOtherComment'
+      | 'upsertReply'
+      | 'deleteReplyNotification'
+      | 'hasActiveOtherReply'
       | 'upsertSubscribe'
       | 'deleteSubscribeNotification'
       | 'countUnread'
@@ -29,6 +32,9 @@ describe(`${NotificationService.name} Unit Test`, () => {
       upsertComment: jest.fn(),
       deleteCommentNotification: jest.fn(),
       hasActiveOtherComment: jest.fn(),
+      upsertReply: jest.fn(),
+      deleteReplyNotification: jest.fn(),
+      hasActiveOtherReply: jest.fn(),
       upsertSubscribe: jest.fn(),
       deleteSubscribeNotification: jest.fn(),
       countUnread: jest.fn(),
@@ -113,6 +119,48 @@ describe(`${NotificationService.name} Unit Test`, () => {
       expect(
         notificationRepository.deleteCommentNotification,
       ).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('upsertReplyNotification', () => {
+    it('recipientId, feedId로 upsertReply를 호출한다.', async () => {
+      // when
+      await notificationService.upsertReplyNotification(1, 10);
+
+      // then
+      expect(notificationRepository.upsertReply).toHaveBeenCalledWith(1, 10);
+    });
+  });
+
+  describe('removeReplyNotificationIfEmpty', () => {
+    it('본인 댓글에 달린 활성 답글이 남아있으면 알림을 삭제하지 않는다.', async () => {
+      // given
+      notificationRepository.hasActiveOtherReply.mockResolvedValue(true);
+
+      // when
+      await notificationService.removeReplyNotificationIfEmpty(10, 1);
+
+      // then
+      expect(notificationRepository.hasActiveOtherReply).toHaveBeenCalledWith(
+        10,
+        1,
+      );
+      expect(
+        notificationRepository.deleteReplyNotification,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('본인 댓글에 달린 활성 답글이 없으면 해당 게시글·수신자의 답글 알림을 삭제한다.', async () => {
+      // given
+      notificationRepository.hasActiveOtherReply.mockResolvedValue(false);
+
+      // when
+      await notificationService.removeReplyNotificationIfEmpty(10, 1);
+
+      // then
+      expect(
+        notificationRepository.deleteReplyNotification,
+      ).toHaveBeenCalledWith(10, 1);
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #781

### 답글 알림

- 댓글에 답글이 달렸을 때, 원본 댓글 작성자에게만 알림이 가도록 구현
- 답글 대상(parentAuthorId) 기준으로 upsert/삭제(활성 답글 없으면 삭제) 처리
- 기존 "댓글 알림"(게시글 소유자용)과 로직이 겹치면서, 답글 작성 시 게시글 소유자==댓글 작성자인 경우 알림이 2개 중복 발생하는 문제 발견 → top-level 댓글일 때만 게시글 소유자 알림을 생성하도록 수정하여 해결

# 📋 작업 내용

- server: `comment.service`에서 답글 생성/삭제 시 parentAuthorId를 이벤트에 실어 전달, `comment.listener`/`notification.service`/`notification.repository`에 답글 알림 upsert·삭제 로직 추가
- server: 답글 알림 생성 시 게시글 소유자용 댓글 알림이 중복 발생하지 않도록 top-level 댓글에 한해서만 생성하도록 수정
- server: 알림 조회 DTO/엔티티에 답글 알림 타입 반영, 관련 유닛 테스트 작성
- client: 알림 서비스 타입에 답글 추가, `NotificationBell`에 답글 알림 카드 UI 구현 및 스토리북/테스트 추가

# 📷 스크린 샷(선택 사항)

<img width="391" height="227" alt="image" src="https://github.com/user-attachments/assets/b25d76c9-436a-4a2e-a1fc-2fa48dee6623" />