### PR TITLE
🧼 clean: Swagger 문서에서 내부/비공개 엔드포인트 제외

### DIFF
--- a/server/src/health/health.controller.ts
+++ b/server/src/health/health.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get } from '@nestjs/common';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 import { ApiResponse } from '@common/response/common.response';
 
 @Controller('health')
 export class HealthController {
   @Get()
+  @ApiExcludeEndpoint()
   check() {
     return ApiResponse.responseWithNoContent('OK');
   }

--- a/server/src/user/controller/oAuth.controller.ts
+++ b/server/src/user/controller/oAuth.controller.ts
@@ -13,7 +13,7 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 
 import { Request, Response } from 'express';
 
@@ -127,6 +127,7 @@ export class OAuthController {
     return ApiResponse.responseWithNoContent('OAuth 연결이 해제되었습니다.');
   }
 
+  @ApiExcludeEndpoint()
   @Get('e2e/callback')
   @HttpCode(HttpStatus.FOUND)
   async e2eCallback(


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   관련 이슈 없음

### Swagger 비공개 엔드포인트 정리

-   전체 컨트롤러를 스캔해 `@ApiExcludeEndpoint()`가 필요한데 누락된 엔드포인트를 확인했습니다.
-   헬스체크(`/health`)는 로드밸런서/오케스트레이터가 호출하는 내부 프로브용 엔드포인트로, 클라이언트가 소비하는 API 계약이 아니므로 Swagger 문서에서 제외했습니다.
-   기존에 이미 같은 성격(비공개용)으로 `@ApiExcludeEndpoint()` 처리된 `oauth/e2e/callback`(E2E 테스트 전용), `feeds/:feedId/og`(OG 크롤러용 HTML 렌더링) 엔드포인트와의 일관성을 맞췄습니다.
-   `/metrics`(Prometheus)는 `@willsoto/nestjs-prometheus` 라이브러리가 자체 등록하는 컨트롤러라 이번 작업 범위에서는 제외했습니다.

# 📋 작업 내용

-   `server/src/health/health.controller.ts`의 `check()` 엔드포인트에 `@ApiExcludeEndpoint()` 추가

# 📷 스크린 샷(선택 사항)

-