### PR TITLE
🐛 fix: 채팅 히스토리 재조회 시 메시지 중복 누적 버그 수정

### DIFF
--- a/client/src/__tests__/store/useChatStore.test.ts
+++ b/client/src/__tests__/store/useChatStore.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type Handler = (...args: unknown[]) => void;
+
+const { mockSocket, ioMock, resetMockSocket } = vi.hoisted(() => {
+  let listeners: Record<string, Handler[]> = {};
+
+  const mockSocket = {
+    connected: false,
+    on: vi.fn((event: string, cb: Handler) => {
+      (listeners[event] ??= []).push(cb);
+    }),
+    off: vi.fn(),
+    emit: vi.fn(),
+    connect: vi.fn(() => {
+      mockSocket.connected = true;
+    }),
+    disconnect: vi.fn(() => {
+      mockSocket.connected = false;
+    }),
+    trigger: (event: string, data?: unknown) => {
+      (listeners[event] ?? []).forEach((cb) => cb(data));
+    },
+    listenerCount: (event: string) => (listeners[event] ?? []).length,
+  };
+
+  const ioMock = vi.fn(() => mockSocket);
+
+  const resetMockSocket = () => {
+    listeners = {};
+    mockSocket.connected = false;
+    mockSocket.on.mockClear();
+    mockSocket.off.mockClear();
+    mockSocket.emit.mockClear();
+    mockSocket.connect.mockClear();
+    mockSocket.disconnect.mockClear();
+  };
+
+  return { mockSocket, ioMock, resetMockSocket };
+});
+
+vi.mock("socket.io-client", () => ({ io: ioMock }));
+
+describe("useChatStore", () => {
+  let useChatStore: typeof import("@/store/useChatStore").useChatStore;
+
+  beforeEach(async () => {
+    resetMockSocket();
+    localStorage.clear();
+    vi.resetModules();
+    ({ useChatStore } = await import("@/store/useChatStore"));
+  });
+
+  it("소켓 재연결로 chatHistory가 다시 수신돼도 메시지가 누적되지 않는다", () => {
+    useChatStore.getState().getHistory();
+
+    const historyPayload = [
+      { messageId: "1", userName: "a", message: "hi", timestamp: "t1" },
+      { messageId: "2", userName: "b", message: "hello", timestamp: "t2" },
+    ];
+
+    mockSocket.trigger("chatHistory", historyPayload);
+    mockSocket.trigger("chatHistory", historyPayload);
+    mockSocket.trigger("chatHistory", historyPayload);
+
+    expect(useChatStore.getState().chatHistory).toHaveLength(2);
+  });
+
+  it("chatHistory로 받은 과거 메시지는 isSend:true로 스탬프된다", () => {
+    useChatStore.getState().getHistory();
+
+    mockSocket.trigger("chatHistory", [{ messageId: "1", userName: "a", message: "hi", timestamp: "t1" }]);
+
+    expect(useChatStore.getState().chatHistory[0].isSend).toBe(true);
+  });
+
+  it("전송 대기/실패 중인 로컬 메시지는 chatHistory 갱신 후에도 유지된다", () => {
+    useChatStore.getState().getHistory();
+    useChatStore.setState({
+      chatHistory: [
+        { messageId: "pending-1", userName: "me", message: "재전송 대기", timestamp: "t", isFailed: true, isSend: false },
+      ],
+    });
+
+    mockSocket.trigger("chatHistory", [{ messageId: "1", userName: "a", message: "hi", timestamp: "t1" }]);
+
+    const { chatHistory } = useChatStore.getState();
+    expect(chatHistory).toHaveLength(2);
+    expect(chatHistory.some((c) => c.messageId === "pending-1")).toBe(true);
+  });
+
+  it("connect/getHistory를 여러 번 호출해도 소켓 리스너가 중복 등록되지 않는다", () => {
+    const { connect, getHistory } = useChatStore.getState();
+
+    connect("anonymous");
+    connect("anonymous");
+    getHistory();
+    getHistory();
+
+    expect(mockSocket.listenerCount("chatHistory")).toBe(1);
+    expect(mockSocket.listenerCount("connect")).toBe(1);
+  });
+});

--- a/client/src/store/useChatStore.ts
+++ b/client/src/store/useChatStore.ts
@@ -57,6 +57,16 @@ export const useChatStore = create<State & Action>((set, get) => {
       });
     });
 
+    socket.on("chatHistory", (data: ChatType[]) => {
+      set((state) => {
+        const failedMessages = state.chatHistory.filter((chat) => chat.isFailed || !chat.isSend);
+        return {
+          chatHistory: [...data.map((chat) => ({ ...chat, isSend: true })), ...failedMessages],
+          isLoading: false,
+        };
+      });
+    });
+
     socket.on("messageDeleted", (data) => {
       set((state) => ({
         chatHistory: state.chatHistory.map((msg) =>
@@ -86,6 +96,7 @@ export const useChatStore = create<State & Action>((set, get) => {
 
     socket.on("connect", () => {
       useChatStore.setState({ isConnected: true });
+      socket?.emit("register", { userId: localStorage.getItem("userID") });
     });
 
     socket.on("disconnect", () => {
@@ -109,9 +120,6 @@ export const useChatStore = create<State & Action>((set, get) => {
       if (!s.connected) {
         s.connect();
       }
-      s.on('connect', () => {
-        s.emit('register', { userId: localStorage.getItem('userID') });
-      });
     },
 
     disconnect: () => {
@@ -125,29 +133,10 @@ export const useChatStore = create<State & Action>((set, get) => {
 
       const s = initializeSocket(roomId);
       s.connect();
-      s.on('connect', () => {
-        s.emit('register', { userId: localStorage.getItem('userID') });
-      });
-      s.on("chatHistory", (data) => {
-        set((state) => {
-          const failedMessages = state.chatHistory.filter((chat) => chat.isFailed || !chat.isSend);
-          return { chatHistory: [...data, ...failedMessages], isLoading: false };
-        });
-      });
     },
 
     getHistory: () => {
-      const s = initializeSocket();
-
-      s.on("chatHistory", (data) => {
-        useChatStore.setState((state) => {
-          const failedMessages = state.chatHistory.filter((chat) => chat.isFailed || !chat.isSend);
-          return {
-            chatHistory: [...data, ...failedMessages],
-            isLoading: false,
-          };
-        });
-      });
+      initializeSocket();
     },
 
     sendMessage: (message: SendChatType) => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #868

### 원인 분석

- `chatHistory` 소켓 핸들러가 실질적으로 append 동작을 함.
  ```js
  const failedMessages = state.chatHistory.filter((chat) => chat.isFailed || !chat.isSend);
  return { chatHistory: [...data, ...failedMessages] };
  ```
- 서버가 `chatHistory` 이벤트로 보내는 과거 메시지 payload엔 `isSend` 필드가 없음 (`server/src/chat/chat.gateway.ts`). 따라서 `!chat.isSend` 필터에 과거 메시지 전체가 걸려 `failedMessages`로 오인됨.
- 소켓 재연결(새로고침, 다른 페이지 이동 후 복귀 등) 때마다 서버가 `chatHistory`를 재전송하는데, 직전 렌더의 데이터가 매번 되풀이해서 붙어 2배, 3배로 누적됨.
- 추가로 `connect()` / `getHistory()` / `switchRoom()` 호출마다 소켓 리스너(`on("chatHistory")`, `on("connect")`)를 매번 새로 등록하고 해제하지 않아, 리스너가 쌓일수록 배수가 커짐.

# 📋 작업 내용

- `client/src/store/useChatStore.ts`
  - `chatHistory` 리스너를 소켓 최초 생성 시 1회만 등록되는 `initializeSocket()` 내부로 이동.
  - 서버에서 받은 과거 메시지에 `isSend: true`를 스탬프하여 pending 메시지와 구분.
  - `register` emit 로직을 `connect` 이벤트 핸들러에 통합, 중복 리스너 등록 제거.

# 📷 스크린 샷(선택 사항)

- client 테스트 21개 통과, `tsc --noEmit` 에러 없음.