### PR TITLE
🐛 fix: 마이페이지 차단 해제 및 유저 차단 메뉴 클릭 불가 수정

### DIFF
--- a/client/src/components/layout/SideButton.tsx
+++ b/client/src/components/layout/SideButton.tsx
@@ -40,7 +40,7 @@ export default function SideButton() {
 
   return (
     <div className="flex h-full items-center">
-      <SidebarProvider defaultOpen={false}>
+      <SidebarProvider defaultOpen={false} className="min-h-0 w-auto">
         <ChatSidebarEffects />
         <Chat />
         <OpenChat />


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #893
- close #890

### 원인

- 헤더 `SideButton`이 채팅 사이드바를 열기 위해 shadcn `SidebarProvider`를 인라인으로 사용하는데, `SidebarProvider` 루트 div의 기본 클래스가 `min-h-svh w-full`(전체 페이지 wrapper 용도)이었음
- 헤더 nav item 안에 삽입되면서 투명한 전체 높이(뷰포트 높이) div가 페이지 우측 영역 전체를 덮어 클릭 이벤트를 가로챔
- 그 결과 마이페이지 차단 관리 탭의 차단 해제 버튼, 다른 유저 프로필의 신고/차단 드롭다운 메뉴가 같은 x축 영역에서 클릭이 먹히지 않는 문제가 발생

# 📋 작업 내용

- `SidebarProvider`에 `className="min-h-0 w-auto"`를 추가해 인라인 사용 시 콘텐츠 크기에 맞게 wrapper 크기를 제한 (Sidebar 패널 자체는 `fixed` 포지션이라 영향 없음)
- Chrome 브라우저로 실제 재현 후 수정 확인: 마이페이지 차단 관리 탭 차단 해제 버튼, 유저 프로필 신고/차단 드롭다운 정상 동작 확인

# 📷 스크린 샷

수정 전: 점 3개 버튼 클릭해도 드롭다운 미노출
<img width="893" height="144" alt="image" src="https://github.com/user-attachments/assets/14df19b6-8155-4d4f-8898-f96f934d8d22" />

수정 후: 신고하기 / 차단하기 메뉴 정상 노출
<img width="904" height="140" alt="image" src="https://github.com/user-attachments/assets/949befb0-2c82-40a9-a709-cf51845f7561" />
