### PR TITLE
🐛 fix: 공지사항 상세 페이지 가독성 및 작성자 표기 개선

### DIFF
--- a/client/src/__tests__/pages/BoardDetailPage.test.tsx
+++ b/client/src/__tests__/pages/BoardDetailPage.test.tsx
@@ -89,6 +89,19 @@ describe("BoardDetailPage", () => {
     );
   });
 
+  it("authorName이 있으면 작성자명을 표시한다", () => {
+    render(<BoardDetailPage />);
+
+    expect(screen.getByText(/관리자/)).toBeInTheDocument();
+  });
+
+  it("authorName이 없으면 작성자명을 표시하지 않는다", () => {
+    boardState = { data: makeDetail({ authorName: null }), isLoading: false, isError: false };
+    render(<BoardDetailPage />);
+
+    expect(screen.queryByText(/관리자/)).not.toBeInTheDocument();
+  });
+
   it("목록으로 버튼 클릭 시 게시판 목록 페이지로 이동한다", () => {
     render(<BoardDetailPage />);
 

--- a/client/src/components/board/BoardContent.tsx
+++ b/client/src/components/board/BoardContent.tsx
@@ -7,7 +7,7 @@ interface BoardContentProps {
 export const BoardContent = ({ content }: BoardContentProps) => {
   return (
     <div
-      className="prose max-w-full prose-p:my-0 [&_p:empty]:min-h-[1.75em]"
+      className="prose max-w-full prose-p:my-2 [&_p:empty]:min-h-[1.75em]"
       dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
     />
   );

--- a/client/src/components/board/BoardContent.tsx
+++ b/client/src/components/board/BoardContent.tsx
@@ -7,7 +7,7 @@ interface BoardContentProps {
 export const BoardContent = ({ content }: BoardContentProps) => {
   return (
     <div
-      className="prose max-w-full prose-p:my-2 [&_p:empty]:min-h-[1.75em]"
+      className="prose max-w-full prose-p:my-2 prose-a:text-primary prose-a:no-underline hover:prose-a:underline [&_p:empty]:min-h-[1.75em]"
       dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
     />
   );

--- a/client/src/components/board/BoardContent.tsx
+++ b/client/src/components/board/BoardContent.tsx
@@ -5,5 +5,10 @@ interface BoardContentProps {
 }
 
 export const BoardContent = ({ content }: BoardContentProps) => {
-  return <div className="prose max-w-full" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }} />;
+  return (
+    <div
+      className="prose max-w-full prose-p:my-0 [&_p:empty]:min-h-[1.75em]"
+      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(content) }}
+    />
+  );
 };

--- a/client/src/pages/BoardDetailPage.tsx
+++ b/client/src/pages/BoardDetailPage.tsx
@@ -28,7 +28,7 @@ export default function BoardDetailPage() {
         <title>{board ? `${board.title} - ${categoryLabel}` : "공지사항 · FAQ"} - 데나무</title>
       </Helmet>
 
-      <div className="mx-auto max-w-3xl px-4 py-10">
+      <div className="mx-auto max-w-4xl px-4 py-10 sm:px-6">
         <Button
           variant="ghost"
           size="sm"

--- a/client/src/pages/BoardDetailPage.tsx
+++ b/client/src/pages/BoardDetailPage.tsx
@@ -46,7 +46,10 @@ export default function BoardDetailPage() {
         ) : (
           <article className="mt-4">
             <h1 className="text-2xl font-bold">{board.title}</h1>
-            <p className="mt-2 text-sm text-gray-400">{new Date(board.createdAt).toLocaleString()}</p>
+            <p className="mt-2 text-sm text-gray-400">
+              {board.authorName && <span>{board.authorName} · </span>}
+              {new Date(board.createdAt).toLocaleString()}
+            </p>
             <div className="mt-6 border-t pt-6">
               <BoardContent content={board.content} />
             </div>


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #879

### 공지사항 상세 작성자 미표기

- `BoardDetail` 타입엔 `authorName`이 있었는데 상세 페이지 JSX에서 렌더링이 누락되어 작성자가 항상 보이지 않던 버그. 날짜 옆에 표기하도록 수정.

### 본문 줄바꿈/여백 문제

- 관리자 에디터(Quill)는 Enter 한 번마다 별도 `<p>`를 생성하는데, `prose` 기본 스타일의 문단 마진(위아래 각 1.25em)이 그대로 적용되어 단순 줄바꿈도 문단만큼 크게 벌어져 보였음.
- 실제 DB 데이터 확인 결과 의도적인 문단 구분은 완전히 빈 `<p></p>`로 저장되어 있어, 단순히 마진을 제거하면 그 빈 줄까지 사라지는 문제가 있었음. `prose-p` 마진을 축소하고 빈 `<p>`에만 최소 높이를 줘서 실제 줄바꿈과 의도된 문단 구분을 구분되게 처리.
- 본문 폭이 좁다는 피드백으로 컨테이너 `max-w-3xl` → `max-w-4xl`, 반응형 패딩 보강.
- 하이퍼링크는 브랜드 컬러(`text-primary`)로 통일.

# 📋 작업 내용

- `client/src/pages/BoardDetailPage.tsx`: 작성자명 렌더링 추가, 상세 페이지 컨테이너 폭 확장
- `client/src/components/board/BoardContent.tsx`: 문단 마진 조정, 빈 줄 최소 높이 처리, 링크 색상 브랜드 컬러 적용

# 📷 스크린 샷(선택 사항)

<img width="926" height="901" alt="image" src="https://github.com/user-attachments/assets/40586d9a-3c09-40c2-95da-6c7a009e1856" />
<img width="897" height="350" alt="image" src="https://github.com/user-attachments/assets/67736789-ffc7-436e-9d6a-a439e5e73a44" />
