### PR TITLE
♻️ refactor: 댓글 삭제 저장 로직

### DIFF
--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -192,9 +192,8 @@ export class CommentService {
       }
 
       const feed = comment.feed;
-      feed.commentCount--;
-      await manager.save(feed);
       await manager.remove(comment);
+      feed.commentCount--;
 
       if (comment.parent?.isDeleted) {
         const remainingReplyCount = await manager.count(Comment, {
@@ -202,11 +201,12 @@ export class CommentService {
         });
 
         if (remainingReplyCount === 0) {
-          feed.commentCount--;
-          await manager.save(feed);
           await manager.remove(comment.parent);
+          feed.commentCount--;
         }
       }
+
+      await manager.save(feed);
     });
 
     this.eventEmitter.emit(


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #121 

### 댓글 삭제 시 save 중복 호출 정리

- `feed.commentCount--` 후 즉시 `manager.save(feed)`를 호출하던 로직이 답글까지 삭제되는 경우 두 번 실행되고 있었음
- `commentCount` 감소는 트랜잭션 끝에서 한 번만 `save`하도록 정리

# 📋 작업 내용

- `comment.service.ts`: 댓글/답글 삭제 시 `feed.commentCount` save를 트랜잭션 종료 시점에 1회로 통합

# 📷 스크린 샷(선택 사항)

- 해당 없음