### PR TITLE
✨ feat: 댓글 입력란 이모지 피커 추가

### DIFF
--- a/client/src/__tests__/__mocks__/external/lucide-react.tsx
+++ b/client/src/__tests__/__mocks__/external/lucide-react.tsx
@@ -12,4 +12,5 @@ export const mockLucideIcons = {
   MoreHorizontal: () => <div data-testid="more-horizontal-icon">Mock More Horizontal Icon</div>,
   ArrowLeft: () => <div data-testid="arrow-left-icon">Mock Arrow Left Icon</div>,
   Rss: () => <div data-testid="rss-icon">Mock Rss Icon</div>,
+  Smile: () => <div data-testid="smile-icon">Mock Smile Icon</div>,
 };

--- a/client/src/components/chat/layout/ChatFooter.tsx
+++ b/client/src/components/chat/layout/ChatFooter.tsx
@@ -1,24 +1,20 @@
-import { Suspense, lazy, useState } from "react";
+import { useState } from "react";
 
-import type { EmojiClickData, Theme } from "emoji-picker-react";
-import { Send, Smile } from "lucide-react";
+import type { EmojiClickData } from "emoji-picker-react";
+import { Send } from "lucide-react";
 
+import EmojiPickerButton from "@/components/common/EmojiPickerButton";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SheetFooter } from "@/components/ui/sheet";
 
 import { useKeyboardShortcut } from "@/hooks/common/useKeyboardShortcut";
 
 import { useChatStore } from "@/store/useChatStore";
-import { useMediaStore } from "@/store/useMediaStore";
-
-const EmojiPicker = lazy(() => import("emoji-picker-react"));
 
 export default function ChatFooter() {
   const [message, setMessage] = useState<string>("");
   const { sendMessage } = useChatStore();
-  const isMobile = useMediaStore((state) => state.isMobile);
 
   const handleEmojiClick = (emojiData: EmojiClickData) => {
     setMessage((prev) => prev + emojiData.emoji);
@@ -46,30 +42,7 @@ export default function ChatFooter() {
           onChange={(e) => setMessage(e.target.value)}
           className="border-none shadow-none bg-transparent focus-visible:ring-0 focus-visible:ring-offset-0 h-8 px-0 text-sm"
         />
-        {!isMobile && (
-          <Popover>
-            <PopoverTrigger asChild>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="rounded-lg shrink-0 h-8 w-8 text-muted-foreground hover:text-foreground"
-              >
-                <Smile className="!h-6 !w-6" />
-              </Button>
-            </PopoverTrigger>
-            <PopoverContent side="top" align="end" className="w-auto border-none p-0 shadow-none">
-              <Suspense fallback={<div style={{ width: 320, height: 400 }} />}>
-                <EmojiPicker
-                  onEmojiClick={handleEmojiClick}
-                  theme={"auto" as Theme}
-                  lazyLoadEmojis
-                  width={320}
-                  height={400}
-                />
-              </Suspense>
-            </PopoverContent>
-          </Popover>
-        )}
+        <EmojiPickerButton onEmojiClick={handleEmojiClick} />
         <Button
           size="icon"
           className="rounded-lg shrink-0 bg-primary hover:bg-[#2ECC71] text-white h-8 w-8 transition-colors"

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useRef, useState } from "react";
 
+import type { EmojiClickData } from "emoji-picker-react";
 import { Flag, MoreVertical } from "lucide-react";
 
 import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
 import CommentAction from "@/components/common/Card/detail/CommentAction";
+import EmojiPickerButton from "@/components/common/EmojiPickerButton";
 import { ReportDialog } from "@/components/common/ReportDialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -79,6 +81,12 @@ export default function PostComment({
   const [reportCommentId, setReportCommentId] = useState<number | null>(null);
 
   const handleModify = (id: number | null) => setModifyId(id);
+
+  const handleContentEmojiClick = (emojiData: EmojiClickData) =>
+    setContent((prev) => prev + emojiData.emoji);
+
+  const handleReplyEmojiClick = (emojiData: EmojiClickData) =>
+    setReplyContent((prev) => prev + emojiData.emoji);
 
   const handleSubmit = () => {
     if (!isAuthenticated) {
@@ -195,7 +203,8 @@ export default function PostComment({
               ></textarea>
             </div>
           </div>
-          <div className="flex justify-end px-4 pb-4">
+          <div className="flex justify-end items-center gap-2 px-4 pb-4">
+            <EmojiPickerButton onEmojiClick={handleContentEmojiClick} />
             <button
               onClick={handleSubmit}
               disabled={isCreating}
@@ -279,7 +288,8 @@ export default function PostComment({
                   placeholder="답글을 입력하세요..."
                   className="w-full bg-gray-50 p-2 rounded-md h-16 outline-none ring-1 ring-gray-300 resize-none"
                 ></textarea>
-                <div className="flex justify-end gap-2 text-sm mt-1">
+                <div className="flex justify-end items-center gap-2 text-sm mt-1">
+                  <EmojiPickerButton onEmojiClick={handleReplyEmojiClick} />
                   <button
                     onClick={() => {
                       setReplyTo(null);

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
 import type { EmojiClickData } from "emoji-picker-react";
-import { Flag, MoreVertical } from "lucide-react";
 import { ChevronDown, ChevronUp, Flag, MoreVertical } from "lucide-react";
 
 import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
@@ -10,7 +9,12 @@ import EmojiPickerButton from "@/components/common/EmojiPickerButton";
 import { ReportDialog } from "@/components/common/ReportDialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast";
 import { useNavigateToProfile } from "@/hooks/common/useNavigateToProfile";
@@ -84,11 +88,9 @@ export default function PostComment({
 
   const handleModify = (id: number | null) => setModifyId(id);
 
-  const handleContentEmojiClick = (emojiData: EmojiClickData) =>
-    setContent((prev) => prev + emojiData.emoji);
+  const handleContentEmojiClick = (emojiData: EmojiClickData) => setContent((prev) => prev + emojiData.emoji);
 
-  const handleReplyEmojiClick = (emojiData: EmojiClickData) =>
-    setReplyContent((prev) => prev + emojiData.emoji);
+  const handleReplyEmojiClick = (emojiData: EmojiClickData) => setReplyContent((prev) => prev + emojiData.emoji);
 
   const toggleReplies = (rootId: number) => {
     setExpandedReplyIds((prev) => {
@@ -132,7 +134,7 @@ export default function PostComment({
           setReplyTo(null);
           setReplyContent("");
         },
-      },
+      }
     );
   };
 
@@ -158,8 +160,7 @@ export default function PostComment({
     );
   };
 
-  const canEditComment = (comment: FeedCommentType) =>
-    !isAdmin && !comment.isDeleted && comment.user.id === userId;
+  const canEditComment = (comment: FeedCommentType) => !isAdmin && !comment.isDeleted && comment.user.id === userId;
   const canDeleteComment = (comment: FeedCommentType) =>
     !comment.isDeleted && (isAdmin || comment.user.id === userId || isFeedOwner);
   const canReportComment = (comment: FeedCommentType) =>
@@ -172,7 +173,7 @@ export default function PostComment({
     return acc;
   }, {});
   Object.values(repliesByParent).forEach((replies) =>
-    replies.sort((a, b) => Number(new Date(a.date)) - Number(new Date(b.date))),
+    replies.sort((a, b) => Number(new Date(a.date)) - Number(new Date(b.date)))
   );
 
   const roots = comments
@@ -288,9 +289,7 @@ export default function PostComment({
                     key={reply.id}
                     id={`comment-${reply.id}`}
                     className={`transition-colors ${
-                      reply.id === highlightCommentId
-                        ? "-m-2 rounded-md bg-yellow-50 p-2 ring-2 ring-yellow-300"
-                        : ""
+                      reply.id === highlightCommentId ? "-m-2 rounded-md bg-yellow-50 p-2 ring-2 ring-yellow-300" : ""
                     }`}
                   >
                     <CommentItem
@@ -406,9 +405,7 @@ const CommentItem = ({
   return (
     <div className="flex items-start gap-3">
       <Avatar className={`w-8 h-8 ${avatarCursor}`} onClick={goToProfile}>
-        {!comment.isDeleted && (
-          <AvatarImage src={comment.user.profileImage ?? undefined} alt={comment.user.userName} />
-        )}
+        {!comment.isDeleted && <AvatarImage src={comment.user.profileImage ?? undefined} alt={comment.user.userName} />}
         <AvatarFallback>{comment.isDeleted ? "?" : comment.user.userName.substring(0, 2)}</AvatarFallback>
       </Avatar>
       <div className="flex-1">

--- a/client/src/components/common/EmojiPickerButton.tsx
+++ b/client/src/components/common/EmojiPickerButton.tsx
@@ -1,0 +1,42 @@
+import { Suspense, lazy } from "react";
+
+import type { EmojiClickData, Theme } from "emoji-picker-react";
+import { Smile } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+
+import { useMediaStore } from "@/store/useMediaStore";
+
+const EmojiPicker = lazy(() => import("emoji-picker-react"));
+
+interface EmojiPickerButtonProps {
+  onEmojiClick: (emojiData: EmojiClickData) => void;
+  className?: string;
+}
+
+export default function EmojiPickerButton({ onEmojiClick, className }: EmojiPickerButtonProps) {
+  const isMobile = useMediaStore((state) => state.isMobile);
+
+  if (isMobile) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className={className ?? "rounded-lg shrink-0 h-8 w-8 text-muted-foreground hover:text-foreground"}
+        >
+          <Smile className="!h-6 !w-6" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent side="top" align="end" className="z-[1000] w-auto border-none p-0 shadow-none">
+        <Suspense fallback={<div style={{ width: 320, height: 400 }} />}>
+          <EmojiPicker onEmojiClick={onEmojiClick} theme={"auto" as Theme} lazyLoadEmojis width={320} height={400} />
+        </Suspense>
+      </PopoverContent>
+    </Popover>
+  );
+}


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   관련 이슈 없음

### 이모지 피커 재사용

-   채팅(ChatFooter)에서만 쓰이던 이모지 피커(Smile 버튼 + Popover + emoji-picker-react)를 `EmojiPickerButton` 공용 컴포넌트로 분리
-   `isMobile` 체크를 컴포넌트 내부로 옮겨 모바일에서는 자동으로 숨김 처리

### 댓글 입력란 적용

-   댓글 작성란, 답글 작성란에 이모지 버튼 추가
-   PostComment는 PostDetail 모달(z-[999])과 로그인 Dialog(z-[1000]) 위에서 렌더되는데, Popover 기본 z-50이 이보다 낮아 피커가 열려도 뒤에 가려 보이지 않는 문제가 있어 해당 인스턴스에 `z-[1000]` 지정

# 📋 작업 내용

-   `client/src/components/common/EmojiPickerButton.tsx` 신규 (공용 컴포넌트)
-   `client/src/components/chat/layout/ChatFooter.tsx` 인라인 피커 로직 제거 후 공용 컴포넌트 사용
-   `client/src/components/common/Card/detail/PostComment.tsx` 댓글/답글 입력란에 이모지 버튼 추가
-   `client/src/__tests__/__mocks__/external/lucide-react.tsx` 전역 lucide 목에 `Smile` 아이콘 추가 (기존 PostComment 테스트가 이 목을 사용해 누락 시 실패)

# 📷 스크린 샷(선택 사항)
<img width="844" height="406" alt="image" src="https://github.com/user-attachments/assets/336dfb61-9084-473a-878d-77dadc9549fe" />