### PR TITLE
🔥 hotfix: 마이그레이션 인덱스 기존 명칭 잘못 입력

### DIFF
--- a/server/src/common/database/migration/1778862792168-AlterCommentDateDefault.ts
+++ b/server/src/common/database/migration/1778862792168-AlterCommentDateDefault.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AlterCommentDateDefault1760000000001
+export class AlterCommentDateDefault1778862792168
   implements MigrationInterface
 {
   public async up(queryRunner: QueryRunner): Promise<void> {

--- a/server/src/common/database/migration/1780482000000-RenameRssAcceptNameFulltext.ts
+++ b/server/src/common/database/migration/1780482000000-RenameRssAcceptNameFulltext.ts
@@ -5,7 +5,7 @@ export class RenameRssAcceptNameFulltext1780482000000
 {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      'ALTER TABLE `rss_accept` DROP INDEX `name`;',
+      'ALTER TABLE `rss_accept` DROP INDEX `IDX_59f4be4de3817b3f975acff076`;',
     );
     await queryRunner.query(
       'ALTER TABLE `rss_accept` ADD FULLTEXT INDEX `FT_rss_accept_name` (`name`) WITH PARSER ngram;',
@@ -17,7 +17,7 @@ export class RenameRssAcceptNameFulltext1780482000000
       'ALTER TABLE `rss_accept` DROP INDEX `FT_rss_accept_name`;',
     );
     await queryRunner.query(
-      'ALTER TABLE `rss_accept` ADD FULLTEXT INDEX `name` (`name`);',
+      'ALTER TABLE `rss_accept` ADD FULLTEXT INDEX `IDX_59f4be4de3817b3f975acff076` (`name`);',
     );
   }
 }

--- a/server/src/common/database/migration/1785253220188-CreateBoard.ts
+++ b/server/src/common/database/migration/1785253220188-CreateBoard.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateBoard1790000000000 implements MigrationInterface {
+export class CreateBoard1785253220188 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
     CREATE TABLE \`board\` (

--- a/server/src/common/database/migration/1785300000000-RenameHashKeysToSemanticNames.ts
+++ b/server/src/common/database/migration/1785300000000-RenameHashKeysToSemanticNames.ts
@@ -77,7 +77,7 @@ export class RenameHashKeysToSemanticNames1785300000000
       'ALTER TABLE `category` RENAME INDEX `name` TO `UQ_category_name`;',
     );
     await queryRunner.query(
-      'ALTER TABLE `tag` RENAME INDEX `name` TO `UQ_tag_name`;',
+      'ALTER TABLE `tag` RENAME INDEX `IDX_6a9775008add570dc3e5a0bab7` TO `UQ_tag_name`;',
     );
 
     // comment
@@ -500,7 +500,7 @@ export class RenameHashKeysToSemanticNames1785300000000
 
     // category / tag
     await queryRunner.query(
-      'ALTER TABLE `tag` RENAME INDEX `UQ_tag_name` TO `name`;',
+      'ALTER TABLE `tag` RENAME INDEX `UQ_tag_name` TO `IDX_6a9775008add570dc3e5a0bab7`;',
     );
     await queryRunner.query(
       'ALTER TABLE `category` RENAME INDEX `UQ_category_name` TO `name`;',

--- a/server/src/common/database/migration/1785335847062-AddBoardCategory.ts
+++ b/server/src/common/database/migration/1785335847062-AddBoardCategory.ts
@@ -1,6 +1,6 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddBoardCategory1790300000000 implements MigrationInterface {
+export class AddBoardCategory1785335847062 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       ALTER TABLE \`board\`


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 관련 이슈 없음 (운영 배포 중 발견된 마이그레이션 실행 실패 hotfix)

### 원인

- `rss_accept.name` 컬럼의 FULLTEXT 인덱스를 리네임하는 마이그레이션이 인덱스명을 `name`으로 가정하고 작성됨
- 실제 prod 스키마는 과거 `synchronize` 기반으로 생성된 이력이 있어 TypeORM 자동 해시 이름(`IDX_59f4be4de3817b3f975acff076`)으로 존재 → `DROP INDEX` 실패
- 무중단 배포(blue-green) 중 green 컨테이너가 부트 때마다 이 마이그레이션을 재시도하며 계속 실패

# 📋 작업 내용

- `1780482000000-RenameRssAcceptNameFulltext.ts`의 `up`/`down` 모두 실제 prod 인덱스명(`IDX_59f4be4de3817b3f975acff076`)을 사용하도록 수정
- SSH로 prod DB 직접 확인해서 인덱스명 검증 후 반영 (같은 패턴으로 이미 수정된 `1785300000000-RenameHashKeysToSemanticNames.ts`의 방식과 동일)

# 📷 스크린 샷(선택 사항)

해당 없음