### PR TITLE
🐛 fix: 프로필 이미지 삭제 시 경로 불일치 및 미존재 예외 문제 해결

### DIFF
--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -67,6 +67,12 @@ export class FileService {
     return filePath.replace(this.basePath, '/objects');
   }
 
+  private resolveInternalPath(accessUrl: string): string {
+    return accessUrl.startsWith('/objects')
+      ? accessUrl.replace('/objects', this.basePath)
+      : accessUrl;
+  }
+
   async findById(id: number): Promise<File> {
     const file = await this.fileRepository.findOne({
       where: { id },
@@ -99,19 +105,21 @@ export class FileService {
     return this.findById(id);
   }
 
-  async deleteByPath(path: string): Promise<void> {
-    const file = await this.fileRepository.findOne({ where: { path } });
-    if (file) {
-      try {
-        await access(file.path);
-        await unlink(file.path);
-      } catch {
-        this.logger.warn(`파일 삭제 실패: ${file.path}`, 'FileService');
-      }
-
-      await this.fileRepository.delete(file.id);
-    } else {
-      throw new NotFoundException('파일을 찾을 수 없습니다.');
+  async deleteByPath(accessUrl: string): Promise<void> {
+    const file = await this.fileRepository.findOne({
+      where: { path: this.resolveInternalPath(accessUrl) },
+    });
+    if (!file) {
+      return;
     }
+
+    try {
+      await access(file.path);
+      await unlink(file.path);
+    } catch {
+      this.logger.warn(`파일 삭제 실패: ${file.path}`, 'FileService');
+    }
+
+    await this.fileRepository.delete(file.id);
   }
 }

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -309,7 +309,9 @@ export class UserService {
       updateData.profileImage !== undefined &&
       user.profileImage !== updateData.profileImage
     ) {
-      await this.fileService.deleteByPath(user.profileImage);
+      if (user.profileImage) {
+        await this.fileService.deleteByPath(user.profileImage);
+      }
       user.profileImage = updateData.profileImage;
     }
     if (updateData.introduction !== undefined) {

--- a/server/test/file/unit/file.service.unit.spec.ts
+++ b/server/test/file/unit/file.service.unit.spec.ts
@@ -150,14 +150,16 @@ describe(`${FileService.name} Unit Test`, () => {
   });
 
   describe('deleteByPath', () => {
-    it('경로에 해당하는 파일이 없으면 NotFoundException을 던진다.', async () => {
+    it('경로에 해당하는 파일이 없으면 아무 동작도 하지 않는다.', async () => {
       // given
       fileRepository.findOne.mockResolvedValue(null);
 
-      // when & then
-      await expect(fileService.deleteByPath('/app/objects/x.png')).rejects.toThrow(
-        NotFoundException,
-      );
+      // when
+      await fileService.deleteByPath('/app/objects/x.png');
+
+      // then
+      expect(mockedFs.unlink).not.toHaveBeenCalled();
+      expect(fileRepository.delete).not.toHaveBeenCalled();
     });
 
     it('파일을 찾으면 물리 파일과 레코드를 삭제한다.', async () => {


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #884 

### 소주제1

-   `deleteByPath`가 파라미터로 클라이언트 공개 URL(`/objects/...`)을 그대로 받아 DB에 저장된 내부 경로(`/app/objects/...`)와 비교하는 바람에 항상 매칭에 실패하던 문제
-   또한 OAuth 로그인 시 저장되는 `profileImage`(외부 CDN URL, 예: 카카오/구글 프로필 사진)에 대해서도 동일 로직을 타면서 파일을 못 찾으면 `NotFoundException`을 던져, 프로필 수정/회원 탈퇴 흐름이 예외로 죽는 문제

### 소주제2

-   `resolveInternalPath`를 추가해 공개 URL prefix(`/objects`)를 내부 경로(`/app/objects`)로 변환한 뒤 조회하도록 수정
-   대상 파일이 없는 경우(OAuth 프로필처럼 애초에 우리 파일 스토리지 소관이 아닌 경우 포함) 예외를 던지지 않고 조용히 종료하도록 변경 — 파일 삭제는 부가 정리 작업이라 실패해도 프로필 갱신/탈퇴 자체를 막을 이유가 없음
-   `user.service.ts`에서 `profileImage`가 falsy일 때 `deleteByPath` 호출 자체를 스킵하도록 가드 추가

# 📋 작업 내용

-   `file.service.ts`: `resolveInternalPath` 추가, `deleteByPath` 시그니처를 `accessUrl` 기준으로 명확화, 파일 미존재 시 예외 대신 early return
-   `user.service.ts`: `profileImage` null 체크 후 `deleteByPath` 호출
-   `file.service.unit.spec.ts`: OAuth 프로필 이미지처럼 파일 레코드가 없는 경우에 대한 테스트 보강