### PR TITLE
✨ feat: 로그인 브루트포스 방어용 IP throttle 추가

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nest-lab/throttler-storage-redis": "^1.2.0",
         "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^10.4.22",
         "@nestjs/config": "^3.3.0",
@@ -20,6 +21,7 @@
         "@nestjs/platform-socket.io": "^10.4.22",
         "@nestjs/schedule": "^4.1.1",
         "@nestjs/swagger": "^8.0.1",
+        "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.4.22",
         "@willsoto/nestjs-prometheus": "^6.0.2",
@@ -2180,6 +2182,39 @@
       "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
       "license": "MIT"
     },
+    "node_modules/@nest-lab/throttler-storage-redis": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@nest-lab/throttler-storage-redis/-/throttler-storage-redis-1.2.0.tgz",
+      "integrity": "sha512-tMkUyo68NCKTR+zILk+EC35SMYBtDPZY2mCj7ZaCietWGVTnuP4zwq9ERYfvU6kJv6h8teNZrC6MJCmY6/dljw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/throttler": ">=6.0.0",
+        "ioredis": ">=5.0.0",
+        "reflect-metadata": "^0.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/common": {
+          "optional": false
+        },
+        "@nestjs/core": {
+          "optional": false
+        },
+        "@nestjs/throttler": {
+          "optional": false
+        },
+        "ioredis": {
+          "optional": false
+        },
+        "reflect-metadata": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/@nestjs/axios": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
@@ -2882,6 +2917,17 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.5.0.tgz",
+      "integrity": "sha512-9j0ZRfH0QE1qyrj9JjIRDz5gQLPqq9yVC2nHsrosDVAfI5HHw08/aUAWx9DZLSdQf4HDkmhTTEGLrRFHENvchQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/typeorm": {

--- a/server/package.json
+++ b/server/package.json
@@ -32,6 +32,7 @@
     "local:migration:generate": "npm run typeorm -- migration:generate -d dataSource.ts"
   },
   "dependencies": {
+    "@nest-lab/throttler-storage-redis": "^1.2.0",
     "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^10.4.22",
     "@nestjs/config": "^3.3.0",
@@ -43,6 +44,7 @@
     "@nestjs/platform-socket.io": "^10.4.22",
     "@nestjs/schedule": "^4.1.1",
     "@nestjs/swagger": "^8.0.1",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.4.22",
     "@willsoto/nestjs-prometheus": "^6.0.2",

--- a/server/src/admin/controller/admin.controller.ts
+++ b/server/src/admin/controller/admin.controller.ts
@@ -40,6 +40,7 @@ import { UpdateAdminProfileRequestDto } from '@admin/dto/request/updateAdminProf
 import { AdminService } from '@admin/service/admin.service';
 
 import { CurrentAdmin } from '@common/decorator/current-admin.decorator';
+import { LoginThrottlerGuard } from '@common/guard/login-throttler.guard';
 import { AdminAuthGuard } from '@common/guard/session.guard';
 import { ApiResponse } from '@common/response/common.response';
 
@@ -51,6 +52,7 @@ export class AdminController {
   @ApiLoginAdmin()
   @Post('/login')
   @HttpCode(HttpStatus.OK)
+  @UseGuards(LoginThrottlerGuard)
   async loginAdmin(
     @Body() loginAdminBodyDto: LoginAdminRequestDto,
     @Res({ passthrough: true }) response: Response,

--- a/server/src/admin/module/admin.module.ts
+++ b/server/src/admin/module/admin.module.ts
@@ -4,8 +4,10 @@ import { AdminController } from '@admin/controller/admin.controller';
 import { AdminRepository } from '@admin/repository/admin.repository';
 import { AdminService } from '@admin/service/admin.service';
 
+import { LoginThrottlerModule } from '@common/throttler/login-throttler.module';
+
 @Module({
-  imports: [],
+  imports: [LoginThrottlerModule],
   controllers: [AdminController],
   providers: [AdminService, AdminRepository],
   exports: [AdminRepository],

--- a/server/src/common/guard/login-throttler.guard.ts
+++ b/server/src/common/guard/login-throttler.guard.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { ThrottlerGuard } from '@nestjs/throttler';
+
+import { Request } from 'express';
+
+import { getIp } from '@common/util/getIp';
+
+@Injectable()
+export class LoginThrottlerGuard extends ThrottlerGuard {
+  protected getTracker(req: Request): Promise<string> {
+    return Promise.resolve(getIp(req) ?? 'unknown');
+  }
+}

--- a/server/src/common/throttler/login-throttler.module.ts
+++ b/server/src/common/throttler/login-throttler.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { ThrottlerModule } from '@nestjs/throttler';
+
+import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
+import Redis from 'ioredis';
+
+@Module({
+  imports: [
+    ThrottlerModule.forRootAsync({
+      inject: ['REDIS_CLIENT'],
+      useFactory: (redisClient: Redis) => ({
+        throttlers: [{ ttl: 60_000, limit: 5 }],
+        storage: new ThrottlerStorageRedisService(redisClient),
+        errorMessage: '로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요.',
+      }),
+    }),
+  ],
+  exports: [ThrottlerModule],
+})
+export class LoginThrottlerModule {}

--- a/server/src/common/throttler/login-throttler.module.ts
+++ b/server/src/common/throttler/login-throttler.module.ts
@@ -2,15 +2,18 @@ import { Module } from '@nestjs/common';
 import { ThrottlerModule } from '@nestjs/throttler';
 
 import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis';
-import Redis from 'ioredis';
+
+import { RedisModule } from '@common/redis/redis.module';
+import { RedisService } from '@common/redis/redis.service';
 
 @Module({
   imports: [
     ThrottlerModule.forRootAsync({
-      inject: ['REDIS_CLIENT'],
-      useFactory: (redisClient: Redis) => ({
+      imports: [RedisModule],
+      inject: [RedisService],
+      useFactory: (redisService: RedisService) => ({
         throttlers: [{ ttl: 60_000, limit: 5 }],
-        storage: new ThrottlerStorageRedisService(redisClient),
+        storage: new ThrottlerStorageRedisService(redisService.redisClient),
         errorMessage: '로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요.',
       }),
     }),

--- a/server/src/common/util/getIp.ts
+++ b/server/src/common/util/getIp.ts
@@ -1,11 +1,15 @@
 import { Request } from 'express';
 
+/**
+ * nginx가 X-Real-IP를 $remote_addr로 무조건 덮어써 설정하므로 신뢰 가능.
+ * X-Forwarded-For는 $proxy_add_x_forwarded_for(append 방식)라 클라이언트가
+ * 임의 값을 앞에 붙여 위조할 수 있어 사용하지 않는다.
+ */
 export function getIp(request: Request) {
-  const forwardedFor = request.headers['x-forwarded-for'];
+  const realIp = request.headers['x-real-ip'];
 
-  if (typeof forwardedFor === 'string') {
-    const forwardedIps = forwardedFor.split(',');
-    return forwardedIps[0].trim();
+  if (typeof realIp === 'string') {
+    return realIp;
   }
 
   return request.socket.remoteAddress;

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -23,6 +23,7 @@ import {
   Payload,
   RefreshJwtGuard,
 } from '@common/guard/jwt.guard';
+import { LoginThrottlerGuard } from '@common/guard/login-throttler.guard';
 import { ApiResponse } from '@common/response/common.response';
 
 import { ApiCertificateUser } from '@user/api-docs/certificateUser.api-docs';
@@ -157,6 +158,7 @@ export class UserController {
   @ApiLoginUser()
   @Post('/login')
   @HttpCode(HttpStatus.OK)
+  @UseGuards(LoginThrottlerGuard)
   async loginUser(
     @Body() loginDto: LoginUserRequestDto,
     @Res({ passthrough: true }) response: Response,

--- a/server/src/user/module/user.module.ts
+++ b/server/src/user/module/user.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 
 import { JwtAuthModule } from '@common/auth/jwt.module';
+import { LoginThrottlerModule } from '@common/throttler/login-throttler.module';
 
 import { FeedRepository } from '@feed/repository/feed.repository';
 
@@ -21,7 +22,7 @@ import { OAuthService } from '@user/service/oAuth.service';
 import { UserService } from '@user/service/user.service';
 
 @Module({
-  imports: [JwtAuthModule, FileModule, RssModule],
+  imports: [JwtAuthModule, FileModule, RssModule, LoginThrottlerModule],
   controllers: [UserController, OAuthController],
   providers: [
     UserService,

--- a/server/test/admin/e2e/login.e2e-spec.ts
+++ b/server/test/admin/e2e/login.e2e-spec.ts
@@ -169,4 +169,21 @@ describe(`POST ${URL} E2E Test`, () => {
     expect(duplicateSession).toBeNull();
     expect(newSession).toBe(admin.email);
   });
+
+  it('[429] 60초 내 5회 초과 로그인 시도 시 요청을 차단한다.', async () => {
+    // given
+    const requestDto = new LoginAdminRequestDto({
+      email: admin.email,
+      password: 'testWrongAdminPassword!',
+    });
+
+    // Http when
+    for (let i = 0; i < 5; i++) {
+      await agent.post(URL).send(requestDto);
+    }
+    const response = await agent.post(URL).send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.TOO_MANY_REQUESTS);
+  });
 });

--- a/server/test/common/unit/getIp.unit.spec.ts
+++ b/server/test/common/unit/getIp.unit.spec.ts
@@ -1,30 +1,26 @@
 import { getIp } from '@common/util/getIp';
 
 const createRequest = (
-  xff: string | string[] | undefined,
+  realIp: string | string[] | undefined,
   remoteAddress = '127.0.0.1',
 ) =>
   ({
-    headers: { 'x-forwarded-for': xff },
+    headers: { 'x-real-ip': realIp },
     socket: { remoteAddress },
   }) as unknown as Parameters<typeof getIp>[0];
 
 describe(`${getIp.name} Unit Test`, () => {
-  it('x-forwarded-for 단일 IP면 해당 IP를 반환한다.', () => {
+  it('x-real-ip가 있으면 해당 IP를 반환한다.', () => {
     expect(getIp(createRequest('203.0.113.1'))).toBe('203.0.113.1');
   });
 
-  it('x-forwarded-for에 여러 IP가 있으면 첫 번째 IP를 trim해 반환한다.', () => {
-    expect(getIp(createRequest('203.0.113.1, 198.51.100.1'))).toBe(
-      '203.0.113.1',
-    );
-  });
-
-  it('x-forwarded-for가 없으면 socket.remoteAddress를 반환한다.', () => {
+  it('x-real-ip가 없으면 socket.remoteAddress를 반환한다.', () => {
     expect(getIp(createRequest(undefined, '10.0.0.5'))).toBe('10.0.0.5');
   });
 
-  it('x-forwarded-for가 배열(문자열 아님)이면 socket.remoteAddress로 폴백한다.', () => {
-    expect(getIp(createRequest(['203.0.113.1'], '10.0.0.5'))).toBe('10.0.0.5');
+  it('x-real-ip가 배열(문자열 아님)이면 socket.remoteAddress로 폴백한다.', () => {
+    expect(getIp(createRequest(['203.0.113.1'], '10.0.0.5'))).toBe(
+      '10.0.0.5',
+    );
   });
 });

--- a/server/test/feed/e2e/up-view-count.e2e-spec.ts
+++ b/server/test/feed/e2e/up-view-count.e2e-spec.ts
@@ -57,7 +57,7 @@ describe(`POST ${URL}/{feedId} E2E Test`, () => {
     const response = await agent
       .post(`${URL}/${feed.id}`)
       .set('Cookie', `View_count_${feed.id}=${feed.id}`)
-      .set('X-Forwarded-For', testIp);
+      .set('X-Real-IP', testIp);
 
     // Http then
     const { data } = response.body;
@@ -84,7 +84,7 @@ describe(`POST ${URL}/{feedId} E2E Test`, () => {
     // Http when
     const response = await agent
       .post(`${URL}/${feed.id}`)
-      .set('X-Forwarded-For', testIp);
+      .set('X-Real-IP', testIp);
 
     // Http then
     const { data } = response.body;
@@ -114,7 +114,7 @@ describe(`POST ${URL}/{feedId} E2E Test`, () => {
     // Http when
     const response = await agent
       .post(`${URL}/${feed.id}`)
-      .set('X-Forwarded-For', testNewIp);
+      .set('X-Real-IP', testNewIp);
 
     // Http then
     const { data } = response.body;
@@ -137,35 +137,8 @@ describe(`POST ${URL}/{feedId} E2E Test`, () => {
     expect(savedFeedReadRedis).not.toBeNull();
   });
 
-  it('[200] X-Forwarded-For 헤더에 여러 IP가 포함된 경우 첫 번째 IP를 사용한다.', async () => {
-    // given
-    const firstIp = '203.0.113.1';
-    const secondIp = '198.51.100.1';
-    const forwardedForHeader = `${firstIp}, ${secondIp}`;
-
-    // Http when
-    const response = await agent
-      .post(`${URL}/${feed.id}`)
-      .set('X-Forwarded-For', forwardedForHeader);
-
-    // Http then
-    const { data } = response.body;
-    expect(response.status).toBe(HttpStatus.OK);
-    expect(data).toBeUndefined();
-
-    // DB, Redis when - 첫 번째 IP만 Redis에 저장되었는지 확인
-    const [firstIpExists, secondIpExists] = await Promise.all([
-      redisService.sismember(redisKeyMake(feed.id.toString()), firstIp),
-      redisService.sismember(redisKeyMake(feed.id.toString()), secondIp),
-    ]);
-
-    // DB, Redis then - sismember는 1(존재) 또는 0(없음)을 반환
-    expect(firstIpExists).toBe(1); // 첫 번째 IP는 저장됨
-    expect(secondIpExists).toBe(0); // 두 번째 IP는 저장되지 않음
-  });
-
-  it('[200] X-Forwarded-For 헤더가 없을 경우 socket remoteAddress를 사용한다.', async () => {
-    // given - X-Forwarded-For 헤더를 설정하지 않음
+  it('[200] X-Real-IP 헤더가 없을 경우 socket remoteAddress를 사용한다.', async () => {
+    // given - X-Real-IP 헤더를 설정하지 않음
     // supertest는 기본적으로 ::ffff:127.0.0.1 또는 유사한 주소를 사용
 
     // Http when

--- a/server/test/user/e2e/login.e2e-spec.ts
+++ b/server/test/user/e2e/login.e2e-spec.ts
@@ -100,4 +100,21 @@ describe(`POST ${URL} E2E Test`, () => {
       accessToken: expect.any(String),
     });
   });
+
+  it('[429] 60초 내 5회 초과 로그인 시도 시 요청을 차단한다.', async () => {
+    // given
+    const requestDto = new LoginUserRequestDto({
+      email: user.email,
+      password: 'testWrongPassword!',
+    });
+
+    // Http when
+    for (let i = 0; i < 5; i++) {
+      await agent.post(URL).send(requestDto);
+    }
+    const response = await agent.post(URL).send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.TOO_MANY_REQUESTS);
+  });
 });


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #857 

### 로그인 브루트포스 방어

- `POST /users/login`, `POST /admins/login`에 rate limit이 전혀 없어 브루트포스에 취약한 상태였음
- `@nestjs/throttler` + `@nest-lab/throttler-storage-redis`로 IP당 5회/60초 제한 적용 (Redis storage 사용 — blue-green 배포로 인스턴스가 바뀌어도 카운터 공유됨)
- 작업 도중 기존 `getIp()`가 `X-Forwarded-For`의 첫 hop을 그대로 신뢰하고 있었는데, nginx가 `$proxy_add_x_forwarded_for`(append 방식)로 설정돼 있어 **클라이언트가 헤더를 위조하면 throttle을 무제한 우회 가능**했던 결함을 같이 발견/수정함. nginx가 무조건 덮어쓰는(`$remote_addr`) `X-Real-IP` 기반으로 변경.

### 검토했지만 이번에 채택하지 않은 대안

- **reCAPTCHA**: 지금 IP throttle로 브루트포스 자체는 충분히 방어됨. 외부 의존성/UX 마찰 비용 대비 이득이 낮다고 판단, 필요성 확인되면 후속으로 검토
- **계정(이메일) 단위 로그인 잠금 (예: 5회 실패 시 15분 락)**: 이메일만 알면 공격자가 실제 계정 주인을 반복적으로 잠글 수 있는 자해형 DoS 벡터라 채택 안 함. 특히 admin 계정이 타겟되면 운영 마비로 이어질 수 있음. 계정 단위 방어가 필요하면 잠금 대신 CAPTCHA 전환, 혹은 (잠금 상태 비노출 + 재시도 시 TTL 비연장 조건을 갖춘) 잠금으로 별도 설계 필요
- **IP throttle 임계치 10회/분으로 상향**: 공격자 시도량만 2배로 늘려주고 얻는 이득이 불분명. 공유 IP(사내망 등) 오탐이 우려라면 limit 상향이 아니라 계정 단위 카운터 병행이 맞는 해법이라 판단해 5회/60초 유지
- **rate limit 도달 시 계정 주인에게 이메일 알림**: 알림 자체가 새로운 공격 벡터(공격자가 요청만 반복해도 피해자 메일함이 폭격당하는 email bombing)가 될 수 있음. 알림 전용 rate limit과 계정별 실패 카운터를 IP throttle과 분리 설계해야 해서 스코프가 커짐 — 이번 PR 범위 밖으로 보류
- **DI 토큰(`REDIS_CLIENT`) 상수화**: 기존 코드베이스의 `OAUTH_PROVIDERS`, `RABBITMQ_CONNECTION` 등 DI 토큰이 전부 리터럴 문자열 컨벤션이라, 여기서만 상수화하면 오히려 일관성이 깨져서 기존 스타일 유지

### NestJS Throttler 동작 방식 (`@nest-lab/throttler-storage-redis` 기준)

- Redis Lua 스크립트로 원자적 처리: 요청마다 `hits` 키를 `INCR`, 그 IP의 **첫 요청 시각 기준**으로 TTL(60s) 고정 — sliding window 아닌 fixed window, 이후 요청이 와도 창이 갱신되지 않음
- `hits`가 limit(5)을 초과하면 `blocked` 키를 blockDuration(별도 설정 안 하면 ttl과 동일, 60s)만큼 세팅하고 즉시 429 반환
- block 상태에서 추가로 요청이 들어와도 block 만료 시각이 늘어나지 않음 — 공격자가 계속 두드려도 최초 block 시점 기준 60초 뒤 자동 해제
- tracker는 기본값(`req.ip`, express `trust proxy` 설정 필요)이 아니라 `LoginThrottlerGuard.getTracker()`에서 프로젝트의 `getIp()`(위 X-Real-IP 수정본)로 오버라이드해서 사용

# 📋 작업 내용

- `@nestjs/throttler`, `@nest-lab/throttler-storage-redis` 의존성 추가
- `common/throttler/login-throttler.module.ts`: Redis storage 기반 ThrottlerModule 설정 (IP당 5회/60초)
- `common/guard/login-throttler.guard.ts`: tracker를 `getIp()` 기반으로 오버라이드하는 가드
- `user.module.ts`, `admin.module.ts`에 모듈 등록, `POST /users/login`/`POST /admins/login`에 가드 적용
- `common/util/getIp.ts`: `X-Forwarded-For`(스푸핑 가능) → `X-Real-IP`(nginx가 덮어씀) 기반으로 변경
- `getIp` 유닛 테스트 갱신, user/admin 로그인 e2e에 "60초 내 5회 초과 시 429" 케이스 추가
- tsc / eslint / 유닛 테스트 통과 확인

# 📷 스크린 샷(선택 사항)

해당 사항 없음 (서버 내부 보안 개선)
