### PR TITLE
♻️ refactor: admin/oauth/board 컨트롤러 request DTO 적용

### DIFF
--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -6,7 +6,6 @@ import {
   HttpCode,
   HttpStatus,
   Param,
-  ParseIntPipe,
   Patch,
   Post,
   Req,
@@ -31,6 +30,7 @@ import { ApiResetPasswordAdmin } from '@admin/api-docs/resetPasswordAdmin.api-do
 import { ApiUpdateAdminProfile } from '@admin/api-docs/updateAdminProfile.api-docs';
 import { CertificateAdminRequestDto } from '@admin/dto/request/certificateAdmin.dto';
 import { ConfirmDeleteAdminParamRequestDto } from '@admin/dto/request/confirmDeleteAdminParam.dto';
+import { DeleteChildAdminParamRequestDto } from '@admin/dto/request/deleteChildAdminParam.dto';
 import { ForgotPasswordAdminRequestDto } from '@admin/dto/request/forgotPasswordAdmin.dto';
 import { LoginAdminRequestDto } from '@admin/dto/request/loginAdmin.dto';
 import { RegisterAdminRequestDto } from '@admin/dto/request/registerAdmin.dto';
@@ -120,9 +120,9 @@ export class AdminController {
   @HttpCode(HttpStatus.OK)
   async deleteChildAdmin(
     @CurrentAdmin() email: string,
-    @Param('id', ParseIntPipe) targetAdminId: number,
+    @Param() paramDto: DeleteChildAdminParamRequestDto,
   ) {
-    await this.adminService.deleteChildAdmin(email, targetAdminId);
+    await this.adminService.deleteChildAdmin(email, paramDto.id);
     return ApiResponse.responseWithNoContent(
       '관리자 계정이 성공적으로 삭제되었습니다.',
     );

--- a/server/src/admin/dto/request/deleteChildAdminParam.dto.ts
+++ b/server/src/admin/dto/request/deleteChildAdminParam.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class DeleteChildAdminParamRequestDto {
+  @ApiProperty({ example: 1, description: '삭제할 관리자 ID' })
+  @IsInt({ message: '정수를 입력해주세요.' })
+  @Min(1, { message: 'id 값은 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  constructor(partial: Partial<DeleteChildAdminParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/board/controller/adminBoard.controller.ts
+++ b/server/src/board/controller/adminBoard.controller.ts
@@ -6,7 +6,6 @@ import {
   HttpCode,
   HttpStatus,
   Param,
-  ParseIntPipe,
   Patch,
   Post,
   Query,
@@ -48,10 +47,10 @@ export class AdminBoardController {
   @ApiGetAdminBoard()
   @Get('/:id')
   @HttpCode(HttpStatus.OK)
-  async getAdminBoard(@Param('id', ParseIntPipe) id: number) {
+  async getAdminBoard(@Param() paramDto: GetBoardRequestDto) {
     return ApiResponse.responseWithData(
       '게시글 상세 조회를 성공했습니다.',
-      await this.boardService.getAdminBoard(id),
+      await this.boardService.getAdminBoard(paramDto.id),
     );
   }
 
@@ -84,8 +83,8 @@ export class AdminBoardController {
   @ApiDeleteBoard()
   @Delete('/:id')
   @HttpCode(HttpStatus.OK)
-  async deleteBoard(@Param('id', ParseIntPipe) id: number) {
-    await this.boardService.deleteBoard(id);
+  async deleteBoard(@Param() paramDto: GetBoardRequestDto) {
+    await this.boardService.deleteBoard(paramDto.id);
     return ApiResponse.responseWithNoContent(
       '게시글이 성공적으로 삭제되었습니다.',
     );

--- a/server/src/user/controller/oAuth.controller.ts
+++ b/server/src/user/controller/oAuth.controller.ts
@@ -7,7 +7,6 @@ import {
   HttpStatus,
   NotFoundException,
   Param,
-  ParseEnumPipe,
   Post,
   Query,
   Req,
@@ -30,11 +29,13 @@ import {
   ApiOAuthUnlink,
 } from '@user/api-docs/oAuthLink.api-docs';
 import { ApiOAuthRegistration } from '@user/api-docs/oAuthRegistration.api-docs';
-import { OAUTH_URL_PATH, OAuthType } from '@user/constant/oauth.constant';
+import { OAUTH_URL_PATH } from '@user/constant/oauth.constant';
 import { OAuthCallbackRequestDto } from '@user/dto/request/oAuthCallbackDto';
+import { OAuthE2eCallbackQueryRequestDto } from '@user/dto/request/oAuthE2eCallbackQuery.dto';
 import { OAuthLinkRequestDto } from '@user/dto/request/oAuthLink.dto';
 import { OAuthRegistrationRequestDto } from '@user/dto/request/oAuthRegistration.dto';
 import { OAuthTypeRequestDto } from '@user/dto/request/oAuthType.dto';
+import { OAuthUnlinkParamRequestDto } from '@user/dto/request/oAuthUnlinkParam.dto';
 import { OAuthService } from '@user/service/oAuth.service';
 
 @ApiTags('OAuth')
@@ -120,23 +121,23 @@ export class OAuthController {
   @HttpCode(HttpStatus.OK)
   async unlinkProvider(
     @CurrentUser() user: Payload,
-    @Param('provider', new ParseEnumPipe(OAuthType)) provider: OAuthType,
+    @Param() paramDto: OAuthUnlinkParamRequestDto,
   ) {
-    await this.oauthService.unlinkProvider(user.id, provider);
+    await this.oauthService.unlinkProvider(user.id, paramDto.provider);
     return ApiResponse.responseWithNoContent('OAuth 연결이 해제되었습니다.');
   }
 
   @Get('e2e/callback')
   @HttpCode(HttpStatus.FOUND)
   async e2eCallback(
-    @Query('provider') provider: OAuthType = OAuthType.Google,
+    @Query() queryDto: OAuthE2eCallbackQueryRequestDto,
     @Res() res: Response,
   ) {
     if (!['LOCAL', 'TEST'].includes(process.env.NODE_ENV ?? '')) {
       throw new NotFoundException();
     }
 
-    await this.oauthService.e2eCallback(provider, res);
+    await this.oauthService.e2eCallback(queryDto.provider, res);
     return res.redirect(`${OAUTH_URL_PATH.BASE_URL}/oauth-success`);
   }
 }

--- a/server/src/user/dto/request/oAuthE2eCallbackQuery.dto.ts
+++ b/server/src/user/dto/request/oAuthE2eCallbackQuery.dto.ts
@@ -1,0 +1,22 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { IsEnum, IsOptional } from 'class-validator';
+
+import { OAuthType } from '@user/constant/oauth.constant';
+
+export class OAuthE2eCallbackQueryRequestDto {
+  @ApiPropertyOptional({
+    example: OAuthType.Google,
+    description: '제공자 타입',
+    default: OAuthType.Google,
+  })
+  @IsOptional()
+  @IsEnum(OAuthType, {
+    message: '지원하지 않는 인증 제공자입니다.',
+  })
+  provider: OAuthType = OAuthType.Google;
+
+  constructor(partial: Partial<OAuthE2eCallbackQueryRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/user/dto/request/oAuthUnlinkParam.dto.ts
+++ b/server/src/user/dto/request/oAuthUnlinkParam.dto.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsEnum } from 'class-validator';
+
+import { OAuthType } from '@user/constant/oauth.constant';
+
+export class OAuthUnlinkParamRequestDto {
+  @ApiProperty({
+    example: OAuthType.Google,
+    description: '연결 해제할 제공자 타입',
+  })
+  @IsEnum(OAuthType, {
+    message: '지원하지 않는 인증 제공자입니다.',
+  })
+  provider: OAuthType;
+
+  constructor(partial: Partial<OAuthUnlinkParamRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/test/admin/dto/deleteChildAdminParam.dto.spec.ts
+++ b/server/test/admin/dto/deleteChildAdminParam.dto.spec.ts
@@ -1,0 +1,59 @@
+import { validate } from 'class-validator';
+
+import { DeleteChildAdminParamRequestDto } from '@admin/dto/request/deleteChildAdminParam.dto';
+
+describe(`${DeleteChildAdminParamRequestDto.name} Test`, () => {
+  let dto: DeleteChildAdminParamRequestDto;
+
+  beforeEach(() => {
+    dto = new DeleteChildAdminParamRequestDto({
+      id: 1,
+    });
+  });
+
+  it('관리자 ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('id', () => {
+    it('관리자 ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('관리자 ID가 정수가 아닌 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('관리자 ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/board/e2e/admin-delete.e2e-spec.ts
+++ b/server/test/board/e2e/admin-delete.e2e-spec.ts
@@ -85,17 +85,4 @@ describe(`DELETE /api/admins/boards/:id E2E Test`, () => {
     // DB then
     expect(await boardRepository.findOneBy({ id: board.id })).not.toBeNull();
   });
-
-  it('[400] 게시글 ID가 정수가 아닐 경우 삭제를 실패한다.', async () => {
-    // Http when
-    const response = await agent
-      .delete(URL('test'))
-      .set('Cookie', `sessionId=${sessionKey}`);
-
-    // Http then
-    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
-
-    // DB then
-    expect(await boardRepository.findOneBy({ id: board.id })).not.toBeNull();
-  });
 });

--- a/server/test/board/e2e/admin-detail.e2e-spec.ts
+++ b/server/test/board/e2e/admin-detail.e2e-spec.ts
@@ -91,24 +91,4 @@ describe(`GET /api/admins/boards/:id E2E Test`, () => {
     // Http then
     expect(response.status).toBe(HttpStatus.NOT_FOUND);
   });
-
-  it('[404] 게시글 ID가 0일 경우 상세 조회를 실패한다.', async () => {
-    // Http when
-    const response = await agent
-      .get(URL(0))
-      .set('Cookie', `sessionId=${sessionKey}`);
-
-    // Http then
-    expect(response.status).toBe(HttpStatus.NOT_FOUND);
-  });
-
-  it('[400] 게시글 ID가 정수가 아닐 경우 상세 조회를 실패한다.', async () => {
-    // Http when
-    const response = await agent
-      .get(URL('test'))
-      .set('Cookie', `sessionId=${sessionKey}`);
-
-    // Http then
-    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
-  });
 });

--- a/server/test/oauth/dto/oAuthE2eCallbackQuery.dto.spec.ts
+++ b/server/test/oauth/dto/oAuthE2eCallbackQuery.dto.spec.ts
@@ -1,0 +1,41 @@
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { OAuthType } from '@user/constant/oauth.constant';
+import { OAuthE2eCallbackQueryRequestDto } from '@user/dto/request/oAuthE2eCallbackQuery.dto';
+
+describe(`${OAuthE2eCallbackQueryRequestDto.name} Test`, () => {
+  const toDto = (partial: Partial<OAuthE2eCallbackQueryRequestDto>) =>
+    plainToInstance(OAuthE2eCallbackQueryRequestDto, partial);
+
+  it('제공자가 타입 목록에 있을 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(toDto({ provider: OAuthType.Github }));
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('제공자가 없을 경우 기본값 Google이 적용되어 유효성 검사에 성공한다.', async () => {
+    // given
+    const dto = toDto({});
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(dto.provider).toBe(OAuthType.Google);
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('provider', () => {
+    it('제공자가 타입 목록에 없을 경우 유효성 검사에 실패한다.', async () => {
+      // when
+      const errors = await validate(toDto({ provider: 'naver' as any }));
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isEnum');
+    });
+  });
+});

--- a/server/test/oauth/dto/oAuthUnlinkParam.dto.spec.ts
+++ b/server/test/oauth/dto/oAuthUnlinkParam.dto.spec.ts
@@ -1,0 +1,48 @@
+import { validate } from 'class-validator';
+
+import { OAuthType } from '@user/constant/oauth.constant';
+import { OAuthUnlinkParamRequestDto } from '@user/dto/request/oAuthUnlinkParam.dto';
+
+describe(`${OAuthUnlinkParamRequestDto.name} Test`, () => {
+  let dto: OAuthUnlinkParamRequestDto;
+
+  beforeEach(() => {
+    dto = new OAuthUnlinkParamRequestDto({
+      provider: OAuthType.Google,
+    });
+  });
+
+  it('연결 해제할 제공자가 타입 목록에 있을 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('provider', () => {
+    it('제공자가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.provider = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isEnum');
+    });
+
+    it('제공자가 타입 목록에 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.provider = 'naver' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isEnum');
+    });
+  });
+});


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #121 (part of NestJS 최종 리팩토링, 부분 해결)

### 소주제1

- Admin/OAuth/Board 컨트롤러의 파라미터, 쿼리 검증 로직을 컨트롤러 코드에서 분리해 request DTO(class-validator)로 이전

### 소주제2

- DTO 도입에 따라 e2e 테스트에서 중복되던 파라미터 검증 케이스를 제거하고, 신규 DTO에 대한 단위 테스트 추가

# 📋 작업 내용

- `DeleteChildAdminParamRequestDto` 추가 및 admin controller에 적용, 단위 테스트 작성
- `OAuthE2eCallbackQueryRequestDto`, `OAuthUnlinkParamRequestDto` 추가 및 oAuth controller에 적용, 단위 테스트 작성
- 게시글(Board) 컨트롤러에 request DTO 적용
- 컨트롤러 레벨 검증이 DTO로 이관됨에 따라 중복되던 e2e 검증 테스트 제거

# 📷 스크린 샷(선택 사항)

해당 사항 없음