### PR TITLE
♻️ refactor: feed/rss 컨트롤러 admin/일반 분리

### DIFF
--- a/client/src/api/services/admin/feed.ts
+++ b/client/src/api/services/admin/feed.ts
@@ -1,14 +1,14 @@
-import { BLOG } from "@/constants/endpoints";
+import { ADMIN } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
 import { NoSummaryFeed, NoSummaryFeedsApiResponse } from "@/types/post";
 
 export const adminFeed = {
   getNoSummaryFeeds: async (): Promise<NoSummaryFeed[]> => {
-    const response = await axiosInstance.get<NoSummaryFeedsApiResponse>(BLOG.NO_SUMMARY);
+    const response = await axiosInstance.get<NoSummaryFeedsApiResponse>(ADMIN.FEED.NO_SUMMARY);
     return response.data.data;
   },
   requestAiSummary: async (feedId: number): Promise<void> => {
-    await axiosInstance.post(BLOG.AI_SUMMARY(feedId));
+    await axiosInstance.post(ADMIN.FEED.AI_SUMMARY(feedId));
   },
 };

--- a/client/src/api/services/admin/rss.ts
+++ b/client/src/api/services/admin/rss.ts
@@ -21,12 +21,12 @@ export const admin = {
   },
   //rss 승인
   acceptRss: async (data: AdminRequest): Promise<AdminResponse> => {
-    const response = await axiosInstance.post<AdminResponse>(`${ADMIN.ACTION.ACCEPT}/${data.id}`);
+    const response = await axiosInstance.post<AdminResponse>(ADMIN.ACTION.ACCEPT(data.id));
     return response.data;
   },
   //rss 거부
   rejectRss: async (data: AdminRequest): Promise<AdminResponse> => {
-    const response = await axiosInstance.post<AdminResponse>(`${ADMIN.ACTION.REJECT}/${data.id}`, {
+    const response = await axiosInstance.post<AdminResponse>(ADMIN.ACTION.REJECT(data.id), {
       description: data.rejectMessage,
     });
     return response.data;

--- a/client/src/components/admin/post/AdminPostDetail.stories.tsx
+++ b/client/src/components/admin/post/AdminPostDetail.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, fn, userEvent, within } from "storybook/test";
 
 import AdminPostDetail from "@/components/admin/post/AdminPostDetail";
-import { BLOG } from "@/constants/endpoints";
+import { ADMIN, BLOG } from "@/constants/endpoints";
 import { mockFeedDetail } from "@/__storybook__/fixtures";
 import { mockApi, ok, fail } from "@/__storybook__/mockApi";
 
@@ -19,7 +19,7 @@ export const Default: Story = {
   beforeEach: () => {
     mockApi.onGet(`${BLOG.POST}/1`).reply(...ok(mockFeedDetail));
     mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
-    mockApi.onPost(BLOG.AI_SUMMARY(1)).reply(...ok(null));
+    mockApi.onPost(ADMIN.FEED.AI_SUMMARY(1)).reply(...ok(null));
     mockApi.onDelete(/\/api\/admins\/comments\/\d+/).reply(...ok(null));
   },
 };
@@ -29,7 +29,7 @@ export const RetrySummary: Story = {
   beforeEach: () => {
     mockApi.onGet(`${BLOG.POST}/1`).reply(...ok(mockFeedDetail));
     mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([]));
-    mockApi.onPost(BLOG.AI_SUMMARY(1)).reply(...ok(null));
+    mockApi.onPost(ADMIN.FEED.AI_SUMMARY(1)).reply(...ok(null));
     mockApi.onDelete(/\/api\/admins\/comments\/\d+/).reply(...ok(null));
   },
   play: async ({ canvasElement }) => {
@@ -46,7 +46,7 @@ export const WithComments: Story = {
     mockApi.onGet(BLOG.COMMENT.LIST(1)).reply(...ok([
       { id: 1, comment: "좋은 글이네요!", date: "2026-06-25T09:00:00.000Z", parentId: null, isDeleted: false, user: { id: 99, userName: "독자", profileImage: null } },
     ]));
-    mockApi.onPost(BLOG.AI_SUMMARY(1)).reply(...ok(null));
+    mockApi.onPost(ADMIN.FEED.AI_SUMMARY(1)).reply(...ok(null));
     mockApi.onDelete(/\/api\/admins\/comments\/\d+/).reply(...ok(null));
   },
 };

--- a/client/src/components/admin/post/AdminPostTab.stories.tsx
+++ b/client/src/components/admin/post/AdminPostTab.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, userEvent, within } from "storybook/test";
 
 import AdminPostTab from "@/components/admin/post/AdminPostTab";
-import { BLOG } from "@/constants/endpoints";
+import { ADMIN, BLOG } from "@/constants/endpoints";
 import { mockFeedsList, mockNoSummaryFeeds, mockFeedDetail } from "@/__storybook__/fixtures";
 import { mockApi, ok, fail } from "@/__storybook__/mockApi";
 
@@ -16,8 +16,8 @@ type Story = StoryObj<typeof meta>;
 
 const setupSuccess = () => {
   mockApi.onGet(BLOG.POST).reply(...ok({ result: mockFeedsList, hasMore: false, lastId: null }));
-  mockApi.onGet(BLOG.NO_SUMMARY).reply(...ok(mockNoSummaryFeeds));
-  mockApi.onPost(/\/api\/feeds\/\d+\/ai-summary-requests/).reply(...ok(null));
+  mockApi.onGet(ADMIN.FEED.NO_SUMMARY).reply(...ok(mockNoSummaryFeeds));
+  mockApi.onPost(/\/api\/admins\/feeds\/\d+\/ai-summary-requests/).reply(...ok(null));
   // For post detail panel when card is clicked
   mockApi.onGet(/\/api\/feeds\/\d+$/).reply(...ok(mockFeedDetail));
   mockApi.onGet(/\/api\/feeds\/\d+\/comments/).reply(...ok([]));
@@ -44,8 +44,8 @@ export const NoSummaryOnly: Story = {
   name: "AI 요약 없는 게시글만",
   beforeEach: () => {
     mockApi.onGet(BLOG.POST).reply(...ok({ result: [], hasMore: false, lastId: null }));
-    mockApi.onGet(BLOG.NO_SUMMARY).reply(...ok(mockNoSummaryFeeds));
-    mockApi.onPost(/\/api\/feeds\/\d+\/ai-summary-requests/).reply(...ok(null));
+    mockApi.onGet(ADMIN.FEED.NO_SUMMARY).reply(...ok(mockNoSummaryFeeds));
+    mockApi.onPost(/\/api\/admins\/feeds\/\d+\/ai-summary-requests/).reply(...ok(null));
   },
 };
 
@@ -53,7 +53,7 @@ export const AllEmpty: Story = {
   name: "게시글 없음",
   beforeEach: () => {
     mockApi.onGet(BLOG.POST).reply(...ok({ result: [], hasMore: false, lastId: null }));
-    mockApi.onGet(BLOG.NO_SUMMARY).reply(...ok([]));
+    mockApi.onGet(ADMIN.FEED.NO_SUMMARY).reply(...ok([]));
   },
 };
 
@@ -61,7 +61,7 @@ export const Loading: Story = {
   name: "로딩 중",
   beforeEach: () => {
     mockApi.onGet(BLOG.POST).reply(() => new Promise(() => {}));
-    mockApi.onGet(BLOG.NO_SUMMARY).reply(() => new Promise(() => {}));
+    mockApi.onGet(ADMIN.FEED.NO_SUMMARY).reply(() => new Promise(() => {}));
   },
 };
 
@@ -69,6 +69,6 @@ export const Error: Story = {
   name: "오류",
   beforeEach: () => {
     mockApi.onGet(BLOG.POST).reply(...fail());
-    mockApi.onGet(BLOG.NO_SUMMARY).reply(...fail());
+    mockApi.onGet(ADMIN.FEED.NO_SUMMARY).reply(...fail());
   },
 };

--- a/client/src/components/admin/rss/RejectModal.stories.tsx
+++ b/client/src/components/admin/rss/RejectModal.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
         {...args}
         rejectMessage={reason}
         handleReason={setReason}
-        onSubmit={() => action("API")(`POST ${ADMIN.ACTION.REJECT}/1`)}
+        onSubmit={() => action("API")(`POST ${ADMIN.ACTION.REJECT(1)}`)}
         onCancel={() => setReason("")}
       />
     );

--- a/client/src/components/admin/rss/RssRequestCard.stories.tsx
+++ b/client/src/components/admin/rss/RssRequestCard.stories.tsx
@@ -10,8 +10,8 @@ const meta = {
   component: RssRequestCard,
   args: {
     request: mockAdminRssList[0],
-    onApprove: (request) => action("API")(`POST ${ADMIN.ACTION.ACCEPT}/${request.id}`),
-    onReject: (request) => action("API")(`POST ${ADMIN.ACTION.REJECT}/${request.id}`),
+    onApprove: (request) => action("API")(`POST ${ADMIN.ACTION.ACCEPT(request.id)}`),
+    onReject: (request) => action("API")(`POST ${ADMIN.ACTION.REJECT(request.id)}`),
   },
 } satisfies Meta<typeof RssRequestCard>;
 

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -21,13 +21,17 @@ export const ADMIN = {
     DELETE: (roomId: string, messageId: string) => `/api/admins/chats/${roomId}/${messageId}`,
   },
   GET: {
-    RSS: "/api/rss",
-    ACCEPT: "/api/rss/history/accept",
-    REJECT: "/api/rss/history/reject",
+    RSS: "/api/admins/rss",
+    ACCEPT: "/api/admins/rss/acceptances",
+    REJECT: "/api/admins/rss/rejections",
   },
   ACTION: {
-    ACCEPT: "/api/rss/accept",
-    REJECT: "/api/rss/reject",
+    ACCEPT: (id: number) => `/api/admins/rss/${id}/acceptances`,
+    REJECT: (id: number) => `/api/admins/rss/${id}/rejections`,
+  },
+  FEED: {
+    NO_SUMMARY: "/api/admins/feeds/no-summary",
+    AI_SUMMARY: (id: number) => `/api/admins/feeds/${id}/ai-summary-requests`,
   },
 };
 
@@ -36,8 +40,6 @@ export const BLOG = {
   RECENT: "/api/feed/recent",
   Trend: "/api/feeds/trend/sse",
   LIKE: (id: number) => `/api/feeds/${id}/likes`,
-  AI_SUMMARY: (id: number) => `/api/feeds/${id}/ai-summary-requests`,
-  NO_SUMMARY: "/api/feeds/no-summary",
   COMMENT: {
     LIST: (feedId: number) => `/api/feeds/${feedId}/comments`,
     ITEM: (feedId: number, commentId: number) => `/api/feeds/${feedId}/comments/${commentId}`,

--- a/server/src/feed/controller/adminFeed.controller.ts
+++ b/server/src/feed/controller/adminFeed.controller.ts
@@ -1,0 +1,37 @@
+import { Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { AdminAuthGuard } from '@common/guard/session.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiReadNoSummaryFeedList } from '@feed/api-docs/readNoSummaryFeedList.api-docs';
+import { ApiRequestAiSummary } from '@feed/api-docs/requestAiSummary.api-docs';
+import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
+import { FeedService } from '@feed/service/feed.service';
+
+@ApiTags('Admin')
+@Controller('admins/feeds')
+@UseGuards(AdminAuthGuard)
+export class AdminFeedController {
+  constructor(private readonly feedService: FeedService) {}
+
+  @ApiReadNoSummaryFeedList()
+  @Get('no-summary')
+  @HttpCode(HttpStatus.OK)
+  async readFeedsWithoutSummary() {
+    return ApiResponse.responseWithData(
+      'AI 요약 없는 게시글 목록 조회 완료',
+      await this.feedService.readFeedsWithoutSummary(),
+    );
+  }
+
+  @ApiRequestAiSummary()
+  @Post(':feedId/ai-summary-requests')
+  @HttpCode(HttpStatus.ACCEPTED)
+  async requestAiSummary(@Param() aiSummaryParamDto: ManageFeedRequestDto) {
+    await this.feedService.requestAiSummary(aiSummaryParamDto.feedId);
+    return ApiResponse.responseWithNoContent(
+      'AI 요약 재요청이 접수되었습니다.',
+    );
+  }
+}

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -19,18 +19,15 @@ import { Request, Response } from 'express';
 import { Observable } from 'rxjs';
 
 import { CurrentUser } from '@common/decorator/current-user.decorator';
-import { AdminAuthGuard } from '@common/guard/session.guard';
 import { JwtGuard, OptionalJwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
 
 import { ApiDeleteCheckFeed } from '@feed/api-docs/deleteCheckFeed.api-docs';
 import { ApiGetFeedDetail } from '@feed/api-docs/getFeedDetail.api-docs';
 import { ApiReadFeedPagination } from '@feed/api-docs/readFeedPagination.api-docs';
-import { ApiReadNoSummaryFeedList } from '@feed/api-docs/readNoSummaryFeedList.api-docs';
 import { ApiReadRecentFeedList } from '@feed/api-docs/readRecentFeedList.api-docs';
 import { ApiReadSubscriptionFeed } from '@feed/api-docs/readSubscriptionFeed.api-docs';
 import { ApiReadTrendFeedList } from '@feed/api-docs/readTrendFeedList.api-docs';
-import { ApiRequestAiSummary } from '@feed/api-docs/requestAiSummary.api-docs';
 import { ApiSearchFeedList } from '@feed/api-docs/searchFeedList.api-docs';
 import { ApiUpdateFeedViewCount } from '@feed/api-docs/updateFeedViewCount.api-docs';
 import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
@@ -125,28 +122,6 @@ export class FeedController {
     );
     return ApiResponse.responseWithNoContent(
       '요청이 성공적으로 처리되었습니다.',
-    );
-  }
-
-  @ApiReadNoSummaryFeedList()
-  @UseGuards(AdminAuthGuard)
-  @Get('/no-summary')
-  @HttpCode(HttpStatus.OK)
-  async readFeedsWithoutSummary() {
-    return ApiResponse.responseWithData(
-      'AI 요약 없는 게시글 목록 조회 완료',
-      await this.feedService.readFeedsWithoutSummary(),
-    );
-  }
-
-  @ApiRequestAiSummary()
-  @UseGuards(AdminAuthGuard)
-  @Post('/:feedId/ai-summary-requests')
-  @HttpCode(HttpStatus.ACCEPTED)
-  async requestAiSummary(@Param() aiSummaryParamDto: ManageFeedRequestDto) {
-    await this.feedService.requestAiSummary(aiSummaryParamDto.feedId);
-    return ApiResponse.responseWithNoContent(
-      'AI 요약 재요청이 접수되었습니다.',
     );
   }
 

--- a/server/src/feed/module/feed.module.ts
+++ b/server/src/feed/module/feed.module.ts
@@ -6,6 +6,7 @@ import { JwtAuthModule } from '@common/auth/jwt.module';
 
 import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 
+import { AdminFeedController } from '@feed/controller/adminFeed.controller';
 import { FeedController } from '@feed/controller/feed.controller';
 import { FeedViewedListener } from '@feed/listener/feed-viewed.listener';
 import {
@@ -21,7 +22,7 @@ import { UserModule } from '@user/module/user.module';
 
 @Module({
   imports: [UserModule, ActivityModule, JwtAuthModule],
-  controllers: [FeedController],
+  controllers: [FeedController, AdminFeedController],
   providers: [
     FeedService,
     FeedRepository,

--- a/server/src/rss/controller/adminRss.controller.ts
+++ b/server/src/rss/controller/adminRss.controller.ts
@@ -1,0 +1,70 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { AdminAuthGuard } from '@common/guard/session.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiAcceptRss } from '@rss/api-docs/acceptRss.api-docs';
+import { ApiReadAllRss } from '@rss/api-docs/readAllRss.api-docs';
+import { ApiReadRssAcceptHistory } from '@rss/api-docs/readRssAcceptHistory.api-docs';
+import { ApiReadRssRejectHistory } from '@rss/api-docs/readRssRejectHistory.api-docs';
+import { ApiRejectRss } from '@rss/api-docs/rejectRss.api-docs';
+import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
+import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
+import { RssService } from '@rss/service/rss.service';
+
+@ApiTags('Admin')
+@Controller('admins/rss')
+@UseGuards(AdminAuthGuard)
+export class AdminRssController {
+  constructor(private readonly rssService: RssService) {}
+
+  @ApiReadAllRss()
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async readAllRss() {
+    return ApiResponse.responseWithData(
+      'Rss 조회 완료',
+      await this.rssService.readAllRss(),
+    );
+  }
+
+  @ApiAcceptRss()
+  @Post(':id/acceptances')
+  @HttpCode(HttpStatus.CREATED)
+  async acceptRss(@Param() rssAcceptParamDto: ManageRssRequestDto) {
+    await this.rssService.acceptRss(rssAcceptParamDto);
+    return ApiResponse.responseWithNoContent('승인이 완료되었습니다.');
+  }
+
+  @ApiRejectRss()
+  @Post(':id/rejections')
+  @HttpCode(HttpStatus.CREATED)
+  async rejectRss(
+    @Body() rssRejectBodyDto: RejectRssRequestDto,
+    @Param() rssRejectParamDto: ManageRssRequestDto,
+  ) {
+    await this.rssService.rejectRss(rssRejectParamDto, rssRejectBodyDto);
+    return ApiResponse.responseWithNoContent('거절이 완료되었습니다.');
+  }
+
+  @ApiReadRssAcceptHistory()
+  @Get('acceptances')
+  @HttpCode(HttpStatus.OK)
+  async readAcceptHistory() {
+    return ApiResponse.responseWithData(
+      '승인 기록 조회가 완료되었습니다.',
+      await this.rssService.readAcceptHistory(),
+    );
+  }
+
+  @ApiReadRssRejectHistory()
+  @Get('rejections')
+  @HttpCode(HttpStatus.OK)
+  async readRejectHistory() {
+    return ApiResponse.responseWithData(
+      'RSS 거절 기록을 조회하였습니다.',
+      await this.rssService.readRejectHistory(),
+    );
+  }
+}

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -17,10 +17,8 @@ import { ReadActivityQueryRequestDto } from '@activity/dto/request/readActivity.
 
 import { CurrentUser } from '@common/decorator';
 import { JwtGuard, OptionalJwtGuard, Payload } from '@common/guard/jwt.guard';
-import { AdminAuthGuard } from '@common/guard/session.guard';
 import { ApiResponse } from '@common/response/common.response';
 
-import { ApiAcceptRss } from '@rss/api-docs/acceptRss.api-docs';
 import { ApiCreateRss } from '@rss/api-docs/createRss.api-docs';
 import { ApiCreateRssCertification } from '@rss/api-docs/createRssCertification.api-docs';
 import { ApiDeleteCertificateRss } from '@rss/api-docs/deleteCertificateRss.api-docs';
@@ -33,10 +31,6 @@ import { ApiGetRssActivityYears } from '@rss/api-docs/getRssActivityYears.api-do
 import { ApiGetRssFeeds } from '@rss/api-docs/getRssFeeds.api-docs';
 import { ApiGetRssInfo } from '@rss/api-docs/getRssInfo.api-docs';
 import { ApiPreviewRssCertification } from '@rss/api-docs/previewRssCertification.api-docs';
-import { ApiReadAllRss } from '@rss/api-docs/readAllRss.api-docs';
-import { ApiReadRssAcceptHistory } from '@rss/api-docs/readRssAcceptHistory.api-docs';
-import { ApiReadRssRejectHistory } from '@rss/api-docs/readRssRejectHistory.api-docs';
-import { ApiRejectRss } from '@rss/api-docs/rejectRss.api-docs';
 import { ApiSearchRss } from '@rss/api-docs/searchRss.api-docs';
 import { ApiSetFeedVisibility } from '@rss/api-docs/setFeedVisibility.api-docs';
 import { ApiUpdateRssCertification } from '@rss/api-docs/updateRssCertification.api-docs';
@@ -49,10 +43,8 @@ import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dt
 import { GetOwnedRssFeedsParamRequestDto } from '@rss/dto/request/getOwnedRssFeedsParam.dto';
 import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
 import { GetRssInfoParamRequestDto } from '@rss/dto/request/getRssInfoParam.dto';
-import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
 import { PreviewRssCertificationRequestDto } from '@rss/dto/request/previewRssCertification.dto';
 import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
-import { RejectRssRequestDto } from '@rss/dto/request/rejectRss';
 import { SearchRssRequestDto } from '@rss/dto/request/searchRss.dto';
 import { SetFeedVisibilityRequestDto } from '@rss/dto/request/setFeedVisibility.dto';
 import { SetFeedVisibilityParamRequestDto } from '@rss/dto/request/setFeedVisibilityParam.dto';
@@ -72,60 +64,6 @@ export class RssController {
   async createRss(@Body() rssRegisterBodyDto: RegisterRssRequestDto) {
     await this.rssService.createRss(rssRegisterBodyDto);
     return ApiResponse.responseWithNoContent('신청이 완료되었습니다.');
-  }
-
-  @ApiReadAllRss()
-  @UseGuards(AdminAuthGuard)
-  @Get()
-  @HttpCode(HttpStatus.OK)
-  async readAllRss() {
-    return ApiResponse.responseWithData(
-      'Rss 조회 완료',
-      await this.rssService.readAllRss(),
-    );
-  }
-
-  @ApiAcceptRss()
-  @UseGuards(AdminAuthGuard)
-  @Post('accept/:id')
-  @HttpCode(HttpStatus.CREATED)
-  async acceptRss(@Param() rssAcceptParamDto: ManageRssRequestDto) {
-    await this.rssService.acceptRss(rssAcceptParamDto);
-    return ApiResponse.responseWithNoContent('승인이 완료되었습니다.');
-  }
-
-  @ApiRejectRss()
-  @UseGuards(AdminAuthGuard)
-  @Post('reject/:id')
-  @HttpCode(HttpStatus.CREATED)
-  async rejectRss(
-    @Body() rssRejectBodyDto: RejectRssRequestDto,
-    @Param() rssRejectParamDto: ManageRssRequestDto,
-  ) {
-    await this.rssService.rejectRss(rssRejectParamDto, rssRejectBodyDto);
-    return ApiResponse.responseWithNoContent('거절이 완료되었습니다.');
-  }
-
-  @ApiReadRssAcceptHistory()
-  @UseGuards(AdminAuthGuard)
-  @Get('history/accept')
-  @HttpCode(HttpStatus.OK)
-  async readAcceptHistory() {
-    return ApiResponse.responseWithData(
-      '승인 기록 조회가 완료되었습니다.',
-      await this.rssService.readAcceptHistory(),
-    );
-  }
-
-  @ApiReadRssRejectHistory()
-  @UseGuards(AdminAuthGuard)
-  @Get('history/reject')
-  @HttpCode(HttpStatus.OK)
-  async readRejectHistory() {
-    return ApiResponse.responseWithData(
-      'RSS 거절 기록을 조회하였습니다.',
-      await this.rssService.readRejectHistory(),
-    );
   }
 
   @ApiDeleteRss()

--- a/server/src/rss/module/rss.module.ts
+++ b/server/src/rss/module/rss.module.ts
@@ -11,6 +11,7 @@ import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
+import { AdminRssController } from '@rss/controller/adminRss.controller';
 import { RssController } from '@rss/controller/rss.controller';
 import {
   RssAcceptRepository,
@@ -21,7 +22,7 @@ import { RssService } from '@rss/service/rss.service';
 
 @Module({
   imports: [AdminModule, NotifierModule, JwtAuthModule],
-  controllers: [RssController],
+  controllers: [RssController, AdminRssController],
   providers: [
     RssService,
     RssRepository,

--- a/server/test/feed/e2e/admin-read-no-summary.e2e-spec.ts
+++ b/server/test/feed/e2e/admin-read-no-summary.e2e-spec.ts
@@ -19,7 +19,7 @@ import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
 import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
-const URL = '/api/feeds/no-summary';
+const URL = '/api/admins/feeds/no-summary';
 const AI_SUMMARY_IN_PROGRESS_MESSAGE = '아직 AI가 요약을 진행중인 게시글 이에요! 💭';
 
 describe(`GET ${URL} E2E Test`, () => {

--- a/server/test/feed/e2e/admin-request-ai-summary.e2e-spec.ts
+++ b/server/test/feed/e2e/admin-request-ai-summary.e2e-spec.ts
@@ -20,10 +20,10 @@ import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = (feedId: number | string) =>
-  `/api/feeds/${feedId}/ai-summary-requests`;
+  `/api/admins/feeds/${feedId}/ai-summary-requests`;
 const IN_PROGRESS = '아직 AI가 요약을 진행중인 게시글 이에요! 💭';
 
-describe(`POST /api/feeds/{feedId}/ai-summary-requests E2E Test`, () => {
+describe(`POST /api/admins/feeds/{feedId}/ai-summary-requests E2E Test`, () => {
   let agent: TestAgent;
   let redisService: RedisService;
   let feedRepository: FeedRepository;

--- a/server/test/rss/e2e/admin-accept-history.e2e-spec.ts
+++ b/server/test/rss/e2e/admin-accept-history.e2e-spec.ts
@@ -8,27 +8,27 @@ import { AdminRepository } from '@admin/repository/admin.repository';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
-import { RssReject } from '@rss/entity/rss.entity';
-import { RssRejectRepository } from '@rss/repository/rss.repository';
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
-import { RssRejectFixture } from '@test/config/common/fixture/rss-reject.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
-const URL = '/api/rss/history/reject';
+const URL = '/api/admins/rss/acceptances';
 
 describe(`GET ${URL} E2E Test`, () => {
   let agent: TestAgent;
-  let rssRejectList: RssReject[];
-  let redisService: RedisService;
-  let rssRejectRepository: RssRejectRepository;
+  let rssAcceptList: RssAccept[];
+  let rssAcceptRepository: RssAcceptRepository;
   let adminRepository: AdminRepository;
+  let redisService: RedisService;
   const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
-  const sessionKey = 'admin-rss-history-reject';
+  const sessionKey = 'admin-rss-history-accept';
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
-    rssRejectRepository = testApp.get(RssRejectRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
     adminRepository = testApp.get(AdminRepository);
     redisService = testApp.get(RedisService);
   });
@@ -37,17 +37,17 @@ describe(`GET ${URL} E2E Test`, () => {
     const admin = await adminRepository.save(
       await AdminFixture.createAdminCryptFixture(),
     );
-    const rssRejects = Array.from({ length: 2 }).map(() =>
-      RssRejectFixture.createRssRejectFixture(),
+    const rssAccepts = Array.from({ length: 2 }).map(() =>
+      RssAcceptFixture.createRssAcceptFixture(),
     );
-    [rssRejectList] = await Promise.all([
-      rssRejectRepository.save(rssRejects),
+    [rssAcceptList] = await Promise.all([
+      rssAcceptRepository.save(rssAccepts),
       redisService.set(redisKeyMake(sessionKey), admin.email),
     ]);
-    rssRejectList.reverse();
+    rssAcceptList.reverse();
   });
 
-  it('[401] 관리자 로그인 쿠키가 없을 경우 RSS 거절 기록 조회를 실패한다.', async () => {
+  it('[401] 관리자 로그인 쿠키가 없을 경우 RSS 승인 기록 조회를 실패한다.', async () => {
     // Http when
     const response = await agent.get(URL);
 
@@ -57,7 +57,7 @@ describe(`GET ${URL} E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
-  it('[401] 관리자 로그인 쿠키가 만료됐을 경우 RSS 거절 기록 조회를 실패한다.', async () => {
+  it('[401] 관리자 로그인 쿠키가 만료됐을 경우 RSS 승인 기록 조회를 실패한다.', async () => {
     // Http when
     const response = await agent
       .get(URL)
@@ -69,7 +69,7 @@ describe(`GET ${URL} E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
-  it('[200] 관리자 로그인이 되어 있을 경우 RSS 거절 기록 조회를 성공한다.', async () => {
+  it('[200] 관리자 로그인이 되어있을 경우 RSS 승인 기록 조회를 성공한다.', async () => {
     // Http when
     const response = await agent
       .get(URL)
@@ -79,15 +79,14 @@ describe(`GET ${URL} E2E Test`, () => {
     const { data } = response.body;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data).toStrictEqual(
-      rssRejectList.map((rssReject) => ({
-        blogImage: null,
-        blogPlatform: rssReject.blogPlatform,
-        description: rssReject.description,
-        email: rssReject.email,
-        id: rssReject.id,
-        name: rssReject.name,
-        rssUrl: rssReject.rssUrl,
-        userName: rssReject.userName,
+      rssAcceptList.map((rssAccept) => ({
+        blogPlatform: rssAccept.blogPlatform,
+        email: rssAccept.email,
+        id: rssAccept.id,
+        blogImage: rssAccept.blogImage ?? null,
+        name: rssAccept.name,
+        rssUrl: rssAccept.rssUrl,
+        userName: rssAccept.userName,
       })),
     );
   });

--- a/server/test/rss/e2e/admin-accept.e2e-spec.ts
+++ b/server/test/rss/e2e/admin-accept.e2e-spec.ts
@@ -19,9 +19,9 @@ import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
 import { RssFixture } from '@test/config/common/fixture/rss.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
-const URL = '/api/rss/accept';
+const URL = (id: number) => `/api/admins/rss/${id}/acceptances`;
 
-describe(`POST ${URL}/{rssId} E2E Test`, () => {
+describe(`POST /api/admins/rss/{rssId}/acceptances E2E Test`, () => {
   let agent: TestAgent;
   let rssRepository: RssRepository;
   let rssAcceptRepository: RssAcceptRepository;
@@ -55,7 +55,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
   it('[401] 관리자 로그인 쿠키가 없을 경우 RSS 승인을 실패한다.', async () => {
     // Http when
-    const response = await agent.post(`${URL}/${Number.MAX_SAFE_INTEGER}`);
+    const response = await agent.post(URL(Number.MAX_SAFE_INTEGER));
 
     // Http then
     const { data } = response.body;
@@ -80,7 +80,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
   it('[401] 관리자 로그인 쿠키가 만료됐을 경우 RSS 승인을 실패한다.', async () => {
     // Http when
     const response = await agent
-      .post(`${URL}/${Number.MAX_SAFE_INTEGER}`)
+      .post(URL(Number.MAX_SAFE_INTEGER))
       .set('Cookie', `sessionId=Wrong${sessionKey}`);
 
     // Http then
@@ -106,7 +106,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
   it('[404] 대기 목록에 없는 RSS를 승인할 경우 RSS 승인을 실패한다.', async () => {
     // Http when
     const response = await agent
-      .post(`${URL}/${Number.MAX_SAFE_INTEGER}`)
+      .post(URL(Number.MAX_SAFE_INTEGER))
       .set('Cookie', `sessionId=${sessionKey}`);
 
     // Http then
@@ -135,7 +135,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
     // Http when
     const response = await agent
-      .post(`${URL}/${rss.id}`)
+      .post(URL(rss.id))
       .set('Cookie', `sessionId=${sessionKey}`);
 
     // Http then
@@ -166,7 +166,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
     // Http when
     const response = await agent
-      .post(`${URL}/${rss.id}`)
+      .post(URL(rss.id))
       .set('Cookie', `sessionId=${sessionKey}`);
 
     // Http then

--- a/server/test/rss/e2e/admin-get.e2e-spec.ts
+++ b/server/test/rss/e2e/admin-get.e2e-spec.ts
@@ -14,7 +14,7 @@ import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
 import { RssFixture } from '@test/config/common/fixture/rss.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
-const URL = '/api/rss';
+const URL = '/api/admins/rss';
 
 describe(`GET ${URL} E2E Test`, () => {
   let agent: TestAgent;

--- a/server/test/rss/e2e/admin-reject-history.e2e-spec.ts
+++ b/server/test/rss/e2e/admin-reject-history.e2e-spec.ts
@@ -8,27 +8,27 @@ import { AdminRepository } from '@admin/repository/admin.repository';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
-import { RssAccept } from '@rss/entity/rss.entity';
-import { RssAcceptRepository } from '@rss/repository/rss.repository';
+import { RssReject } from '@rss/entity/rss.entity';
+import { RssRejectRepository } from '@rss/repository/rss.repository';
 
 import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
-import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { RssRejectFixture } from '@test/config/common/fixture/rss-reject.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
-const URL = '/api/rss/history/accept';
+const URL = '/api/admins/rss/rejections';
 
 describe(`GET ${URL} E2E Test`, () => {
   let agent: TestAgent;
-  let rssAcceptList: RssAccept[];
-  let rssAcceptRepository: RssAcceptRepository;
-  let adminRepository: AdminRepository;
+  let rssRejectList: RssReject[];
   let redisService: RedisService;
+  let rssRejectRepository: RssRejectRepository;
+  let adminRepository: AdminRepository;
   const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
-  const sessionKey = 'admin-rss-history-accept';
+  const sessionKey = 'admin-rss-history-reject';
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
-    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    rssRejectRepository = testApp.get(RssRejectRepository);
     adminRepository = testApp.get(AdminRepository);
     redisService = testApp.get(RedisService);
   });
@@ -37,17 +37,17 @@ describe(`GET ${URL} E2E Test`, () => {
     const admin = await adminRepository.save(
       await AdminFixture.createAdminCryptFixture(),
     );
-    const rssAccepts = Array.from({ length: 2 }).map(() =>
-      RssAcceptFixture.createRssAcceptFixture(),
+    const rssRejects = Array.from({ length: 2 }).map(() =>
+      RssRejectFixture.createRssRejectFixture(),
     );
-    [rssAcceptList] = await Promise.all([
-      rssAcceptRepository.save(rssAccepts),
+    [rssRejectList] = await Promise.all([
+      rssRejectRepository.save(rssRejects),
       redisService.set(redisKeyMake(sessionKey), admin.email),
     ]);
-    rssAcceptList.reverse();
+    rssRejectList.reverse();
   });
 
-  it('[401] 관리자 로그인 쿠키가 없을 경우 RSS 승인 기록 조회를 실패한다.', async () => {
+  it('[401] 관리자 로그인 쿠키가 없을 경우 RSS 거절 기록 조회를 실패한다.', async () => {
     // Http when
     const response = await agent.get(URL);
 
@@ -57,7 +57,7 @@ describe(`GET ${URL} E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
-  it('[401] 관리자 로그인 쿠키가 만료됐을 경우 RSS 승인 기록 조회를 실패한다.', async () => {
+  it('[401] 관리자 로그인 쿠키가 만료됐을 경우 RSS 거절 기록 조회를 실패한다.', async () => {
     // Http when
     const response = await agent
       .get(URL)
@@ -69,7 +69,7 @@ describe(`GET ${URL} E2E Test`, () => {
     expect(data).toBeUndefined();
   });
 
-  it('[200] 관리자 로그인이 되어있을 경우 RSS 승인 기록 조회를 성공한다.', async () => {
+  it('[200] 관리자 로그인이 되어 있을 경우 RSS 거절 기록 조회를 성공한다.', async () => {
     // Http when
     const response = await agent
       .get(URL)
@@ -79,14 +79,15 @@ describe(`GET ${URL} E2E Test`, () => {
     const { data } = response.body;
     expect(response.status).toBe(HttpStatus.OK);
     expect(data).toStrictEqual(
-      rssAcceptList.map((rssAccept) => ({
-        blogPlatform: rssAccept.blogPlatform,
-        email: rssAccept.email,
-        id: rssAccept.id,
-        blogImage: rssAccept.blogImage ?? null,
-        name: rssAccept.name,
-        rssUrl: rssAccept.rssUrl,
-        userName: rssAccept.userName,
+      rssRejectList.map((rssReject) => ({
+        blogImage: null,
+        blogPlatform: rssReject.blogPlatform,
+        description: rssReject.description,
+        email: rssReject.email,
+        id: rssReject.id,
+        name: rssReject.name,
+        rssUrl: rssReject.rssUrl,
+        userName: rssReject.userName,
       })),
     );
   });

--- a/server/test/rss/e2e/admin-reject.e2e-spec.ts
+++ b/server/test/rss/e2e/admin-reject.e2e-spec.ts
@@ -17,9 +17,9 @@ import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
 import { RssFixture } from '@test/config/common/fixture/rss.fixture';
 import { testApp } from '@test/config/e2e/env/jest.setup';
 
-const URL = '/api/rss/reject';
+const URL = (id: number) => `/api/admins/rss/${id}/rejections`;
 
-describe(`POST ${URL}/{rssId} E2E Test`, () => {
+describe(`POST /api/admins/rss/{rssId}/rejections E2E Test`, () => {
   let agent: TestAgent;
   let rssRepository: RssRepository;
   let rssRejectRepository: RssRejectRepository;
@@ -49,7 +49,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
   it('[401] 관리자 로그인 쿠키가 없을 경우 RSS 거부를 실패한다.', async () => {
     // Http when
-    const response = await agent.post(`${URL}/${Number.MAX_SAFE_INTEGER}`);
+    const response = await agent.post(URL(Number.MAX_SAFE_INTEGER));
 
     // Http then
     const { data } = response.body;
@@ -73,7 +73,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
   it('[401] 관리자 로그인 쿠키가 만료됐을 경우 RSS 거부를 실패한다.', async () => {
     // Http when
     const response = await agent
-      .post(`${URL}/${Number.MAX_SAFE_INTEGER}`)
+      .post(URL(Number.MAX_SAFE_INTEGER))
       .set('Cookie', `sessionId=Wrong${sessionKey}`);
 
     // Http then
@@ -104,7 +104,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
     // Http when
     const response = await agent
-      .post(`${URL}/${Number.MAX_SAFE_INTEGER}`)
+      .post(URL(Number.MAX_SAFE_INTEGER))
       .set('Cookie', `sessionId=${sessionKey}`)
       .send(requestDTO);
 
@@ -136,7 +136,7 @@ describe(`POST ${URL}/{rssId} E2E Test`, () => {
 
     // Http when
     const response = await agent
-      .post(`${URL}/${rss.id}`)
+      .post(URL(rss.id))
       .set('Cookie', `sessionId=${sessionKey}`)
       .send(requestDto);
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #121 

### feed/rss 컨트롤러 분리

- `FeedController`, `RssController`에 일반 사용자용 엔드포인트와 admin 전용 엔드포인트가 함께 있어 책임이 섞여있었음
- `AdminFeedController`, `AdminRssController`를 신설해 admin 전용 엔드포인트를 이관하고, 각 모듈의 `controllers`에 등록
- 클라이언트 `endpoints.ts` 및 admin API 서비스(`feed.ts`, `rss.ts`)의 경로를 변경된 admin 엔드포인트 경로에 맞게 반영
- e2e 스펙 파일명을 `admin-*` 접두사로 정리해 admin 컨트롤러 테스트임을 명확히 함

# 📋 작업 내용

- `server/src/feed/controller/adminFeed.controller.ts` 신설, `feed.controller.ts`에서 admin 전용 라우트 제거
- `server/src/rss/controller/adminRss.controller.ts` 신설, `rss.controller.ts`에서 admin 전용 라우트 제거
- `feed.module.ts`, `rss.module.ts`에 신규 admin 컨트롤러 등록
- `client/src/constants/endpoints.ts`, `client/src/api/services/admin/{feed,rss}.ts` 경로 반영
- 관련 e2e 스펙, Storybook 스토리 경로/명칭 갱신

# 📷 스크린 샷(선택 사항)

- 서버 컨트롤러 리팩토링으로 UI 변경 없음