### PR TITLE
✨ feat: 신고 접수 디스코드 알림 및 알림 객체 토큰 분리

### DIFF
--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -99,6 +99,9 @@ jobs:
             echo "SERVER_PORT=${{ secrets.SERVER_PORT }}"
             echo "OAUTH_BASE_URL=${{ vars.OAUTH_BASE_URL }}"
             echo "SERVER_DISCORD_WEBHOOK_URL=${{ secrets.SERVER_DISCORD_WEBHOOK_URL }}"
+            echo "RSS_DISCORD_WEBHOOK_URL=${{ secrets.RSS_DISCORD_WEBHOOK_URL }}"
+            echo "REPORT_DISCORD_WEBHOOK_URL=${{ secrets.REPORT_DISCORD_WEBHOOK_URL }}"
+            echo "QNA_DISCORD_WEBHOOK_URL=${{ secrets.QNA_DISCORD_WEBHOOK_URL }}"
           } | sudo tee "${{env.SERVER_ENV_FILE}}" >/dev/null
 
       - name: Blue-Green 무중단 배포

--- a/server/src/common/logger/logger.service.ts
+++ b/server/src/common/logger/logger.service.ts
@@ -5,12 +5,13 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 
 import { NotifierRegistry } from '@common/notification/notifier-registry';
+import { SERVER_NOTIFIER } from '@common/notification/notifier.constant';
 
 @Injectable()
 export class WinstonLoggerService implements LoggerService {
   constructor(
     @Inject(WINSTON_MODULE_PROVIDER) private readonly logger: Logger,
-    private readonly notifierRegistry: NotifierRegistry,
+    @Inject(SERVER_NOTIFIER) private readonly notifierRegistry: NotifierRegistry,
   ) {}
 
   log(message: string, context?: string) {

--- a/server/src/common/notification/discord.notifier.ts
+++ b/server/src/common/notification/discord.notifier.ts
@@ -1,16 +1,9 @@
-import { Injectable } from '@nestjs/common';
-
 import axios from 'axios';
 
 import { Notifier } from '@common/notification/notifier.interface';
 
-@Injectable()
 export class DiscordNotifier implements Notifier {
-  private readonly webhookUrl: string;
-
-  constructor() {
-    this.webhookUrl = process.env.SERVER_DISCORD_WEBHOOK_URL ?? '';
-  }
+  constructor(private readonly webhookUrl: string) {}
 
   async sendAlert(message: string): Promise<void> {
     if (!this.webhookUrl) return;

--- a/server/src/common/notification/notifier.constant.ts
+++ b/server/src/common/notification/notifier.constant.ts
@@ -1,0 +1,4 @@
+export const SERVER_NOTIFIER = 'SERVER_NOTIFIER';
+export const RSS_NOTIFIER = 'RSS_NOTIFIER';
+export const REPORT_NOTIFIER = 'REPORT_NOTIFIER';
+export const QNA_NOTIFIER = 'QNA_NOTIFIER';

--- a/server/src/common/notification/notifier.module.ts
+++ b/server/src/common/notification/notifier.module.ts
@@ -2,20 +2,60 @@ import { Module } from '@nestjs/common';
 
 import { DiscordNotifier } from '@common/notification/discord.notifier';
 import { NotifierRegistry } from '@common/notification/notifier-registry';
+import {
+  QNA_NOTIFIER,
+  REPORT_NOTIFIER,
+  RSS_NOTIFIER,
+  SERVER_NOTIFIER,
+} from '@common/notification/notifier.constant';
 
 @Module({
   providers: [
-    DiscordNotifier,
     {
-      provide: NotifierRegistry,
-      useFactory: (discord: DiscordNotifier) => {
+      provide: SERVER_NOTIFIER,
+      useFactory: () => {
         const registry = new NotifierRegistry();
-        registry.register('discord', discord);
+        registry.register(
+          'discord',
+          new DiscordNotifier(process.env.SERVER_DISCORD_WEBHOOK_URL ?? ''),
+        );
         return registry;
       },
-      inject: [DiscordNotifier],
+    },
+    {
+      provide: RSS_NOTIFIER,
+      useFactory: () => {
+        const registry = new NotifierRegistry();
+        registry.register(
+          'discord',
+          new DiscordNotifier(process.env.RSS_DISCORD_WEBHOOK_URL ?? ''),
+        );
+        return registry;
+      },
+    },
+    {
+      provide: REPORT_NOTIFIER,
+      useFactory: () => {
+        const registry = new NotifierRegistry();
+        registry.register(
+          'discord',
+          new DiscordNotifier(process.env.REPORT_DISCORD_WEBHOOK_URL ?? ''),
+        );
+        return registry;
+      },
+    },
+    {
+      provide: QNA_NOTIFIER,
+      useFactory: () => {
+        const registry = new NotifierRegistry();
+        registry.register(
+          'discord',
+          new DiscordNotifier(process.env.QNA_DISCORD_WEBHOOK_URL ?? ''),
+        );
+        return registry;
+      },
     },
   ],
-  exports: [NotifierRegistry],
+  exports: [SERVER_NOTIFIER, RSS_NOTIFIER, REPORT_NOTIFIER, QNA_NOTIFIER],
 })
 export class NotifierModule {}

--- a/server/src/qna/service/qna.service.ts
+++ b/server/src/qna/service/qna.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ForbiddenException,
+  Inject,
   Injectable,
   NotFoundException,
   UnauthorizedException,
@@ -15,6 +16,7 @@ import { EmailProducer } from '@common/email/email.producer';
 import { Payload } from '@common/guard/jwt.guard';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { NotifierRegistry } from '@common/notification/notifier-registry';
+import { QNA_NOTIFIER } from '@common/notification/notifier.constant';
 import { createHashedPassword } from '@common/util/createHashedPassword';
 
 import {
@@ -47,7 +49,7 @@ export class QnaService {
     private readonly adminRepository: AdminRepository,
     private readonly userRepository: UserRepository,
     private readonly emailProducer: EmailProducer,
-    private readonly notifierRegistry: NotifierRegistry,
+    @Inject(QNA_NOTIFIER) private readonly notifierRegistry: NotifierRegistry,
     private readonly logger: WinstonLoggerService,
     private readonly dataSource: DataSource,
   ) {}

--- a/server/src/report/module/report.module.ts
+++ b/server/src/report/module/report.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 
-import { JwtAuthModule } from '@common/auth/jwt.module';
-
 import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { JwtAuthModule } from '@common/auth/jwt.module';
+import { NotifierModule } from '@common/notification/notifier.module';
 
 import { FeedModule } from '@feed/module/feed.module';
 
@@ -16,9 +17,14 @@ import { RssAcceptRepository } from '@rss/repository/rss.repository';
 import { UserModule } from '@user/module/user.module';
 
 @Module({
-  imports: [JwtAuthModule, UserModule, FeedModule],
+  imports: [JwtAuthModule, UserModule, FeedModule, NotifierModule],
   controllers: [ReportController, AdminReportController],
-  providers: [ReportService, ReportRepository, RssAcceptRepository, CommentRepository],
+  providers: [
+    ReportService,
+    ReportRepository,
+    RssAcceptRepository,
+    CommentRepository,
+  ],
   exports: [],
 })
 export class ReportModule {}

--- a/server/src/report/service/report.service.ts
+++ b/server/src/report/service/report.service.ts
@@ -1,6 +1,7 @@
 import {
   BadRequestException,
   ConflictException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -10,15 +11,17 @@ import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity
 import { CommentRepository } from '@comment/repository/comment.repository';
 
 import { Payload } from '@common/guard/jwt.guard';
+import { NotifierRegistry } from '@common/notification/notifier-registry';
+import { REPORT_NOTIFIER } from '@common/notification/notifier.constant';
 
 import { FeedRepository } from '@feed/repository/feed.repository';
 
+import { ReportTargetType } from '@report/constant/report.constant';
 import { CreateReportRequestDto } from '@report/dto/request/createReport.dto';
 import { GetReportsRequestDto } from '@report/dto/request/getReports.dto';
 import { GetReportsResponseDto } from '@report/dto/response/getReports.dto';
 import { Report } from '@report/entity/report.entity';
 import { ReportRepository } from '@report/repository/report.repository';
-import { ReportTargetType } from '@report/constant/report.constant';
 
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
@@ -34,6 +37,8 @@ export class ReportService {
     private readonly commentRepository: CommentRepository,
     private readonly feedRepository: FeedRepository,
     private readonly userService: UserService,
+    @Inject(REPORT_NOTIFIER)
+    private readonly notifierRegistry: NotifierRegistry,
   ) {}
 
   private async saveReport(report: QueryDeepPartialEntity<Report>) {
@@ -45,6 +50,10 @@ export class ReportService {
       }
       throw error;
     }
+
+    void this.notifierRegistry.sendAlert(
+      `🚫 새로운 신고가 접수되었습니다.\n대상 유형: ${report.targetType as ReportTargetType}\n대상 ID: ${report.targetId as number}\n사유: ${report.reason as string}`,
+    );
   }
 
   async reportUser(

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  Inject,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
@@ -23,6 +24,7 @@ import { EmailProducer } from '@common/email/email.producer';
 import { Payload } from '@common/guard/jwt.guard';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { NotifierRegistry } from '@common/notification/notifier-registry';
+import { RSS_NOTIFIER } from '@common/notification/notifier.constant';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
@@ -81,7 +83,7 @@ export class RssService {
     private readonly dataSource: DataSource,
     private readonly redisService: RedisService,
     private readonly adminRepository: AdminRepository,
-    private readonly notifierRegistry: NotifierRegistry,
+    @Inject(RSS_NOTIFIER) private readonly notifierRegistry: NotifierRegistry,
     private readonly logger: WinstonLoggerService,
     private readonly rssBlockRepository: RssBlockRepository,
   ) {}

--- a/server/test/report/unit/report.service.unit.spec.ts
+++ b/server/test/report/unit/report.service.unit.spec.ts
@@ -1,12 +1,20 @@
-import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+} from '@nestjs/common';
 
 import { CommentRepository } from '@comment/repository/comment.repository';
 
 import { Payload } from '@common/guard/jwt.guard';
+import { NotifierRegistry } from '@common/notification/notifier-registry';
 
 import { FeedRepository } from '@feed/repository/feed.repository';
 
-import { ReportReason, ReportTargetType } from '@report/constant/report.constant';
+import {
+  ReportReason,
+  ReportTargetType,
+} from '@report/constant/report.constant';
 import { ReportRepository } from '@report/repository/report.repository';
 import { ReportService } from '@report/service/report.service';
 
@@ -16,13 +24,21 @@ import { UserService } from '@user/service/user.service';
 
 describe(`${ReportService.name} Unit Test`, () => {
   let reportService: ReportService;
-  let reportRepository: jest.Mocked<Pick<ReportRepository, 'insert' | 'getReports'>>;
+  let reportRepository: jest.Mocked<
+    Pick<ReportRepository, 'insert' | 'getReports'>
+  >;
   let rssAcceptRepository: jest.Mocked<Pick<RssAcceptRepository, 'findOne'>>;
   let commentRepository: jest.Mocked<Pick<CommentRepository, 'findOne'>>;
   let feedRepository: jest.Mocked<Pick<FeedRepository, 'findOne'>>;
   let userService: jest.Mocked<Pick<UserService, 'getUser'>>;
+  let notifierRegistry: jest.Mocked<Pick<NotifierRegistry, 'sendAlert'>>;
 
-  const user: Payload = { id: 1, email: 'user@test.com', userName: 'tester', role: 'user' };
+  const user: Payload = {
+    id: 1,
+    email: 'user@test.com',
+    userName: 'tester',
+    role: 'user',
+  };
   const reportDto = { reason: ReportReason.SPAM, detail: '광고성 내용입니다.' };
 
   beforeEach(() => {
@@ -34,6 +50,7 @@ describe(`${ReportService.name} Unit Test`, () => {
     commentRepository = { findOne: jest.fn() };
     feedRepository = { findOne: jest.fn() };
     userService = { getUser: jest.fn() };
+    notifierRegistry = { sendAlert: jest.fn() };
 
     reportService = new ReportService(
       reportRepository as unknown as ReportRepository,
@@ -41,22 +58,29 @@ describe(`${ReportService.name} Unit Test`, () => {
       commentRepository as unknown as CommentRepository,
       feedRepository as unknown as FeedRepository,
       userService as unknown as UserService,
+      notifierRegistry as unknown as NotifierRegistry,
     );
   });
 
   describe('reportUser', () => {
     it('자기 자신을 신고하면 BadRequestException을 던진다.', async () => {
       // when & then
-      await expect(reportService.reportUser(user, user.id, reportDto)).rejects.toThrow(BadRequestException);
+      await expect(
+        reportService.reportUser(user, user.id, reportDto),
+      ).rejects.toThrow(BadRequestException);
       expect(reportRepository.insert).not.toHaveBeenCalled();
     });
 
     it('신고 대상 유저가 존재하지 않으면 NotFoundException을 던진다.', async () => {
       // given
-      userService.getUser.mockRejectedValue(new NotFoundException('존재하지 않는 유저입니다.'));
+      userService.getUser.mockRejectedValue(
+        new NotFoundException('존재하지 않는 유저입니다.'),
+      );
 
       // when & then
-      await expect(reportService.reportUser(user, 2, reportDto)).rejects.toThrow(NotFoundException);
+      await expect(
+        reportService.reportUser(user, 2, reportDto),
+      ).rejects.toThrow(NotFoundException);
       expect(reportRepository.insert).not.toHaveBeenCalled();
     });
 
@@ -66,7 +90,9 @@ describe(`${ReportService.name} Unit Test`, () => {
       reportRepository.insert.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
 
       // when & then
-      await expect(reportService.reportUser(user, 2, reportDto)).rejects.toThrow(ConflictException);
+      await expect(
+        reportService.reportUser(user, 2, reportDto),
+      ).rejects.toThrow(ConflictException);
     });
 
     it('사용자 신고 등록에 성공한다.', async () => {
@@ -95,22 +121,32 @@ describe(`${ReportService.name} Unit Test`, () => {
       rssAcceptRepository.findOne.mockResolvedValue(null);
 
       // when & then
-      await expect(reportService.reportRss(user, 5, reportDto)).rejects.toThrow(NotFoundException);
+      await expect(reportService.reportRss(user, 5, reportDto)).rejects.toThrow(
+        NotFoundException,
+      );
       expect(reportRepository.insert).not.toHaveBeenCalled();
     });
 
     it('본인 소유의 RSS를 신고하면 BadRequestException을 던진다.', async () => {
       // given
-      rssAcceptRepository.findOne.mockResolvedValue({ id: 5, userId: user.id } as any);
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 5,
+        userId: user.id,
+      } as any);
 
       // when & then
-      await expect(reportService.reportRss(user, 5, reportDto)).rejects.toThrow(BadRequestException);
+      await expect(reportService.reportRss(user, 5, reportDto)).rejects.toThrow(
+        BadRequestException,
+      );
       expect(reportRepository.insert).not.toHaveBeenCalled();
     });
 
     it('RSS 신고 등록에 성공한다.', async () => {
       // given
-      rssAcceptRepository.findOne.mockResolvedValue({ id: 5, userId: 99 } as any);
+      rssAcceptRepository.findOne.mockResolvedValue({
+        id: 5,
+        userId: 99,
+      } as any);
       reportRepository.insert.mockResolvedValue(undefined);
 
       // when
@@ -134,21 +170,31 @@ describe(`${ReportService.name} Unit Test`, () => {
       commentRepository.findOne.mockResolvedValue(null);
 
       // when & then
-      await expect(reportService.reportComment(user, 10, reportDto)).rejects.toThrow(NotFoundException);
+      await expect(
+        reportService.reportComment(user, 10, reportDto),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('자신의 댓글을 신고하면 BadRequestException을 던진다.', async () => {
       // given
-      commentRepository.findOne.mockResolvedValue({ id: 10, user: { id: user.id } } as any);
+      commentRepository.findOne.mockResolvedValue({
+        id: 10,
+        user: { id: user.id },
+      } as any);
 
       // when & then
-      await expect(reportService.reportComment(user, 10, reportDto)).rejects.toThrow(BadRequestException);
+      await expect(
+        reportService.reportComment(user, 10, reportDto),
+      ).rejects.toThrow(BadRequestException);
       expect(reportRepository.insert).not.toHaveBeenCalled();
     });
 
     it('댓글 신고 등록에 성공한다.', async () => {
       // given
-      commentRepository.findOne.mockResolvedValue({ id: 10, user: { id: 99 } } as any);
+      commentRepository.findOne.mockResolvedValue({
+        id: 10,
+        user: { id: 99 },
+      } as any);
       reportRepository.insert.mockResolvedValue(undefined);
 
       // when
@@ -172,21 +218,31 @@ describe(`${ReportService.name} Unit Test`, () => {
       feedRepository.findOne.mockResolvedValue(null);
 
       // when & then
-      await expect(reportService.reportFeed(user, 20, reportDto)).rejects.toThrow(NotFoundException);
+      await expect(
+        reportService.reportFeed(user, 20, reportDto),
+      ).rejects.toThrow(NotFoundException);
     });
 
     it('자신의 게시글을 신고하면 BadRequestException을 던진다.', async () => {
       // given
-      feedRepository.findOne.mockResolvedValue({ id: 20, blog: { userId: user.id } } as any);
+      feedRepository.findOne.mockResolvedValue({
+        id: 20,
+        blog: { userId: user.id },
+      } as any);
 
       // when & then
-      await expect(reportService.reportFeed(user, 20, reportDto)).rejects.toThrow(BadRequestException);
+      await expect(
+        reportService.reportFeed(user, 20, reportDto),
+      ).rejects.toThrow(BadRequestException);
       expect(reportRepository.insert).not.toHaveBeenCalled();
     });
 
     it('게시글 신고 등록에 성공한다.', async () => {
       // given
-      feedRepository.findOne.mockResolvedValue({ id: 20, blog: { userId: 99 } } as any);
+      feedRepository.findOne.mockResolvedValue({
+        id: 20,
+        blog: { userId: 99 },
+      } as any);
       reportRepository.insert.mockResolvedValue(undefined);
 
       // when


### PR DESCRIPTION
# 🔨 테스크

### Issue
- close #832 

### 신고 접수 디스코드 알림

-   신고가 접수되면 담당자가 즉시 인지할 수 있도록 Report 도메인에도 Discord 알림을 연동했습니다.

### 알림 객체 token별 분리

-   기존에는 `NotifierRegistry`가 서버 전역에서 단일 인스턴스로 공유되어, 도메인별로 다른 웹훅 채널을 사용할 수 없었습니다.
-   `SERVER_NOTIFIER` / `RSS_NOTIFIER` / `REPORT_NOTIFIER` / `QNA_NOTIFIER` 토큰으로 분리해 도메인마다 독립된 웹훅 URL과 `NotifierRegistry` 인스턴스를 주입받도록 변경했습니다.
-   `DiscordNotifier`가 자체적으로 `process.env`를 읽던 방식에서, 생성 시점에 webhookUrl을 주입받는 방식으로 바꿔 모듈에서 토큰별 웹훅 URL을 명시적으로 구성하도록 했습니다.

# 📋 작업 내용

-   `.github/workflows/deploy_server.yml`에 `RSS_DISCORD_WEBHOOK_URL`, `REPORT_DISCORD_WEBHOOK_URL`, `QNA_DISCORD_WEBHOOK_URL` 환경변수 추가
-   `DiscordNotifier`가 webhookUrl을 생성자 주입받도록 변경 (환경변수 직접 참조 제거)
-   `notifier.constant.ts`에 도메인별 DI 토큰(`SERVER_NOTIFIER`, `RSS_NOTIFIER`, `REPORT_NOTIFIER`, `QNA_NOTIFIER`) 추가
-   `NotifierModule`에서 토큰별 `NotifierRegistry` 인스턴스를 각각 생성 및 export
-   `WinstonLoggerService`, `RssService`, `QnaService`가 각자의 토큰으로 `NotifierRegistry`를 주입받도록 변경
-   `ReportService`에 `REPORT_NOTIFIER` 주입 및 신고 접수 시 Discord 알림 발송 로직 추가
-   `report.service.unit.spec.ts`에 알림 발송 관련 테스트 보강
