### PR TITLE
♻️ refactor: 쿼리 빌더 -> TypeORM 방식으로 변경

### DIFF
--- a/server/src/activity/repository/activity.repository.ts
+++ b/server/src/activity/repository/activity.repository.ts
@@ -35,8 +35,8 @@ export class ActivityRepository extends Repository<Activity> {
     userId: number,
     year: number,
   ): Promise<Activity[]> {
-    const startDate = new Date(`${year}-01-01`);
-    const endDate = new Date(`${year}-12-31`);
+    const startDate = new Date(year, 0, 1);
+    const endDate = new Date(year, 11, 31);
 
     return this.find({
       where: { user: { id: userId }, activityDate: Between(startDate, endDate) },

--- a/server/src/activity/repository/activity.repository.ts
+++ b/server/src/activity/repository/activity.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { DataSource, Repository } from 'typeorm';
+import { Between, DataSource, Repository } from 'typeorm';
 
 import { Activity } from '@activity/entity/activity.entity';
 
@@ -35,15 +35,13 @@ export class ActivityRepository extends Repository<Activity> {
     userId: number,
     year: number,
   ): Promise<Activity[]> {
-    const startDate = `${year}-01-01`;
-    const endDate = `${year}-12-31`;
+    const startDate = new Date(`${year}-01-01`);
+    const endDate = new Date(`${year}-12-31`);
 
-    return this.createQueryBuilder('activity')
-      .leftJoinAndSelect('activity.user', 'user')
-      .where('user.id = :userId', { userId })
-      .andWhere('activity.activityDate >= :startDate', { startDate })
-      .andWhere('activity.activityDate <= :endDate', { endDate })
-      .orderBy('activity.activityDate', 'ASC')
-      .getMany();
+    return this.find({
+      where: { user: { id: userId }, activityDate: Between(startDate, endDate) },
+      relations: { user: true },
+      order: { activityDate: 'ASC' },
+    });
   }
 }

--- a/server/src/block/repository/rssBlock.repository.ts
+++ b/server/src/block/repository/rssBlock.repository.ts
@@ -11,28 +11,35 @@ export class RssBlockRepository extends Repository<RssBlock> {
   }
 
   async getBlockedRssList(blockerId: number) {
-    return await this.createQueryBuilder('rssBlock')
-      .innerJoin('rssBlock.blockedRss', 'blockedRss')
-      .select(['rssBlock.id', 'rssBlock.createdAt'])
-      .addSelect(['blockedRss.id', 'blockedRss.name', 'blockedRss.blogPlatform', 'blockedRss.blogImage'])
-      .where('rssBlock.blocker_id = :blockerId', { blockerId })
-      .orderBy('rssBlock.id', 'DESC')
-      .getMany();
+    return this.find({
+      where: { blocker: { id: blockerId } },
+      relations: { blockedRss: true },
+      select: {
+        id: true,
+        createdAt: true,
+        blockedRss: {
+          id: true,
+          name: true,
+          blogPlatform: true,
+          blogImage: true,
+        },
+      },
+      order: { id: 'DESC' },
+    });
   }
 
   async getBlockedRssIds(blockerId: number) {
-    const rssBlocks = await this.createQueryBuilder('rssBlock')
-      .select('rssBlock.blocked_rss_id', 'blockedRssId')
-      .where('rssBlock.blocker_id = :blockerId', { blockerId })
-      .getRawMany<{ blockedRssId: number }>();
-    return rssBlocks.map((rssBlock) => rssBlock.blockedRssId);
+    const rssBlocks = await this.find({
+      where: { blocker: { id: blockerId } },
+      relations: { blockedRss: true },
+      select: { blockedRss: { id: true } },
+    });
+    return rssBlocks.map((rssBlock) => rssBlock.blockedRss.id);
   }
 
   async existsByBlockerAndRss(blockerId: number, rssId: number) {
-    const count = await this.createQueryBuilder('rssBlock')
-      .where('rssBlock.blocker_id = :blockerId', { blockerId })
-      .andWhere('rssBlock.blocked_rss_id = :rssId', { rssId })
-      .getCount();
-    return count > 0;
+    return this.exists({
+      where: { blocker: { id: blockerId }, blockedRss: { id: rssId } },
+    });
   }
 }

--- a/server/src/block/repository/userBlock.repository.ts
+++ b/server/src/block/repository/userBlock.repository.ts
@@ -11,12 +11,15 @@ export class UserBlockRepository extends Repository<UserBlock> {
   }
 
   async getBlockedUsers(blockerId: number) {
-    return await this.createQueryBuilder('block')
-      .innerJoin('block.blocked', 'blocked')
-      .select(['block.id', 'block.createdAt'])
-      .addSelect(['blocked.id', 'blocked.userName', 'blocked.profileImage'])
-      .where('block.blocker_id = :blockerId', { blockerId })
-      .orderBy('block.id', 'DESC')
-      .getMany();
+    return this.find({
+      where: { blocker: { id: blockerId } },
+      relations: { blocked: true },
+      select: {
+        id: true,
+        createdAt: true,
+        blocked: { id: true, userName: true, profileImage: true },
+      },
+      order: { id: 'DESC' },
+    });
   }
 }

--- a/server/src/board/repository/board.repository.ts
+++ b/server/src/board/repository/board.repository.ts
@@ -57,20 +57,15 @@ export class BoardRepository extends Repository<Board> {
     status?: BoardStatus,
     category?: BoardCategory,
   ) {
-    const query = this.createQueryBuilder('board');
-    if (status) {
-      query.andWhere('board.status = :status', { status });
-    }
-    if (category) {
-      query.andWhere('board.category = :category', { category });
-    }
-
-    const [items, totalCount] = await query
-      .orderBy('board.isPinned', 'DESC')
-      .addOrderBy('board.id', 'DESC')
-      .skip((page - 1) * limit)
-      .take(limit)
-      .getManyAndCount();
+    const [items, totalCount] = await this.findAndCount({
+      where: {
+        ...(status && { status }),
+        ...(category && { category }),
+      },
+      order: { isPinned: 'DESC', id: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
 
     return { items, totalCount };
   }

--- a/server/src/comment/repository/comment.repository.ts
+++ b/server/src/comment/repository/comment.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, LessThan, Repository } from 'typeorm';
 
 import { Comment } from '@comment/entity/comment.entity';
 
@@ -33,20 +33,16 @@ export class CommentRepository extends Repository<Comment> {
   }
 
   async getCommentsByUser(userId: number, lastId: number, limit: number) {
-    const query = this.createQueryBuilder('comment')
-      .innerJoin('comment.feed', 'feed')
-      .select(['comment.id', 'comment.comment', 'comment.date'])
-      .addSelect(['feed.id', 'feed.title', 'feed.path'])
-      .where('comment.user_id = :userId', { userId })
-      .andWhere('feed.is_public = 1');
-
-    if (lastId) {
-      query.andWhere('comment.id < :lastId', { lastId });
-    }
-
-    return await query
-      .orderBy('comment.id', 'DESC')
-      .take(limit + 1)
-      .getMany();
+    return this.find({
+      where: {
+        user: { id: userId },
+        feed: { isPublic: true },
+        ...(lastId && { id: LessThan(lastId) }),
+      },
+      relations: { feed: true },
+      select: { id: true, comment: true, date: true, feed: { id: true, title: true, path: true } },
+      order: { id: 'DESC' },
+      take: limit + 1,
+    });
   }
 }

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { Brackets, DataSource, Repository } from 'typeorm';
+import { Brackets, DataSource, In, IsNull, LessThan, Raw, Repository } from 'typeorm';
 
 import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
 import { SearchType } from '@feed/dto/request/searchFeed.dto';
@@ -68,39 +68,32 @@ export class FeedRepository extends Repository<Feed> {
     onlyPublic: boolean,
     date?: string,
   ) {
-    const query = this.createQueryBuilder('feed')
-      .select([
-        'feed.id',
-        'feed.title',
-        'feed.path',
-        'feed.thumbnail',
-        'feed.createdAt',
-        'feed.commentCount',
-        'feed.likeCount',
-        'feed.isPublic',
-      ])
-      .where('feed.blog_id = :blogId', { blogId });
-
-    if (onlyPublic) {
-      query.andWhere('feed.is_public = 1');
-    }
-
-    if (lastId) {
-      query.andWhere('feed.id < :lastId', { lastId });
-    }
-
-    // 잔디 집계(DATE_FORMAT 기준)와 동일한 날짜 범위. 인덱스 활용을 위해 범위 조건 사용.
-    if (date) {
-      query.andWhere(
-        'feed.created_at >= :date AND feed.created_at < DATE_ADD(:date, INTERVAL 1 DAY)',
-        { date },
-      );
-    }
-
-    return await query
-      .orderBy('feed.id', 'DESC')
-      .take(limit + 1)
-      .getMany();
+    return this.find({
+      where: {
+        blog: { id: blogId },
+        ...(onlyPublic && { isPublic: true }),
+        ...(lastId && { id: LessThan(lastId) }),
+        // 잔디 집계(DATE_FORMAT 기준)와 동일한 날짜 범위. 인덱스 활용을 위해 범위 조건 사용.
+        ...(date && {
+          createdAt: Raw(
+            (alias) => `${alias} >= :date AND ${alias} < DATE_ADD(:date, INTERVAL 1 DAY)`,
+            { date },
+          ),
+        }),
+      },
+      select: [
+        'id',
+        'title',
+        'path',
+        'thumbnail',
+        'createdAt',
+        'commentCount',
+        'likeCount',
+        'isPublic',
+      ],
+      order: { id: 'DESC' },
+      take: limit + 1,
+    });
   }
 
   async getLatestPublicFeedDate(blogId: number): Promise<Date | null> {
@@ -167,33 +160,23 @@ export class FeedRepository extends Repository<Feed> {
     blogId: number,
     isPublic: boolean,
   ) {
-    const result = await this.createQueryBuilder()
-      .update(Feed)
-      .set({ isPublic })
-      .where('id = :feedId AND blog_id = :blogId', { feedId, blogId })
-      .execute();
+    const result = await this.update({ id: feedId, blog: { id: blogId } }, { isPublic });
 
     return result.affected ?? 0;
   }
 
   async isOwnedByUser(feedId: number, userId: number): Promise<boolean> {
-    const count = await this.createQueryBuilder('feed')
-      .innerJoin('feed.blog', 'blog')
-      .where('feed.id = :feedId', { feedId })
-      .andWhere('blog.user_id = :userId', { userId })
-      .getCount();
-
-    return count > 0;
+    return this.exists({ where: { id: feedId, blog: { userId } } });
   }
 
   async getBlogMetaByFeedId(
     feedId: number,
   ): Promise<{ id: number; userName: string; userId: number | null } | null> {
-    const feed = await this.createQueryBuilder('feed')
-      .innerJoin('feed.blog', 'blog')
-      .select(['feed.id', 'blog.id', 'blog.userName', 'blog.userId'])
-      .where('feed.id = :feedId', { feedId })
-      .getOne();
+    const feed = await this.findOne({
+      where: { id: feedId },
+      relations: { blog: true },
+      select: { id: true, blog: { id: true, userName: true, userId: true } },
+    });
 
     if (!feed?.blog) return null;
 
@@ -207,29 +190,27 @@ export class FeedRepository extends Repository<Feed> {
   async getSubscriptionFeeds(blogIds: number[], lastId: number, limit: number) {
     if (!blogIds.length) return [];
 
-    const query = this.createQueryBuilder('feed')
-      .innerJoinAndSelect('feed.blog', 'blog')
-      .leftJoinAndSelect('feed.tags', 'tag')
-      .where('feed.blog_id IN (:...blogIds)', { blogIds })
-      .andWhere('feed.is_public = 1');
-
-    if (lastId) {
-      query.andWhere('feed.id < :lastId', { lastId });
-    }
-
-    return await query
-      .orderBy('feed.id', 'DESC')
-      .take(limit + 1)
-      .getMany();
+    return this.find({
+      where: {
+        blog: { id: In(blogIds) },
+        isPublic: true,
+        ...(lastId && { id: LessThan(lastId) }),
+      },
+      relations: { blog: true, tags: true },
+      order: { id: 'DESC' },
+      take: limit + 1,
+    });
   }
 
   async findFeedsWithoutSummary() {
-    return this.createQueryBuilder('feed')
-      .select(['feed.id', 'feed.title', 'feed.likeCount', 'feed.commentCount'])
-      .where('feed.is_public = 1')
-      .andWhere("(feed.summary IS NULL OR feed.summary = '')")
-      .orderBy('feed.id', 'DESC')
-      .getMany();
+    return this.find({
+      where: [
+        { isPublic: true, summary: IsNull() },
+        { isPublic: true, summary: '' },
+      ],
+      select: ['id', 'title', 'likeCount', 'commentCount'],
+      order: { id: 'DESC' },
+    });
   }
 
   async findAllStatisticsOrderByViewCount(limit: number) {

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { DataSource, LessThan, Repository } from 'typeorm';
+import { DataSource, LessThan, MoreThanOrEqual, Repository } from 'typeorm';
 
 import { Feed } from '@feed/entity/feed.entity';
 
@@ -186,20 +186,20 @@ export class NotificationRepository extends Repository<Notification> {
   }
 
   async countUnread(recipientId: number) {
-    return this.createQueryBuilder('n')
-      .where('n.recipient_user_id = :recipientId', { recipientId })
-      .andWhere('n.is_read = 0')
-      .andWhere('n.updated_at >= :cutoff', { cutoff: getNotificationCutoffDate() })
-      .getCount();
+    return this.count({
+      where: {
+        recipient: { id: recipientId } as User,
+        isRead: false,
+        updatedAt: MoreThanOrEqual(getNotificationCutoffDate()),
+      },
+    });
   }
 
   async markRead(id: number, recipientId: number) {
-    const result = await this.createQueryBuilder()
-      .update(Notification)
-      .set({ isRead: true })
-      .where('id = :id', { id })
-      .andWhere('recipient_user_id = :recipientId', { recipientId })
-      .execute();
+    const result = await this.update(
+      { id, recipient: { id: recipientId } as User },
+      { isRead: true },
+    );
 
     return (result.affected ?? 0) > 0;
   }

--- a/server/src/subscribe/repository/subscription.repository.ts
+++ b/server/src/subscribe/repository/subscription.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, LessThan, Repository } from 'typeorm';
 
 import { Subscription } from '@subscribe/entity/subscription.entity';
 
@@ -11,12 +11,13 @@ export class SubscriptionRepository extends Repository<Subscription> {
   }
 
   async getSubscribedBlogIds(userId: number): Promise<number[]> {
-    const rows = await this.createQueryBuilder('subscription')
-      .select('subscription.rss_accept_id', 'rssAcceptId')
-      .where('subscription.user_id = :userId', { userId })
-      .getRawMany();
+    const rows = await this.find({
+      where: { user: { id: userId } },
+      relations: { rssAccept: true },
+      select: { id: true, rssAccept: { id: true } },
+    });
 
-    return rows.map((row: { rssAcceptId: number }) => Number(row.rssAcceptId));
+    return rows.map((row) => row.rssAccept.id);
   }
 
   async countByBlogId(blogId: number): Promise<number> {
@@ -42,19 +43,15 @@ export class SubscriptionRepository extends Repository<Subscription> {
   }
 
   async getSubscribersByBlog(blogId: number, lastId: number, limit: number) {
-    const query = this.createQueryBuilder('subscription')
-      .innerJoin('subscription.user', 'user')
-      .select(['subscription.id'])
-      .addSelect(['user.id', 'user.userName', 'user.profileImage'])
-      .where('subscription.rss_accept_id = :blogId', { blogId });
-
-    if (lastId) {
-      query.andWhere('subscription.id < :lastId', { lastId });
-    }
-
-    return await query
-      .orderBy('subscription.id', 'DESC')
-      .take(limit + 1)
-      .getMany();
+    return this.find({
+      where: {
+        rssAccept: { id: blogId },
+        ...(lastId && { id: LessThan(lastId) }),
+      },
+      relations: { user: true },
+      select: { id: true, user: { id: true, userName: true, profileImage: true } },
+      order: { id: 'DESC' },
+      take: limit + 1,
+    });
   }
 }

--- a/server/src/user/scheduler/user.scheduler.ts
+++ b/server/src/user/scheduler/user.scheduler.ts
@@ -38,12 +38,10 @@ export class UserScheduler {
       });
 
       if (usersToUpdate.length > 0) {
-        await this.userRepository
-          .createQueryBuilder()
-          .update()
-          .set({ currentStreak: 0 })
-          .whereInIds(usersToUpdate.map((user) => user.id))
-          .execute();
+        await this.userRepository.update(
+          usersToUpdate.map((user) => user.id),
+          { currentStreak: 0 },
+        );
 
         this.logger.log(
           `[UserScheduler]: ${usersToUpdate.length} 명의 streak 정보 업데이트 완료.`,


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연관 이슈 없음 (자체 리팩토링)

### 쿼리 빌더 -> TypeORM 표준 API 전환

- QueryBuilder로 작성된 조회/수정 쿼리를 TypeORM의 `find`, `update` 등 표준 Repository API로 전환
- 문자열 기반 조건 조합 대신 객체 스프레드(`...(condition && {...})`) 패턴으로 동적 where 절 구성
- 날짜 범위 조건은 `Raw`, 미만 조건은 `LessThan` 등 TypeORM 연산자를 사용해 인덱스 활용은 유지하면서 가독성/타입 안정성 확보
- 영향 범위: activity, block, board, chat, comment, feed, notification, subscribe, user 도메인의 repository 계층

### 날짜 처리 방식 수정

- activity.repository.ts에서 날짜를 문자열로 다루던 부분을 Date 객체 기준으로 변경 (타입 불일치로 인한 잠재적 버그 방지)

# 📋 작업 내용

- 서버 각 도메인 repository의 QueryBuilder 사용 코드를 TypeORM 표준 API로 교체
- 관련 DTO 및 클라이언트 타입 정의를 서버 응답 형태에 맞게 함께 수정
- 변경된 응답 형태에 맞춰 서버/클라이언트 테스트 코드 갱신

# 📷 스크린 샷(선택 사항)

- 해당 없음 (서버 내부 리팩토링)