### PR TITLE
🐛 fix: 블로그 플랫폼 뱃지 색상 누락 수정

### DIFF
--- a/client/src/__tests__/components/sections/RecentRssSection.test.tsx
+++ b/client/src/__tests__/components/sections/RecentRssSection.test.tsx
@@ -145,7 +145,7 @@ describe("RecentRssSection", () => {
 
     expect(screen.getByText("tistory")).toHaveStyle({ backgroundColor: "#EB531F" });
     expect(screen.getByText("velog")).toHaveStyle({ backgroundColor: "#20C997" });
-    expect(screen.getByText("github")).toHaveStyle({ backgroundColor: "#000000" });
+    expect(screen.getByText("github")).toHaveStyle({ backgroundColor: "#7F00AF" });
     expect(screen.getByText("etc")).toHaveStyle({ backgroundColor: "#6B7280" });
   });
 

--- a/client/src/constants/rss.ts
+++ b/client/src/constants/rss.ts
@@ -11,7 +11,9 @@ interface Platform {
 export const PLATFORM_BADGE_COLORS: Record<string, string> = {
   tistory: "#EB531F",
   velog: "#20C997",
-  github: "#000000",
+  github: "#7F00AF",
+  naver: "#2DB400",
+  medium: "#000000",
 };
 
 export const DEFAULT_BADGE_COLOR = "#6B7280";


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #867

### 플랫폼 뱃지 색상 누락

-   `PLATFORM_BADGE_COLORS`에 naver, medium 색상 누락되어 있어 기본 회색으로 표시되던 문제 수정
-   github 뱃지 색상도 브랜드 컬러(#7F00AF)로 변경

# 📋 작업 내용

-   `client/src/constants/rss.ts`
    -   naver: `#2DB400` 추가
    -   medium: `#000000` 추가
    -   github: `#000000` → `#7F00AF` 변경

# 📷 스크린 샷(선택 사항)
<img width="383" height="30" alt="image" src="https://github.com/user-attachments/assets/06f0a9ef-2da1-45bd-a4d4-e1db1b1de628" />