### PR TITLE
🐛 fix: 중복 신고 시 신고 실패 메시지 출력

### DIFF
--- a/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
-
 import PostComment from "@/components/common/Card/detail/PostComment.tsx";
 
 import { FeedCommentType } from "@/types/post.ts";
@@ -12,8 +10,9 @@ const createComment = vi.fn();
 const updateComment = vi.fn();
 const deleteComment = vi.fn();
 const mockBlockUser = vi.fn().mockResolvedValue(undefined);
-const mockReportComment = vi.fn((_vars: unknown, options?: { onSuccess?: () => void; onError?: () => void }) =>
-  options?.onSuccess?.()
+const mockToast = vi.fn();
+const mockReportComment = vi.fn(
+  (_vars: unknown, options?: { onSuccess?: () => void; onError?: (error: unknown) => void }) => options?.onSuccess?.()
 );
 let isAuthenticated: boolean;
 let comments: FeedCommentType[];
@@ -38,10 +37,14 @@ vi.mock("@/hooks/queries/useReport", () => ({
 vi.mock("@/hooks/queries/useBlock", () => ({
   useBlockUser: () => ({ mutateAsync: mockBlockUser }),
 }));
+vi.mock("@/hooks/common/useCustomToast", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
 vi.mock("@/hooks/common/useNavigateToProfile", () => ({ useNavigateToProfile: () => vi.fn() }));
 vi.mock("@/utils/timeago", () => ({ timeAgo: () => "방금 전" }));
 vi.mock("@/components/auth/AuthSignInForm", () => ({ AuthSignInForm: () => <div data-testid="signin-form" /> }));
-vi.mock("lucide-react", () => lucideProxy());
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
 vi.mock("@/components/ui/select", () => {
   const pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
   return {
@@ -252,5 +255,56 @@ describe("PostComment", () => {
     await user.click(screen.getByRole("button", { name: "신고하기" }));
 
     await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+  });
+
+  it("이미 신고한 댓글을 다시 신고하면 중복 신고 안내 토스트를 보여준다", async () => {
+    comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
+    mockReportComment.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 409, data: { message: "이미 신고한 대상입니다." } },
+      })
+    );
+    render(<PostComment feedId={10} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "이미 신청된 신고입니다." });
+  });
+
+  it("존재하지 않는 댓글을 신고하면 찾을 수 없다는 토스트를 보여준다", async () => {
+    comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
+    mockReportComment.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 404, data: { message: "존재하지 않는 댓글입니다." } },
+      })
+    );
+    render(<PostComment feedId={10} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "댓글을 찾을 수 없습니다." });
+  });
+
+  it("그 외 오류로 신고에 실패하면 서버 오류 토스트를 보여준다", async () => {
+    comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
+    mockReportComment.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({ isAxiosError: true, response: { status: 500, data: { message: "Internal Server Error" } } })
+    );
+    render(<PostComment feedId={10} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "신고 실패",
+      description: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    });
   });
 });

--- a/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
@@ -2,8 +2,6 @@ import { MemoryRouter } from "react-router-dom";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
-
 import { PostHeader } from "@/components/common/Card/detail/PostHeader.tsx";
 
 import { FeedDetail } from "@/types/post.ts";
@@ -11,8 +9,9 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mockBlockRss = vi.fn().mockResolvedValue(undefined);
-const mockReportFeed = vi.fn((_vars: unknown, options?: { onSuccess?: () => void; onError?: () => void }) =>
-  options?.onSuccess?.()
+const mockToast = vi.fn();
+const mockReportFeed = vi.fn(
+  (_vars: unknown, options?: { onSuccess?: () => void; onError?: (error: unknown) => void }) => options?.onSuccess?.()
 );
 
 vi.mock("@/components/common/Card/detail/SubscribeButton", () => ({
@@ -25,10 +24,14 @@ vi.mock("@/hooks/queries/useReport", () => ({
 vi.mock("@/hooks/queries/useBlock", () => ({
   useBlockRss: () => ({ mutateAsync: mockBlockRss }),
 }));
+vi.mock("@/hooks/common/useCustomToast", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
 vi.mock("@/store/useAuthStore", () => ({
   useAuthStore: (selector: (s: { isAuthenticated: boolean }) => unknown) => selector({ isAuthenticated: true }),
 }));
-vi.mock("lucide-react", () => lucideProxy());
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
 vi.mock("@/components/ui/select", () => {
   const pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
   return {
@@ -133,5 +136,47 @@ describe("PostHeader", () => {
     await user.click(screen.getByRole("button", { name: "신고하기" }));
 
     await waitFor(() => expect(mockBlockRss).toHaveBeenCalledWith(42));
+  });
+
+  it("이미 신고한 게시글을 다시 신고하면 중복 신고 안내 토스트를 보여준다", async () => {
+    mockReportFeed.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 409, data: { message: "이미 신고한 대상입니다." } },
+      })
+    );
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "이미 신청된 신고입니다." });
+  });
+
+  it("존재하지 않는 게시글을 신고하면 찾을 수 없다는 토스트를 보여준다", async () => {
+    mockReportFeed.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 404, data: { message: "존재하지 않는 게시글입니다." } },
+      })
+    );
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "게시글을 찾을 수 없습니다." });
+  });
+
+  it("그 외 오류로 신고에 실패하면 서버 오류 토스트를 보여준다", async () => {
+    mockReportFeed.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({ isAxiosError: true, response: { status: 500, data: { message: "Internal Server Error" } } })
+    );
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "신고 실패",
+      description: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    });
   });
 });

--- a/client/src/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/client/src/__tests__/components/profile/ProfileHeader.test.tsx
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
-
 import { ProfileHeader } from "@/components/profile/ProfileHeader.tsx";
 
 import { render, screen, waitFor } from "@testing-library/react";
@@ -12,11 +10,14 @@ const mockBlockUser = vi.fn().mockResolvedValue(undefined);
 const mockBlockRss = vi.fn().mockResolvedValue(undefined);
 type RssRow = { id: number; name: string; blogPlatform: string };
 const mockCertifiedRss = vi.fn<() => { data: RssRow[] }>(() => ({ data: [] }));
-const mockReportUser = vi.fn((_vars: unknown, options?: { onSuccess?: () => void; onError?: () => void }) =>
-  options?.onSuccess?.()
+const mockReportUser = vi.fn(
+  (_vars: unknown, options?: { onSuccess?: () => void; onError?: (error: unknown) => void }) => options?.onSuccess?.()
 );
 
-vi.mock("lucide-react", () => lucideProxy());
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
 vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
 vi.mock("@/hooks/queries/useBlock.ts", () => ({
   useBlockUser: () => ({ mutateAsync: mockBlockUser }),
@@ -207,5 +208,53 @@ describe("ProfileHeader", () => {
     await user.click(screen.getByRole("button", { name: "신고하기" }));
 
     await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+  });
+
+  it("이미 신고한 유저를 다시 신고하면 중복 신고 안내 토스트를 보여준다", async () => {
+    mockReportUser.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 409, data: { message: "이미 신고한 대상입니다." } },
+      })
+    );
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "이미 신청된 신고입니다." });
+  });
+
+  it("존재하지 않는 유저를 신고하면 찾을 수 없다는 토스트를 보여준다", async () => {
+    mockReportUser.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 404, data: { message: "존재하지 않는 유저입니다." } },
+      })
+    );
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "유저를 찾을 수 없습니다." });
+  });
+
+  it("그 외 오류로 신고에 실패하면 서버 오류 토스트를 보여준다", async () => {
+    mockReportUser.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({ isAxiosError: true, response: { status: 500, data: { message: "Internal Server Error" } } })
+    );
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "신고 실패",
+      description: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    });
   });
 });

--- a/client/src/__tests__/pages/RssPage.test.tsx
+++ b/client/src/__tests__/pages/RssPage.test.tsx
@@ -2,17 +2,19 @@ import type { ReactNode } from "react";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
-
 import RssPage from "@/pages/RssPage.tsx";
 
 import { useAuthStore } from "@/store/useAuthStore";
 import { RssInfo } from "@/types/profile.ts";
 import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 let rssInfoState: { data: RssInfo | undefined; isLoading: boolean; isError: boolean };
 
-vi.mock("lucide-react", () => lucideProxy());
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
 
 vi.mock("react-router-dom", () => ({
   useParams: () => ({ rssId: "5" }),
@@ -59,15 +61,47 @@ vi.mock("@/components/profile/header/ui/ActivityGraph/ActivityGraph.tsx", () => 
 
 const blockRssMock = vi.hoisted(() => vi.fn());
 const unblockRssMock = vi.hoisted(() => vi.fn());
+const mockToast = vi.hoisted(() => vi.fn());
+const reportRssMock = vi.hoisted(() =>
+  vi.fn((_vars: unknown, options?: { onSuccess?: () => void; onError?: (error: unknown) => void }) =>
+    options?.onSuccess?.()
+  )
+);
 
 vi.mock("@/hooks/queries/useBlock.ts", () => ({
   useBlockRss: () => ({ mutate: blockRssMock, isPending: false }),
   useUnblockRss: () => ({ mutate: unblockRssMock, isPending: false }),
 }));
 
+vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
+
 vi.mock("@/hooks/queries/useReport", () => ({
-  useReportRss: () => ({ mutate: vi.fn(), isPending: false }),
+  useReportRss: () => ({ mutate: reportRssMock, isPending: false }),
 }));
+
+vi.mock("@/components/ui/select", () => {
+  const pass = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return {
+    Select: ({ children, onValueChange }: { children: ReactNode; onValueChange: (value: string) => void }) => (
+      <div
+        onClick={(event) => {
+          const value = (event.target as HTMLElement).getAttribute("data-value");
+          if (value) onValueChange(value);
+        }}
+      >
+        {children}
+      </div>
+    ),
+    SelectContent: pass,
+    SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
+      <div role="option" data-value={value}>
+        {children}
+      </div>
+    ),
+    SelectTrigger: pass,
+    SelectValue: () => null,
+  };
+});
 
 vi.mock("@/hooks/queries/useRssCertification.ts", () => ({
   useOwnedRssFeeds: () => ({
@@ -114,6 +148,8 @@ describe("RssPage", () => {
   beforeEach(() => {
     rssInfoState = { data: baseRss, isLoading: false, isError: false };
     useAuthStore.setState({ isAuthenticated: false });
+    mockToast.mockClear();
+    reportRssMock.mockClear();
   });
 
   it("소유자 없는 RSS는 인증 배지와 소유자 카드를 노출하지 않는다", () => {
@@ -231,5 +267,65 @@ describe("RssPage", () => {
     fireEvent.click(screen.getByRole("button", { name: "차단 해제" }));
 
     expect(unblockRssMock).toHaveBeenCalledWith(5, expect.any(Object));
+  });
+
+  it("이미 신고한 RSS를 다시 신고하면 중복 신고 안내 토스트를 보여준다", async () => {
+    useAuthStore.setState({ isAuthenticated: true });
+    reportRssMock.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 409, data: { message: "이미 신고한 대상입니다." } },
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<RssPage />);
+
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "이미 신청된 신고입니다." });
+  });
+
+  it("존재하지 않는 RSS를 신고하면 찾을 수 없다는 토스트를 보여준다", async () => {
+    useAuthStore.setState({ isAuthenticated: true });
+    reportRssMock.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({
+        isAxiosError: true,
+        response: { status: 404, data: { message: "존재하지 않는 RSS입니다." } },
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<RssPage />);
+
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({ title: "신고 실패", description: "RSS를 찾을 수 없습니다." });
+  });
+
+  it("그 외 오류로 신고에 실패하면 서버 오류 토스트를 보여준다", async () => {
+    useAuthStore.setState({ isAuthenticated: true });
+    reportRssMock.mockImplementationOnce((_vars, options) =>
+      options?.onError?.({ isAxiosError: true, response: { status: 500, data: { message: "Internal Server Error" } } })
+    );
+
+    const user = userEvent.setup();
+    render(<RssPage />);
+
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(mockToast).toHaveBeenCalledWith({
+      title: "신고 실패",
+      description: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+    });
   });
 });

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -29,6 +29,7 @@ import {
 import { useUserProfile } from "@/hooks/queries/useProfile";
 import { useReportComment } from "@/hooks/queries/useReport";
 
+import { getReportErrorMessage } from "@/utils/reportError";
 import { timeAgo } from "@/utils/timeago";
 
 import { useAuthStore } from "@/store/useAuthStore";
@@ -168,8 +169,8 @@ export default function PostComment({
             });
           }
         },
-        onError: () => {
-          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        onError: (error) => {
+          toast({ title: "신고 실패", description: getReportErrorMessage(error, "댓글을 찾을 수 없습니다.") });
         },
       }
     );

--- a/client/src/components/common/Card/detail/PostHeader.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.tsx
@@ -19,6 +19,7 @@ import { useBlockRss } from "@/hooks/queries/useBlock";
 import { useReportFeed } from "@/hooks/queries/useReport";
 
 import { detailFormatDate } from "@/utils/date";
+import { getReportErrorMessage } from "@/utils/reportError";
 
 import { useAuthStore } from "@/store/useAuthStore";
 import { FeedDetail } from "@/types/post";
@@ -55,8 +56,8 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
             });
           }
         },
-        onError: () => {
-          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        onError: (error) => {
+          toast({ title: "신고 실패", description: getReportErrorMessage(error, "게시글을 찾을 수 없습니다.") });
         },
       }
     );

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import axios from "axios";
 import { MoreVertical, Ban, FileText, Flag, Users } from "lucide-react";
 
 import { ReportDialog } from "@/components/common/ReportDialog";
@@ -29,6 +30,8 @@ import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 import { useBlockRss, useBlockUser } from "@/hooks/queries/useBlock.ts";
 import { useCertifiedRss } from "@/hooks/queries/useProfile.ts";
 import { useReportUser } from "@/hooks/queries/useReport";
+
+import { getReportErrorMessage } from "@/utils/reportError";
 
 import { CreateReportPayload } from "@/types/report";
 
@@ -69,6 +72,9 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
     setSelectedRssIds(allSelected ? new Set() : new Set(ownedRss.map((rss) => rss.id)));
   };
 
+  const extractErrorMessage = (error: unknown, fallback: string) =>
+    (axios.isAxiosError(error) && (error.response?.data as { message?: string })?.message) || fallback;
+
   const handleBlock = async () => {
     if (!blockableUserId) return;
     const rssIdsToBlock = [...selectedRssIds];
@@ -87,8 +93,8 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
       } else {
         toast({ title: "차단 완료", description: `${name}님을 차단했습니다.` });
       }
-    } catch {
-      toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
+    } catch (error) {
+      toast({ title: "차단 실패", description: extractErrorMessage(error, "잠시 후 다시 시도해주세요.") });
     } finally {
       setSelectedRssIds(new Set());
     }
@@ -115,8 +121,8 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
             });
           }
         },
-        onError: () => {
-          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        onError: (error) => {
+          toast({ title: "신고 실패", description: getReportErrorMessage(error, "유저를 찾을 수 없습니다.") });
         },
       }
     );

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 
+import axios from "axios";
 import {
   Ban,
   CalendarClock,
@@ -52,6 +53,7 @@ import { useOwnedRssFeeds, useSetFeedVisibility } from "@/hooks/queries/useRssCe
 import { useRssActivities, useRssActivityYears, useRssInfo, useRssPageFeeds } from "@/hooks/queries/useRssPage.ts";
 
 import { formatDate } from "@/utils/date.ts";
+import { getReportErrorMessage } from "@/utils/reportError";
 
 import { useAuthStore } from "@/store/useAuthStore";
 import { RssInfo } from "@/types/profile.ts";
@@ -324,13 +326,16 @@ export default function RssPage() {
 
   const feeds = feedData?.pages.flatMap((page) => page.result) ?? [];
 
+  const extractErrorMessage = (error: unknown, fallback: string) =>
+    (axios.isAxiosError(error) && (error.response?.data as { message?: string })?.message) || fallback;
+
   const handleBlock = () => {
     blockRss(rss.id, {
       onSuccess: () => {
         toast({ title: "차단 완료", description: `${rss.name} RSS를 차단했습니다.` });
       },
-      onError: () => {
-        toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
+      onError: (error) => {
+        toast({ title: "차단 실패", description: extractErrorMessage(error, "잠시 후 다시 시도해주세요.") });
       },
     });
     setShowBlockConfirm(false);
@@ -344,8 +349,8 @@ export default function RssPage() {
           setShowReportDialog(false);
           toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
         },
-        onError: () => {
-          toast({ title: "신고 실패", description: "잠시 후 다시 시도해주세요." });
+        onError: (error) => {
+          toast({ title: "신고 실패", description: getReportErrorMessage(error, "RSS를 찾을 수 없습니다.") });
         },
       }
     );

--- a/client/src/utils/reportError.ts
+++ b/client/src/utils/reportError.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+export const getReportErrorMessage = (error: unknown, notFoundMessage: string) => {
+  const status = axios.isAxiosError(error) ? error.response?.status : undefined;
+
+  if (status === 409) return "이미 신청된 신고입니다.";
+  if (status === 404) return notFoundMessage;
+  return "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.";
+};


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #895

### 신고 중복 오류 메시지 출력

-   신고 실패 시 항상 동일한 안내 문구만 노출되어, 이미 신고한 대상을 다시 신고했을 때도 원인을 알 수 없었음
-   응답 상태 코드(409/404)에 따라 분기하는 `getReportErrorMessage` util을 추가하여 중복 신고(409)는 "이미 신청된 신고입니다.", 대상 없음(404)은 각 상황에 맞는 메시지를 노출하도록 처리
-   RSS 차단 실패 메시지도 서버 응답의 `message`를 우선 노출하도록 함께 개선

# 📋 작업 내용

-   `client/src/utils/reportError.ts`: 신고 에러 상태 코드별 메시지 반환 util 추가
-   `RssPage.tsx`, `PostHeader.tsx`, `PostComment.tsx`, `ProfileHeader.tsx`: 신고 실패 핸들러에 util 적용
-   각 컴포넌트 테스트에 중복 신고(409) 케이스 추가

# 📷 스크린 샷
<img width="1196" height="658" alt="image" src="https://github.com/user-attachments/assets/d004f3d3-af0c-4530-9795-4ba0d7f57c9f" />
