### PR TITLE
📦 chore: nginx static 폴더 배포 CI 동기화 추가

### DIFF
--- a/.github/workflows/deploy_nginx.yml
+++ b/.github/workflows/deploy_nginx.yml
@@ -3,7 +3,7 @@ name: Nginx Configuration Deployment
 on:
   push:
     branches: [main]
-    paths: ["nginx.conf", ".github/workflows/deploy_nginx.yml"]
+    paths: ["nginx.conf", "static/**", ".github/workflows/deploy_nginx.yml"]
   workflow_dispatch:
 
 env:
@@ -26,6 +26,12 @@ jobs:
             echo "ℹ️  $ACTIVE_FILE 없음 → blue(${BLUE_PORT}) 로 시드 (upstream include 검증 통과용)"
             echo "server 127.0.0.1:${BLUE_PORT};" | sudo tee "$ACTIVE_FILE"
           fi
+
+      - name: static 파일 동기화
+        run: |
+          sudo mkdir -p /var/prod_data/static
+          sudo rsync -av --delete ./static/ /var/prod_data/static/
+          sudo chown -R www-data:www-data /var/prod_data/static
 
       - name: nginx 설정 검사 및 reload
         run: |


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 관련 이슈 없음

### static 파일 미동기화 문제

- `nginx.conf`의 `/files` location은 prod 호스트의 `/var/prod_data/static/`을 alias로 서빙하지만, repo `static/` 폴더를 이 경로로 옮기는 배포 스텝이 없어 새 정적 파일(`naver-icon.svg` 등)이 404로 응답되던 문제가 있었음.
- `deploy_client.yml`은 `client/dist` → `/var/dist`만 동기화하고, `deploy_nginx.yml`은 `nginx.conf` 검증/reload만 수행해서 static 자산은 어떤 워크플로도 다루지 않고 있었음.
- CI 러너 workspace 경로를 nginx alias로 직접 잡는 방식도 검토했으나, checkout 시 clean 동작으로 인한 서빙 중 race, 러너 workspace 경로의 CI 내부 구현 의존성, 권한 경계 문제로 기각. 기존 `/var/dist`, `/var/prod_data` 컨벤션에 맞춰 별도 데이터 디렉토리로 동기화하는 방식 채택.

# 📋 작업 내용

- `deploy_nginx.yml`에 static 파일 동기화 스텝 추가 (`rsync -av --delete ./static/ /var/prod_data/static/` + `www-data` 소유권 부여).
- workflow 트리거 `paths`에 `static/**` 추가.

# 📷 스크린 샷(선택 사항)

해당 없음