### PR TITLE
♻️ refactor: DB 키 이름 의미 기반 네이밍으로 변경

### DIFF
--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -8,9 +8,9 @@ CREATE TABLE `admin` (
   `email_notification` tinyint NOT NULL DEFAULT 1,
   `parent_admin_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_a026be7ca12f8999cbdf96dec2` (`name`),
-  UNIQUE KEY `IDX_de87485f6489f5d0995f584195` (`email`),
-    CONSTRAINT `FK_78ba73b3dd2c586476eccd1867f`
+  UNIQUE KEY `UQ_admin_name` (`name`),
+  UNIQUE KEY `UQ_admin_email` (`email`),
+    CONSTRAINT `FK_admin_parent_admin_id`
     FOREIGN KEY (`parent_admin_id`)
     REFERENCES `admin` (`id`)
     ON DELETE CASCADE
@@ -28,8 +28,8 @@ CREATE TABLE `rss` (
   `platform` varchar(255) NOT NULL DEFAULT 'etc',
   `image` text,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_21beac47feacb87e57c59d6958` (`name`),
-  UNIQUE KEY `IDX_af1d102908727aa95ef09e1606` (`rss_url`)
+  UNIQUE KEY `UQ_rss_name` (`name`),
+  UNIQUE KEY `UQ_rss_rss_url` (`rss_url`)
 );
 
 -- denamu.`user` definition
@@ -54,8 +54,8 @@ CREATE TABLE `user` (
   `notice_email_agreed` tinyint NOT NULL DEFAULT 0,
   `notice_email_agreed_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_d34106f8ec1ebaf66f4f8609dd` (`user_name`),
-  UNIQUE KEY `IDX_e12875dfb3b1d92d7d7c5377e2` (`email`)
+  UNIQUE KEY `UQ_user_user_name` (`user_name`),
+  UNIQUE KEY `UQ_user_email` (`email`)
 );
 
 -- denamu.rss_accept definition
@@ -71,11 +71,11 @@ CREATE TABLE `rss_accept` (
   `user_id` int DEFAULT NULL,
   `image` text,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_59f4be4de3817b3f975acff076` (`name`),
-  UNIQUE KEY `IDX_b3a5d4196368864d938dae4e9f` (`rss_url`),
-  KEY `FK_c6af67149ff8aa87d001091acbe` (`user_id`),
+  UNIQUE KEY `UQ_rss_accept_name` (`name`),
+  UNIQUE KEY `UQ_rss_accept_rss_url` (`rss_url`),
+  KEY `FK_rss_accept_user_id` (`user_id`),
   FULLTEXT KEY `FT_rss_accept_name` (`name`),
-  CONSTRAINT `FK_c6af67149ff8aa87d001091acbe` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+  CONSTRAINT `FK_rss_accept_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 -- denamu.rss_reject definition
@@ -107,11 +107,11 @@ CREATE TABLE `feed` (
   `like_count` int NOT NULL DEFAULT '0',
   `is_public` tinyint NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_cbdceca2d71f784a8bb160268e` (`path`),
-  KEY `IDX_fda780ffdcc013b739cdc6f31d` (`created_at`),
-  KEY `FK_7474d489d05b8051874b227f868` (`blog_id`),
-  FULLTEXT KEY `IDX_7d93e66e624232af470d2f7bb3` (`title`),
-  CONSTRAINT `FK_7474d489d05b8051874b227f868` FOREIGN KEY (`blog_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `UQ_feed_path` (`path`),
+  KEY `IDX_feed_created_at` (`created_at`),
+  KEY `FK_feed_blog_id` (`blog_id`),
+  FULLTEXT KEY `FT_feed_title` (`title`),
+  CONSTRAINT `FK_feed_blog_id` FOREIGN KEY (`blog_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.activity definition
@@ -122,9 +122,9 @@ CREATE TABLE `activity` (
   `view_count` int NOT NULL,
   `user_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_78f3786d644ca9747fc82db9fb` (`user_id`,`activity_date`),
-  KEY `FK_10bf0c2dd4736190070e8475119` (`user_id`),
-  CONSTRAINT `FK_10bf0c2dd4736190070e8475119` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+  UNIQUE KEY `UQ_activity_user_id_activity_date` (`user_id`,`activity_date`),
+  KEY `FK_activity_user_id` (`user_id`),
+  CONSTRAINT `FK_activity_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 );
 
 -- denamu.category definition
@@ -134,7 +134,7 @@ CREATE TABLE `category` (
   `name` varchar(30) NOT NULL,
   `display_order` int NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_23c05c292c439d77b0de816b50` (`name`)
+  UNIQUE KEY `UQ_category_name` (`name`)
 );
 
 -- denamu.tag definition
@@ -144,8 +144,8 @@ CREATE TABLE `tag` (
   `name` varchar(50) NOT NULL,
   `category_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_6a9775008add570dc3e5a0bab7` (`name`),
-  CONSTRAINT `FK_3249fd70734f41f513a1d5d3ef7` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`) ON DELETE SET NULL
+  UNIQUE KEY `UQ_tag_name` (`name`),
+  CONSTRAINT `FK_tag_category` FOREIGN KEY (`category_id`) REFERENCES `category` (`id`) ON DELETE SET NULL
 );
 
 -- denamu.tag_map definition
@@ -154,10 +154,10 @@ CREATE TABLE `tag_map` (
   `tag_id` int NOT NULL,
   `feed_id` int NOT NULL,
   PRIMARY KEY (`feed_id`,`tag_id`),
-  KEY `IDX_170d19639c49b5735ae8261ff0` (`feed_id`),
-  KEY `IDX_9a3ed1e034e7f378f89f590294` (`tag_id`),
-  CONSTRAINT `FK_170d19639c49b5735ae8261ff0b` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_9a3ed1e034e7f378f89f5902941` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`)
+  KEY `FK_tag_map_feed_id` (`feed_id`),
+  KEY `FK_tag_map_tag_id` (`tag_id`),
+  CONSTRAINT `FK_tag_map_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_tag_map_tag_id` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`)
 );
 
 -- denamu.comment definition
@@ -172,12 +172,12 @@ CREATE TABLE `comment` (
   `user_id` int NOT NULL,
   `parent_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `FK_df1fd1eaf7cc0224ab5e829bf64` (`feed_id`),
-  KEY `FK_bbfe153fa60aa06483ed35ff4a7` (`user_id`),
-  KEY `FK_8bd8d0985c0d077c8129fb4a209` (`parent_id`),
-  CONSTRAINT `FK_bbfe153fa60aa06483ed35ff4a7` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_df1fd1eaf7cc0224ab5e829bf64` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_8bd8d0985c0d077c8129fb4a209` FOREIGN KEY (`parent_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  KEY `FK_comment_feed_id` (`feed_id`),
+  KEY `FK_comment_user_id` (`user_id`),
+  KEY `FK_comment_parent_id` (`parent_id`),
+  CONSTRAINT `FK_comment_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_comment_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_comment_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.likes definition
@@ -188,10 +188,10 @@ CREATE TABLE `likes` (
   `feed_id` int NOT NULL,
   `user_id` int NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_0be1d6ca115f56ed76c65e6bda` (`user_id`,`feed_id`),
-  KEY `FK_85b0dbd1e7836d0f8cdc38fe830` (`feed_id`),
-  CONSTRAINT `FK_3f519ed95f775c781a254089171` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_85b0dbd1e7836d0f8cdc38fe830` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `UQ_likes_user_id_feed_id` (`user_id`,`feed_id`),
+  KEY `FK_likes_feed_id` (`feed_id`),
+  CONSTRAINT `FK_likes_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_likes_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.notification definition
@@ -206,14 +206,14 @@ CREATE TABLE `notification` (
   `feed_id` int NULL,
   `rss_accept_id` int NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_632ea8b2f172248eccfb067bfc` (`recipient_user_id`,`type`,`feed_id`),
-  UNIQUE KEY `IDX_f87770358a4e011a7ab7f560f9` (`recipient_user_id`,`type`,`rss_accept_id`),
-  KEY `IDX_e13cf12d6a05407dbac647761c` (`updated_at`),
-  KEY `FK_916163bd318675ea0c33d517f82` (`feed_id`),
-  KEY `FK_70ba9f1bd291e6ad2a9e5c166a3` (`rss_accept_id`),
-  CONSTRAINT `FK_7d7f411e854516f615ba846c6a4` FOREIGN KEY (`recipient_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_70ba9f1bd291e6ad2a9e5c166a3` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `UQ_notification_recipient_user_id_type_feed_id` (`recipient_user_id`,`type`,`feed_id`),
+  UNIQUE KEY `IDX_notification_recipient_type_rss_accept` (`recipient_user_id`,`type`,`rss_accept_id`),
+  KEY `IDX_notification_updated_at` (`updated_at`),
+  KEY `FK_notification_feed_id` (`feed_id`),
+  KEY `FK_notification_rss_accept_id` (`rss_accept_id`),
+  CONSTRAINT `FK_notification_recipient_user_id` FOREIGN KEY (`recipient_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_notification_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_notification_rss_accept_id` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.blocks definition
@@ -224,10 +224,10 @@ CREATE TABLE `blocks` (
   `blocker_id` int NOT NULL,
   `blocked_id` int NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_806f6a5d38d031cdd868fd5e37` (`blocker_id`,`blocked_id`),
-  KEY `FK_8aa6c887bed61ad10829450f2f0` (`blocked_id`),
-  CONSTRAINT `FK_74f530c6fbffc357047b263818d` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_8aa6c887bed61ad10829450f2f0` FOREIGN KEY (`blocked_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `UQ_blocks_blocker_id_blocked_id` (`blocker_id`,`blocked_id`),
+  KEY `FK_blocks_blocked_id` (`blocked_id`),
+  CONSTRAINT `FK_blocks_blocker_id` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_blocks_blocked_id` FOREIGN KEY (`blocked_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.rss_blocks definition
@@ -238,10 +238,10 @@ CREATE TABLE `rss_blocks` (
   `blocker_id` int NOT NULL,
   `blocked_rss_id` int NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_db6b27acdc83264d33a75a0a47` (`blocker_id`,`blocked_rss_id`),
-  KEY `FK_e73dfdcbc10b6c48b749886d9b5` (`blocked_rss_id`),
-  CONSTRAINT `FK_d7a0693b47b13a59bd72133c5ba` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_e73dfdcbc10b6c48b749886d9b5` FOREIGN KEY (`blocked_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `UQ_rss_blocks_blocker_id_blocked_rss_id` (`blocker_id`,`blocked_rss_id`),
+  KEY `FK_rss_blocks_blocked_rss_id` (`blocked_rss_id`),
+  CONSTRAINT `FK_rss_blocks_blocker_id` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_rss_blocks_blocked_rss_id` FOREIGN KEY (`blocked_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.subscription definition
@@ -252,10 +252,10 @@ CREATE TABLE `subscription` (
   `rss_accept_id` int NOT NULL,
   `user_id` int NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_be6abee15b8a92cc7fe2a25975` (`user_id`,`rss_accept_id`),
-  KEY `FK_f196cabdcb20cfbcf552ae61321` (`rss_accept_id`),
-  CONSTRAINT `FK_940d49a105d50bbd616be540013` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_f196cabdcb20cfbcf552ae61321` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `UQ_subscription_user_rss` (`user_id`,`rss_accept_id`),
+  KEY `FK_subscription_rss` (`rss_accept_id`),
+  CONSTRAINT `FK_subscription_user` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_subscription_rss` FOREIGN KEY (`rss_accept_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.file definition
@@ -269,8 +269,8 @@ CREATE TABLE `file` (
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `user_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `FK_516f1cf15166fd07b732b4b6ab0` (`user_id`),
-  CONSTRAINT `FK_516f1cf15166fd07b732b4b6ab0` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
+  KEY `FK_file_user_id` (`user_id`),
+  CONSTRAINT `FK_file_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`)
 );
 
 -- denamu.provider definition
@@ -287,8 +287,8 @@ CREATE TABLE `provider` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `UQ_provider_type_user_id` (`provider_type`,`provider_user_id`),
   UNIQUE KEY `UQ_user_provider_type` (`user_id`,`provider_type`),
-  KEY `FK_d3d18186b602240b93c9f1621ea` (`user_id`),
-  CONSTRAINT `FK_d3d18186b602240b93c9f1621ea` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  KEY `FK_provider_user_id` (`user_id`),
+  CONSTRAINT `FK_provider_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.report definition
@@ -308,16 +308,16 @@ CREATE TABLE `report` (
   `reported_comment_id` int DEFAULT NULL,
   `reported_feed_id` int DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `IDX_610f01b4829736eaac7acb4efb` (`reporter_id`,`target_type`,`target_id`),
-  KEY `FK_798954c041abe4b92a8f47d6638` (`reported_user_id`),
-  KEY `FK_a3396a7c98378e18ae4cb18b3a3` (`reported_rss_id`),
-  KEY `FK_12f75e00919ec73fa05c3986773` (`reported_comment_id`),
-  KEY `FK_1466885a174468bc1a94203b785` (`reported_feed_id`),
-  CONSTRAINT `FK_d41df66b60944992386ed47cf2e` FOREIGN KEY (`reporter_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_798954c041abe4b92a8f47d6638` FOREIGN KEY (`reported_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_a3396a7c98378e18ae4cb18b3a3` FOREIGN KEY (`reported_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_12f75e00919ec73fa05c3986773` FOREIGN KEY (`reported_comment_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
-  CONSTRAINT `FK_1466885a174468bc1a94203b785` FOREIGN KEY (`reported_feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+  UNIQUE KEY `UQ_report_reporter_id_target_type_target_id` (`reporter_id`,`target_type`,`target_id`),
+  KEY `FK_report_reported_user_id` (`reported_user_id`),
+  KEY `FK_report_reported_rss_id` (`reported_rss_id`),
+  KEY `FK_report_reported_comment_id` (`reported_comment_id`),
+  KEY `FK_report_reported_feed_id` (`reported_feed_id`),
+  CONSTRAINT `FK_report_reporter_id` FOREIGN KEY (`reporter_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_report_reported_user_id` FOREIGN KEY (`reported_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_report_reported_rss_id` FOREIGN KEY (`reported_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_report_reported_comment_id` FOREIGN KEY (`reported_comment_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `FK_report_reported_feed_id` FOREIGN KEY (`reported_feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 );
 
 -- denamu.notice definition

--- a/server/src/activity/entity/activity.entity.ts
+++ b/server/src/activity/entity/activity.entity.ts
@@ -13,7 +13,7 @@ import { User } from '@user/entity/user.entity';
 @Entity({
   name: 'activity',
 })
-@Unique(['user', 'activityDate'])
+@Unique('UQ_activity_user_id_activity_date', ['user', 'activityDate'])
 export class Activity extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -42,6 +42,6 @@ export class Activity extends BaseEntity {
   viewCount: number;
 
   @ManyToOne(() => User, (user) => user.activities)
-  @JoinColumn({ name: 'user_id' })
+  @JoinColumn({ name: 'user_id', foreignKeyConstraintName: 'FK_activity_user_id' })
   user: User;
 }

--- a/server/src/admin/entity/admin.entity.ts
+++ b/server/src/admin/entity/admin.entity.ts
@@ -5,11 +5,14 @@ import {
   JoinColumn,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
 } from 'typeorm';
 
 @Entity({
   name: 'admin',
 })
+@Unique('UQ_admin_name', ['name'])
+@Unique('UQ_admin_email', ['email'])
 export class Admin extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -23,14 +26,12 @@ export class Admin extends BaseEntity {
   @Column({
     length: 255,
     nullable: false,
-    unique: true,
   })
   name: string;
 
   @Column({
     length: 255,
     nullable: false,
-    unique: true,
   })
   email: string;
 
@@ -53,6 +54,9 @@ export class Admin extends BaseEntity {
     onDelete: 'CASCADE',
     nullable: true,
   })
-  @JoinColumn({ name: 'parent_admin_id' })
+  @JoinColumn({
+    name: 'parent_admin_id',
+    foreignKeyConstraintName: 'FK_admin_parent_admin_id',
+  })
   parent: Admin | null;
 }

--- a/server/src/block/entity/rssBlock.entity.ts
+++ b/server/src/block/entity/rssBlock.entity.ts
@@ -13,7 +13,7 @@ import { RssAccept } from '@rss/entity/rss.entity';
 import { User } from '@user/entity/user.entity';
 
 @Entity({ name: 'rss_blocks' })
-@Unique(['blocker', 'blockedRss'])
+@Unique('UQ_rss_blocks_blocker_id_blocked_rss_id', ['blocker', 'blockedRss'])
 export class RssBlock extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -25,6 +25,7 @@ export class RssBlock extends BaseEntity {
   })
   @JoinColumn({
     name: 'blocker_id',
+    foreignKeyConstraintName: 'FK_rss_blocks_blocker_id',
   })
   blocker: User;
 
@@ -35,6 +36,7 @@ export class RssBlock extends BaseEntity {
   })
   @JoinColumn({
     name: 'blocked_rss_id',
+    foreignKeyConstraintName: 'FK_rss_blocks_blocked_rss_id',
   })
   blockedRss: RssAccept;
 

--- a/server/src/block/entity/userBlock.entity.ts
+++ b/server/src/block/entity/userBlock.entity.ts
@@ -11,7 +11,7 @@ import {
 import { User } from '@user/entity/user.entity';
 
 @Entity({ name: 'blocks' })
-@Unique(['blocker', 'blocked'])
+@Unique('UQ_blocks_blocker_id_blocked_id', ['blocker', 'blocked'])
 export class UserBlock extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -23,6 +23,7 @@ export class UserBlock extends BaseEntity {
   })
   @JoinColumn({
     name: 'blocker_id',
+    foreignKeyConstraintName: 'FK_blocks_blocker_id',
   })
   blocker: User;
 
@@ -33,6 +34,7 @@ export class UserBlock extends BaseEntity {
   })
   @JoinColumn({
     name: 'blocked_id',
+    foreignKeyConstraintName: 'FK_blocks_blocked_id',
   })
   blocked: User;
 

--- a/server/src/comment/entity/comment.entity.ts
+++ b/server/src/comment/entity/comment.entity.ts
@@ -56,6 +56,7 @@ export class Comment extends BaseEntity {
   })
   @JoinColumn({
     name: 'parent_id',
+    foreignKeyConstraintName: 'FK_comment_parent_id',
   })
   parent: Comment | null;
 
@@ -66,6 +67,7 @@ export class Comment extends BaseEntity {
   })
   @JoinColumn({
     name: 'feed_id',
+    foreignKeyConstraintName: 'FK_comment_feed_id',
   })
   feed: Feed;
 
@@ -76,6 +78,7 @@ export class Comment extends BaseEntity {
   })
   @JoinColumn({
     name: 'user_id',
+    foreignKeyConstraintName: 'FK_comment_user_id',
   })
   user: User;
 }

--- a/server/src/common/database/migration/1785300000000-RenameHashKeysToSemanticNames.ts
+++ b/server/src/common/database/migration/1785300000000-RenameHashKeysToSemanticNames.ts
@@ -1,0 +1,573 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * MySQL은 FOREIGN KEY 제약을 RENAME 할 수 없으므로 DROP 후 동일 정의로 재생성한다.
+ * RENAME INDEX는 UNIQUE/INDEX/FULLTEXT에 한해 메타데이터 수준으로 처리된다.
+ */
+export class RenameHashKeysToSemanticNames1785300000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // rss
+    await queryRunner.query(
+      'ALTER TABLE `rss` RENAME INDEX `UQ_21beac47feacb87e57c59d6958f` TO `UQ_rss_name`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss` RENAME INDEX `UQ_af1d102908727aa95ef09e16065` TO `UQ_rss_rss_url`;',
+    );
+
+    // rss_accept
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` RENAME INDEX `UQ_59f4be4de3817b3f975acff0766` TO `UQ_rss_accept_name`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` RENAME INDEX `UQ_b3a5d4196368864d938dae4e9ff` TO `UQ_rss_accept_rss_url`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP FOREIGN KEY `FK_c6af67149ff8aa87d001091acbe`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP INDEX `FK_c6af67149ff8aa87d001091acbe`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` ADD CONSTRAINT `FK_rss_accept_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;',
+    );
+
+    // user
+    await queryRunner.query(
+      'ALTER TABLE `user` RENAME INDEX `IDX_e12875dfb3b1d92d7d7c5377e2` TO `UQ_user_email`;',
+    );
+
+    // feed
+    await queryRunner.query(
+      'ALTER TABLE `feed` RENAME INDEX `IDX_cbdceca2d71f784a8bb160268e` TO `UQ_feed_path`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` RENAME INDEX `IDX_fda780ffdcc013b739cdc6f31d` TO `IDX_feed_created_at`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` RENAME INDEX `IDX_7d93e66e624232af470d2f7bb3` TO `FT_feed_title`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` DROP FOREIGN KEY `FK_7474d489d05b8051874b227f868`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` DROP INDEX `FK_7474d489d05b8051874b227f868`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` ADD CONSTRAINT `FK_feed_blog_id` FOREIGN KEY (`blog_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // activity
+    await queryRunner.query(
+      'ALTER TABLE `activity` RENAME INDEX `IDX_78f3786d644ca9747fc82db9fb` TO `UQ_activity_user_id_activity_date`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `activity` DROP FOREIGN KEY `FK_10bf0c2dd4736190070e8475119`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `activity` DROP INDEX `FK_10bf0c2dd4736190070e8475119`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `activity` ADD CONSTRAINT `FK_activity_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`);',
+    );
+
+    // category / tag (컬럼명 그대로 자동 생성된 무명 UNIQUE 인덱스)
+    await queryRunner.query(
+      'ALTER TABLE `category` RENAME INDEX `name` TO `UQ_category_name`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag` RENAME INDEX `name` TO `UQ_tag_name`;',
+    );
+
+    // comment
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP FOREIGN KEY `FK_bbfe153fa60aa06483ed35ff4a7`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP INDEX `FK_bbfe153fa60aa06483ed35ff4a7`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` ADD CONSTRAINT `FK_comment_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP FOREIGN KEY `FK_df1fd1eaf7cc0224ab5e829bf64`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP INDEX `FK_df1fd1eaf7cc0224ab5e829bf64`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` ADD CONSTRAINT `FK_comment_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP FOREIGN KEY `FK_8bd8d0985c0d077c8129fb4a209`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP INDEX `FK_8bd8d0985c0d077c8129fb4a209`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` ADD CONSTRAINT `FK_comment_parent_id` FOREIGN KEY (`parent_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // likes
+    await queryRunner.query(
+      'ALTER TABLE `likes` RENAME INDEX `IDX_0be1d6ca115f56ed76c65e6bda` TO `UQ_likes_user_id_feed_id`;',
+    );
+    // 2025-07-16 RenameLikeForeignKey 마이그레이션이 FK만 새 이름으로 바꾸고 백킹 인덱스는
+    // 정리하지 않아, 실제 인덱스명이 FK_like_feed로 남아있음(직접 검증으로 확인).
+    await queryRunner.query(
+      'ALTER TABLE `likes` DROP FOREIGN KEY `FK_85b0dbd1e7836d0f8cdc38fe830`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` DROP INDEX `FK_like_feed`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` ADD CONSTRAINT `FK_likes_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` DROP FOREIGN KEY `FK_3f519ed95f775c781a254089171`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` ADD CONSTRAINT `FK_likes_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // notification
+    await queryRunner.query(
+      'ALTER TABLE `notification` RENAME INDEX `IDX_632ea8b2f172248eccfb067bfc` TO `UQ_notification_recipient_user_id_type_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` RENAME INDEX `IDX_e13cf12d6a05407dbac647761c` TO `IDX_notification_updated_at`;',
+    );
+    // recipient_user_id는 별도 인덱스가 없고 위에서 이름을 바꾼 복합 UNIQUE
+    // (UQ_notification_recipient_user_id_type_feed_id)를 leftmost-prefix로 재사용하므로
+    // DROP INDEX 불필요 (직접 검증: information_schema.STATISTICS에 단일 컬럼 인덱스 없음)
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP FOREIGN KEY `FK_7d7f411e854516f615ba846c6a4`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD CONSTRAINT `FK_notification_recipient_user_id` FOREIGN KEY (`recipient_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP FOREIGN KEY `FK_916163bd318675ea0c33d517f82`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP INDEX `FK_916163bd318675ea0c33d517f82`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD CONSTRAINT `FK_notification_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // blocks
+    await queryRunner.query(
+      'ALTER TABLE `blocks` RENAME INDEX `IDX_806f6a5d38d031cdd868fd5e37` TO `UQ_blocks_blocker_id_blocked_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` DROP FOREIGN KEY `FK_74f530c6fbffc357047b263818d`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` ADD CONSTRAINT `FK_blocks_blocker_id` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` DROP FOREIGN KEY `FK_8aa6c887bed61ad10829450f2f0`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` DROP INDEX `FK_8aa6c887bed61ad10829450f2f0`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` ADD CONSTRAINT `FK_blocks_blocked_id` FOREIGN KEY (`blocked_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // rss_blocks
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` RENAME INDEX `IDX_db6b27acdc83264d33a75a0a47` TO `UQ_rss_blocks_blocker_id_blocked_rss_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` DROP FOREIGN KEY `FK_d7a0693b47b13a59bd72133c5ba`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` ADD CONSTRAINT `FK_rss_blocks_blocker_id` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` DROP FOREIGN KEY `FK_e73dfdcbc10b6c48b749886d9b5`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` DROP INDEX `FK_e73dfdcbc10b6c48b749886d9b5`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` ADD CONSTRAINT `FK_rss_blocks_blocked_rss_id` FOREIGN KEY (`blocked_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // file
+    await queryRunner.query(
+      'ALTER TABLE `file` DROP FOREIGN KEY `FK_516f1cf15166fd07b732b4b6ab0`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `file` DROP INDEX `FK_516f1cf15166fd07b732b4b6ab0`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `file` ADD CONSTRAINT `FK_file_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION;',
+    );
+
+    // provider
+    await queryRunner.query(
+      'ALTER TABLE `provider` DROP FOREIGN KEY `FK_d3d18186b602240b93c9f1621ea`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `provider` DROP INDEX `FK_d3d18186b602240b93c9f1621ea`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `provider` ADD CONSTRAINT `FK_provider_user_id` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // report
+    await queryRunner.query(
+      'ALTER TABLE `report` RENAME INDEX `IDX_610f01b4829736eaac7acb4efb` TO `UQ_report_reporter_id_target_type_target_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_d41df66b60944992386ed47cf2e`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_report_reporter_id` FOREIGN KEY (`reporter_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_798954c041abe4b92a8f47d6638`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_798954c041abe4b92a8f47d6638`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_report_reported_user_id` FOREIGN KEY (`reported_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_a3396a7c98378e18ae4cb18b3a3`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_a3396a7c98378e18ae4cb18b3a3`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_report_reported_rss_id` FOREIGN KEY (`reported_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_12f75e00919ec73fa05c3986773`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_12f75e00919ec73fa05c3986773`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_report_reported_comment_id` FOREIGN KEY (`reported_comment_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_1466885a174468bc1a94203b785`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_1466885a174468bc1a94203b785`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_report_reported_feed_id` FOREIGN KEY (`reported_feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // tag_map
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP FOREIGN KEY `FK_170d19639c49b5735ae8261ff0b`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP INDEX `IDX_170d19639c49b5735ae8261ff0`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` ADD CONSTRAINT `FK_tag_map_feed_id` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP FOREIGN KEY `FK_9a3ed1e034e7f378f89f5902941`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP INDEX `IDX_9a3ed1e034e7f378f89f590294`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` ADD CONSTRAINT `FK_tag_map_tag_id` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`);',
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // tag_map
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP FOREIGN KEY `FK_tag_map_tag_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP INDEX `FK_tag_map_tag_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` ADD INDEX `IDX_9a3ed1e034e7f378f89f590294` (`tag_id`);',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` ADD CONSTRAINT `FK_9a3ed1e034e7f378f89f5902941` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`);',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP FOREIGN KEY `FK_tag_map_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` DROP INDEX `FK_tag_map_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` ADD INDEX `IDX_170d19639c49b5735ae8261ff0` (`feed_id`);',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` ADD CONSTRAINT `FK_170d19639c49b5735ae8261ff0b` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `tag_map` ADD INDEX `IDX_170d19639c49b5735ae8261ff0` (`feed_id`);',
+    );
+
+    // report
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_report_reported_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_report_reported_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_1466885a174468bc1a94203b785` FOREIGN KEY (`reported_feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_report_reported_comment_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_report_reported_comment_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_12f75e00919ec73fa05c3986773` FOREIGN KEY (`reported_comment_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_report_reported_rss_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_report_reported_rss_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_a3396a7c98378e18ae4cb18b3a3` FOREIGN KEY (`reported_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_report_reported_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP INDEX `FK_report_reported_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_798954c041abe4b92a8f47d6638` FOREIGN KEY (`reported_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` DROP FOREIGN KEY `FK_report_reporter_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` ADD CONSTRAINT `FK_d41df66b60944992386ed47cf2e` FOREIGN KEY (`reporter_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `report` RENAME INDEX `UQ_report_reporter_id_target_type_target_id` TO `IDX_610f01b4829736eaac7acb4efb`;',
+    );
+
+    // provider
+    await queryRunner.query(
+      'ALTER TABLE `provider` DROP FOREIGN KEY `FK_provider_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `provider` DROP INDEX `FK_provider_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `provider` ADD CONSTRAINT `FK_d3d18186b602240b93c9f1621ea` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // file
+    await queryRunner.query(
+      'ALTER TABLE `file` DROP FOREIGN KEY `FK_file_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `file` DROP INDEX `FK_file_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `file` ADD CONSTRAINT `FK_516f1cf15166fd07b732b4b6ab0` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION;',
+    );
+
+    // rss_blocks
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` DROP FOREIGN KEY `FK_rss_blocks_blocked_rss_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` DROP INDEX `FK_rss_blocks_blocked_rss_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` ADD CONSTRAINT `FK_e73dfdcbc10b6c48b749886d9b5` FOREIGN KEY (`blocked_rss_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` DROP FOREIGN KEY `FK_rss_blocks_blocker_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` ADD CONSTRAINT `FK_d7a0693b47b13a59bd72133c5ba` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_blocks` RENAME INDEX `UQ_rss_blocks_blocker_id_blocked_rss_id` TO `IDX_db6b27acdc83264d33a75a0a47`;',
+    );
+
+    // blocks
+    await queryRunner.query(
+      'ALTER TABLE `blocks` DROP FOREIGN KEY `FK_blocks_blocked_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` DROP INDEX `FK_blocks_blocked_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` ADD CONSTRAINT `FK_8aa6c887bed61ad10829450f2f0` FOREIGN KEY (`blocked_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` DROP FOREIGN KEY `FK_blocks_blocker_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` ADD CONSTRAINT `FK_74f530c6fbffc357047b263818d` FOREIGN KEY (`blocker_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `blocks` RENAME INDEX `UQ_blocks_blocker_id_blocked_id` TO `IDX_806f6a5d38d031cdd868fd5e37`;',
+    );
+
+    // notification
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP FOREIGN KEY `FK_notification_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP INDEX `FK_notification_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD CONSTRAINT `FK_916163bd318675ea0c33d517f82` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` DROP FOREIGN KEY `FK_notification_recipient_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` ADD CONSTRAINT `FK_7d7f411e854516f615ba846c6a4` FOREIGN KEY (`recipient_user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` RENAME INDEX `IDX_notification_updated_at` TO `IDX_e13cf12d6a05407dbac647761c`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `notification` RENAME INDEX `UQ_notification_recipient_user_id_type_feed_id` TO `IDX_632ea8b2f172248eccfb067bfc`;',
+    );
+
+    // likes
+    await queryRunner.query(
+      'ALTER TABLE `likes` DROP FOREIGN KEY `FK_likes_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` ADD CONSTRAINT `FK_3f519ed95f775c781a254089171` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` DROP FOREIGN KEY `FK_likes_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` DROP INDEX `FK_likes_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` ADD CONSTRAINT `FK_85b0dbd1e7836d0f8cdc38fe830` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `likes` RENAME INDEX `UQ_likes_user_id_feed_id` TO `IDX_0be1d6ca115f56ed76c65e6bda`;',
+    );
+
+    // comment
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP FOREIGN KEY `FK_comment_parent_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP INDEX `FK_comment_parent_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` ADD CONSTRAINT `FK_8bd8d0985c0d077c8129fb4a209` FOREIGN KEY (`parent_id`) REFERENCES `comment` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP FOREIGN KEY `FK_comment_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP INDEX `FK_comment_feed_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` ADD CONSTRAINT `FK_df1fd1eaf7cc0224ab5e829bf64` FOREIGN KEY (`feed_id`) REFERENCES `feed` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP FOREIGN KEY `FK_comment_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` DROP INDEX `FK_comment_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `comment` ADD CONSTRAINT `FK_bbfe153fa60aa06483ed35ff4a7` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+
+    // category / tag
+    await queryRunner.query(
+      'ALTER TABLE `tag` RENAME INDEX `UQ_tag_name` TO `name`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `category` RENAME INDEX `UQ_category_name` TO `name`;',
+    );
+
+    // activity
+    await queryRunner.query(
+      'ALTER TABLE `activity` DROP FOREIGN KEY `FK_activity_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `activity` DROP INDEX `FK_activity_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `activity` ADD CONSTRAINT `FK_10bf0c2dd4736190070e8475119` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`);',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `activity` RENAME INDEX `UQ_activity_user_id_activity_date` TO `IDX_78f3786d644ca9747fc82db9fb`;',
+    );
+
+    // feed
+    await queryRunner.query(
+      'ALTER TABLE `feed` DROP FOREIGN KEY `FK_feed_blog_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` DROP INDEX `FK_feed_blog_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` ADD CONSTRAINT `FK_7474d489d05b8051874b227f868` FOREIGN KEY (`blog_id`) REFERENCES `rss_accept` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` RENAME INDEX `FT_feed_title` TO `IDX_7d93e66e624232af470d2f7bb3`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` RENAME INDEX `IDX_feed_created_at` TO `IDX_fda780ffdcc013b739cdc6f31d`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `feed` RENAME INDEX `UQ_feed_path` TO `IDX_cbdceca2d71f784a8bb160268e`;',
+    );
+
+    // user
+    await queryRunner.query(
+      'ALTER TABLE `user` RENAME INDEX `UQ_user_email` TO `IDX_e12875dfb3b1d92d7d7c5377e2`;',
+    );
+
+    // rss_accept
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP FOREIGN KEY `FK_rss_accept_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` DROP INDEX `FK_rss_accept_user_id`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` ADD CONSTRAINT `FK_c6af67149ff8aa87d001091acbe` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` RENAME INDEX `UQ_rss_accept_rss_url` TO `UQ_b3a5d4196368864d938dae4e9ff`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss_accept` RENAME INDEX `UQ_rss_accept_name` TO `UQ_59f4be4de3817b3f975acff0766`;',
+    );
+
+    // rss
+    await queryRunner.query(
+      'ALTER TABLE `rss` RENAME INDEX `UQ_rss_rss_url` TO `UQ_af1d102908727aa95ef09e16065`;',
+    );
+    await queryRunner.query(
+      'ALTER TABLE `rss` RENAME INDEX `UQ_rss_name` TO `UQ_21beac47feacb87e57c59d6958f`;',
+    );
+  }
+}

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -9,6 +9,7 @@ import {
   ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
   ViewColumn,
   ViewEntity,
 } from 'typeorm';
@@ -18,6 +19,7 @@ import { RssAccept } from '@rss/entity/rss.entity';
 import { Tag } from '@tag/entity/tag.entity';
 
 @Entity({ name: 'feed' })
+@Unique('UQ_feed_path', ['path'])
 export class Feed extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -27,10 +29,10 @@ export class Feed extends BaseEntity {
     type: 'datetime',
     nullable: false,
   })
-  @Index()
+  @Index('IDX_feed_created_at')
   createdAt: Date;
 
-  @Index({ fulltext: true, parser: 'ngram' })
+  @Index('FT_feed_title', { fulltext: true, parser: 'ngram' })
   @Column({ name: 'title', nullable: false })
   title: string;
 
@@ -40,7 +42,6 @@ export class Feed extends BaseEntity {
   @Column({
     length: 512,
     nullable: false,
-    unique: true,
   })
   path: string;
 
@@ -84,14 +85,23 @@ export class Feed extends BaseEntity {
   })
   @JoinColumn({
     name: 'blog_id',
+    foreignKeyConstraintName: 'FK_feed_blog_id',
   })
   blog: RssAccept;
 
   @ManyToMany(() => Tag, (tag) => tag.feeds, { cascade: true })
   @JoinTable({
     name: 'tag_map',
-    joinColumn: { name: 'feed_id', referencedColumnName: 'id' },
-    inverseJoinColumn: { name: 'tag_id', referencedColumnName: 'id' },
+    joinColumn: {
+      name: 'feed_id',
+      referencedColumnName: 'id',
+      foreignKeyConstraintName: 'FK_tag_map_feed_id',
+    },
+    inverseJoinColumn: {
+      name: 'tag_id',
+      referencedColumnName: 'id',
+      foreignKeyConstraintName: 'FK_tag_map_tag_id',
+    },
   })
   tags: Tag[];
 }

--- a/server/src/file/entity/file.entity.ts
+++ b/server/src/file/entity/file.entity.ts
@@ -29,7 +29,10 @@ export class File {
   size: number;
 
   @ManyToOne(() => User)
-  @JoinColumn({ name: 'user_id' })
+  @JoinColumn({
+    name: 'user_id',
+    foreignKeyConstraintName: 'FK_file_user_id',
+  })
   user: User;
 
   @CreateDateColumn({

--- a/server/src/like/entity/like.entity.ts
+++ b/server/src/like/entity/like.entity.ts
@@ -13,7 +13,7 @@ import { Feed } from '@feed/entity/feed.entity';
 import { User } from '@user/entity/user.entity';
 
 @Entity({ name: 'likes' })
-@Unique(['user', 'feed'])
+@Unique('UQ_likes_user_id_feed_id', ['user', 'feed'])
 export class Like extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -25,6 +25,7 @@ export class Like extends BaseEntity {
   })
   @JoinColumn({
     name: 'feed_id',
+    foreignKeyConstraintName: 'FK_likes_feed_id',
   })
   feed: Feed;
 
@@ -35,6 +36,7 @@ export class Like extends BaseEntity {
   })
   @JoinColumn({
     name: 'user_id',
+    foreignKeyConstraintName: 'FK_likes_user_id',
   })
   user: User;
 

--- a/server/src/notice/entity/notice.entity.ts
+++ b/server/src/notice/entity/notice.entity.ts
@@ -41,7 +41,10 @@ export class Notice extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'SET NULL',
   })
-  @JoinColumn({ name: 'author_admin_id' })
+  @JoinColumn({
+    name: 'author_admin_id',
+    foreignKeyConstraintName: 'FK_notice_author_admin_id',
+  })
   author: Admin | null;
 
   @CreateDateColumn({ name: 'created_at', type: 'datetime', nullable: false })

--- a/server/src/notification/entity/notification.entity.ts
+++ b/server/src/notification/entity/notification.entity.ts
@@ -25,8 +25,16 @@ export enum NotificationType {
 }
 
 @Entity({ name: 'notification' })
-@Unique(['recipient', 'type', 'feed'])
-@Unique(['recipient', 'type', 'rssAccept'])
+@Unique('UQ_notification_recipient_user_id_type_feed_id', [
+  'recipient',
+  'type',
+  'feed',
+])
+@Unique('IDX_notification_recipient_type_rss_accept', [
+  'recipient',
+  'type',
+  'rssAccept',
+])
 export class Notification extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -36,7 +44,10 @@ export class Notification extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'recipient_user_id' })
+  @JoinColumn({
+    name: 'recipient_user_id',
+    foreignKeyConstraintName: 'FK_notification_recipient_user_id',
+  })
   recipient: User;
 
   @Column({
@@ -51,7 +62,10 @@ export class Notification extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'feed_id' })
+  @JoinColumn({
+    name: 'feed_id',
+    foreignKeyConstraintName: 'FK_notification_feed_id',
+  })
   feed: Feed | null;
 
   @ManyToOne(() => RssAccept, {
@@ -59,7 +73,10 @@ export class Notification extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'rss_accept_id' })
+  @JoinColumn({
+    name: 'rss_accept_id',
+    foreignKeyConstraintName: 'FK_notification_rss_accept_id',
+  })
   rssAccept: RssAccept | null;
 
   @Column({ name: 'is_read', default: false })
@@ -68,7 +85,7 @@ export class Notification extends BaseEntity {
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
 
-  @Index()
+  @Index('IDX_notification_updated_at')
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
 }

--- a/server/src/report/entity/report.entity.ts
+++ b/server/src/report/entity/report.entity.ts
@@ -20,7 +20,11 @@ import { RssAccept } from '@rss/entity/rss.entity';
 import { User } from '@user/entity/user.entity';
 
 @Entity({ name: 'report' })
-@Unique(['reporter', 'targetType', 'targetId'])
+@Unique('UQ_report_reporter_id_target_type_target_id', [
+  'reporter',
+  'targetType',
+  'targetId',
+])
 export class Report extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -51,7 +55,10 @@ export class Report extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'reporter_id' })
+  @JoinColumn({
+    name: 'reporter_id',
+    foreignKeyConstraintName: 'FK_report_reporter_id',
+  })
   reporter: User;
 
   @ManyToOne(() => User, (user) => user.id, {
@@ -59,7 +66,10 @@ export class Report extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'reported_user_id' })
+  @JoinColumn({
+    name: 'reported_user_id',
+    foreignKeyConstraintName: 'FK_report_reported_user_id',
+  })
   reportedUser: User | null;
 
   @ManyToOne(() => RssAccept, (rssAccept) => rssAccept.id, {
@@ -67,7 +77,10 @@ export class Report extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'reported_rss_id' })
+  @JoinColumn({
+    name: 'reported_rss_id',
+    foreignKeyConstraintName: 'FK_report_reported_rss_id',
+  })
   reportedRss: RssAccept | null;
 
   @ManyToOne(() => Comment, (comment) => comment.id, {
@@ -75,7 +88,10 @@ export class Report extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'reported_comment_id' })
+  @JoinColumn({
+    name: 'reported_comment_id',
+    foreignKeyConstraintName: 'FK_report_reported_comment_id',
+  })
   reportedComment: Comment | null;
 
   @ManyToOne(() => Feed, (feed) => feed.id, {
@@ -83,6 +99,9 @@ export class Report extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'reported_feed_id' })
+  @JoinColumn({
+    name: 'reported_feed_id',
+    foreignKeyConstraintName: 'FK_report_reported_feed_id',
+  })
   reportedFeed: Feed | null;
 }

--- a/server/src/rss/entity/rss.entity.ts
+++ b/server/src/rss/entity/rss.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
+  Unique,
 } from 'typeorm';
 
 import { Feed } from '@feed/entity/feed.entity';
@@ -61,11 +62,13 @@ export class RssInformation extends BaseEntity {
 @Entity({
   name: 'rss',
 })
+@Unique('UQ_rss_name', ['name'])
+@Unique('UQ_rss_rss_url', ['rssUrl'])
 export class Rss extends RssInformation {
-  @Column({ name: 'name', nullable: false, unique: true })
+  @Column({ name: 'name', nullable: false })
   name: string;
 
-  @Column({ name: 'rss_url', length: 255, nullable: false, unique: true })
+  @Column({ name: 'rss_url', length: 255, nullable: false })
   rssUrl: string;
 
   @Column({ name: 'image', type: 'text', nullable: true })
@@ -89,15 +92,17 @@ export class RssReject extends RssInformation {
 @Entity({
   name: 'rss_accept',
 })
+@Unique('UQ_rss_accept_name', ['name'])
+@Unique('UQ_rss_accept_rss_url', ['rssUrl'])
 export class RssAccept extends RssInformation {
   @OneToMany(() => Feed, (feed) => feed.blog)
   feeds: Feed[];
 
   @Index('FT_rss_accept_name', { fulltext: true, parser: 'ngram' })
-  @Column({ name: 'name', nullable: false, unique: true })
+  @Column({ name: 'name', nullable: false })
   name: string;
 
-  @Column({ name: 'rss_url', length: 255, nullable: false, unique: true })
+  @Column({ name: 'rss_url', length: 255, nullable: false })
   rssUrl: string;
 
   @Column({ name: 'platform', default: 'etc', nullable: false })
@@ -111,7 +116,10 @@ export class RssAccept extends RssInformation {
     onUpdate: 'CASCADE',
     onDelete: 'SET NULL',
   })
-  @JoinColumn({ name: 'user_id' })
+  @JoinColumn({
+    name: 'user_id',
+    foreignKeyConstraintName: 'FK_rss_accept_user_id',
+  })
   user: User | null;
 
   @Column({ name: 'image', type: 'text', nullable: true })

--- a/server/src/subscribe/entity/subscription.entity.ts
+++ b/server/src/subscribe/entity/subscription.entity.ts
@@ -13,7 +13,7 @@ import { RssAccept } from '@rss/entity/rss.entity';
 import { User } from '@user/entity/user.entity';
 
 @Entity({ name: 'subscription' })
-@Unique(['user', 'rssAccept'])
+@Unique('UQ_subscription_user_rss', ['user', 'rssAccept'])
 export class Subscription extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -25,6 +25,7 @@ export class Subscription extends BaseEntity {
   })
   @JoinColumn({
     name: 'rss_accept_id',
+    foreignKeyConstraintName: 'FK_subscription_rss',
   })
   rssAccept: RssAccept;
 
@@ -35,6 +36,7 @@ export class Subscription extends BaseEntity {
   })
   @JoinColumn({
     name: 'user_id',
+    foreignKeyConstraintName: 'FK_subscription_user',
   })
   user: User;
 

--- a/server/src/tag/entity/category.entity.ts
+++ b/server/src/tag/entity/category.entity.ts
@@ -1,13 +1,14 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn, Unique } from 'typeorm';
 
 import { Tag } from '@tag/entity/tag.entity';
 
 @Entity({ name: 'category' })
+@Unique('UQ_category_name', ['name'])
 export class Category {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ length: 30, unique: true })
+  @Column({ length: 30 })
   name: string;
 
   @Column({ name: 'display_order' })

--- a/server/src/tag/entity/tag.entity.ts
+++ b/server/src/tag/entity/tag.entity.ts
@@ -5,24 +5,29 @@ import {
   ManyToMany,
   ManyToOne,
   PrimaryGeneratedColumn,
+  Unique,
 } from 'typeorm';
 
 import { Feed } from '@feed/entity/feed.entity';
 import { Category } from '@tag/entity/category.entity';
 
 @Entity({ name: 'tag' })
+@Unique('UQ_tag_name', ['name'])
 export class Tag {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ length: 50, unique: true })
+  @Column({ length: 50 })
   name: string;
 
   @ManyToOne(() => Category, (category) => category.tags, {
     nullable: true,
     onDelete: 'SET NULL',
   })
-  @JoinColumn({ name: 'category_id' })
+  @JoinColumn({
+    name: 'category_id',
+    foreignKeyConstraintName: 'FK_tag_category',
+  })
   category: Category;
 
   @ManyToMany(() => Feed, (feed) => feed.tags)

--- a/server/src/user/entity/provider.entity.ts
+++ b/server/src/user/entity/provider.entity.ts
@@ -60,6 +60,9 @@ export class Provider extends BaseEntity {
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
   })
-  @JoinColumn({ name: 'user_id' })
+  @JoinColumn({
+    name: 'user_id',
+    foreignKeyConstraintName: 'FK_provider_user_id',
+  })
   user: User;
 }

--- a/server/src/user/entity/user.entity.ts
+++ b/server/src/user/entity/user.entity.ts
@@ -5,6 +5,7 @@ import {
   Entity,
   OneToMany,
   PrimaryGeneratedColumn,
+  Unique,
   UpdateDateColumn,
 } from 'typeorm';
 
@@ -15,6 +16,8 @@ import { Provider } from '@user/entity/provider.entity';
 @Entity({
   name: 'user',
 })
+@Unique('UQ_user_email', ['email'])
+@Unique('UQ_user_user_name', ['userName'])
 export class User extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
@@ -23,7 +26,6 @@ export class User extends BaseEntity {
     name: 'email',
     length: 255,
     nullable: false,
-    unique: true,
   })
   email: string;
 
@@ -37,7 +39,6 @@ export class User extends BaseEntity {
     name: 'user_name',
     length: '60',
     nullable: false,
-    unique: true,
   })
   userName: string;
 


### PR DESCRIPTION
### Issue

- #121 관련 (완전 해결 아님, DB 스키마 네이밍 정리 범위)

### 소주제1

- `init.sql`, TypeORM 엔티티, 마이그레이션에서 인덱스/FK/UNIQUE 제약 이름이 TypeORM이 자동 생성한 해시 기반 이름(`IDX_xxxxxxxx` 등)으로 되어 있어, DB를 직접 열람하거나 마이그레이션 diff를 볼 때 어떤 컬럼/의도를 가진 제약인지 파악이 어려웠음.
- 모든 제약 이름을 `IDX_테이블_컬럼`, `FK_테이블_컬럼`, `UQ_테이블_컬럼`, `FT_테이블_컬럼` 형태의 의미 기반 이름으로 명시적으로 지정하도록 변경.

### 소주제2

- 기존 운영 DB와의 스키마 정합성을 위해 해시 이름 → 의미 기반 이름으로 제약을 rename하는 마이그레이션(`1785300000000-RenameHashKeysToSemanticNames.ts`) 추가.
- `down()`에서 원래 해시 이름으로 되돌리는 로직도 함께 작성해 롤백 가능하도록 함.

# 📋 작업 내용

- `docker-compose/db/init.sql`: 초기 스키마의 인덱스/FK/UNIQUE 제약 이름을 의미 기반으로 변경
- 각 엔티티(`activity`, `admin`, `rssBlock`, `userBlock`, `comment`, `feed`, `file`, `like`, `notice`, `notification`, `report`, `rss`, `subscription`, `category`, `tag`, `provider`, `user`)의 `@Index`, `@JoinColumn`, `@Unique` 등에 명시적 제약 이름 지정
- 기존 해시 기반 제약 이름 → 의미 기반 이름으로 rename하는 TypeORM 마이그레이션 추가 (up/down 모두 지원)

# 📷 스크린 샷(선택 사항)

해당 사항 없음 (스키마/엔티티 레벨 변경)