### PR TITLE
🐛 fix: 소프트 삭제된 부모 댓글의 마지막 답글 삭제 시 부모 완전 삭제

### DIFF
--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -195,6 +195,18 @@ export class CommentService {
       feed.commentCount--;
       await manager.save(feed);
       await manager.remove(comment);
+
+      if (comment.parent?.isDeleted) {
+        const remainingReplyCount = await manager.count(Comment, {
+          where: { parentId: comment.parentId },
+        });
+
+        if (remainingReplyCount === 0) {
+          feed.commentCount--;
+          await manager.save(feed);
+          await manager.remove(comment.parent);
+        }
+      }
     });
 
     this.eventEmitter.emit(

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -35,7 +35,7 @@ describe(`${CommentService.name} Unit Test`, () => {
   >;
   let feedService: jest.Mocked<Pick<FeedService, 'getPublicFeed'>>;
   let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
-  let manager: { save: jest.Mock; remove: jest.Mock };
+  let manager: { save: jest.Mock; remove: jest.Mock; count: jest.Mock };
   let dataSource: jest.Mocked<Pick<DataSource, 'transaction'>>;
   let eventEmitter: jest.Mocked<Pick<EventEmitter2, 'emit'>>;
 
@@ -56,7 +56,7 @@ describe(`${CommentService.name} Unit Test`, () => {
     };
     feedService = { getPublicFeed: jest.fn() };
     userService = { getUser: jest.fn() };
-    manager = { save: jest.fn(), remove: jest.fn() };
+    manager = { save: jest.fn(), remove: jest.fn(), count: jest.fn() };
     dataSource = {
       transaction: jest.fn((cb: any) => cb(manager)),
     } as any;
@@ -410,6 +410,59 @@ describe(`${CommentService.name} Unit Test`, () => {
         'comment.deleted',
         new CommentDeletedEvent(10, 42),
       );
+    });
+
+    it('소프트 삭제된 부모 댓글의 마지막 답글을 삭제하면 부모 댓글도 완전히 삭제한다.', async () => {
+      // given
+      const feed = { id: 10, commentCount: 3, blog: { userId: 888 } };
+      const parent = { id: 1, isDeleted: true, user: { id: 42 } };
+      const comment = {
+        id: 5,
+        parentId: 1,
+        user: { id: user.id },
+        parent,
+        feed,
+      } as Comment;
+      commentRepository.findOne.mockResolvedValue(comment);
+      manager.count.mockResolvedValue(0);
+
+      // when
+      await commentService.delete(user, dto);
+
+      // then
+      expect(manager.count).toHaveBeenCalledWith(Comment, {
+        where: { parentId: 1 },
+      });
+      expect(feed.commentCount).toBe(1);
+      expect(manager.remove).toHaveBeenCalledWith(comment);
+      expect(manager.remove).toHaveBeenCalledWith(parent);
+      expect(eventEmitter.emit).toHaveBeenCalledWith(
+        'comment.deleted',
+        new CommentDeletedEvent(10, 42),
+      );
+    });
+
+    it('소프트 삭제된 부모 댓글에 답글이 남아있으면 부모 댓글은 삭제하지 않는다.', async () => {
+      // given
+      const feed = { id: 10, commentCount: 3, blog: { userId: 888 } };
+      const parent = { id: 1, isDeleted: true, user: { id: 42 } };
+      const comment = {
+        id: 5,
+        parentId: 1,
+        user: { id: user.id },
+        parent,
+        feed,
+      } as Comment;
+      commentRepository.findOne.mockResolvedValue(comment);
+      manager.count.mockResolvedValue(1);
+
+      // when
+      await commentService.delete(user, dto);
+
+      // then
+      expect(feed.commentCount).toBe(2);
+      expect(manager.remove).toHaveBeenCalledWith(comment);
+      expect(manager.remove).not.toHaveBeenCalledWith(parent);
     });
 
     it('본인 댓글이 아니어도 RSS 소유자면 댓글 수를 감소시키고 댓글을 제거한다.', async () => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   연관 이슈 없음

### 댓글 소프트 삭제 후 잔여 답글 정리

-   답글이 있는 부모 댓글은 `isDeleted=true`로 soft delete만 되고 `feed.commentCount`는 유지됨
-   이후 답글이 하나씩 삭제되다 마지막 답글까지 지워져도 부모 댓글은 계속 soft delete 상태(`삭제된 댓글입니다` placeholder)로 DB에 남아 완전히 정리되지 않는 문제가 있었음
-   `delete()`에서 답글을 hard delete 한 뒤, `comment.parent.isDeleted`가 true이고 해당 부모의 남은 답글 수가 0이면 부모 댓글도 hard delete하고 `feed.commentCount`를 추가로 1 감소시키도록 수정
-   동시성 관련 고민: 같은 부모의 마지막 답글 두 개를 정확히 동시에 삭제하면 두 트랜잭션이 서로의 미커밋 삭제를 보지 못해 부모가 정리되지 않을 수 있는 엣지 케이스가 있음. 다만 실패 시에도 데이터 유실 없이 orphan row 하나 + commentCount 오차 1 수준이라 우선 락 없이 진행. 필요 시 부모 row에 `SELECT ... FOR UPDATE` 적용 예정

# 📋 작업 내용

-   `server/src/comment/service/comment.service.ts`: `delete()`에 부모 완전 삭제 로직 추가
-   `server/test/comment/unit/comment.service.unit.spec.ts`: 마지막 답글 삭제 시 부모 hard delete / 답글이 남아있으면 부모 유지 케이스 테스트 추가

# 📷 스크린 샷(선택 사항)

-   해당 없음