### PR TITLE
✨ feat: 답글 목록 기본 접힘 및 펼치기/접기 기능 추가

### DIFF
--- a/client/src/__tests__/__mocks__/external/lucide-react.tsx
+++ b/client/src/__tests__/__mocks__/external/lucide-react.tsx
@@ -9,6 +9,8 @@ export const mockLucideIcons = {
   Loader: () => <div data-testid="loader-icon">Mock Loader Icon</div>,
   ChevronLeft: () => <div data-testid="chevron-left-icon">Mock Chevron Left Icon</div>,
   ChevronRight: () => <div data-testid="chevron-right-icon">Mock Chevron Right Icon</div>,
+  ChevronDown: () => <div data-testid="chevron-down-icon">Mock Chevron Down Icon</div>,
+  ChevronUp: () => <div data-testid="chevron-up-icon">Mock Chevron Up Icon</div>,
   MoreHorizontal: () => <div data-testid="more-horizontal-icon">Mock More Horizontal Icon</div>,
   ArrowLeft: () => <div data-testid="arrow-left-icon">Mock Arrow Left Icon</div>,
   Rss: () => <div data-testid="rss-icon">Mock Rss Icon</div>,

--- a/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
@@ -114,9 +114,15 @@ describe("PostComment", () => {
     );
   });
 
-  it("대댓글(parentId)이 있으면 루트 댓글 아래에 함께 렌더링해야 한다", () => {
+  it("대댓글(parentId)이 있으면 기본적으로 숨겨지고 답글 개수가 표시되며, 클릭하면 펼쳐진다", () => {
     comments = [makeComment(1), makeComment(3, { parentId: 1, comment: "대댓글" })];
     render(<PostComment feedId={10} />);
+
+    expect(screen.queryByText("대댓글")).not.toBeInTheDocument();
+    const toggleBtn = screen.getByRole("button", { name: /답글 1개/ });
+    expect(toggleBtn).toBeInTheDocument();
+
+    fireEvent.click(toggleBtn);
 
     expect(screen.getByText("대댓글")).toBeInTheDocument();
   });

--- a/client/src/components/common/Card/detail/PostComment.stories.tsx
+++ b/client/src/components/common/Card/detail/PostComment.stories.tsx
@@ -25,6 +25,33 @@ const mockComments = [
   },
 ];
 
+const mockCommentsWithReplies = [
+  {
+    id: 1,
+    comment: "좋은 글 감사합니다!",
+    date: "2026-06-25T09:00:00.000Z",
+    parentId: null,
+    isDeleted: false,
+    user: { id: 99, userName: "다른유저", profileImage: null },
+  },
+  {
+    id: 2,
+    comment: "저도 동의합니다.",
+    date: "2026-06-25T09:10:00.000Z",
+    parentId: 1,
+    isDeleted: false,
+    user: { id: 98, userName: "또다른유저", profileImage: null },
+  },
+  {
+    id: 3,
+    comment: "@또다른유저 맞아요!",
+    date: "2026-06-25T09:20:00.000Z",
+    parentId: 1,
+    isDeleted: false,
+    user: { id: 97, userName: "세번째유저", profileImage: null },
+  },
+];
+
 const meta = {
   title: "common/Card/detail/PostComment",
   component: PostComment,
@@ -59,6 +86,34 @@ export const WithComments: Story = {
     mockApi.onPost(BLOG.COMMENT.LIST(1)).reply(...ok(null));
     mockApi.onPatch(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
     mockApi.onDelete(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+  },
+};
+
+export const WithReplies: Story = {
+  name: "답글 있음 (기본 접힘 → 펼치기/접기)",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok(mockCommentsWithReplies));
+    mockApi.onPost(BLOG.COMMENT.LIST(1)).reply(...ok(null));
+    mockApi.onPatch(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+    mockApi.onDelete(/\/api\/feeds\/1\/comments\/\d+/).reply(...ok(null));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await canvas.findByText("좋은 글 감사합니다!");
+    const toggleBtn = await canvas.findByRole("button", { name: /답글 2개/ });
+
+    // 기본 상태: 답글은 숨겨져 있어야 한다
+    expect(canvas.queryByText("저도 동의합니다.")).not.toBeInTheDocument();
+
+    // 펼치기
+    await userEvent.click(toggleBtn);
+    await canvas.findByText("저도 동의합니다.");
+    expect(canvas.getByText("@또다른유저 맞아요!")).toBeInTheDocument();
+
+    // 접기
+    await userEvent.click(canvas.getByRole("button", { name: /답글 2개/ }));
+    await waitFor(() => expect(canvas.queryByText("저도 동의합니다.")).not.toBeInTheDocument());
   },
 };
 

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { Flag, MoreVertical } from "lucide-react";
+import { ChevronDown, ChevronUp, Flag, MoreVertical } from "lucide-react";
 
 import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
 import CommentAction from "@/components/common/Card/detail/CommentAction";
@@ -77,8 +77,21 @@ export default function PostComment({
   const [replyTo, setReplyTo] = useState<number | null>(null);
   const [replyContent, setReplyContent] = useState("");
   const [reportCommentId, setReportCommentId] = useState<number | null>(null);
+  const [expandedReplyIds, setExpandedReplyIds] = useState<Set<number>>(new Set());
 
   const handleModify = (id: number | null) => setModifyId(id);
+
+  const toggleReplies = (rootId: number) => {
+    setExpandedReplyIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(rootId)) {
+        next.delete(rootId);
+      } else {
+        next.add(rootId);
+      }
+      return next;
+    });
+  };
 
   const handleSubmit = () => {
     if (!isAuthenticated) {
@@ -97,6 +110,7 @@ export default function PostComment({
     }
     setReplyTo(rootId);
     setReplyContent(mention ? `@${mention} ` : "");
+    setExpandedReplyIds((prev) => new Set(prev).add(rootId));
   };
 
   const handleReplySubmit = (rootId: number) => {
@@ -164,6 +178,9 @@ export default function PostComment({
     const rootId = target.parentId ?? target.id;
     const rootIndex = roots.findIndex((root) => root.id === rootId);
     if (rootIndex >= INITIAL_VISIBLE) setShowAll(true);
+    if (target.parentId !== null) {
+      setExpandedReplyIds((prev) => new Set(prev).add(rootId));
+    }
   }, [highlightCommentId, comments]);
 
   const scrolledToRef = useRef<number | null>(null);
@@ -238,8 +255,23 @@ export default function PostComment({
               onReport={setReportCommentId}
             />
 
-            {/* 답글 목록 */}
+            {/* 답글 펼치기/접기 토글 */}
             {(repliesByParent[root.id] ?? []).length > 0 && (
+              <button
+                onClick={() => toggleReplies(root.id)}
+                className="mt-2 ml-11 flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600"
+              >
+                {expandedReplyIds.has(root.id) ? (
+                  <ChevronUp className="w-3.5 h-3.5" />
+                ) : (
+                  <ChevronDown className="w-3.5 h-3.5" />
+                )}
+                답글 {repliesByParent[root.id].length}개
+              </button>
+            )}
+
+            {/* 답글 목록 */}
+            {expandedReplyIds.has(root.id) && (repliesByParent[root.id] ?? []).length > 0 && (
               <ul className="mt-3 ml-11 space-y-3 border-l-2 border-gray-100 pl-4">
                 {repliesByParent[root.id].map((reply) => (
                   <li


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 관련 이슈 없음 (댓글 UX 개선)

### 답글 목록 기본 접힘 처리

- 댓글에 달린 답글이 많아질수록 스크롤이 길어지고 정작 중요한 루트 댓글을 찾기 어려워지는 문제가 있었음
- 답글은 기본적으로 숨기고, 댓글 아래에 "답글 N개" 형태로 개수만 노출하도록 변경
- 답글 작성 버튼 클릭 시 / 알림을 통해 특정 답글로 딥링크 진입 시에는 자동으로 해당 답글 목록을 펼치도록 처리해 맥락이 끊기지 않게 함

# 📋 작업 내용

- `PostComment.tsx`: 루트 댓글별로 답글 펼침 상태(`expandedReplyIds`)를 관리하고, 답글 개수 + 펼치기/접기 토글 버튼 추가
- `highlightCommentId`가 답글일 경우 해당 부모의 답글 목록을 자동으로 펼치도록 기존 스크롤 로직 보강
- 테스트: 답글 기본 숨김 및 토글 동작 검증하도록 기존 테스트 수정, `lucide-react` 목에 아이콘 추가
- 스토리북: 답글이 있는 상태(펼치기/접기 인터랙션)와 답글 작성 플로우 스토리 추가

# 📷 스크린 샷(선택 사항)
<img width="324" height="215" alt="image" src="https://github.com/user-attachments/assets/b57a18c1-6594-421d-8b5b-89ab15d1a11d" />

<img width="448" height="401" alt="image" src="https://github.com/user-attachments/assets/a706f87c-16b4-4c4f-a628-f9b406cfd7b8" />