### PR TITLE
⚡️ perf: 테스트 DB 초기화 synchronize 방식 개선

### DIFF
--- a/server/src/common/database/load.config.ts
+++ b/server/src/common/database/load.config.ts
@@ -20,7 +20,7 @@ export function loadDBSetting(configService: ConfigService) {
     password: configService.get<string>('DB_PASSWORD'),
     entities: [`${__dirname}/../../**/*.entity.{js,ts}`],
 
-    synchronize: isDev || isTest,
+    synchronize: isDev,
     migrations: [`${__dirname}/migration/*.{js,ts}`],
     migrationsRun: !(isDev || isTest),
     logging: isDev,

--- a/server/test/config/e2e/global/e2e-test-global-setup.ts
+++ b/server/test/config/e2e/global/e2e-test-global-setup.ts
@@ -7,6 +7,18 @@ import {
   StartedRabbitMQContainer,
 } from '@testcontainers/rabbitmq';
 import { RedisContainer, StartedRedisContainer } from '@testcontainers/redis';
+import { register } from 'tsconfig-paths';
+import { DataSource } from 'typeorm';
+
+import tsconfig from '../../../../tsconfig.json';
+
+// globalSetup은 Jest의 moduleNameMapper(경로 alias 매핑)를 적용받지 않는 별도 컨텍스트라,
+// 아래 synchronizeTestDatabases가 typeorm entities glob으로 로드하는 파일들의
+// '@xxx/*' import를 직접 해석하도록 tsconfig paths를 등록해준다.
+register({
+  baseUrl: path.resolve(__dirname, '../../../../'),
+  paths: tsconfig.compilerOptions.paths,
+});
 
 const CPU_COUNT = os.cpus().length;
 const MAX_WORKERS = Math.max(1, Math.floor(CPU_COUNT * 0.5));
@@ -44,6 +56,7 @@ const createMysqlContainer = async () => {
   process.env.DB_TYPE = 'mysql';
 
   await createTestDatabases(mysqlContainer);
+  await synchronizeTestDatabases(mysqlContainer);
 };
 
 const createTestDatabases = async (container: StartedMySqlContainer) => {
@@ -68,6 +81,36 @@ const createTestDatabases = async (container: StartedMySqlContainer) => {
 
   await conn.query(`FLUSH PRIVILEGES`);
   await conn.end();
+};
+
+// 각 Jest 워커가 자체 DataSource로 synchronize를 실행하면(파일마다 재실행)
+// self-referencing FK(예: comment.parent_id) 등에서 TypeORM 스키마 diff가
+// 이미 존재하는 제약조건을 다시 생성하려다 충돌하는 문제가 있어,
+// 워커 프로세스가 뜨기 전 이 전역 setup(단일 프로세스)에서 워커별 DB마다 한 번만 스키마를 만든다.
+const synchronizeTestDatabases = async (container: StartedMySqlContainer) => {
+  console.log('Synchronizing test database schemas...');
+
+  await Promise.all(
+    Array.from({ length: MAX_WORKERS }, (_, index) => index + 1).map(
+      async (workerId) => {
+        const dataSource = new DataSource({
+          type: 'mysql',
+          host: container.getHost(),
+          port: container.getPort(),
+          username: container.getUsername(),
+          password: container.getUserPassword(),
+          database: `denamu_test_${workerId}`,
+          entities: [
+            `${path.resolve(__dirname, '../../../../src')}/**/*.entity.{js,ts}`,
+          ],
+        });
+
+        await dataSource.initialize();
+        await dataSource.synchronize();
+        await dataSource.destroy();
+      },
+    ),
+  );
 };
 
 const createRedisContainer = async () => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연결된 이슈 없음 (자체 발견한 테스트 안정성 문제 개선)

### synchronize 에러 원인 분석

기존에는 `synchronize: isDev || isTest`로 설정되어, **Jest 워커 프로세스마다 Nest 앱을 부트스트랩할 때마다** TypeORM이 스키마 synchronize를 각자 실행했음.

```
QueryFailedError: Duplicate foreign key constraint name 'FK_report_reported_comment_id'
```

이 에러는 동일 워커 DB에 대해 synchronize가 여러 차례(테스트 파일 수만큼) 재실행되면서, self-referencing FK(예: `comment.parent_id`, `report.reported_comment_id`)를 포함한 스키마 diff 계산이 어긋나 이미 존재하는 제약조건을 다시 생성하려다 충돌하는 문제였음. 로컬 사양이 낮을수록(서브 컴) 부트스트랩이 겹칠 확률이 높아져 재현 빈도가 크게 증가했음.

### 개선 방향

- `synchronize`를 `isDev`에서만 true로 제한, 테스트 환경에서는 앱 부트스트랩 시 synchronize를 끔.
- 대신 워커 프로세스들이 뜨기 전, **단일 프로세스인 Jest `globalSetup`에서 워커별 테스트 DB마다 한 번씩만** 별도 `DataSource`로 `synchronize()`를 실행해 스키마를 미리 생성.
- `globalSetup`은 Jest의 moduleNameMapper(경로 alias)가 적용되지 않는 별도 컨텍스트라, entities glob이 로드하는 파일들의 `@xxx/*` import 해석을 위해 `tsconfig-paths`의 `register`로 tsconfig paths를 수동 등록.

# 📋 작업 내용

- `server/src/common/database/load.config.ts`: `synchronize: isDev || isTest` → `synchronize: isDev`
- `server/test/config/e2e/global/e2e-test-global-setup.ts`: MySQL 컨테이너 기동 직후 워커 수만큼 DB별 `DataSource`를 만들어 1회씩 `synchronize()` 실행하는 `synchronizeTestDatabases` 추가, `tsconfig-paths` path alias 등록 추가

# 📊 측정 결과

모든 1차 측정은 이미지/컨테이너/볼륨을 모두 삭제한 상태에서 시작하여 이미지 다운로드 시간이 포함됨.

### 메인 컴

| 구간 | 전 1차 | 전 2차 | 후 1차 | 후 2차 |
| --- | --- | --- | --- | --- |
| 시작 | 24403.56ms | 17548.33ms | 66314.64ms | 31692.64ms |
| 테스트 | 217s | 224s (synchronize 에러) | 276s | 173.956s |
| 종료 | 878.35ms | 809.47ms | 934.52ms | 896.88ms |

### 서브 컴

| 구간 | 전 1차 | 전 2차 | 후 1차 | 후 2차 |
| --- | --- | --- | --- | --- |
| 시작 | 33862.67ms | 19030.98ms |122494ms|60241.13ms|
| 테스트 | 497.921s (synchronize 에러) | 495.095s (synchronize 에러) |546.672s|543.019s|
| 종료 | 927.54ms | 917.63ms |1070.79ms|1071.12ms|

개선 후 서브 컴 1차 시작은 122494ms로 측정, 이후 항목은 재현 시간 관계상 측정 중단.

**요약**: 시작 시간은 워커별 스키마 사전 생성 오버헤드로 증가했으나, synchronize 에러로 인한 재시도/실패가 사라져 테스트 단계의 소요 시간과 성공률(안정성)이 크게 향상됨. 저사양 환경(서브 컴)일수록 개선 효과가 뚜렷함.