### PR TITLE
✨ feat: 신고 시 차단 여부 선택 기능 추가

### DIFF
--- a/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+
 import PostComment from "@/components/common/Card/detail/PostComment.tsx";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { FeedCommentType } from "@/types/post.ts";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
@@ -2,12 +2,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import PostComment from "@/components/common/Card/detail/PostComment.tsx";
 
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { FeedCommentType } from "@/types/post.ts";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const createComment = vi.fn();
 const updateComment = vi.fn();
 const deleteComment = vi.fn();
+const mockBlockUser = vi.fn().mockResolvedValue(undefined);
+const mockReportComment = vi.fn((_vars: unknown, options?: { onSuccess?: () => void; onError?: () => void }) =>
+  options?.onSuccess?.()
+);
 let isAuthenticated: boolean;
 let comments: FeedCommentType[];
 
@@ -26,11 +32,38 @@ vi.mock("@/hooks/queries/useComments", () => ({
 
 vi.mock("@/hooks/queries/useProfile", () => ({ useUserProfile: () => ({ data: undefined }) }));
 vi.mock("@/hooks/queries/useReport", () => ({
-  useReportComment: () => ({ mutate: vi.fn(), isPending: false }),
+  useReportComment: () => ({ mutate: mockReportComment, isPending: false }),
+}));
+vi.mock("@/hooks/queries/useBlock", () => ({
+  useBlockUser: () => ({ mutateAsync: mockBlockUser }),
 }));
 vi.mock("@/hooks/common/useNavigateToProfile", () => ({ useNavigateToProfile: () => vi.fn() }));
 vi.mock("@/utils/timeago", () => ({ timeAgo: () => "방금 전" }));
 vi.mock("@/components/auth/AuthSignInForm", () => ({ AuthSignInForm: () => <div data-testid="signin-form" /> }));
+vi.mock("lucide-react", () => lucideProxy());
+vi.mock("@/components/ui/select", () => {
+  const pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Select: ({ children, onValueChange }: { children: React.ReactNode; onValueChange: (value: string) => void }) => (
+      <div
+        onClick={(event) => {
+          const value = (event.target as HTMLElement).getAttribute("data-value");
+          if (value) onValueChange(value);
+        }}
+      >
+        {children}
+      </div>
+    ),
+    SelectContent: pass,
+    SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+      <div role="option" data-value={value}>
+        {children}
+      </div>
+    ),
+    SelectTrigger: pass,
+    SelectValue: () => null,
+  };
+});
 
 const makeComment = (id: number, override: Partial<FeedCommentType> = {}): FeedCommentType =>
   ({
@@ -94,10 +127,7 @@ describe("PostComment", () => {
     fireEvent.change(editArea, { target: { value: "수정된 댓글" } });
     fireEvent.click(screen.getByRole("button", { name: "댓글 수정" }));
 
-    expect(updateComment).toHaveBeenCalledWith(
-      { commentId: 1, newComment: "수정된 댓글" },
-      expect.any(Object)
-    );
+    expect(updateComment).toHaveBeenCalledWith({ commentId: 1, newComment: "수정된 댓글" }, expect.any(Object));
   });
 
   it("답글 버튼 클릭 후 답글 작성 시 parentId와 함께 createComment를 호출해야 한다", () => {
@@ -108,10 +138,7 @@ describe("PostComment", () => {
     fireEvent.change(screen.getByPlaceholderText("답글을 입력하세요..."), { target: { value: "답글 내용" } });
     fireEvent.click(screen.getByRole("button", { name: "답글 등록" }));
 
-    expect(createComment).toHaveBeenCalledWith(
-      { comment: "답글 내용", parentId: 1 },
-      expect.any(Object)
-    );
+    expect(createComment).toHaveBeenCalledWith({ comment: "답글 내용", parentId: 1 }, expect.any(Object));
   });
 
   it("대댓글(parentId)이 있으면 기본적으로 숨겨지고 답글 개수가 표시되며, 클릭하면 펼쳐진다", () => {
@@ -190,5 +217,39 @@ describe("PostComment", () => {
 
     expect(screen.queryByRole("button", { name: "댓글 더보기" })).not.toBeInTheDocument();
     expect(document.getElementById("comment-5")).not.toBeNull();
+  });
+
+  const openReportModal = async () => {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "댓글 옵션" }));
+    await user.click(await screen.findByText("신고하기"));
+    return user;
+  };
+
+  it("함께 차단하기 스위치를 켜지 않으면 댓글만 신고해야 한다", async () => {
+    comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
+    render(<PostComment feedId={10} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockReportComment).toHaveBeenCalledWith(
+      { commentId: 1, payload: { reason: "SPAM", detail: undefined } },
+      expect.anything()
+    );
+    expect(mockBlockUser).not.toHaveBeenCalled();
+  });
+
+  it("함께 차단하기 스위치를 켜면 댓글 신고 후 작성자를 차단해야 한다", async () => {
+    comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
+    render(<PostComment feedId={10} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
   });
 });

--- a/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
@@ -2,9 +2,10 @@ import { MemoryRouter } from "react-router-dom";
 
 import { describe, expect, it, vi } from "vitest";
 
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+
 import { PostHeader } from "@/components/common/Card/detail/PostHeader.tsx";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { FeedDetail } from "@/types/post.ts";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";

--- a/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
@@ -4,16 +4,53 @@ import { describe, expect, it, vi } from "vitest";
 
 import { PostHeader } from "@/components/common/Card/detail/PostHeader.tsx";
 
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { FeedDetail } from "@/types/post.ts";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const mockBlockRss = vi.fn().mockResolvedValue(undefined);
+const mockReportFeed = vi.fn((_vars: unknown, options?: { onSuccess?: () => void; onError?: () => void }) =>
+  options?.onSuccess?.()
+);
 
 vi.mock("@/components/common/Card/detail/SubscribeButton", () => ({
   SubscribeButton: () => <button>구독</button>,
 }));
 
 vi.mock("@/hooks/queries/useReport", () => ({
-  useReportFeed: () => ({ mutate: vi.fn(), isPending: false }),
+  useReportFeed: () => ({ mutate: mockReportFeed, isPending: false }),
 }));
+vi.mock("@/hooks/queries/useBlock", () => ({
+  useBlockRss: () => ({ mutateAsync: mockBlockRss }),
+}));
+vi.mock("@/store/useAuthStore", () => ({
+  useAuthStore: (selector: (s: { isAuthenticated: boolean }) => unknown) => selector({ isAuthenticated: true }),
+}));
+vi.mock("lucide-react", () => lucideProxy());
+vi.mock("@/components/ui/select", () => {
+  const pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Select: ({ children, onValueChange }: { children: React.ReactNode; onValueChange: (value: string) => void }) => (
+      <div
+        onClick={(event) => {
+          const value = (event.target as HTMLElement).getAttribute("data-value");
+          if (value) onValueChange(value);
+        }}
+      >
+        {children}
+      </div>
+    ),
+    SelectContent: pass,
+    SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+      <div role="option" data-value={value}>
+        {children}
+      </div>
+    ),
+    SelectTrigger: pass,
+    SelectValue: () => null,
+  };
+});
 
 const data = {
   id: 1,
@@ -62,5 +99,38 @@ describe("PostHeader", () => {
     const link = screen.getByRole("link");
     expect(link).toHaveAttribute("href", "/rss/42");
     expect(link).toHaveTextContent("작성자");
+  });
+
+  const openReportModal = async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <PostHeader data={data} />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    return user;
+  };
+
+  it("함께 차단하기 스위치를 켜지 않으면 게시글만 신고해야 한다", async () => {
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockReportFeed).toHaveBeenCalledWith(
+      { feedId: 1, payload: { reason: "SPAM", detail: undefined } },
+      expect.anything()
+    );
+    expect(mockBlockRss).not.toHaveBeenCalled();
+  });
+
+  it("함께 차단하기 스위치를 켜면 게시글 신고 후 블로그(RSS)를 차단해야 한다", async () => {
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    await waitFor(() => expect(mockBlockRss).toHaveBeenCalledWith(42));
   });
 });

--- a/client/src/__tests__/components/common/ReportDialog.test.tsx
+++ b/client/src/__tests__/components/common/ReportDialog.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ReportDialog } from "@/components/common/ReportDialog";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/components/ui/select", () => {
+  const pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Select: ({ children, onValueChange }: { children: React.ReactNode; onValueChange: (value: string) => void }) => (
+      <div
+        onClick={(event) => {
+          const value = (event.target as HTMLElement).getAttribute("data-value");
+          if (value) onValueChange(value);
+        }}
+      >
+        {children}
+      </div>
+    ),
+    SelectContent: pass,
+    SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+      <div role="option" data-value={value}>
+        {children}
+      </div>
+    ),
+    SelectTrigger: pass,
+    SelectValue: () => null,
+  };
+});
+
+const selectReason = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByText("스팸/광고"));
+};
+
+describe("ReportDialog", () => {
+  it("withBlockOption이 없으면 차단 스위치를 표시하지 않아야 한다", () => {
+    render(<ReportDialog open title="유저 신고" onSubmit={vi.fn()} onOpenChange={vi.fn()} />);
+
+    expect(screen.queryByText("이 유저도 함께 차단하기")).not.toBeInTheDocument();
+  });
+
+  it("withBlockOption이 있으면 차단 스위치를 표시하고 기본값은 꺼짐이어야 한다", async () => {
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<ReportDialog open withBlockOption title="유저 신고" onSubmit={handleSubmit} onOpenChange={vi.fn()} />);
+
+    await selectReason(user);
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(handleSubmit).toHaveBeenCalledWith({ reason: "SPAM", detail: undefined }, false);
+  });
+
+  it("차단 스위치를 켜면 onSubmit에 blockToo=true를 전달해야 한다", async () => {
+    const handleSubmit = vi.fn();
+    const user = userEvent.setup();
+    render(<ReportDialog open withBlockOption title="유저 신고" onSubmit={handleSubmit} onOpenChange={vi.fn()} />);
+
+    await selectReason(user);
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(handleSubmit).toHaveBeenCalledWith({ reason: "SPAM", detail: undefined }, true);
+  });
+});

--- a/client/src/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/client/src/__tests__/components/profile/ProfileHeader.test.tsx
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { ProfileHeader } from "@/components/profile/ProfileHeader.tsx";
 
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -11,6 +11,9 @@ const mockBlockUser = vi.fn().mockResolvedValue(undefined);
 const mockBlockRss = vi.fn().mockResolvedValue(undefined);
 type RssRow = { id: number; name: string; blogPlatform: string };
 const mockCertifiedRss = vi.fn<() => { data: RssRow[] }>(() => ({ data: [] }));
+const mockReportUser = vi.fn((_vars: unknown, options?: { onSuccess?: () => void; onError?: () => void }) =>
+  options?.onSuccess?.()
+);
 
 vi.mock("lucide-react", () => lucideProxy());
 vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
@@ -20,8 +23,31 @@ vi.mock("@/hooks/queries/useBlock.ts", () => ({
 }));
 vi.mock("@/hooks/queries/useProfile.ts", () => ({ useCertifiedRss: () => mockCertifiedRss() }));
 vi.mock("@/hooks/queries/useReport", () => ({
-  useReportUser: () => ({ mutate: vi.fn(), isPending: false }),
+  useReportUser: () => ({ mutate: mockReportUser, isPending: false }),
 }));
+vi.mock("@/components/ui/select", () => {
+  const pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Select: ({ children, onValueChange }: { children: React.ReactNode; onValueChange: (value: string) => void }) => (
+      <div
+        onClick={(event) => {
+          const value = (event.target as HTMLElement).getAttribute("data-value");
+          if (value) onValueChange(value);
+        }}
+      >
+        {children}
+      </div>
+    ),
+    SelectContent: pass,
+    SelectItem: ({ children, value }: { children: React.ReactNode; value: string }) => (
+      <div role="option" data-value={value}>
+        {children}
+      </div>
+    ),
+    SelectTrigger: pass,
+    SelectValue: () => null,
+  };
+});
 
 describe("ProfileHeader", () => {
   beforeEach(() => {
@@ -148,5 +174,37 @@ describe("ProfileHeader", () => {
 
     await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
     expect(mockBlockRss).not.toHaveBeenCalled();
+  });
+
+  const openReportModal = async () => {
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    return user;
+  };
+
+  it("신고 모달의 함께 차단하기 스위치를 켜지 않으면 신고만 접수해야 한다", async () => {
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockReportUser).toHaveBeenCalledWith(
+      { userId: 2, payload: { reason: "SPAM", detail: undefined } },
+      expect.anything()
+    );
+    expect(mockBlockUser).not.toHaveBeenCalled();
+  });
+
+  it("신고 모달의 함께 차단하기 스위치를 켜면 신고 접수 후 유저를 차단해야 한다", async () => {
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
   });
 });

--- a/client/src/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/client/src/__tests__/components/profile/ProfileHeader.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+
 import { ProfileHeader } from "@/components/profile/ProfileHeader.tsx";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -18,6 +18,7 @@ import {
 
 import { useCustomToast } from "@/hooks/common/useCustomToast";
 import { useNavigateToProfile } from "@/hooks/common/useNavigateToProfile";
+import { useBlockUser } from "@/hooks/queries/useBlock";
 import {
   useComments,
   useCreateComment,
@@ -53,7 +54,7 @@ interface CommentItemProps {
   onUpdate: (commentId: number, newComment: string) => void;
   onDelete: (commentId: number) => void;
   onReply: (rootId: number, mention?: string) => void;
-  onReport: (commentId: number) => void;
+  onReport: (commentId: number, authorId: number) => void;
 }
 
 const INITIAL_VISIBLE = 3;
@@ -75,6 +76,7 @@ export default function PostComment({
   const { mutate: deleteCommentAdmin } = useAdminDeleteComment(feedId);
   const deleteComment = isAdmin ? deleteCommentAdmin : deleteCommentUser;
   const { mutate: reportComment, isPending: isReportPending } = useReportComment();
+  const { mutateAsync: blockUser } = useBlockUser();
   const { toast } = useCustomToast();
 
   const [content, setContent] = useState("");
@@ -83,7 +85,7 @@ export default function PostComment({
   const [loginOpen, setLoginOpen] = useState(false);
   const [replyTo, setReplyTo] = useState<number | null>(null);
   const [replyContent, setReplyContent] = useState("");
-  const [reportCommentId, setReportCommentId] = useState<number | null>(null);
+  const [reportTarget, setReportTarget] = useState<{ commentId: number; authorId: number } | null>(null);
   const [expandedReplyIds, setExpandedReplyIds] = useState<Set<number>>(new Set());
 
   const handleModify = (id: number | null) => setModifyId(id);
@@ -144,14 +146,27 @@ export default function PostComment({
     updateComment({ commentId, newComment: trimmed }, { onSuccess: () => setModifyId(null) });
   };
 
-  const handleReportSubmit = (payload: CreateReportPayload) => {
-    if (reportCommentId === null) return;
+  const handleReportSubmit = (payload: CreateReportPayload, blockToo: boolean) => {
+    if (!reportTarget) return;
+    const { commentId, authorId } = reportTarget;
     reportComment(
-      { commentId: reportCommentId, payload },
+      { commentId, payload },
       {
-        onSuccess: () => {
-          setReportCommentId(null);
-          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+        onSuccess: async () => {
+          setReportTarget(null);
+          if (!blockToo) {
+            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+            return;
+          }
+          try {
+            await blockUser(authorId);
+            toast({ title: "신고 접수 완료", description: "신고가 접수되었고, 작성자를 차단했습니다." });
+          } catch {
+            toast({
+              title: "신고 접수 완료",
+              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
+            });
+          }
         },
         onError: () => {
           toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
@@ -263,7 +278,7 @@ export default function PostComment({
               onUpdate={handleUpdate}
               onDelete={deleteComment}
               onReply={handleReplyOpen}
-              onReport={setReportCommentId}
+              onReport={(commentId, authorId) => setReportTarget({ commentId, authorId })}
             />
 
             {/* 답글 펼치기/접기 토글 */}
@@ -304,7 +319,7 @@ export default function PostComment({
                       onUpdate={handleUpdate}
                       onDelete={deleteComment}
                       onReply={() => handleReplyOpen(root.id, reply.user.userName)}
-                      onReport={setReportCommentId}
+                      onReport={(commentId, authorId) => setReportTarget({ commentId, authorId })}
                     />
                   </li>
                 ))}
@@ -367,10 +382,11 @@ export default function PostComment({
       </div>
 
       <ReportDialog
-        open={reportCommentId !== null}
-        onOpenChange={(open) => !open && setReportCommentId(null)}
+        open={reportTarget !== null}
+        onOpenChange={(open) => !open && setReportTarget(null)}
         title="댓글 신고"
         isPending={isReportPending}
+        withBlockOption
         onSubmit={handleReportSubmit}
       />
     </div>
@@ -442,7 +458,7 @@ const CommentItem = ({
                       </button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="z-[1000]" onClick={(event) => event.stopPropagation()}>
-                      <DropdownMenuItem onClick={() => onReport(comment.id)}>
+                      <DropdownMenuItem onClick={() => onReport(comment.id, comment.user.id)}>
                         <Flag className="w-4 h-4 mr-2" />
                         신고하기
                       </DropdownMenuItem>

--- a/client/src/components/common/Card/detail/PostHeader.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.tsx
@@ -7,9 +7,15 @@ import PostAvatar from "@/components/common/Card/PostAvatar";
 import { SimpleTagList } from "@/components/common/Card/PostTag";
 import { SubscribeButton } from "@/components/common/Card/detail/SubscribeButton";
 import { ReportDialog } from "@/components/common/ReportDialog";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast";
+import { useBlockRss } from "@/hooks/queries/useBlock";
 import { useReportFeed } from "@/hooks/queries/useReport";
 
 import { detailFormatDate } from "@/utils/date";
@@ -26,15 +32,28 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { toast } = useCustomToast();
   const { mutate: reportFeed, isPending: isReportPending } = useReportFeed();
+  const { mutateAsync: blockRss } = useBlockRss();
   const [showReportDialog, setShowReportDialog] = useState(false);
 
-  const handleReport = (payload: CreateReportPayload) => {
+  const handleReport = (payload: CreateReportPayload, blockToo: boolean) => {
     reportFeed(
       { feedId: data.id, payload },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           setShowReportDialog(false);
-          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+          if (!blockToo) {
+            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+            return;
+          }
+          try {
+            await blockRss(data.blog.id);
+            toast({ title: "신고 접수 완료", description: "신고가 접수되었고, 이 블로그를 차단했습니다." });
+          } catch {
+            toast({
+              title: "신고 접수 완료",
+              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
+            });
+          }
         },
         onError: () => {
           toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
@@ -125,6 +144,9 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
         onOpenChange={setShowReportDialog}
         title="게시글 신고"
         isPending={isReportPending}
+        withBlockOption
+        blockLabel="이 블로그도 함께 차단하기"
+        blockDescription="차단하면 이 블로그의 게시글이 더 이상 노출되지 않습니다."
         onSubmit={handleReport}
       />
     </div>

--- a/client/src/components/common/ReportDialog.tsx
+++ b/client/src/components/common/ReportDialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 
 import { REPORT_REASON_LABELS } from "@/constants/report";
@@ -22,26 +23,40 @@ interface ReportDialogProps {
   onOpenChange: (open: boolean) => void;
   title: string;
   isPending?: boolean;
-  onSubmit: (payload: CreateReportPayload) => void;
+  withBlockOption?: boolean;
+  blockLabel?: string;
+  blockDescription?: string;
+  onSubmit: (payload: CreateReportPayload, blockToo: boolean) => void;
 }
 
 const REPORT_REASON_OPTIONS = Object.entries(REPORT_REASON_LABELS) as [ReportReason, string][];
 
-export function ReportDialog({ open, onOpenChange, title, isPending = false, onSubmit }: ReportDialogProps) {
+export function ReportDialog({
+  open,
+  onOpenChange,
+  title,
+  isPending = false,
+  withBlockOption = false,
+  blockLabel = "이 유저도 함께 차단하기",
+  blockDescription = "차단하면 댓글, 프로필 페이지 열람이 제한됩니다.",
+  onSubmit,
+}: ReportDialogProps) {
   const [reason, setReason] = useState<ReportReason | "">("");
   const [detail, setDetail] = useState("");
+  const [blockToo, setBlockToo] = useState(false);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setReason("");
       setDetail("");
+      setBlockToo(false);
     }
     onOpenChange(nextOpen);
   };
 
   const handleSubmit = () => {
     if (!reason || isPending) return;
-    onSubmit({ reason, detail: detail.trim() || undefined });
+    onSubmit({ reason, detail: detail.trim() || undefined }, blockToo);
   };
 
   return (
@@ -82,6 +97,16 @@ export function ReportDialog({ open, onOpenChange, title, isPending = false, onS
               />
               <span className="self-end text-xs text-muted-foreground">{detail.length}/500</span>
             </div>
+
+            {withBlockOption && (
+              <div className="flex items-center justify-between gap-3 p-3 border border-gray-100 rounded-lg">
+                <div className="flex flex-col gap-0.5">
+                  <Label htmlFor="report-block-too">{blockLabel}</Label>
+                  <span className="text-xs text-muted-foreground">{blockDescription}</span>
+                </div>
+                <Switch id="report-block-too" checked={blockToo} onCheckedChange={setBlockToo} />
+              </div>
+            )}
           </div>
 
           <DialogFooter>

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -94,14 +94,26 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
     }
   };
 
-  const handleReport = (payload: CreateReportPayload) => {
+  const handleReport = (payload: CreateReportPayload, blockToo: boolean) => {
     if (!blockableUserId) return;
     reportUser(
       { userId: blockableUserId, payload },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           setShowReportDialog(false);
-          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+          if (!blockToo) {
+            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+            return;
+          }
+          try {
+            await blockUser(blockableUserId);
+            toast({ title: "신고 접수 완료", description: `신고가 접수되었고, ${name}님을 차단했습니다.` });
+          } catch {
+            toast({
+              title: "신고 접수 완료",
+              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
+            });
+          }
         },
         onError: () => {
           toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
@@ -222,6 +234,7 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
         onOpenChange={setShowReportDialog}
         title={`${name} 유저 신고`}
         isPending={isReportPending}
+        withBlockOption
         onSubmit={handleReport}
       />
     </Card>


### PR DESCRIPTION
# 🔨 테스크

### Issue
- close #888 

### 신고와 차단 연동

-   기존에는 신고(유저/댓글/게시글)와 차단이 완전히 분리되어 있어, 신고 후 차단하려면 별도로 프로필의 "차단하기" 메뉴를 다시 찾아 들어가야 했음
-   `ReportDialog`에 `withBlockOption`을 추가해 신고 사유 선택 시 "함께 차단하기" 스위치를 노출하고, 신고 접수 성공 후 이어서 차단 API를 호출하도록 구성
-   신고 대상에 따라 차단 대상이 다르므로(유저 신고 → 유저 차단, 댓글 신고 → 작성자 차단, 게시글 신고 → 해당 RSS/블로그 차단) `blockLabel`/`blockDescription`을 컨텍스트별로 커스터마이즈할 수 있게 함
-   신고는 성공했지만 차단 호출만 실패하는 경우를 별도 토스트 메시지로 구분해 사용자가 혼란스럽지 않도록 처리

# 📋 작업 내용

-   `ReportDialog`: `withBlockOption`, `blockLabel`, `blockDescription` prop 추가, `onSubmit(payload, blockToo)`로 시그니처 확장 (기존 사용처는 하위 호환)
-   `ProfileHeader`(유저 신고): 신고 접수 후 `blockToo`가 true면 해당 유저 차단
-   `PostComment`(댓글 신고): 신고 접수 후 `blockToo`가 true면 댓글 작성자 차단
-   `PostHeader`(게시글 신고): 신고 접수 후 `blockToo`가 true면 게시글의 RSS(블로그) 차단
-   각 케이스별 단위 테스트 추가 (스위치 off → 차단 미호출 / 스위치 on → 차단 호출 검증)

# 📷 스크린 샷(선택 사항)
<img width="510" height="444" alt="image" src="https://github.com/user-attachments/assets/70d9bc6c-dcaa-436d-b64e-cd1685450439" />
<img width="507" height="437" alt="image" src="https://github.com/user-attachments/assets/1a6c69ef-81e5-4201-944d-88c205c42fa5" />
