### PR TITLE
♻️ refactor: 서비스 계층 순수 함수 util 분리 및 common 통합

### DIFF
--- a/server/src/admin/service/admin.service.ts
+++ b/server/src/admin/service/admin.service.ts
@@ -24,6 +24,7 @@ import { cookieConfig } from '@common/cookie/cookie.config';
 import { EmailProducer } from '@common/email/email.producer';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
+import { createHashedPassword } from '@common/util/createHashedPassword';
 
 const ADMIN_REGISTER_TTL = 600;
 
@@ -123,10 +124,8 @@ export class AdminService {
       where: { email: creatorEmail },
     });
 
-    const saltRounds = 10;
-    registerAdminBodyDto.password = await bcrypt.hash(
+    registerAdminBodyDto.password = await createHashedPassword(
       registerAdminBodyDto.password,
-      saltRounds,
     );
 
     const admin = registerAdminBodyDto.toEntity();
@@ -316,8 +315,7 @@ export class AdminService {
       throw new NotFoundException('인증에 실패했습니다.');
     }
 
-    const saltRounds = 10;
-    admin.password = await bcrypt.hash(password, saltRounds);
+    admin.password = await createHashedPassword(password);
     await this.adminRepository.save(admin);
 
     await this.redisService.del(resetRequestKey);
@@ -402,8 +400,7 @@ export class AdminService {
 
     const passwordChanged = password !== undefined;
     if (passwordChanged) {
-      const saltRounds = 10;
-      admin.password = await bcrypt.hash(password, saltRounds);
+      admin.password = await createHashedPassword(password);
     }
 
     if (emailNotification !== undefined) {

--- a/server/src/board/service/board.service.ts
+++ b/server/src/board/service/board.service.ts
@@ -1,8 +1,4 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
 import { CreateBoardRequestDto } from '@board/dto/request/createBoard.dto';
@@ -14,6 +10,7 @@ import {
   BoardListResponseDto,
 } from '@board/dto/response/board.dto';
 import { BoardRepository } from '@board/repository/board.repository';
+import { validateWindow } from '@board/util/validateWindow';
 
 import { AdminRepository } from '@admin/repository/admin.repository';
 
@@ -25,14 +22,6 @@ export class BoardService {
     private readonly boardRepository: BoardRepository,
     private readonly adminRepository: AdminRepository,
   ) {}
-
-  private validateWindow(startAt: Date | null, endAt: Date | null) {
-    if (startAt && endAt && startAt.getTime() >= endAt.getTime()) {
-      throw new BadRequestException(
-        '노출 시작일은 종료일보다 이전이어야 합니다.',
-      );
-    }
-  }
 
   async getPublicBoards(queryDto: GetBoardsRequestDto) {
     const { page, limit, category } = queryDto;
@@ -81,7 +70,7 @@ export class BoardService {
   ): Promise<BoardDetailDto> {
     const startAt = dto.startAt ? new Date(dto.startAt) : null;
     const endAt = dto.endAt ? new Date(dto.endAt) : null;
-    this.validateWindow(startAt, endAt);
+    validateWindow(startAt, endAt);
 
     const author = await this.adminRepository.findOneBy({ email: authorEmail });
 
@@ -124,7 +113,7 @@ export class BoardService {
           ? new Date(dto.endAt)
           : null
         : board.endAt;
-    this.validateWindow(startAt, endAt);
+    validateWindow(startAt, endAt);
 
     if (dto.title !== undefined) board.title = dto.title;
     if (dto.content !== undefined) board.content = dto.content;

--- a/server/src/board/util/validateWindow.ts
+++ b/server/src/board/util/validateWindow.ts
@@ -1,0 +1,9 @@
+import { BadRequestException } from '@nestjs/common';
+
+export function validateWindow(startAt: Date | null, endAt: Date | null) {
+  if (startAt && endAt && startAt.getTime() >= endAt.getTime()) {
+    throw new BadRequestException(
+      '노출 시작일은 종료일보다 이전이어야 합니다.',
+    );
+  }
+}

--- a/server/src/common/logger/logger.interceptor.ts
+++ b/server/src/common/logger/logger.interceptor.ts
@@ -9,6 +9,7 @@ import { Request } from 'express';
 import { finalize } from 'rxjs';
 
 import { WinstonLoggerService } from '@common/logger/logger.service';
+import { getIp } from '@common/util/getIp';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
@@ -26,7 +27,7 @@ export class LoggingInterceptor implements NestInterceptor {
     if (shouldLog) {
       this.logger.log(
         JSON.stringify({
-          host: this.getIp(request),
+          host: getIp(request),
           method: request.method,
           url: request.url,
           body: request.body,
@@ -45,16 +46,5 @@ export class LoggingInterceptor implements NestInterceptor {
         }
       }),
     );
-  }
-
-  private getIp(request: Request) {
-    const forwardedFor = request.headers['x-forwarded-for'];
-
-    if (typeof forwardedFor === 'string') {
-      const forwardedIps = forwardedFor.split(',');
-      return forwardedIps[0].trim();
-    }
-
-    return request.socket.remoteAddress;
   }
 }

--- a/server/src/common/util/createHashedPassword.ts
+++ b/server/src/common/util/createHashedPassword.ts
@@ -1,6 +1,6 @@
 import * as bcrypt from 'bcrypt';
 
-import { SALT_ROUNDS } from '@user/constant/user.constants';
+const SALT_ROUNDS = 10;
 
 export async function createHashedPassword(password: string) {
   return await bcrypt.hash(password, SALT_ROUNDS);

--- a/server/src/common/util/getIp.ts
+++ b/server/src/common/util/getIp.ts
@@ -1,0 +1,12 @@
+import { Request } from 'express';
+
+export function getIp(request: Request) {
+  const forwardedFor = request.headers['x-forwarded-for'];
+
+  if (typeof forwardedFor === 'string') {
+    const forwardedIps = forwardedFor.split(',');
+    return forwardedIps[0].trim();
+  }
+
+  return request.socket.remoteAddress;
+}

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -12,6 +12,7 @@ import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
+import { getIp } from '@common/util/getIp';
 
 import { AI_RETRY_LOCK_TTL_SECONDS } from '@feed/constant/feed.constant';
 import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
@@ -40,7 +41,7 @@ import {
   FeedViewRepository,
 } from '@feed/repository/feed.repository';
 import { existNextFeed, getLastIdFromFeedList } from '@feed/util/pagination';
-import { createCookie, getIp, isString } from '@feed/util/viewCookie';
+import { createCookie, isString } from '@feed/util/viewCookie';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -8,21 +8,16 @@ import {
 import axios from 'axios';
 import { Request, Response } from 'express';
 
-import { cookieConfig } from '@common/cookie/cookie.config';
-import { REDIS_KEYS } from '@common/redis/redis.constant';
-import { RedisService } from '@common/redis/redis.service';
-
 import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 
-import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
 
 import { AI_RETRY_LOCK_TTL_SECONDS } from '@feed/constant/feed.constant';
 import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
 import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
-import { ReadSubscriptionFeedResponseDto } from '@feed/dto/response/readSubscriptionFeed.dto';
 import { SearchFeedRequestDto } from '@feed/dto/request/searchFeed.dto';
 import { GetFeedDetailResponseDto } from '@feed/dto/response/getFeedDetail';
-import { ReadNoSummaryFeedResponseDto } from '@feed/dto/response/readNoSummaryFeed.dto';
 import {
   FeedPaginationResult,
   FeedResult,
@@ -33,6 +28,8 @@ import {
   FeedRecentRedis,
   ReadFeedRecentResponseDto,
 } from '@feed/dto/response/readFeedRecent.dto';
+import { ReadNoSummaryFeedResponseDto } from '@feed/dto/response/readNoSummaryFeed.dto';
+import { ReadSubscriptionFeedResponseDto } from '@feed/dto/response/readSubscriptionFeed.dto';
 import {
   SearchFeedResponseDto,
   SearchFeedResult,
@@ -42,6 +39,10 @@ import {
   FeedRepository,
   FeedViewRepository,
 } from '@feed/repository/feed.repository';
+import { existNextFeed, getLastIdFromFeedList } from '@feed/util/pagination';
+import { createCookie, getIp, isString } from '@feed/util/viewCookie';
+
+import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 type AiSummaryRetryMessage = {
   feedId: number;
@@ -126,9 +127,9 @@ export class FeedService {
       blockerId,
     );
 
-    const hasMore = this.existNextFeed(feedList, feedPaginationQueryDto.limit);
+    const hasMore = existNextFeed(feedList, feedPaginationQueryDto.limit);
     if (hasMore) feedList.pop();
-    const lastId = this.getLastIdFromFeedList(feedList);
+    const lastId = getLastIdFromFeedList(feedList);
     const newCheckFeedList = await this.checkNewFeeds(feedList);
     const feedPagination = FeedResult.toResultDtoArray(newCheckFeedList);
     return ReadFeedPaginationResponseDto.toResponseDto(
@@ -136,14 +137,6 @@ export class FeedService {
       lastId,
       hasMore,
     );
-  }
-
-  private existNextFeed(feedList: FeedView[], limit: number) {
-    return feedList.length > limit;
-  }
-
-  private getLastIdFromFeedList(feedList: FeedView[]) {
-    return feedList.length ? feedList[feedList.length - 1].feedId : 0;
   }
 
   private async checkNewFeeds(feedList: FeedView[]) {
@@ -213,9 +206,9 @@ export class FeedService {
     await this.getFeed(feedId);
 
     const cookie = request.headers.cookie;
-    const ip = this.getIp(request);
+    const ip = getIp(request);
 
-    if (!ip || !this.isString(ip)) {
+    if (!ip || !isString(ip)) {
       return;
     }
 
@@ -232,11 +225,11 @@ export class FeedService {
     );
 
     if (hasIpFlag) {
-      this.createCookie(response, feedId);
+      createCookie(response, feedId);
       return;
     }
 
-    this.createCookie(response, feedId);
+    createCookie(response, feedId);
 
     await Promise.all([
       this.redisService.sadd(`feed:${feedId}:ip`, ip),
@@ -249,25 +242,6 @@ export class FeedService {
         feedId.toString(),
       ),
     ]);
-  }
-
-  private isString(ip: string | string[]): ip is string {
-    return !Array.isArray(ip);
-  }
-
-  private createCookie(response: Response, feedId: number) {
-    const cookieConfigWithExpiration = {
-      ...cookieConfig[process.env.NODE_ENV],
-      expires: this.getExpirationTime(),
-    };
-    response.cookie(`View_count_${feedId}`, feedId, cookieConfigWithExpiration);
-  }
-
-  private getExpirationTime() {
-    const tomorrow = new Date();
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    tomorrow.setHours(0, 0, 0, 0);
-    return tomorrow;
   }
 
   async readRecentFeedList() {
@@ -300,17 +274,6 @@ export class FeedService {
       );
 
     return ReadFeedRecentResponseDto.toResponseDtoArray(recentFeedList);
-  }
-
-  private getIp(request: Request) {
-    const forwardedFor = request.headers['x-forwarded-for'];
-
-    if (typeof forwardedFor === 'string') {
-      const forwardedIps = forwardedFor.split(',');
-      return forwardedIps[0].trim();
-    }
-
-    return request.socket.remoteAddress;
   }
 
   async getFeedDetail(
@@ -376,7 +339,11 @@ export class FeedService {
     if (hasMore) feeds.pop();
     const lastId = feeds.length ? feeds[feeds.length - 1].id : 0;
 
-    return ReadSubscriptionFeedResponseDto.toResponseDto(feeds, lastId, hasMore);
+    return ReadSubscriptionFeedResponseDto.toResponseDto(
+      feeds,
+      lastId,
+      hasMore,
+    );
   }
 
   async deleteCheckFeed(feedDeleteCheckDto: ManageFeedRequestDto) {

--- a/server/src/feed/util/pagination.ts
+++ b/server/src/feed/util/pagination.ts
@@ -1,0 +1,9 @@
+import { FeedView } from '@feed/entity/feed.entity';
+
+export function existNextFeed(feedList: FeedView[], limit: number) {
+  return feedList.length > limit;
+}
+
+export function getLastIdFromFeedList(feedList: FeedView[]) {
+  return feedList.length ? feedList[feedList.length - 1].feedId : 0;
+}

--- a/server/src/feed/util/viewCookie.ts
+++ b/server/src/feed/util/viewCookie.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from 'express';
+
+import { cookieConfig } from '@common/cookie/cookie.config';
+
+export function isString(ip: string | string[]): ip is string {
+  return !Array.isArray(ip);
+}
+
+export function getIp(request: Request) {
+  const forwardedFor = request.headers['x-forwarded-for'];
+
+  if (typeof forwardedFor === 'string') {
+    const forwardedIps = forwardedFor.split(',');
+    return forwardedIps[0].trim();
+  }
+
+  return request.socket.remoteAddress;
+}
+
+function getExpirationTime() {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  tomorrow.setHours(0, 0, 0, 0);
+  return tomorrow;
+}
+
+export function createCookie(response: Response, feedId: number) {
+  const cookieConfigWithExpiration = {
+    ...cookieConfig[process.env.NODE_ENV],
+    expires: getExpirationTime(),
+  };
+  response.cookie(`View_count_${feedId}`, feedId, cookieConfigWithExpiration);
+}

--- a/server/src/feed/util/viewCookie.ts
+++ b/server/src/feed/util/viewCookie.ts
@@ -1,20 +1,9 @@
-import { Request, Response } from 'express';
+import { Response } from 'express';
 
 import { cookieConfig } from '@common/cookie/cookie.config';
 
 export function isString(ip: string | string[]): ip is string {
   return !Array.isArray(ip);
-}
-
-export function getIp(request: Request) {
-  const forwardedFor = request.headers['x-forwarded-for'];
-
-  if (typeof forwardedFor === 'string') {
-    const forwardedIps = forwardedFor.split(',');
-    return forwardedIps[0].trim();
-  }
-
-  return request.socket.remoteAddress;
 }
 
 function getExpirationTime() {

--- a/server/src/qna/service/qna.service.ts
+++ b/server/src/qna/service/qna.service.ts
@@ -15,6 +15,7 @@ import { EmailProducer } from '@common/email/email.producer';
 import { Payload } from '@common/guard/jwt.guard';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { NotifierRegistry } from '@common/notification/notifier-registry';
+import { createHashedPassword } from '@common/util/createHashedPassword';
 
 import {
   QNA_NOT_FOUND_MESSAGE,
@@ -37,7 +38,6 @@ import { Qna } from '@qna/entity/qna.entity';
 import { QnaMessage } from '@qna/entity/qnaMessage.entity';
 import { QnaRepository } from '@qna/repository/qna.repository';
 
-import { SALT_ROUNDS } from '@user/constant/user.constants';
 import { UserRepository } from '@user/repository/user.repository';
 
 @Injectable()
@@ -84,7 +84,7 @@ export class QnaService {
     const shouldHashPassword = user ? dto.isSecret : true;
     const hashedPassword =
       shouldHashPassword && dto.password
-        ? await bcrypt.hash(dto.password, SALT_ROUNDS)
+        ? await createHashedPassword(dto.password)
         : null;
 
     let qnaId: number;

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -55,8 +55,9 @@ import {
   RssRejectRepository,
   RssRepository,
 } from '@rss/repository/rss.repository';
+import { assertUrlAccessible } from '@rss/util/assertUrlAccessible';
 import { blogUrlToRss } from '@rss/util/blogUrlToRss';
-import { extractChannelImage } from '@rss/util/extractChannelImage';
+import { fetchChannelImage } from '@rss/util/fetchChannelImage';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
@@ -109,55 +110,15 @@ export class RssService {
     }
 
     await Promise.all([
-      this.assertUrlAccessible(blogUrl),
-      this.assertUrlAccessible(rssUrl),
+      assertUrlAccessible(blogUrl),
+      assertUrlAccessible(rssUrl),
     ]);
 
     const rssEntity = rssRegisterBodyDto.toEntity(rssUrl);
-    rssEntity.blogImage = await this.fetchChannelImage(rssUrl);
+    rssEntity.blogImage = await fetchChannelImage(rssUrl);
     await this.rssRepository.insert(rssEntity);
 
     await this.notifyRssRegistrationRequest(rssEntity);
-  }
-
-  private async assertUrlAccessible(url: string) {
-    try {
-      await axios.get(url, {
-        timeout: 5000,
-        maxRedirects: 5,
-        maxContentLength: 5 * 1024 * 1024,
-      });
-    } catch (error) {
-      const status = axios.isAxiosError(error)
-        ? error.response?.status
-        : undefined;
-
-      if (status === 404) {
-        throw new NotFoundException(
-          `${url}을(를) 찾을 수 없습니다. 올바른 블로그 주소를 입력해주세요.`,
-        );
-      }
-
-      throw new BadRequestException(
-        `${url}에 접속할 수 없습니다. 올바른 블로그 주소를 입력해주세요.`,
-      );
-    }
-  }
-
-  private async fetchChannelImage(rssUrl: string): Promise<string | null> {
-    try {
-      const { data } = await axios.get<string>(rssUrl, {
-        headers: {
-          Accept: 'application/rss+xml, application/xml, text/xml',
-        },
-        responseType: 'text',
-        timeout: 5000,
-        maxContentLength: 5 * 1024 * 1024,
-      });
-      return typeof data === 'string' ? extractChannelImage(data) : null;
-    } catch {
-      return null;
-    }
   }
 
   private async notifyRssRegistrationRequest(rss: Rss) {

--- a/server/src/rss/util/assertUrlAccessible.ts
+++ b/server/src/rss/util/assertUrlAccessible.ts
@@ -1,0 +1,27 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+
+import axios from 'axios';
+
+export async function assertUrlAccessible(url: string) {
+  try {
+    await axios.get(url, {
+      timeout: 5000,
+      maxRedirects: 5,
+      maxContentLength: 5 * 1024 * 1024,
+    });
+  } catch (error) {
+    const status = axios.isAxiosError(error)
+      ? error.response?.status
+      : undefined;
+
+    if (status === 404) {
+      throw new NotFoundException(
+        `${url}을(를) 찾을 수 없습니다. 올바른 블로그 주소를 입력해주세요.`,
+      );
+    }
+
+    throw new BadRequestException(
+      `${url}에 접속할 수 없습니다. 올바른 블로그 주소를 입력해주세요.`,
+    );
+  }
+}

--- a/server/src/rss/util/fetchChannelImage.ts
+++ b/server/src/rss/util/fetchChannelImage.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+import { extractChannelImage } from '@rss/util/extractChannelImage';
+
+export async function fetchChannelImage(
+  rssUrl: string,
+): Promise<string | null> {
+  try {
+    const { data } = await axios.get<string>(rssUrl, {
+      headers: {
+        Accept: 'application/rss+xml, application/xml, text/xml',
+      },
+      responseType: 'text',
+      timeout: 5000,
+      maxContentLength: 5 * 1024 * 1024,
+    });
+    return typeof data === 'string' ? extractChannelImage(data) : null;
+  } catch {
+    return null;
+  }
+}

--- a/server/src/user/constant/user.constants.ts
+++ b/server/src/user/constant/user.constants.ts
@@ -1,2 +1,1 @@
 export const REFRESH_TOKEN_TTL = 1000 * 60 * 60 * 24 * 7;
-export const SALT_ROUNDS = 10;

--- a/server/src/user/service/oAuth.service.ts
+++ b/server/src/user/service/oAuth.service.ts
@@ -28,7 +28,6 @@ import {
   OAuthPendingData,
   OAuthTokenResponse,
   OAuthType,
-  StateData,
   UserInfo,
 } from '@user/constant/oauth.constant';
 import { OAuthCallbackRequestDto } from '@user/dto/request/oAuthCallbackDto';
@@ -40,6 +39,7 @@ import { OAuthProvider } from '@user/provider/oauth-provider.interface';
 import { ProviderRepository } from '@user/repository/provider.repository';
 import { UserRepository } from '@user/repository/user.repository';
 import { UserService } from '@user/service/user.service';
+import { parseStateData } from '@user/util/parseStateData';
 
 @Injectable()
 export class OAuthService {
@@ -181,7 +181,7 @@ export class OAuthService {
     res: Response,
     req: Request,
   ) {
-    const stateData = this.parseStateData(callbackDto.state);
+    const stateData = parseStateData(callbackDto.state);
     const { provider: providerType, csrfToken: csrfTokenKey } = stateData;
     const cookieCsrfToken = req.cookies['oauth_csrf_token'];
 
@@ -531,14 +531,6 @@ export class OAuthService {
     };
 
     this.userService.issueRefreshToken(jwtPayload, res);
-  }
-
-  private parseStateData(stateString: string): StateData {
-    try {
-      return JSON.parse(Buffer.from(stateString, 'base64').toString());
-    } catch {
-      throw new BadRequestException('잘못된 state 형식입니다.');
-    }
   }
 
   private async findExistingProvider(

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -17,6 +17,7 @@ import { EmailProducer } from '@common/email/email.producer';
 import { Payload } from '@common/guard/jwt.guard';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
+import { createHashedPassword } from '@common/util/createHashedPassword';
 
 import { FeedRepository } from '@feed/repository/feed.repository';
 
@@ -44,7 +45,6 @@ import {
 } from '@user/dto/response/searchUser.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
-import { createHashedPassword } from '@user/util/createHashedPassword';
 
 @Injectable()
 export class UserService {

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -27,7 +27,7 @@ import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
-import { REFRESH_TOKEN_TTL, SALT_ROUNDS } from '@user/constant/user.constants';
+import { REFRESH_TOKEN_TTL } from '@user/constant/user.constants';
 import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
@@ -44,6 +44,7 @@ import {
 } from '@user/dto/response/searchUser.dto';
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
+import { createHashedPassword } from '@user/util/createHashedPassword';
 
 @Injectable()
 export class UserService {
@@ -131,7 +132,7 @@ export class UserService {
     }
 
     const newUser = registerDto.toEntity();
-    newUser.password = await this.createHashedPassword(registerDto.password);
+    newUser.password = await createHashedPassword(registerDto.password);
 
     const userRegisterCode = uuid.v4();
     await this.redisService.set(
@@ -255,10 +256,6 @@ export class UserService {
     });
   }
 
-  private async createHashedPassword(password: string) {
-    return await bcrypt.hash(password, SALT_ROUNDS);
-  }
-
   async updateUserActivity(userId: number) {
     const user = await this.getUser(userId);
 
@@ -367,9 +364,7 @@ export class UserService {
       }
     }
 
-    user.password = await this.createHashedPassword(
-      changePasswordDto.newPassword,
-    );
+    user.password = await createHashedPassword(changePasswordDto.newPassword);
     await this.userRepository.save(user);
     await this.invalidateUserTokens(user.id);
   }
@@ -415,7 +410,7 @@ export class UserService {
       throw new NotFoundException('존재하지 않는 유저입니다.');
     }
 
-    user.password = await this.createHashedPassword(password);
+    user.password = await createHashedPassword(password);
 
     await this.redisService.del(
       `${REDIS_KEYS.USER_RESET_PASSWORD_KEY}:${uuid}`,

--- a/server/src/user/util/createHashedPassword.ts
+++ b/server/src/user/util/createHashedPassword.ts
@@ -1,0 +1,7 @@
+import * as bcrypt from 'bcrypt';
+
+import { SALT_ROUNDS } from '@user/constant/user.constants';
+
+export async function createHashedPassword(password: string) {
+  return await bcrypt.hash(password, SALT_ROUNDS);
+}

--- a/server/src/user/util/parseStateData.ts
+++ b/server/src/user/util/parseStateData.ts
@@ -1,0 +1,11 @@
+import { BadRequestException } from '@nestjs/common';
+
+import { StateData } from '@user/constant/oauth.constant';
+
+export function parseStateData(stateString: string): StateData {
+  try {
+    return JSON.parse(Buffer.from(stateString, 'base64').toString());
+  } catch {
+    throw new BadRequestException('잘못된 state 형식입니다.');
+  }
+}

--- a/server/test/common/unit/getIp.unit.spec.ts
+++ b/server/test/common/unit/getIp.unit.spec.ts
@@ -1,4 +1,4 @@
-import { getIp } from '@feed/util/viewCookie';
+import { getIp } from '@common/util/getIp';
 
 const createRequest = (
   xff: string | string[] | undefined,

--- a/server/test/config/common/fixture/admin.fixture.ts
+++ b/server/test/config/common/fixture/admin.fixture.ts
@@ -1,9 +1,8 @@
-import * as bcrypt from 'bcrypt';
 import * as uuid from 'uuid';
 
 import { Admin } from '@admin/entity/admin.entity';
 
-import { SALT_ROUNDS } from '@user/constant/user.constants';
+import { createHashedPassword } from '@common/util/createHashedPassword';
 
 export const ADMIN_DEFAULT_PASSWORD = 'test1234!';
 
@@ -19,7 +18,7 @@ export class AdminFixture {
   static async createAdminCryptFixture(overwrites: Partial<Admin> = {}) {
     const admin = new Admin();
     Object.assign(admin, this.createGeneralAdmin(), overwrites);
-    admin.password = await bcrypt.hash(admin.password, SALT_ROUNDS);
+    admin.password = await createHashedPassword(admin.password);
     return admin;
   }
 

--- a/server/test/config/common/fixture/user.fixture.ts
+++ b/server/test/config/common/fixture/user.fixture.ts
@@ -1,7 +1,7 @@
-import * as bcrypt from 'bcrypt';
 import * as uuid from 'uuid';
 
-import { SALT_ROUNDS } from '@user/constant/user.constants';
+import { createHashedPassword } from '@common/util/createHashedPassword';
+
 import { User } from '@user/entity/user.entity';
 
 export const USER_DEFAULT_PASSWORD = 'test1234!';
@@ -21,7 +21,7 @@ export class UserFixture {
   static async createUserCryptFixture(overwrites: Partial<User> = {}) {
     const user = new User();
     Object.assign(user, this.createGeneralUser(), overwrites);
-    user.password = await bcrypt.hash(user.password, SALT_ROUNDS);
+    user.password = await createHashedPassword(user.password);
     return user;
   }
 

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -499,41 +499,4 @@ describe(`${FeedService.name} Unit Test`, () => {
       expect(feedRepository.delete).not.toHaveBeenCalled();
     });
   });
-
-  // getIp는 헤더 문자열 파싱만 하는 순수 로직이라 e2e 대신 단위로 격리 검증한다.
-  // (실제 헤더가 Express→서비스로 흐르는지는 up-view-count e2e가 Redis 상태로 검증)
-  describe('getIp (private)', () => {
-    const getIp = (request: unknown) =>
-      (feedService as unknown as { getIp(request: unknown): string }).getIp(
-        request,
-      );
-
-    const createRequest = (
-      xff: string | string[] | undefined,
-      remoteAddress = '127.0.0.1',
-    ) => ({
-      headers: { 'x-forwarded-for': xff },
-      socket: { remoteAddress },
-    });
-
-    it('x-forwarded-for 단일 IP면 해당 IP를 반환한다.', () => {
-      expect(getIp(createRequest('203.0.113.1'))).toBe('203.0.113.1');
-    });
-
-    it('x-forwarded-for에 여러 IP가 있으면 첫 번째 IP를 trim해 반환한다.', () => {
-      expect(getIp(createRequest('203.0.113.1, 198.51.100.1'))).toBe(
-        '203.0.113.1',
-      );
-    });
-
-    it('x-forwarded-for가 없으면 socket.remoteAddress를 반환한다.', () => {
-      expect(getIp(createRequest(undefined, '10.0.0.5'))).toBe('10.0.0.5');
-    });
-
-    it('x-forwarded-for가 배열(문자열 아님)이면 socket.remoteAddress로 폴백한다.', () => {
-      expect(getIp(createRequest(['203.0.113.1'], '10.0.0.5'))).toBe(
-        '10.0.0.5',
-      );
-    });
-  });
 });

--- a/server/test/feed/unit/viewCookie.unit.spec.ts
+++ b/server/test/feed/unit/viewCookie.unit.spec.ts
@@ -1,0 +1,30 @@
+import { getIp } from '@feed/util/viewCookie';
+
+const createRequest = (
+  xff: string | string[] | undefined,
+  remoteAddress = '127.0.0.1',
+) =>
+  ({
+    headers: { 'x-forwarded-for': xff },
+    socket: { remoteAddress },
+  }) as unknown as Parameters<typeof getIp>[0];
+
+describe(`${getIp.name} Unit Test`, () => {
+  it('x-forwarded-for 단일 IP면 해당 IP를 반환한다.', () => {
+    expect(getIp(createRequest('203.0.113.1'))).toBe('203.0.113.1');
+  });
+
+  it('x-forwarded-for에 여러 IP가 있으면 첫 번째 IP를 trim해 반환한다.', () => {
+    expect(getIp(createRequest('203.0.113.1, 198.51.100.1'))).toBe(
+      '203.0.113.1',
+    );
+  });
+
+  it('x-forwarded-for가 없으면 socket.remoteAddress를 반환한다.', () => {
+    expect(getIp(createRequest(undefined, '10.0.0.5'))).toBe('10.0.0.5');
+  });
+
+  it('x-forwarded-for가 배열(문자열 아님)이면 socket.remoteAddress로 폴백한다.', () => {
+    expect(getIp(createRequest(['203.0.113.1'], '10.0.0.5'))).toBe('10.0.0.5');
+  });
+});


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   #121

### 비대해진 서비스에서 순수 함수 util 분리

-   rss/oAuth/user/feed/board 서비스 메서드 중 `this.<repository/redis/configService>` 등 DI 의존이 없는 순수 함수만 골라 도메인별 `util/`로 추출
-   `this.configService`, `this.adminRepository` 등에 의존하는 메서드(`parseTimeToSeconds`, `collectSubtreeEmails` 등)는 util로 뽑으면 결국 DI를 다시 필요로 하게 되어 제외
-   추출: URL 접근성 검증/RSS 채널 이미지 파싱(rss), OAuth state 파싱(user), 비밀번호 해싱(user), 페이지네이션 계산/조회수 쿠키 처리(feed), 게시글 노출기간 검증(board)

### 도메인 간 중복 로직 common/util로 통합

-   비밀번호 해싱: admin/qna/user 세 서비스에 각각 다르게(admin은 salt rounds 하드코딩 3중 중복) 구현되어 있던 bcrypt 해싱을 `common/util/createHashedPassword`로 통합
-   클라이언트 IP 추출: feed 서비스와 `LoggingInterceptor`에 완전히 동일한 로직이 중복 구현되어 있던 것을 발견해 `common/util/getIp`로 통합

# 📋 작업 내용

-   `rss/util`, `user/util`, `feed/util`, `board/util`에 순수 함수 추출 (기존 서비스 로직/메시지는 변경 없음)
-   `common/util/createHashedPassword` 신설, admin/qna/user 3곳의 중복 bcrypt 해싱 로직 통합, 이제 안 쓰는 `SALT_ROUNDS` 상수 제거
-   `common/util/getIp` 신설, feed 서비스와 logger interceptor의 중복 IP 추출 로직 통합
-   private 메서드를 캐스팅해서 테스트하던 기존 방식 대신, 추출한 순수 함수를 직접 임포트해 테스트하도록 유닛 테스트 이동/추가 (`test/common/unit/getIp.unit.spec.ts` 등)
-   기존 유닛 테스트(222개) 전체 통과 확인, tsc/eslint/prettier 통과 확인

# 📷 스크린 샷(선택 사항)

해당 사항 없음 (서버 내부 리팩토링)