### PR TITLE
✨ feat: 공지사항 등록 시 이메일 알림 전송

### DIFF
--- a/email-worker/scripts/preview-email.ts
+++ b/email-worker/scripts/preview-email.ts
@@ -5,6 +5,7 @@ import {
   createAdminDeleteAccountContent,
   createAdminVerificationMailContent,
   createDeleteAccountContent,
+  createNoticePublishedContent,
   createPasswordResetMailContent,
   createQnaAnsweredContent,
   createRssCertificationContent,
@@ -97,6 +98,16 @@ const previews: [string, string, string][] = [
     createQnaAnsweredContent(
       '김데나무',
       '로그인이 안 돼요',
+      1,
+      SERVICE_ADDRESS,
+    ),
+  ],
+  [
+    'notice-published',
+    '공지사항 등록 알림',
+    createNoticePublishedContent(
+      '김데나무',
+      '서비스 점검 안내',
       1,
       SERVICE_ADDRESS,
     ),

--- a/email-worker/src/common/types.ts
+++ b/email-worker/src/common/types.ts
@@ -49,3 +49,10 @@ export interface QnaAnswered {
   qnaId: number;
   qnaTitle: string;
 }
+
+export interface NoticePublished {
+  email: string;
+  userName: string;
+  boardId: number;
+  title: string;
+}

--- a/email-worker/src/email/constant.ts
+++ b/email-worker/src/email/constant.ts
@@ -10,4 +10,5 @@ export const EmailPayloadConstant = {
   ADMIN_ACCOUNT_DELETION: 'adminAccountDeletion',
   ADMIN_PASSWORD_RESET: 'adminPasswordReset',
   QNA_ANSWERED: 'qnaAnswered',
+  NOTICE_PUBLISHED: 'noticePublished',
 } as const;

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -129,6 +129,10 @@ export class EmailConsumer implements Lifecycle {
         await this.emailService.sendQnaAnsweredMail(payload.data);
         break;
 
+      case EmailPayloadConstant.NOTICE_PUBLISHED:
+        await this.emailService.sendNoticePublishedMail(payload.data);
+        break;
+
       case EmailPayloadConstant.ADMIN_CERTIFICATION:
         await this.emailService.sendAdminCertificationMail(payload.data);
         break;

--- a/email-worker/src/email/email.content.ts
+++ b/email-worker/src/email/email.content.ts
@@ -284,6 +284,28 @@ export function createQnaAnsweredContent(
   return mailLayout(body, serviceAddress);
 }
 
+export function createNoticePublishedContent(
+  userName: string,
+  title: string,
+  boardId: number,
+  serviceAddress: string,
+) {
+  const noticeLink = `${PRODUCT_DOMAIN}/board/${boardId}`;
+
+  const body = `
+        ${heading('새로운 공지사항이 등록되었습니다', '#007bff')}
+        ${infoBox(`
+          <p><strong>안녕하세요, ${userName}님!</strong></p>
+          <p>'${title}' 공지사항이 등록되었습니다.</p>
+        `)}
+        ${button(noticeLink, '공지사항 확인하러 가기')}
+        ${noticeBox(`
+          ${fallbackLink(noticeLink)}
+        `)}
+  `;
+  return mailLayout(body, serviceAddress);
+}
+
 export function createDeleteAccountContent(
   userName: string,
   verificationLink: string,

--- a/email-worker/src/email/email.service.ts
+++ b/email-worker/src/email/email.service.ts
@@ -7,6 +7,7 @@ import logger from '@common/logger/logger';
 import { EmailMetrics } from '@common/metrics/email-metrics';
 import {
   AdminCertification,
+  NoticePublished,
   QnaAnswered,
   Rss,
   RssCertification,
@@ -20,6 +21,7 @@ import {
   createAdminDeleteAccountContent,
   createAdminVerificationMailContent,
   createDeleteAccountContent,
+  createNoticePublishedContent,
   createPasswordResetMailContent,
   createQnaAnsweredContent,
   createRssCertificationContent,
@@ -326,6 +328,28 @@ export class EmailService {
         qnaAnswered.recipientName,
         qnaAnswered.qnaTitle,
         qnaAnswered.qnaId,
+        this.emailUser,
+      ),
+    };
+  }
+
+  async sendNoticePublishedMail(notice: NoticePublished): Promise<void> {
+    const mailOptions = this.createNoticePublishedMail(notice);
+
+    await this.sendMail(mailOptions);
+  }
+
+  private createNoticePublishedMail(
+    notice: NoticePublished,
+  ): nodemailer.SendMailOptions {
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: `${notice.userName}<${notice.email}>`,
+      subject: `[🎋 Denamu] 새로운 공지사항이 등록되었습니다.`,
+      html: createNoticePublishedContent(
+        notice.userName,
+        notice.title,
+        notice.boardId,
         this.emailUser,
       ),
     };

--- a/email-worker/src/email/types.ts
+++ b/email-worker/src/email/types.ts
@@ -1,5 +1,6 @@
 import {
   AdminCertification,
+  NoticePublished,
   QnaAnswered,
   RssCertification,
   RssRegistration,
@@ -39,7 +40,11 @@ export type EmailPayload =
       type: typeof EmailPayloadConstant.ADMIN_PASSWORD_RESET;
       data: AdminCertification;
     }
-  | { type: typeof EmailPayloadConstant.QNA_ANSWERED; data: QnaAnswered };
+  | { type: typeof EmailPayloadConstant.QNA_ANSWERED; data: QnaAnswered }
+  | {
+      type: typeof EmailPayloadConstant.NOTICE_PUBLISHED;
+      data: NoticePublished;
+    };
 
 export type NodeMailerError = Error & {
   code?: string;

--- a/server/src/board/module/board.module.ts
+++ b/server/src/board/module/board.module.ts
@@ -7,10 +7,12 @@ import { BoardService } from '@board/service/board.service';
 
 import { AdminModule } from '@admin/module/admin.module';
 
+import { UserRepository } from '@user/repository/user.repository';
+
 @Module({
   imports: [AdminModule],
   controllers: [BoardController, AdminBoardController],
-  providers: [BoardService, BoardRepository],
+  providers: [BoardService, BoardRepository, UserRepository],
   exports: [],
 })
 export class BoardModule {}

--- a/server/src/board/service/board.service.ts
+++ b/server/src/board/service/board.service.ts
@@ -9,10 +9,16 @@ import {
   BoardDetailDto,
   BoardListResponseDto,
 } from '@board/dto/response/board.dto';
+import { Board } from '@board/entity/board.entity';
 import { BoardRepository } from '@board/repository/board.repository';
 import { validateWindow } from '@board/util/validateWindow';
 
 import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { EmailProducer } from '@common/email/email.producer';
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { UserRepository } from '@user/repository/user.repository';
 
 const NOT_FOUND_MESSAGE = '존재하지 않는 게시글입니다.';
 
@@ -21,6 +27,9 @@ export class BoardService {
   constructor(
     private readonly boardRepository: BoardRepository,
     private readonly adminRepository: AdminRepository,
+    private readonly userRepository: UserRepository,
+    private readonly emailProducer: EmailProducer,
+    private readonly logger: WinstonLoggerService,
   ) {}
 
   async getPublicBoards(queryDto: GetBoardsRequestDto) {
@@ -85,7 +94,51 @@ export class BoardService {
       author,
     });
     await this.boardRepository.save(board);
+
+    if (this.isNoticeVisibleNow(board)) {
+      await this.notifyNoticePublished(board);
+    }
+
     return BoardDetailDto.fromDetail(board);
+  }
+
+  private isNoticeVisibleNow(board: Board): boolean {
+    const now = new Date();
+    return (
+      board.category === BoardCategory.NOTICE &&
+      board.status === BoardStatus.PUBLISHED &&
+      (!board.startAt || board.startAt <= now) &&
+      (!board.endAt || board.endAt >= now)
+    );
+  }
+
+  private async notifyNoticePublished(board: Board): Promise<void> {
+    try {
+      const recipients = await this.userRepository.findNoticeAgreedUsers();
+      const results = await Promise.allSettled(
+        recipients.map((recipient) =>
+          this.emailProducer.produceNoticePublished({
+            email: recipient.email,
+            userName: recipient.userName,
+            boardId: board.id,
+            title: board.title,
+          }),
+        ),
+      );
+
+      const failedCount = results.filter(
+        (result) => result.status === 'rejected',
+      ).length;
+      if (failedCount > 0) {
+        this.logger.error(
+          `공지사항 이메일 발행 중 일부가 실패했습니다.: boardId=${board.id}, failed=${failedCount}/${recipients.length}`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `공지사항 이메일 발행에 실패했습니다.: boardId=${board.id}, error=${error}`,
+      );
+    }
   }
 
   async updateBoard(

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   EmailPayload,
   EmailPayloadConstant,
+  NoticePublished,
   QnaAnswered,
 } from '@common/email/email.type';
 import { WinstonLoggerService } from '@common/logger/logger.service';
@@ -192,6 +193,13 @@ export class EmailProducer {
   async produceQnaAnswered(payload: QnaAnswered) {
     await this.produceMessage({
       type: EmailPayloadConstant.QNA_ANSWERED,
+      data: payload,
+    });
+  }
+
+  async produceNoticePublished(payload: NoticePublished) {
+    await this.produceMessage({
+      type: EmailPayloadConstant.NOTICE_PUBLISHED,
       data: payload,
     });
   }

--- a/server/src/common/email/email.type.ts
+++ b/server/src/common/email/email.type.ts
@@ -49,6 +49,13 @@ export interface QnaAnswered {
   qnaTitle: string;
 }
 
+export interface NoticePublished {
+  email: string;
+  userName: string;
+  boardId: number;
+  title: string;
+}
+
 export const EmailPayloadConstant = {
   USER_CERTIFICATION: 'userCertification',
   RSS_REMOVAL: 'rssRemoval',
@@ -61,6 +68,7 @@ export const EmailPayloadConstant = {
   ADMIN_ACCOUNT_DELETION: 'adminAccountDeletion',
   ADMIN_PASSWORD_RESET: 'adminPasswordReset',
   QNA_ANSWERED: 'qnaAnswered',
+  NOTICE_PUBLISHED: 'noticePublished',
 } as const;
 
 export type EmailPayload =
@@ -92,4 +100,8 @@ export type EmailPayload =
       type: typeof EmailPayloadConstant.ADMIN_PASSWORD_RESET;
       data: AdminCertification;
     }
-  | { type: typeof EmailPayloadConstant.QNA_ANSWERED; data: QnaAnswered };
+  | { type: typeof EmailPayloadConstant.QNA_ANSWERED; data: QnaAnswered }
+  | {
+      type: typeof EmailPayloadConstant.NOTICE_PUBLISHED;
+      data: NoticePublished;
+    };

--- a/server/src/user/repository/user.repository.ts
+++ b/server/src/user/repository/user.repository.ts
@@ -47,4 +47,11 @@ export class UserRepository extends Repository<User> {
       },
     });
   }
+
+  async findNoticeAgreedUsers(): Promise<Pick<User, 'email' | 'userName'>[]> {
+    return this.find({
+      where: { noticeEmailAgreed: true },
+      select: ['email', 'userName'],
+    });
+  }
 }

--- a/server/test/board/unit/board.service.unit.spec.ts
+++ b/server/test/board/unit/board.service.unit.spec.ts
@@ -1,7 +1,5 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 
-import { AdminRepository } from '@admin/repository/admin.repository';
-
 import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
 import { CreateBoardRequestDto } from '@board/dto/request/createBoard.dto';
 import { GetAdminBoardsRequestDto } from '@board/dto/request/getAdminBoards.dto';
@@ -10,6 +8,13 @@ import { UpdateBoardRequestDto } from '@board/dto/request/updateBoard.dto';
 import { Board } from '@board/entity/board.entity';
 import { BoardRepository } from '@board/repository/board.repository';
 import { BoardService } from '@board/service/board.service';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { EmailProducer } from '@common/email/email.producer';
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { UserRepository } from '@user/repository/user.repository';
 
 import { BoardFixture } from '@test/config/common/fixture/board.fixture';
 
@@ -26,6 +31,11 @@ describe(`${BoardService.name} Unit Test`, () => {
     jest.Mock
   >;
   let adminRepository: Record<'findOneBy', jest.Mock>;
+  let userRepository: jest.Mocked<
+    Pick<UserRepository, 'findNoticeAgreedUsers'>
+  >;
+  let emailProducer: jest.Mocked<Pick<EmailProducer, 'produceNoticePublished'>>;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
 
   const createBoard = (overwrites: Partial<Board> = {}): Board =>
     BoardFixture.createBoardFixture({
@@ -48,10 +58,20 @@ describe(`${BoardService.name} Unit Test`, () => {
     adminRepository = {
       findOneBy: jest.fn(),
     };
+    userRepository = {
+      findNoticeAgreedUsers: jest.fn().mockResolvedValue([]),
+    };
+    emailProducer = {
+      produceNoticePublished: jest.fn(),
+    };
+    logger = { error: jest.fn() };
 
     boardService = new BoardService(
       boardRepository as unknown as BoardRepository,
       adminRepository as unknown as AdminRepository,
+      userRepository as unknown as UserRepository,
+      emailProducer as unknown as EmailProducer,
+      logger as unknown as WinstonLoggerService,
     );
   });
 
@@ -145,7 +165,11 @@ describe(`${BoardService.name} Unit Test`, () => {
 
       // when
       await boardService.getPublicBoards(
-        new GetBoardsRequestDto({ page: 1, limit: 10, category: BoardCategory.FAQ }),
+        new GetBoardsRequestDto({
+          page: 1,
+          limit: 10,
+          category: BoardCategory.FAQ,
+        }),
       );
 
       // then
@@ -319,9 +343,9 @@ describe(`${BoardService.name} Unit Test`, () => {
       });
 
       // when & then
-      await expect(boardService.createBoard('admin@test.com', dto)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        boardService.createBoard('admin@test.com', dto),
+      ).rejects.toThrow(BadRequestException);
       expect(boardRepository.save).not.toHaveBeenCalled();
     });
 
@@ -335,9 +359,9 @@ describe(`${BoardService.name} Unit Test`, () => {
       });
 
       // when & then
-      await expect(boardService.createBoard('admin@test.com', dto)).rejects.toThrow(
-        BadRequestException,
-      );
+      await expect(
+        boardService.createBoard('admin@test.com', dto),
+      ).rejects.toThrow(BadRequestException);
       expect(boardRepository.save).not.toHaveBeenCalled();
     });
 
@@ -400,6 +424,108 @@ describe(`${BoardService.name} Unit Test`, () => {
       );
       expect(result.authorName).toBeNull();
     });
+
+    it('공지사항이 공개 상태로 즉시 노출될 경우 알림 수신에 동의한 사용자에게 이메일을 발행한다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+      boardRepository.save.mockImplementation((entity: Board) => {
+        entity.id = 1;
+        return entity;
+      });
+      userRepository.findNoticeAgreedUsers.mockResolvedValue([
+        { email: 'a@test.com', userName: 'a' },
+        { email: 'b@test.com', userName: 'b' },
+      ]);
+      const dto = new CreateBoardRequestDto({
+        title: '점검 안내',
+        content: '<p>본문</p>',
+        category: BoardCategory.NOTICE,
+        status: BoardStatus.PUBLISHED,
+      });
+
+      // when
+      await boardService.createBoard('admin@test.com', dto);
+
+      // then
+      expect(userRepository.findNoticeAgreedUsers).toHaveBeenCalled();
+      expect(emailProducer.produceNoticePublished).toHaveBeenCalledTimes(2);
+      expect(emailProducer.produceNoticePublished).toHaveBeenCalledWith({
+        email: 'a@test.com',
+        userName: 'a',
+        boardId: 1,
+        title: '점검 안내',
+      });
+    });
+
+    it('임시저장 상태일 경우 이메일을 발행하지 않는다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+      const dto = new CreateBoardRequestDto({
+        title: '점검 안내',
+        content: '<p>본문</p>',
+      });
+
+      // when
+      await boardService.createBoard('admin@test.com', dto);
+
+      // then
+      expect(userRepository.findNoticeAgreedUsers).not.toHaveBeenCalled();
+      expect(emailProducer.produceNoticePublished).not.toHaveBeenCalled();
+    });
+
+    it('FAQ 분류일 경우 이메일을 발행하지 않는다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+      const dto = new CreateBoardRequestDto({
+        title: '질문',
+        content: '<p>본문</p>',
+        category: BoardCategory.FAQ,
+        status: BoardStatus.PUBLISHED,
+      });
+
+      // when
+      await boardService.createBoard('admin@test.com', dto);
+
+      // then
+      expect(emailProducer.produceNoticePublished).not.toHaveBeenCalled();
+    });
+
+    it('노출 시작일이 미래일 경우 이메일을 발행하지 않는다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+      const dto = new CreateBoardRequestDto({
+        title: '점검 안내',
+        content: '<p>본문</p>',
+        status: BoardStatus.PUBLISHED,
+        startAt: '2099-01-01T00:00:00.000Z',
+      });
+
+      // when
+      await boardService.createBoard('admin@test.com', dto);
+
+      // then
+      expect(emailProducer.produceNoticePublished).not.toHaveBeenCalled();
+    });
+
+    it('이메일 발행에 실패해도 게시글 작성 자체는 성공한다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+      userRepository.findNoticeAgreedUsers.mockRejectedValue(
+        new Error('DB 오류'),
+      );
+      const dto = new CreateBoardRequestDto({
+        title: '점검 안내',
+        content: '<p>본문</p>',
+        status: BoardStatus.PUBLISHED,
+      });
+
+      // when
+      const result = await boardService.createBoard('admin@test.com', dto);
+
+      // then
+      expect(result.title).toBe('점검 안내');
+      expect(logger.error).toHaveBeenCalled();
+    });
   });
 
   describe('updateBoard', () => {
@@ -409,7 +535,10 @@ describe(`${BoardService.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        boardService.updateBoard(1, new UpdateBoardRequestDto({ title: '수정' })),
+        boardService.updateBoard(
+          1,
+          new UpdateBoardRequestDto({ title: '수정' }),
+        ),
       ).rejects.toThrow(NotFoundException);
       expect(boardRepository.save).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
# 🔨 테스크

### Issue

- #781

### 공지사항 이메일 알림

- 공지사항이 게시(PUBLISHED)되고 노출 기간(startAt~endAt) 조건을 만족하는 시점에, 이메일 수신에 동의한 사용자 전원에게 알림 메일을 발송하도록 구현했습니다.
- 발송은 기존 RabbitMQ 기반 email-worker 파이프라인에 `noticePublished` 타입을 추가하는 방식으로 처리하여, 서버가 대량 발송을 동기로 기다리지 않도록 했습니다.
- 수신자 조회/발송 과정에서 일부가 실패해도 게시글 등록 자체는 실패하지 않도록 `Promise.allSettled`로 격리하고, 실패 건수는 로깅만 남깁니다.

# 📋 작업 내용

- `BoardService.createBoard`: 공지사항이 즉시 노출 대상이면 `notifyNoticePublished` 호출
- `UserRepository.findNoticeAgreedUsers`: 이메일 수신 동의 사용자 조회 추가
- `EmailProducer.produceNoticePublished` / `EmailPayloadConstant.NOTICE_PUBLISHED`: 큐 발행 타입 추가
- email-worker: `NOTICE_PUBLISHED` consumer 분기, 메일 컨텐츠(`createNoticePublishedContent`), `sendNoticePublishedMail` 추가
- email-worker `preview-email.ts`에 공지사항 알림 메일 프리뷰 항목 추가
- `board.service.unit.spec.ts`에 알림 발송 성공/부분 실패/전체 실패 케이스 테스트 추가