### PR TITLE
✨ feat: 신고 시 유저·RSS 차단 기능 통합 구현

### DIFF
--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -3,10 +3,9 @@ import { FileText, Sparkles } from "lucide-react";
 import type { FeatureItem } from "@/types/about";
 import type { DayInfo, WeekInfo } from "@/types/activity";
 import type { ChildAdmin } from "@/types/admin";
+import type { BoardDetail, BoardPage, BoardSummary } from "@/types/board";
 import type { ChartPlatform, ChartType } from "@/types/chart";
 import type { AdminChatRoom, ChatType } from "@/types/chat";
-import type { BoardDetail, BoardPage, BoardSummary } from "@/types/board";
-import type { QnaPage, QnaSummary, QnaThread } from "@/types/qna";
 import type { FeedDetail, FeedList } from "@/types/post";
 import type {
   BlockedRss,
@@ -19,6 +18,7 @@ import type {
   User,
   UserProfile,
 } from "@/types/profile";
+import type { QnaPage, QnaSummary, QnaThread } from "@/types/qna";
 import type { ReportItem } from "@/types/report";
 import type { AdminRssData, RecentRss } from "@/types/rss";
 import type { RssSearchResult, SearchResult, UserSearchResult } from "@/types/search";
@@ -45,6 +45,7 @@ export const mockFeedDetail: FeedDetail = {
   blog: {
     id: 1,
     name: "데나무",
+    ownerId: 1,
     ownerName: "조민석",
     isOwnerCertified: true,
     platform: "tistory",

--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -45,9 +45,8 @@ export const mockFeedDetail: FeedDetail = {
   blog: {
     id: 1,
     name: "데나무",
-    ownerId: 1,
-    ownerName: "조민석",
-    isOwnerCertified: true,
+    userName: "조민석",
+    owner: { id: 1, userName: "조민석", profileImage: null },
     platform: "tistory",
     image: null,
   },

--- a/client/src/__tests__/components/common/BlockConfirmDialog.test.tsx
+++ b/client/src/__tests__/components/common/BlockConfirmDialog.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { BlockConfirmDialog } from "@/components/common/BlockConfirmDialog";
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const ownedRss = [
+  {
+    id: 10,
+    name: "seok.log",
+    userName: "u",
+    rssUrl: "",
+    blogPlatform: "velog",
+    feedCount: 3,
+    subscriberCount: 1,
+    isSubscribed: false,
+    blogImage: null,
+  },
+];
+
+describe("BlockConfirmDialog", () => {
+  it("owner와 ownedRss가 없으면 차단 확인만 요청하고 onConfirm에 빈 값을 전달해야 한다", async () => {
+    const handleConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BlockConfirmDialog open title="유저를 차단하시겠습니까?" onOpenChange={vi.fn()} onConfirm={handleConfirm} />
+    );
+
+    expect(screen.queryByText("해당 유저가 소유중인 RSS 차단")).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    expect(handleConfirm).toHaveBeenCalledWith({ blockOwner: false, rssIds: [] });
+  });
+
+  it("ownedRss가 있으면 목록을 표시하고 선택한 rssIds를 전달해야 한다", async () => {
+    const handleConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BlockConfirmDialog
+        open
+        title="RSS를 차단하시겠습니까?"
+        ownedRss={ownedRss}
+        onOpenChange={vi.fn()}
+        onConfirm={handleConfirm}
+      />
+    );
+
+    expect(screen.getByText("해당 유저가 소유중인 RSS 차단")).toBeInTheDocument();
+    await user.click(screen.getByRole("switch", { name: "seok.log 차단" }));
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    expect(handleConfirm).toHaveBeenCalledWith({ blockOwner: false, rssIds: [10] });
+  });
+
+  it("owner가 있으면 유저 차단 행을 표시하고 켜면 blockOwner=true를 전달해야 한다", async () => {
+    const handleConfirm = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BlockConfirmDialog
+        open
+        title="RSS를 차단하시겠습니까?"
+        owner={{ id: 1, userName: "김개발" }}
+        onOpenChange={vi.fn()}
+        onConfirm={handleConfirm}
+      />
+    );
+
+    await user.click(screen.getByRole("switch", { name: "김개발 유저도 차단" }));
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    expect(handleConfirm).toHaveBeenCalledWith({ blockOwner: true, rssIds: [] });
+  });
+
+  it("취소를 누르면 onOpenChange(false)를 호출하고 onConfirm은 호출하지 않아야 한다", async () => {
+    const handleConfirm = vi.fn();
+    const handleOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <BlockConfirmDialog
+        open
+        title="RSS를 차단하시겠습니까?"
+        onOpenChange={handleOpenChange}
+        onConfirm={handleConfirm}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+    expect(handleConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostComment.test.tsx
@@ -10,6 +10,8 @@ const createComment = vi.fn();
 const updateComment = vi.fn();
 const deleteComment = vi.fn();
 const mockBlockUser = vi.fn().mockResolvedValue(undefined);
+const mockBlockRss = vi.fn().mockResolvedValue(undefined);
+const mockCertifiedRss = vi.fn(() => ({ data: [] as { id: number; name: string; blogPlatform: string }[] }));
 const mockToast = vi.fn();
 const mockReportComment = vi.fn(
   (_vars: unknown, options?: { onSuccess?: () => void; onError?: (error: unknown) => void }) => options?.onSuccess?.()
@@ -30,12 +32,16 @@ vi.mock("@/hooks/queries/useComments", () => ({
   useAdminDeleteComment: () => ({ mutate: vi.fn() }),
 }));
 
-vi.mock("@/hooks/queries/useProfile", () => ({ useUserProfile: () => ({ data: undefined }) }));
+vi.mock("@/hooks/queries/useProfile", () => ({
+  useUserProfile: () => ({ data: undefined }),
+  useCertifiedRss: () => mockCertifiedRss(),
+}));
 vi.mock("@/hooks/queries/useReport", () => ({
   useReportComment: () => ({ mutate: mockReportComment, isPending: false }),
 }));
 vi.mock("@/hooks/queries/useBlock", () => ({
   useBlockUser: () => ({ mutateAsync: mockBlockUser }),
+  useBlockRss: () => ({ mutateAsync: mockBlockRss }),
 }));
 vi.mock("@/hooks/common/useCustomToast", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
 vi.mock("@/hooks/common/useNavigateToProfile", () => ({ useNavigateToProfile: () => vi.fn() }));
@@ -85,6 +91,7 @@ describe("PostComment", () => {
     vi.clearAllMocks();
     isAuthenticated = true;
     comments = [makeComment(1), makeComment(2)];
+    mockCertifiedRss.mockReturnValue({ data: [] });
   });
 
   it("댓글 개수와 목록, 작성시간을 렌더링해야 한다", () => {
@@ -230,7 +237,7 @@ describe("PostComment", () => {
     return user;
   };
 
-  it("함께 차단하기 스위치를 켜지 않으면 댓글만 신고해야 한다", async () => {
+  it("신고 접수 후에는 작성자를 자동으로 차단하지 않고 차단 확인 모달을 띄운다", async () => {
     comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
     render(<PostComment feedId={10} />);
 
@@ -243,18 +250,35 @@ describe("PostComment", () => {
       expect.anything()
     );
     expect(mockBlockUser).not.toHaveBeenCalled();
+    expect(await screen.findByText("작성자를 차단하시겠습니까?")).toBeInTheDocument();
   });
 
-  it("함께 차단하기 스위치를 켜면 댓글 신고 후 작성자를 차단해야 한다", async () => {
+  it("신고 후 뜬 차단 모달에서 확정하면 작성자를 차단해야 한다", async () => {
     comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
     render(<PostComment feedId={10} />);
 
     const user = await openReportModal();
     await user.click(screen.getByText("스팸/광고"));
-    await user.click(screen.getByRole("switch"));
     await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("button", { name: "차단" }));
 
     await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+    expect(mockBlockRss).not.toHaveBeenCalled();
+  });
+
+  it("작성자가 인증한 RSS가 있으면 신고 후 뜬 차단 모달에서 선택해 차단할 수 있어야 한다", async () => {
+    mockCertifiedRss.mockReturnValue({ data: [{ id: 55, name: "author.log", blogPlatform: "velog" }] });
+    comments = [makeComment(1, { user: { id: 2, userName: "타인", profileImage: null } })];
+    render(<PostComment feedId={10} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("switch", { name: "author.log 차단" }));
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+    expect(mockBlockRss).toHaveBeenCalledWith(55);
   });
 
   it("이미 신고한 댓글을 다시 신고하면 중복 신고 안내 토스트를 보여준다", async () => {

--- a/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
@@ -1,6 +1,6 @@
 import { MemoryRouter } from "react-router-dom";
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PostHeader } from "@/components/common/Card/detail/PostHeader.tsx";
 
@@ -21,9 +21,14 @@ vi.mock("@/components/common/Card/detail/SubscribeButton", () => ({
 vi.mock("@/hooks/queries/useReport", () => ({
   useReportFeed: () => ({ mutate: mockReportFeed, isPending: false }),
 }));
+const mockBlockUser = vi.fn().mockResolvedValue(undefined);
+const mockCertifiedRss = vi.fn(() => ({ data: [] as { id: number; name: string; blogPlatform: string }[] }));
+
 vi.mock("@/hooks/queries/useBlock", () => ({
   useBlockRss: () => ({ mutateAsync: mockBlockRss }),
+  useBlockUser: () => ({ mutateAsync: mockBlockUser }),
 }));
+vi.mock("@/hooks/queries/useProfile", () => ({ useCertifiedRss: () => mockCertifiedRss() }));
 vi.mock("@/hooks/common/useCustomToast", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
 vi.mock("@/store/useAuthStore", () => ({
   useAuthStore: (selector: (s: { isAuthenticated: boolean }) => unknown) => selector({ isAuthenticated: true }),
@@ -59,7 +64,15 @@ vi.mock("@/components/ui/select", () => {
 const data = {
   id: 1,
   title: "상세 제목",
-  blog: { id: 42, name: "작성자", ownerName: null, isOwnerCertified: false, platform: "velog", image: null },
+  blog: {
+    id: 42,
+    name: "작성자",
+    ownerId: null,
+    ownerName: null,
+    isOwnerCertified: false,
+    platform: "velog",
+    image: null,
+  },
   createdAt: "2024-03-26T00:00:00Z",
   viewCount: 123,
   tag: ["React", "Test"],
@@ -70,6 +83,10 @@ const data = {
 } as unknown as FeedDetail;
 
 describe("PostHeader", () => {
+  beforeEach(() => {
+    mockCertifiedRss.mockReturnValue({ data: [] });
+  });
+
   it("제목, 작성자, 조회수를 렌더링해야 한다", () => {
     render(
       <MemoryRouter>
@@ -117,7 +134,7 @@ describe("PostHeader", () => {
     return user;
   };
 
-  it("함께 차단하기 스위치를 켜지 않으면 게시글만 신고해야 한다", async () => {
+  it("신고 접수 후에는 블로그를 자동으로 차단하지 않고 차단 확인 모달을 띄운다", async () => {
     const user = await openReportModal();
     await user.click(screen.getByText("스팸/광고"));
     await user.click(screen.getByRole("button", { name: "신고하기" }));
@@ -127,15 +144,43 @@ describe("PostHeader", () => {
       expect.anything()
     );
     expect(mockBlockRss).not.toHaveBeenCalled();
+    expect(await screen.findByText("이 블로그를 차단하시겠습니까?")).toBeInTheDocument();
   });
 
-  it("함께 차단하기 스위치를 켜면 게시글 신고 후 블로그(RSS)를 차단해야 한다", async () => {
+  it("신고 후 뜬 차단 모달에서 확정하면 블로그(RSS)를 차단해야 한다", async () => {
     const user = await openReportModal();
     await user.click(screen.getByText("스팸/광고"));
-    await user.click(screen.getByRole("switch"));
     await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("button", { name: "차단" }));
 
     await waitFor(() => expect(mockBlockRss).toHaveBeenCalledWith(42));
+    expect(mockBlockUser).not.toHaveBeenCalled();
+  });
+
+  it("블로그 소유자가 있으면 신고 후 뜬 차단 모달에서 소유자 유저도 선택해 차단할 수 있어야 한다", async () => {
+    mockCertifiedRss.mockReturnValue({ data: [{ id: 77, name: "other.log", blogPlatform: "velog" }] });
+    const ownedData = {
+      ...data,
+      blog: { ...data.blog, ownerId: 7, ownerName: "김개발", isOwnerCertified: true },
+    } as unknown as FeedDetail;
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <PostHeader data={ownedData} />
+      </MemoryRouter>
+    );
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("switch", { name: "김개발 유저도 차단" }));
+    await user.click(screen.getByRole("switch", { name: "other.log 차단" }));
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    await waitFor(() => expect(mockBlockRss).toHaveBeenCalledWith(42));
+    expect(mockBlockRss).toHaveBeenCalledWith(77);
+    expect(mockBlockUser).toHaveBeenCalledWith(7);
   });
 
   it("이미 신고한 게시글을 다시 신고하면 중복 신고 안내 토스트를 보여준다", async () => {

--- a/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
+++ b/client/src/__tests__/components/common/Card/detail/PostHeader.test.tsx
@@ -67,9 +67,8 @@ const data = {
   blog: {
     id: 42,
     name: "작성자",
-    ownerId: null,
-    ownerName: null,
-    isOwnerCertified: false,
+    userName: "",
+    owner: null,
     platform: "velog",
     image: null,
   },
@@ -161,7 +160,7 @@ describe("PostHeader", () => {
     mockCertifiedRss.mockReturnValue({ data: [{ id: 77, name: "other.log", blogPlatform: "velog" }] });
     const ownedData = {
       ...data,
-      blog: { ...data.blog, ownerId: 7, ownerName: "김개발", isOwnerCertified: true },
+      blog: { ...data.blog, owner: { id: 7, userName: "김개발", profileImage: null } },
     } as unknown as FeedDetail;
 
     const user = userEvent.setup();

--- a/client/src/__tests__/components/common/ReportDialog.test.tsx
+++ b/client/src/__tests__/components/common/ReportDialog.test.tsx
@@ -34,32 +34,42 @@ const selectReason = async (user: ReturnType<typeof userEvent.setup>) => {
 };
 
 describe("ReportDialog", () => {
-  it("withBlockOption이 없으면 차단 스위치를 표시하지 않아야 한다", () => {
+  it("사유를 선택하지 않으면 신고하기 버튼이 비활성화되어야 한다", () => {
     render(<ReportDialog open title="유저 신고" onSubmit={vi.fn()} onOpenChange={vi.fn()} />);
 
-    expect(screen.queryByText("이 유저도 함께 차단하기")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "신고하기" })).toBeDisabled();
   });
 
-  it("withBlockOption이 있으면 차단 스위치를 표시하고 기본값은 꺼짐이어야 한다", async () => {
+  it("사유를 선택하고 제출하면 onSubmit에 payload를 전달해야 한다", async () => {
     const handleSubmit = vi.fn();
     const user = userEvent.setup();
-    render(<ReportDialog open withBlockOption title="유저 신고" onSubmit={handleSubmit} onOpenChange={vi.fn()} />);
+    render(<ReportDialog open title="유저 신고" onSubmit={handleSubmit} onOpenChange={vi.fn()} />);
 
     await selectReason(user);
     await user.click(screen.getByRole("button", { name: "신고하기" }));
 
-    expect(handleSubmit).toHaveBeenCalledWith({ reason: "SPAM", detail: undefined }, false);
+    expect(handleSubmit).toHaveBeenCalledWith({ reason: "SPAM", detail: undefined });
   });
 
-  it("차단 스위치를 켜면 onSubmit에 blockToo=true를 전달해야 한다", async () => {
+  it("상세 내용을 입력하면 onSubmit에 detail을 포함해 전달해야 한다", async () => {
     const handleSubmit = vi.fn();
     const user = userEvent.setup();
-    render(<ReportDialog open withBlockOption title="유저 신고" onSubmit={handleSubmit} onOpenChange={vi.fn()} />);
+    render(<ReportDialog open title="유저 신고" onSubmit={handleSubmit} onOpenChange={vi.fn()} />);
 
     await selectReason(user);
-    await user.click(screen.getByRole("switch"));
+    await user.type(screen.getByPlaceholderText("신고 사유에 대해 자세히 설명해주세요."), "반복 광고");
     await user.click(screen.getByRole("button", { name: "신고하기" }));
 
-    expect(handleSubmit).toHaveBeenCalledWith({ reason: "SPAM", detail: undefined }, true);
+    expect(handleSubmit).toHaveBeenCalledWith({ reason: "SPAM", detail: "반복 광고" });
+  });
+
+  it("취소를 누르면 onOpenChange(false)를 호출해야 한다", async () => {
+    const handleOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ReportDialog open title="유저 신고" onSubmit={vi.fn()} onOpenChange={handleOpenChange} />);
+
+    await user.click(screen.getByRole("button", { name: "취소" }));
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
   });
 });

--- a/client/src/__tests__/components/profile/ProfileHeader.test.tsx
+++ b/client/src/__tests__/components/profile/ProfileHeader.test.tsx
@@ -106,7 +106,7 @@ describe("ProfileHeader", () => {
 
     await openBlockModal();
 
-    expect(await screen.findByText("함께 차단할 RSS")).toBeInTheDocument();
+    expect(await screen.findByText("해당 유저가 소유중인 RSS 차단")).toBeInTheDocument();
     expect(screen.getByText("seok.log")).toBeInTheDocument();
     expect(screen.getByRole("switch", { name: "seok.log 차단" })).toBeInTheDocument();
   });
@@ -185,7 +185,7 @@ describe("ProfileHeader", () => {
     return user;
   };
 
-  it("신고 모달의 함께 차단하기 스위치를 켜지 않으면 신고만 접수해야 한다", async () => {
+  it("신고 접수 후에는 유저를 자동으로 차단하지 않고 차단 확인 모달을 띄운다", async () => {
     render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
 
     const user = await openReportModal();
@@ -197,17 +197,46 @@ describe("ProfileHeader", () => {
       expect.anything()
     );
     expect(mockBlockUser).not.toHaveBeenCalled();
+    expect(await screen.findByText("민석 유저를 차단하시겠습니까?")).toBeInTheDocument();
   });
 
-  it("신고 모달의 함께 차단하기 스위치를 켜면 신고 접수 후 유저를 차단해야 한다", async () => {
+  it("신고 후 뜬 차단 모달을 취소하면 유저를 차단하지 않아야 한다", async () => {
     render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
 
     const user = await openReportModal();
     await user.click(screen.getByText("스팸/광고"));
-    await user.click(screen.getByRole("switch"));
     await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("button", { name: "취소" }));
+
+    expect(mockBlockUser).not.toHaveBeenCalled();
+  });
+
+  it("신고 후 뜬 차단 모달에서 차단을 확정하면 유저를 차단해야 한다", async () => {
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("button", { name: "차단" }));
 
     await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+    expect(mockBlockRss).not.toHaveBeenCalled();
+  });
+
+  it("신고 후 뜬 차단 모달에서 소유 RSS 목록을 선택해 함께 차단할 수 있어야 한다", async () => {
+    mockCertifiedRss.mockReturnValue({
+      data: [{ id: 10, name: "seok.log", blogPlatform: "velog" }],
+    });
+    render(<ProfileHeader name="민석" email="" profileImage={null} introduction={null} blockableUserId={2} />);
+
+    const user = await openReportModal();
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("switch", { name: "seok.log 차단" }));
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    await waitFor(() => expect(mockBlockUser).toHaveBeenCalledWith(2));
+    expect(mockBlockRss).toHaveBeenCalledWith(10);
   });
 
   it("이미 신고한 유저를 다시 신고하면 중복 신고 안내 토스트를 보여준다", async () => {

--- a/client/src/__tests__/pages/RssPage.test.tsx
+++ b/client/src/__tests__/pages/RssPage.test.tsx
@@ -60,6 +60,8 @@ vi.mock("@/components/profile/header/ui/ActivityGraph/ActivityGraph.tsx", () => 
 }));
 
 const blockRssMock = vi.hoisted(() => vi.fn());
+const blockRssAsyncMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const blockUserAsyncMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 const unblockRssMock = vi.hoisted(() => vi.fn());
 const mockToast = vi.hoisted(() => vi.fn());
 const reportRssMock = vi.hoisted(() =>
@@ -69,11 +71,15 @@ const reportRssMock = vi.hoisted(() =>
 );
 
 vi.mock("@/hooks/queries/useBlock.ts", () => ({
-  useBlockRss: () => ({ mutate: blockRssMock, isPending: false }),
+  useBlockRss: () => ({ mutate: blockRssMock, mutateAsync: blockRssAsyncMock, isPending: false }),
+  useBlockUser: () => ({ mutateAsync: blockUserAsyncMock }),
   useUnblockRss: () => ({ mutate: unblockRssMock, isPending: false }),
 }));
 
 vi.mock("@/hooks/common/useCustomToast.ts", () => ({ useCustomToast: () => ({ toast: mockToast }) }));
+
+const mockCertifiedRss = vi.hoisted(() => vi.fn(() => ({ data: [] })));
+vi.mock("@/hooks/queries/useProfile.ts", () => ({ useCertifiedRss: () => mockCertifiedRss() }));
 
 vi.mock("@/hooks/queries/useReport", () => ({
   useReportRss: () => ({ mutate: reportRssMock, isPending: false }),
@@ -150,6 +156,9 @@ describe("RssPage", () => {
     useAuthStore.setState({ isAuthenticated: false });
     mockToast.mockClear();
     reportRssMock.mockClear();
+    blockRssAsyncMock.mockClear();
+    blockUserAsyncMock.mockClear();
+    mockCertifiedRss.mockReturnValue({ data: [] });
   });
 
   it("소유자 없는 RSS는 인증 배지와 소유자 카드를 노출하지 않는다", () => {
@@ -327,5 +336,56 @@ describe("RssPage", () => {
       title: "신고 실패",
       description: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
     });
+  });
+
+  it("신고 접수 후에는 RSS를 자동으로 차단하지 않고 차단 확인 모달을 띄운다", async () => {
+    useAuthStore.setState({ isAuthenticated: true });
+
+    const user = userEvent.setup();
+    render(<RssPage />);
+
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+
+    expect(blockRssAsyncMock).not.toHaveBeenCalled();
+    expect(await screen.findByText("데나무 블로그 RSS를 차단하시겠습니까?")).toBeInTheDocument();
+  });
+
+  it("신고 후 뜬 차단 모달에서 확정하면 이 RSS와 함께 소유자 유저도 선택해 차단할 수 있어야 한다", async () => {
+    useAuthStore.setState({ isAuthenticated: true });
+    rssInfoState = {
+      data: { ...baseRss, owner: { id: 99, userName: "김개발", profileImage: null } },
+      isLoading: false,
+      isError: false,
+    };
+
+    const user = userEvent.setup();
+    render(<RssPage />);
+
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("신고하기"));
+    await user.click(screen.getByText("스팸/광고"));
+    await user.click(screen.getByRole("button", { name: "신고하기" }));
+    await user.click(await screen.findByRole("switch", { name: "김개발 유저도 차단" }));
+    await user.click(screen.getByRole("button", { name: "차단" }));
+
+    expect(blockRssAsyncMock).toHaveBeenCalledWith(5);
+    expect(blockUserAsyncMock).toHaveBeenCalledWith(99);
+  });
+
+  it("차단하기 메뉴에서 바로 차단 모달을 띄워 RSS를 차단할 수 있어야 한다", async () => {
+    useAuthStore.setState({ isAuthenticated: true });
+
+    const user = userEvent.setup();
+    render(<RssPage />);
+
+    await user.click(screen.getByRole("button", { name: "더보기" }));
+    await user.click(await screen.findByText("차단하기"));
+    await user.click(await screen.findByRole("button", { name: "차단" }));
+
+    expect(blockRssAsyncMock).toHaveBeenCalledWith(5);
+    expect(reportRssMock).not.toHaveBeenCalled();
   });
 });

--- a/client/src/components/common/BlockConfirmDialog.tsx
+++ b/client/src/components/common/BlockConfirmDialog.tsx
@@ -1,0 +1,153 @@
+import { useState } from "react";
+
+import { FileText, Users } from "lucide-react";
+
+import { BlogPlatformBadge } from "@/components/profile/rss/BlogPlatformBadge.tsx";
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog.tsx";
+import { Switch } from "@/components/ui/switch.tsx";
+
+import { CertifiedRss } from "@/types/profile";
+
+interface BlockConfirmDialogOwner {
+  id: number;
+  userName: string;
+}
+
+interface BlockConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  owner?: BlockConfirmDialogOwner;
+  ownedRss?: CertifiedRss[];
+  onConfirm: (block: { blockOwner: boolean; rssIds: number[] }) => void;
+}
+
+export function BlockConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  owner,
+  ownedRss = [],
+  onConfirm,
+}: BlockConfirmDialogProps) {
+  const [blockOwnerToo, setBlockOwnerToo] = useState(false);
+  const [selectedRssIds, setSelectedRssIds] = useState<Set<number>>(new Set());
+
+  const allSelected = ownedRss.length > 0 && ownedRss.every((rss) => selectedRssIds.has(rss.id));
+
+  const toggleRss = (rssId: number) => {
+    setSelectedRssIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(rssId)) {
+        next.delete(rssId);
+      } else {
+        next.add(rssId);
+      }
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    setSelectedRssIds(allSelected ? new Set() : new Set(ownedRss.map((rss) => rss.id)));
+  };
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setBlockOwnerToo(false);
+      setSelectedRssIds(new Set());
+    }
+    onOpenChange(nextOpen);
+  };
+
+  const handleConfirm = () => {
+    handleOpenChange(false);
+    onConfirm({ blockOwner: blockOwnerToo, rssIds: [...selectedRssIds] });
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && <AlertDialogDescription>{description}</AlertDialogDescription>}
+        </AlertDialogHeader>
+
+        {owner && (
+          <div className="flex items-center justify-between gap-3 p-3 border border-gray-100 rounded-lg">
+            <p className="text-sm truncate">{owner.userName} 유저도 함께 차단</p>
+            <Switch
+              checked={blockOwnerToo}
+              onCheckedChange={setBlockOwnerToo}
+              aria-label={`${owner.userName} 유저도 차단`}
+              className="flex-shrink-0"
+            />
+          </div>
+        )}
+
+        {ownedRss.length > 0 && (
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-gray-700">해당 유저가 소유중인 RSS 차단</p>
+              <button type="button" onClick={toggleAll} className="text-xs font-medium text-[#FF870D] hover:underline">
+                {allSelected ? "모두 해제" : "모두 선택"}
+              </button>
+            </div>
+            <ul className="pr-1 space-y-2 overflow-y-auto max-h-60">
+              {ownedRss.map((rss) => (
+                <li
+                  key={rss.id}
+                  className="flex items-center justify-between gap-3 p-3 border border-gray-100 rounded-lg"
+                >
+                  <div className="flex items-center min-w-0 gap-3">
+                    <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="flex-shrink-0 w-9 h-9" />
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-2">
+                        <p className="text-sm font-medium truncate">{rss.name}</p>
+                        <BlogPlatformBadge platform={rss.blogPlatform} className="flex-shrink-0" />
+                      </div>
+                      <p className="flex items-center gap-3 mt-0.5 text-xs text-gray-400">
+                        <span className="flex items-center gap-1">
+                          <FileText className="w-3.5 h-3.5" />
+                          게시글 {rss.feedCount}개
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Users className="w-3.5 h-3.5" />
+                          구독자 {rss.subscriberCount}명
+                        </span>
+                      </p>
+                    </div>
+                  </div>
+                  <Switch
+                    checked={selectedRssIds.has(rss.id)}
+                    onCheckedChange={() => toggleRss(rss.id)}
+                    aria-label={`${rss.name} 차단`}
+                    className="flex-shrink-0"
+                  />
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>취소</AlertDialogCancel>
+          <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleConfirm}>
+            차단
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/client/src/components/common/Card/detail/PostComment.tsx
+++ b/client/src/components/common/Card/detail/PostComment.tsx
@@ -4,6 +4,7 @@ import type { EmojiClickData } from "emoji-picker-react";
 import { ChevronDown, ChevronUp, Flag, MoreVertical } from "lucide-react";
 
 import { AuthSignInForm } from "@/components/auth/AuthSignInForm";
+import { BlockConfirmDialog } from "@/components/common/BlockConfirmDialog";
 import CommentAction from "@/components/common/Card/detail/CommentAction";
 import EmojiPickerButton from "@/components/common/EmojiPickerButton";
 import { ReportDialog } from "@/components/common/ReportDialog";
@@ -18,7 +19,7 @@ import {
 
 import { useCustomToast } from "@/hooks/common/useCustomToast";
 import { useNavigateToProfile } from "@/hooks/common/useNavigateToProfile";
-import { useBlockUser } from "@/hooks/queries/useBlock";
+import { useBlockRss, useBlockUser } from "@/hooks/queries/useBlock";
 import {
   useComments,
   useCreateComment,
@@ -26,7 +27,7 @@ import {
   useDeleteComment,
   useAdminDeleteComment,
 } from "@/hooks/queries/useComments";
-import { useUserProfile } from "@/hooks/queries/useProfile";
+import { useCertifiedRss, useUserProfile } from "@/hooks/queries/useProfile";
 import { useReportComment } from "@/hooks/queries/useReport";
 
 import { getReportErrorMessage } from "@/utils/reportError";
@@ -78,6 +79,7 @@ export default function PostComment({
   const deleteComment = isAdmin ? deleteCommentAdmin : deleteCommentUser;
   const { mutate: reportComment, isPending: isReportPending } = useReportComment();
   const { mutateAsync: blockUser } = useBlockUser();
+  const { mutateAsync: blockRss } = useBlockRss();
   const { toast } = useCustomToast();
 
   const [content, setContent] = useState("");
@@ -87,6 +89,8 @@ export default function PostComment({
   const [replyTo, setReplyTo] = useState<number | null>(null);
   const [replyContent, setReplyContent] = useState("");
   const [reportTarget, setReportTarget] = useState<{ commentId: number; authorId: number } | null>(null);
+  const [blockAuthorId, setBlockAuthorId] = useState<number | null>(null);
+  const { data: blockTargetOwnedRss = [] } = useCertifiedRss(blockAuthorId ?? 0);
   const [expandedReplyIds, setExpandedReplyIds] = useState<Set<number>>(new Set());
 
   const handleModify = (id: number | null) => setModifyId(id);
@@ -147,33 +151,41 @@ export default function PostComment({
     updateComment({ commentId, newComment: trimmed }, { onSuccess: () => setModifyId(null) });
   };
 
-  const handleReportSubmit = (payload: CreateReportPayload, blockToo: boolean) => {
+  const handleReportSubmit = (payload: CreateReportPayload) => {
     if (!reportTarget) return;
     const { commentId, authorId } = reportTarget;
     reportComment(
       { commentId, payload },
       {
-        onSuccess: async () => {
+        onSuccess: () => {
           setReportTarget(null);
-          if (!blockToo) {
-            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
-            return;
-          }
-          try {
-            await blockUser(authorId);
-            toast({ title: "신고 접수 완료", description: "신고가 접수되었고, 작성자를 차단했습니다." });
-          } catch {
-            toast({
-              title: "신고 접수 완료",
-              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
-            });
-          }
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+          setBlockAuthorId(authorId);
         },
         onError: (error) => {
           toast({ title: "신고 실패", description: getReportErrorMessage(error, "댓글을 찾을 수 없습니다.") });
         },
       }
     );
+  };
+
+  const handleBlock = async (block: { rssIds: number[] }) => {
+    if (!blockAuthorId) return;
+    try {
+      await blockUser(blockAuthorId);
+      const results = await Promise.allSettled(block.rssIds.map((rssId) => blockRss(rssId)));
+      const failedRssCount = results.filter((result) => result.status === "rejected").length;
+      if (failedRssCount > 0) {
+        toast({
+          title: "차단 완료",
+          description: `작성자를 차단했습니다. RSS ${failedRssCount}건은 차단하지 못했습니다.`,
+        });
+      } else {
+        toast({ title: "차단 완료", description: "작성자를 차단했습니다." });
+      }
+    } catch {
+      toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
+    }
   };
 
   const canEditComment = (comment: FeedCommentType) => !isAdmin && !comment.isDeleted && comment.user.id === userId;
@@ -387,8 +399,16 @@ export default function PostComment({
         onOpenChange={(open) => !open && setReportTarget(null)}
         title="댓글 신고"
         isPending={isReportPending}
-        withBlockOption
         onSubmit={handleReportSubmit}
+      />
+
+      <BlockConfirmDialog
+        open={blockAuthorId !== null}
+        onOpenChange={(open) => !open && setBlockAuthorId(null)}
+        title="작성자를 차단하시겠습니까?"
+        description="차단하면 댓글, 프로필 페이지 열람이 제한됩니다."
+        ownedRss={blockTargetOwnedRss}
+        onConfirm={handleBlock}
       />
     </div>
   );

--- a/client/src/components/common/Card/detail/PostHeader.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.tsx
@@ -40,13 +40,13 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
   const [showReportDialog, setShowReportDialog] = useState(false);
   const [showBlockConfirm, setShowBlockConfirm] = useState(false);
 
-  const { data: ownerOwnedRss = [] } = useCertifiedRss(data.blog.ownerId ?? 0);
+  const { data: ownerOwnedRss = [] } = useCertifiedRss(data.blog.owner?.id ?? 0);
   const otherOwnedRss = ownerOwnedRss.filter((rss) => rss.id !== data.blog.id);
 
   const handleBlock = async (block: { blockOwner: boolean; rssIds: number[] }) => {
     try {
       const rssTasks = [data.blog.id, ...block.rssIds].map((rssId) => blockRss(rssId));
-      const ownerTasks = block.blockOwner && data.blog.ownerId ? [blockUser(data.blog.ownerId)] : [];
+      const ownerTasks = block.blockOwner && data.blog.owner ? [blockUser(data.blog.owner.id)] : [];
       const results = await Promise.allSettled([...rssTasks, ...ownerTasks]);
       const failedCount = results.filter((result) => result.status === "rejected").length;
       if (failedCount > 0) {
@@ -89,7 +89,7 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
       <span className="flex flex-col min-w-0">
         <span className="flex items-center gap-1.5">
           <span className="font-medium truncate">{data.blog.name}</span>
-          {data.blog.isOwnerCertified && (
+          {data.blog.owner && (
             <span className="flex items-center gap-0.5 text-xs text-blue-500" title="RSS 소유 인증 블로그">
               <CheckCircle2 className="w-4 h-4" />
               인증
@@ -97,9 +97,9 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
           )}
         </span>
         <span className="flex gap-2 text-sm text-gray-400">
-          {data.blog.ownerName && (
+          {data.blog.userName && (
             <>
-              <span>{data.blog.ownerName}</span>
+              <span>{data.blog.userName}</span>
               <span>·</span>
             </>
           )}
@@ -168,7 +168,7 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
         onOpenChange={setShowBlockConfirm}
         title="이 블로그를 차단하시겠습니까?"
         description="차단하면 이 블로그의 게시글이 더 이상 노출되지 않습니다."
-        owner={data.blog.ownerId ? { id: data.blog.ownerId, userName: data.blog.ownerName ?? "작성자" } : undefined}
+        owner={data.blog.owner ?? undefined}
         ownedRss={otherOwnedRss}
         onConfirm={handleBlock}
       />

--- a/client/src/components/common/Card/detail/PostHeader.tsx
+++ b/client/src/components/common/Card/detail/PostHeader.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 
 import { CheckCircle2, Flag, MoreVertical } from "lucide-react";
 
+import { BlockConfirmDialog } from "@/components/common/BlockConfirmDialog";
 import PostAvatar from "@/components/common/Card/PostAvatar";
 import { SimpleTagList } from "@/components/common/Card/PostTag";
 import { SubscribeButton } from "@/components/common/Card/detail/SubscribeButton";
@@ -15,7 +16,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast";
-import { useBlockRss } from "@/hooks/queries/useBlock";
+import { useBlockRss, useBlockUser } from "@/hooks/queries/useBlock";
+import { useCertifiedRss } from "@/hooks/queries/useProfile";
 import { useReportFeed } from "@/hooks/queries/useReport";
 
 import { detailFormatDate } from "@/utils/date";
@@ -34,27 +36,40 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
   const { toast } = useCustomToast();
   const { mutate: reportFeed, isPending: isReportPending } = useReportFeed();
   const { mutateAsync: blockRss } = useBlockRss();
+  const { mutateAsync: blockUser } = useBlockUser();
   const [showReportDialog, setShowReportDialog] = useState(false);
+  const [showBlockConfirm, setShowBlockConfirm] = useState(false);
 
-  const handleReport = (payload: CreateReportPayload, blockToo: boolean) => {
+  const { data: ownerOwnedRss = [] } = useCertifiedRss(data.blog.ownerId ?? 0);
+  const otherOwnedRss = ownerOwnedRss.filter((rss) => rss.id !== data.blog.id);
+
+  const handleBlock = async (block: { blockOwner: boolean; rssIds: number[] }) => {
+    try {
+      const rssTasks = [data.blog.id, ...block.rssIds].map((rssId) => blockRss(rssId));
+      const ownerTasks = block.blockOwner && data.blog.ownerId ? [blockUser(data.blog.ownerId)] : [];
+      const results = await Promise.allSettled([...rssTasks, ...ownerTasks]);
+      const failedCount = results.filter((result) => result.status === "rejected").length;
+      if (failedCount > 0) {
+        toast({
+          title: "차단 완료",
+          description: `차단 대상 ${failedCount}건은 차단하지 못했습니다.`,
+        });
+      } else {
+        toast({ title: "차단 완료", description: "선택한 대상을 차단했습니다." });
+      }
+    } catch {
+      toast({ title: "차단 실패", description: "잠시 후 다시 시도해주세요." });
+    }
+  };
+
+  const handleReport = (payload: CreateReportPayload) => {
     reportFeed(
       { feedId: data.id, payload },
       {
-        onSuccess: async () => {
+        onSuccess: () => {
           setShowReportDialog(false);
-          if (!blockToo) {
-            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
-            return;
-          }
-          try {
-            await blockRss(data.blog.id);
-            toast({ title: "신고 접수 완료", description: "신고가 접수되었고, 이 블로그를 차단했습니다." });
-          } catch {
-            toast({
-              title: "신고 접수 완료",
-              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
-            });
-          }
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+          setShowBlockConfirm(true);
         },
         onError: (error) => {
           toast({ title: "신고 실패", description: getReportErrorMessage(error, "게시글을 찾을 수 없습니다.") });
@@ -145,10 +160,17 @@ export const PostHeader = React.memo(({ data }: PostHeaderProps) => {
         onOpenChange={setShowReportDialog}
         title="게시글 신고"
         isPending={isReportPending}
-        withBlockOption
-        blockLabel="이 블로그도 함께 차단하기"
-        blockDescription="차단하면 이 블로그의 게시글이 더 이상 노출되지 않습니다."
         onSubmit={handleReport}
+      />
+
+      <BlockConfirmDialog
+        open={showBlockConfirm}
+        onOpenChange={setShowBlockConfirm}
+        title="이 블로그를 차단하시겠습니까?"
+        description="차단하면 이 블로그의 게시글이 더 이상 노출되지 않습니다."
+        owner={data.blog.ownerId ? { id: data.blog.ownerId, userName: data.blog.ownerName ?? "작성자" } : undefined}
+        ownedRss={otherOwnedRss}
+        onConfirm={handleBlock}
       />
     </div>
   );

--- a/client/src/components/common/ReportDialog.tsx
+++ b/client/src/components/common/ReportDialog.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 
 import { REPORT_REASON_LABELS } from "@/constants/report";
@@ -23,40 +22,26 @@ interface ReportDialogProps {
   onOpenChange: (open: boolean) => void;
   title: string;
   isPending?: boolean;
-  withBlockOption?: boolean;
-  blockLabel?: string;
-  blockDescription?: string;
-  onSubmit: (payload: CreateReportPayload, blockToo: boolean) => void;
+  onSubmit: (payload: CreateReportPayload) => void;
 }
 
 const REPORT_REASON_OPTIONS = Object.entries(REPORT_REASON_LABELS) as [ReportReason, string][];
 
-export function ReportDialog({
-  open,
-  onOpenChange,
-  title,
-  isPending = false,
-  withBlockOption = false,
-  blockLabel = "이 유저도 함께 차단하기",
-  blockDescription = "차단하면 댓글, 프로필 페이지 열람이 제한됩니다.",
-  onSubmit,
-}: ReportDialogProps) {
+export function ReportDialog({ open, onOpenChange, title, isPending = false, onSubmit }: ReportDialogProps) {
   const [reason, setReason] = useState<ReportReason | "">("");
   const [detail, setDetail] = useState("");
-  const [blockToo, setBlockToo] = useState(false);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setReason("");
       setDetail("");
-      setBlockToo(false);
     }
     onOpenChange(nextOpen);
   };
 
   const handleSubmit = () => {
     if (!reason || isPending) return;
-    onSubmit({ reason, detail: detail.trim() || undefined }, blockToo);
+    onSubmit({ reason, detail: detail.trim() || undefined });
   };
 
   return (
@@ -97,16 +82,6 @@ export function ReportDialog({
               />
               <span className="self-end text-xs text-muted-foreground">{detail.length}/500</span>
             </div>
-
-            {withBlockOption && (
-              <div className="flex items-center justify-between gap-3 p-3 border border-gray-100 rounded-lg">
-                <div className="flex flex-col gap-0.5">
-                  <Label htmlFor="report-block-too">{blockLabel}</Label>
-                  <span className="text-xs text-muted-foreground">{blockDescription}</span>
-                </div>
-                <Switch id="report-block-too" checked={blockToo} onCheckedChange={setBlockToo} />
-              </div>
-            )}
           </div>
 
           <DialogFooter>

--- a/client/src/components/profile/ProfileHeader.tsx
+++ b/client/src/components/profile/ProfileHeader.tsx
@@ -1,21 +1,10 @@
 import { useState } from "react";
 
 import axios from "axios";
-import { MoreVertical, Ban, FileText, Flag, Users } from "lucide-react";
+import { MoreVertical, Ban, Flag } from "lucide-react";
 
+import { BlockConfirmDialog } from "@/components/common/BlockConfirmDialog";
 import { ReportDialog } from "@/components/common/ReportDialog";
-import { BlogPlatformBadge } from "@/components/profile/rss/BlogPlatformBadge.tsx";
-import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
 import { Card, CardContent } from "@/components/ui/card.tsx";
 import {
@@ -24,7 +13,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu.tsx";
-import { Switch } from "@/components/ui/switch.tsx";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
 import { useBlockRss, useBlockUser } from "@/hooks/queries/useBlock.ts";
@@ -47,44 +35,22 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
   const initials = name ? name.substring(0, 2).toUpperCase() : "사용자";
   const [showBlockConfirm, setShowBlockConfirm] = useState(false);
   const [showReportDialog, setShowReportDialog] = useState(false);
-  const [selectedRssIds, setSelectedRssIds] = useState<Set<number>>(new Set());
   const { toast } = useCustomToast();
   const { mutateAsync: blockUser } = useBlockUser();
   const { mutateAsync: blockRss } = useBlockRss();
   const { mutate: reportUser, isPending: isReportPending } = useReportUser();
   const { data: ownedRss = [] } = useCertifiedRss(blockableUserId ?? 0);
 
-  const allSelected = ownedRss.length > 0 && ownedRss.every((rss) => selectedRssIds.has(rss.id));
-
-  const toggleRss = (rssId: number) => {
-    setSelectedRssIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(rssId)) {
-        next.delete(rssId);
-      } else {
-        next.add(rssId);
-      }
-      return next;
-    });
-  };
-
-  const toggleAll = () => {
-    setSelectedRssIds(allSelected ? new Set() : new Set(ownedRss.map((rss) => rss.id)));
-  };
-
   const extractErrorMessage = (error: unknown, fallback: string) =>
     (axios.isAxiosError(error) && (error.response?.data as { message?: string })?.message) || fallback;
 
-  const handleBlock = async () => {
+  const handleBlock = async (block: { rssIds: number[] }) => {
     if (!blockableUserId) return;
-    const rssIdsToBlock = [...selectedRssIds];
-    setShowBlockConfirm(false);
 
     try {
       await blockUser(blockableUserId);
-      const results = await Promise.allSettled(rssIdsToBlock.map((rssId) => blockRss(rssId)));
+      const results = await Promise.allSettled(block.rssIds.map((rssId) => blockRss(rssId)));
       const failedRssCount = results.filter((result) => result.status === "rejected").length;
-
       if (failedRssCount > 0) {
         toast({
           title: "차단 완료",
@@ -95,31 +61,18 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
       }
     } catch (error) {
       toast({ title: "차단 실패", description: extractErrorMessage(error, "잠시 후 다시 시도해주세요.") });
-    } finally {
-      setSelectedRssIds(new Set());
     }
   };
 
-  const handleReport = (payload: CreateReportPayload, blockToo: boolean) => {
+  const handleReport = (payload: CreateReportPayload) => {
     if (!blockableUserId) return;
     reportUser(
       { userId: blockableUserId, payload },
       {
-        onSuccess: async () => {
+        onSuccess: () => {
           setShowReportDialog(false);
-          if (!blockToo) {
-            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
-            return;
-          }
-          try {
-            await blockUser(blockableUserId);
-            toast({ title: "신고 접수 완료", description: `신고가 접수되었고, ${name}님을 차단했습니다.` });
-          } catch {
-            toast({
-              title: "신고 접수 완료",
-              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
-            });
-          }
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+          setShowBlockConfirm(true);
         },
         onError: (error) => {
           toast({ title: "신고 실패", description: getReportErrorMessage(error, "유저를 찾을 수 없습니다.") });
@@ -168,79 +121,20 @@ export const ProfileHeader = ({ name, email, profileImage, introduction, blockab
         </div>
       </CardContent>
 
-      <AlertDialog open={showBlockConfirm} onOpenChange={setShowBlockConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>{name} 유저를 차단하시겠습니까?</AlertDialogTitle>
-            <AlertDialogDescription>댓글, 프로필 페이지 열람이 제한됩니다.</AlertDialogDescription>
-          </AlertDialogHeader>
-          {ownedRss.length > 0 && (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <p className="text-sm font-medium text-gray-700">함께 차단할 RSS</p>
-                <button
-                  type="button"
-                  onClick={toggleAll}
-                  className="text-xs font-medium text-[#FF870D] hover:underline"
-                >
-                  {allSelected ? "모두 해제" : "모두 선택"}
-                </button>
-              </div>
-              <ul className="pr-1 space-y-2 overflow-y-auto max-h-60">
-                {ownedRss.map((rss) => (
-                  <li
-                    key={rss.id}
-                    className="flex items-center justify-between gap-3 p-3 border border-gray-100 rounded-lg"
-                  >
-                    <div className="flex items-center min-w-0 gap-3">
-                      <PlatformIcon
-                        platform={rss.blogPlatform}
-                        image={rss.blogImage}
-                        className="flex-shrink-0 w-9 h-9"
-                      />
-                      <div className="min-w-0">
-                        <div className="flex items-center gap-2">
-                          <p className="text-sm font-medium truncate">{rss.name}</p>
-                          <BlogPlatformBadge platform={rss.blogPlatform} className="flex-shrink-0" />
-                        </div>
-                        <p className="flex items-center gap-3 mt-0.5 text-xs text-gray-400">
-                          <span className="flex items-center gap-1">
-                            <FileText className="w-3.5 h-3.5" />
-                            게시글 {rss.feedCount}개
-                          </span>
-                          <span className="flex items-center gap-1">
-                            <Users className="w-3.5 h-3.5" />
-                            구독자 {rss.subscriberCount}명
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                    <Switch
-                      checked={selectedRssIds.has(rss.id)}
-                      onCheckedChange={() => toggleRss(rss.id)}
-                      aria-label={`${rss.name} 차단`}
-                      className="flex-shrink-0"
-                    />
-                  </li>
-                ))}
-              </ul>
-            </div>
-          )}
-          <AlertDialogFooter>
-            <AlertDialogCancel>취소</AlertDialogCancel>
-            <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleBlock}>
-              차단
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+      <BlockConfirmDialog
+        open={showBlockConfirm}
+        onOpenChange={setShowBlockConfirm}
+        title={`${name} 유저를 차단하시겠습니까?`}
+        description="댓글, 프로필 페이지 열람이 제한됩니다."
+        ownedRss={ownedRss}
+        onConfirm={handleBlock}
+      />
 
       <ReportDialog
         open={showReportDialog}
         onOpenChange={setShowReportDialog}
         title={`${name} 유저 신고`}
         isPending={isReportPending}
-        withBlockOption
         onSubmit={handleReport}
       />
     </Card>

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -282,7 +282,7 @@ export default function RssPage() {
 
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { toast } = useCustomToast();
-  const { mutate: blockRss } = useBlockRss();
+  const { mutate: blockRss, mutateAsync: blockRssAsync } = useBlockRss();
   const { mutate: reportRss, isPending: isReportPending } = useReportRss();
 
   const { data: rss, isLoading, isError } = useRssInfo(numericId);
@@ -341,13 +341,25 @@ export default function RssPage() {
     setShowBlockConfirm(false);
   };
 
-  const handleReport = (payload: CreateReportPayload) => {
+  const handleReport = (payload: CreateReportPayload, blockToo: boolean) => {
     reportRss(
       { rssId: rss.id, payload },
       {
-        onSuccess: () => {
+        onSuccess: async () => {
           setShowReportDialog(false);
-          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+          if (!blockToo) {
+            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+            return;
+          }
+          try {
+            await blockRssAsync(rss.id);
+            toast({ title: "신고 접수 완료", description: "신고가 접수되었고, 이 RSS를 차단했습니다." });
+          } catch {
+            toast({
+              title: "신고 접수 완료",
+              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
+            });
+          }
         },
         onError: (error) => {
           toast({ title: "신고 실패", description: getReportErrorMessage(error, "RSS를 찾을 수 없습니다.") });
@@ -461,6 +473,9 @@ export default function RssPage() {
           onOpenChange={setShowReportDialog}
           title={`${rss.name} RSS 신고`}
           isPending={isReportPending}
+          withBlockOption
+          blockLabel="이 RSS도 함께 차단하기"
+          blockDescription="차단하면 이 RSS의 게시글이 더 이상 노출되지 않습니다."
           onSubmit={handleReport}
         />
       </Layout>

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 
 import { Footer } from "@/components/about/Footer";
+import { BlockConfirmDialog } from "@/components/common/BlockConfirmDialog";
 import { SubscribeButton } from "@/components/common/Card/detail/SubscribeButton.tsx";
 import { ReportDialog } from "@/components/common/ReportDialog";
 import Layout from "@/components/layout/Layout";
@@ -24,16 +25,6 @@ import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 import { RssEditModal } from "@/components/profile/rss/RssEditModal.tsx";
 import { RssFeedCard } from "@/components/profile/rss/RssFeedCard.tsx";
 import { RssFeedRow } from "@/components/profile/rss/RssFeedRow.tsx";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog.tsx";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar.tsx";
 import { Button } from "@/components/ui/button.tsx";
 import { Card, CardContent } from "@/components/ui/card.tsx";
@@ -47,7 +38,8 @@ import {
 import NotFound from "@/pages/NotFound";
 
 import { useCustomToast } from "@/hooks/common/useCustomToast.ts";
-import { useBlockRss, useUnblockRss } from "@/hooks/queries/useBlock.ts";
+import { useBlockRss, useBlockUser, useUnblockRss } from "@/hooks/queries/useBlock.ts";
+import { useCertifiedRss } from "@/hooks/queries/useProfile.ts";
 import { useReportRss } from "@/hooks/queries/useReport";
 import { useOwnedRssFeeds, useSetFeedVisibility } from "@/hooks/queries/useRssCertification.ts";
 import { useRssActivities, useRssActivityYears, useRssInfo, useRssPageFeeds } from "@/hooks/queries/useRssPage.ts";
@@ -282,10 +274,12 @@ export default function RssPage() {
 
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
   const { toast } = useCustomToast();
-  const { mutate: blockRss, mutateAsync: blockRssAsync } = useBlockRss();
+  const { mutateAsync: blockRssAsync } = useBlockRss();
+  const { mutateAsync: blockUserAsync } = useBlockUser();
   const { mutate: reportRss, isPending: isReportPending } = useReportRss();
 
   const { data: rss, isLoading, isError } = useRssInfo(numericId);
+  const { data: ownerOwnedRss = [] } = useCertifiedRss(rss?.owner?.id ?? 0);
   const {
     data: feedData,
     isLoading: feedsLoading,
@@ -325,41 +319,38 @@ export default function RssPage() {
   }
 
   const feeds = feedData?.pages.flatMap((page) => page.result) ?? [];
+  const otherOwnedRss = ownerOwnedRss.filter((ownedRss) => ownedRss.id !== rss.id);
 
   const extractErrorMessage = (error: unknown, fallback: string) =>
     (axios.isAxiosError(error) && (error.response?.data as { message?: string })?.message) || fallback;
 
-  const handleBlock = () => {
-    blockRss(rss.id, {
-      onSuccess: () => {
+  const handleBlock = async (block: { blockOwner: boolean; rssIds: number[] }) => {
+    try {
+      const rssTasks = [rss.id, ...block.rssIds].map((rssId) => blockRssAsync(rssId));
+      const ownerTasks = block.blockOwner && rss.owner ? [blockUserAsync(rss.owner.id)] : [];
+      const results = await Promise.allSettled([...rssTasks, ...ownerTasks]);
+      const failedCount = results.filter((result) => result.status === "rejected").length;
+      if (failedCount > 0) {
+        toast({
+          title: "차단 완료",
+          description: `${rss.name} RSS를 차단했습니다. 차단 대상 ${failedCount}건은 차단하지 못했습니다.`,
+        });
+      } else {
         toast({ title: "차단 완료", description: `${rss.name} RSS를 차단했습니다.` });
-      },
-      onError: (error) => {
-        toast({ title: "차단 실패", description: extractErrorMessage(error, "잠시 후 다시 시도해주세요.") });
-      },
-    });
-    setShowBlockConfirm(false);
+      }
+    } catch (error) {
+      toast({ title: "차단 실패", description: extractErrorMessage(error, "잠시 후 다시 시도해주세요.") });
+    }
   };
 
-  const handleReport = (payload: CreateReportPayload, blockToo: boolean) => {
+  const handleReport = (payload: CreateReportPayload) => {
     reportRss(
       { rssId: rss.id, payload },
       {
-        onSuccess: async () => {
+        onSuccess: () => {
           setShowReportDialog(false);
-          if (!blockToo) {
-            toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
-            return;
-          }
-          try {
-            await blockRssAsync(rss.id);
-            toast({ title: "신고 접수 완료", description: "신고가 접수되었고, 이 RSS를 차단했습니다." });
-          } catch {
-            toast({
-              title: "신고 접수 완료",
-              description: "신고는 접수되었지만 차단에 실패했습니다. 잠시 후 다시 시도해주세요.",
-            });
-          }
+          toast({ title: "신고 접수 완료", description: "신고가 접수되었습니다." });
+          setShowBlockConfirm(true);
         },
         onError: (error) => {
           toast({ title: "신고 실패", description: getReportErrorMessage(error, "RSS를 찾을 수 없습니다.") });
@@ -453,29 +444,21 @@ export default function RssPage() {
           </Card>
         </div>
 
-        <AlertDialog open={showBlockConfirm} onOpenChange={setShowBlockConfirm}>
-          <AlertDialogContent>
-            <AlertDialogHeader>
-              <AlertDialogTitle>{rss.name} RSS를 차단하시겠습니까?</AlertDialogTitle>
-              <AlertDialogDescription>게시글 및 RSS 프로필 페이지 조회가 제한됩니다.</AlertDialogDescription>
-            </AlertDialogHeader>
-            <AlertDialogFooter>
-              <AlertDialogCancel>취소</AlertDialogCancel>
-              <AlertDialogAction className="bg-red-600 hover:bg-red-700" onClick={handleBlock}>
-                차단
-              </AlertDialogAction>
-            </AlertDialogFooter>
-          </AlertDialogContent>
-        </AlertDialog>
+        <BlockConfirmDialog
+          open={showBlockConfirm}
+          onOpenChange={setShowBlockConfirm}
+          title={`${rss.name} RSS를 차단하시겠습니까?`}
+          description="게시글 및 RSS 프로필 페이지 조회가 제한됩니다."
+          owner={rss.owner ? { id: rss.owner.id, userName: rss.owner.userName } : undefined}
+          ownedRss={otherOwnedRss}
+          onConfirm={handleBlock}
+        />
 
         <ReportDialog
           open={showReportDialog}
           onOpenChange={setShowReportDialog}
           title={`${rss.name} RSS 신고`}
           isPending={isReportPending}
-          withBlockOption
-          blockLabel="이 RSS도 함께 차단하기"
-          blockDescription="차단하면 이 RSS의 게시글이 더 이상 노출되지 않습니다."
           onSubmit={handleReport}
         />
       </Layout>

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -1,4 +1,5 @@
 import { ApiData } from "@/types/api";
+import { RssOwner } from "@/types/profile";
 
 export interface FeedBase {
   id: number;
@@ -26,9 +27,8 @@ export interface FeedDetail extends Omit<FeedBase, "blog"> {
   blog: {
     id: number;
     name: string;
-    ownerId: number | null;
-    ownerName: string | null;
-    isOwnerCertified: boolean;
+    userName: string;
+    owner: RssOwner | null;
     platform: string;
     image: string | null;
   };

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -26,6 +26,7 @@ export interface FeedDetail extends Omit<FeedBase, "blog"> {
   blog: {
     id: number;
     name: string;
+    ownerId: number | null;
     ownerName: string | null;
     isOwnerCertified: boolean;
     platform: string;

--- a/server/src/feed/dto/response/getFeedDetail.ts
+++ b/server/src/feed/dto/response/getFeedDetail.ts
@@ -2,6 +2,8 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { FeedView } from '@feed/entity/feed.entity';
 
+import { RssOwnerDto } from '@rss/dto/response/getRssInfo.dto';
+
 export class GetFeedDetailResponseDto {
   @ApiProperty({
     example: 1,
@@ -73,9 +75,8 @@ export class GetFeedDetailResponseDto {
     example: {
       id: 1,
       name: 'example author',
-      ownerId: 1,
-      ownerName: '조민석',
-      isOwnerCertified: true,
+      userName: '조민석',
+      owner: { id: 1, userName: '조민석', profileImage: null },
       platform: 'example platform',
       image: 'https://example.com/profile.png',
     },
@@ -84,9 +85,8 @@ export class GetFeedDetailResponseDto {
   blog: {
     id: number;
     name: string;
-    ownerId: number | null;
-    ownerName: string | null;
-    isOwnerCertified: boolean;
+    userName: string;
+    owner: RssOwnerDto | null;
     platform: string;
     image: string | null;
   };
@@ -111,7 +111,15 @@ export class GetFeedDetailResponseDto {
   static toResponseDto(
     feed: FeedView,
     isOwner = false,
-    blogMeta: { id: number; userName: string; userId: number | null },
+    blogMeta: {
+      id: number;
+      userName: string;
+      owner: {
+        id: number;
+        userName: string;
+        profileImage: string | null;
+      } | null;
+    },
     isSubscribed = false,
     isBlocked = false,
   ) {
@@ -130,9 +138,8 @@ export class GetFeedDetailResponseDto {
       blog: {
         id: blogMeta.id,
         name: feed.blogName,
-        ownerId: blogMeta.userId ?? null,
-        ownerName: blogMeta.userName,
-        isOwnerCertified: blogMeta.userId != null,
+        userName: blogMeta.userName,
+        owner: blogMeta.owner,
         platform: feed.blogPlatform,
         image: feed.blogImage ?? null,
       },

--- a/server/src/feed/dto/response/getFeedDetail.ts
+++ b/server/src/feed/dto/response/getFeedDetail.ts
@@ -73,6 +73,7 @@ export class GetFeedDetailResponseDto {
     example: {
       id: 1,
       name: 'example author',
+      ownerId: 1,
       ownerName: '조민석',
       isOwnerCertified: true,
       platform: 'example platform',
@@ -83,6 +84,7 @@ export class GetFeedDetailResponseDto {
   blog: {
     id: number;
     name: string;
+    ownerId: number | null;
     ownerName: string | null;
     isOwnerCertified: boolean;
     platform: string;
@@ -97,7 +99,8 @@ export class GetFeedDetailResponseDto {
 
   @ApiProperty({
     example: false,
-    description: '요청자가 해당 게시글의 RSS를 차단했는지 여부 (비로그인 시 false)',
+    description:
+      '요청자가 해당 게시글의 RSS를 차단했는지 여부 (비로그인 시 false)',
   })
   isBlocked: boolean;
 
@@ -127,6 +130,7 @@ export class GetFeedDetailResponseDto {
       blog: {
         id: blogMeta.id,
         name: feed.blogName,
+        ownerId: blogMeta.userId ?? null,
         ownerName: blogMeta.userName,
         isOwnerCertified: blogMeta.userId != null,
         platform: feed.blogPlatform,

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -1,6 +1,14 @@
 import { Injectable } from '@nestjs/common';
 
-import { Brackets, DataSource, In, IsNull, LessThan, Raw, Repository } from 'typeorm';
+import {
+  Brackets,
+  DataSource,
+  In,
+  IsNull,
+  LessThan,
+  Raw,
+  Repository,
+} from 'typeorm';
 
 import { ReadFeedPaginationRequestDto } from '@feed/dto/request/readFeedPagination.dto';
 import { SearchType } from '@feed/dto/request/searchFeed.dto';
@@ -76,7 +84,8 @@ export class FeedRepository extends Repository<Feed> {
         // 잔디 집계(DATE_FORMAT 기준)와 동일한 날짜 범위. 인덱스 활용을 위해 범위 조건 사용.
         ...(date && {
           createdAt: Raw(
-            (alias) => `${alias} >= :date AND ${alias} < DATE_ADD(:date, INTERVAL 1 DAY)`,
+            (alias) =>
+              `${alias} >= :date AND ${alias} < DATE_ADD(:date, INTERVAL 1 DAY)`,
             { date },
           ),
         }),
@@ -160,7 +169,10 @@ export class FeedRepository extends Repository<Feed> {
     blogId: number,
     isPublic: boolean,
   ) {
-    const result = await this.update({ id: feedId, blog: { id: blogId } }, { isPublic });
+    const result = await this.update(
+      { id: feedId, blog: { id: blogId } },
+      { isPublic },
+    );
 
     return result.affected ?? 0;
   }
@@ -169,13 +181,22 @@ export class FeedRepository extends Repository<Feed> {
     return this.exists({ where: { id: feedId, blog: { userId } } });
   }
 
-  async getBlogMetaByFeedId(
-    feedId: number,
-  ): Promise<{ id: number; userName: string; userId: number | null } | null> {
+  async getBlogMetaByFeedId(feedId: number): Promise<{
+    id: number;
+    userName: string;
+    owner: { id: number; userName: string; profileImage: string | null } | null;
+  } | null> {
     const feed = await this.findOne({
       where: { id: feedId },
-      relations: { blog: true },
-      select: { id: true, blog: { id: true, userName: true, userId: true } },
+      relations: { blog: { user: true } },
+      select: {
+        id: true,
+        blog: {
+          id: true,
+          userName: true,
+          user: { id: true, userName: true, profileImage: true },
+        },
+      },
     });
 
     if (!feed?.blog) return null;
@@ -183,7 +204,13 @@ export class FeedRepository extends Repository<Feed> {
     return {
       id: feed.blog.id,
       userName: feed.blog.userName,
-      userId: feed.blog.userId,
+      owner: feed.blog.user
+        ? {
+            id: feed.blog.user.id,
+            userName: feed.blog.user.userName,
+            profileImage: feed.blog.user.profileImage ?? null,
+          }
+        : null,
     };
   }
 

--- a/server/src/notification/listener/comment.listener.ts
+++ b/server/src/notification/listener/comment.listener.ts
@@ -27,9 +27,9 @@ export class CommentListener {
     if (parentAuthorId === null) {
       try {
         const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
-        if (blogMeta?.userId && blogMeta.userId !== commenterUserId) {
+        if (blogMeta?.owner && blogMeta.owner.id !== commenterUserId) {
           await this.notificationService.upsertCommentNotification(
-            blogMeta.userId,
+            blogMeta.owner.id,
             feedId,
           );
         }
@@ -58,10 +58,10 @@ export class CommentListener {
   async handleCommentDeleted({ feedId, parentAuthorId }: CommentDeletedEvent) {
     try {
       const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
-      if (blogMeta?.userId) {
+      if (blogMeta?.owner) {
         await this.notificationService.removeCommentNotificationIfEmpty(
           feedId,
-          blogMeta.userId,
+          blogMeta.owner.id,
         );
       }
     } catch (error) {

--- a/server/src/notification/listener/like.listener.ts
+++ b/server/src/notification/listener/like.listener.ts
@@ -22,10 +22,13 @@ export class LikeListener {
   async handleLikeCreated({ feedId, likerUserId }: LikeCreatedEvent) {
     try {
       const blogMeta = await this.feedRepository.getBlogMetaByFeedId(feedId);
-      if (!blogMeta?.userId) return;
-      if (blogMeta.userId === likerUserId) return;
+      if (!blogMeta?.owner) return;
+      if (blogMeta.owner.id === likerUserId) return;
 
-      await this.notificationService.upsertLikeNotification(blogMeta.userId, feedId);
+      await this.notificationService.upsertLikeNotification(
+        blogMeta.owner.id,
+        feedId,
+      );
     } catch (error) {
       this.logger.error(
         `[LikeListener]: 좋아요 알림 생성 중 오류 발생 (feedId: ${feedId}): ${error}`,
@@ -39,7 +42,10 @@ export class LikeListener {
       const feed = await this.feedRepository.findOneBy({ id: feedId });
       if (!feed) return;
 
-      await this.notificationService.removeLikeNotificationIfEmpty(feedId, feed.likeCount);
+      await this.notificationService.removeLikeNotificationIfEmpty(
+        feedId,
+        feed.likeCount,
+      );
     } catch (error) {
       this.logger.error(
         `[LikeListener]: 좋아요 알림 삭제 중 오류 발생 (feedId: ${feedId}): ${error}`,

--- a/server/test/feed/e2e/detail.e2e-spec.ts
+++ b/server/test/feed/e2e/detail.e2e-spec.ts
@@ -6,9 +6,9 @@ import TestAgent from 'supertest/lib/agent';
 import { Activity } from '@activity/entity/activity.entity';
 import { ActivityRepository } from '@activity/repository/activity.repository';
 
-import { RedisService } from '@common/redis/redis.service';
-
 import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { RedisService } from '@common/redis/redis.service';
 
 import { ManageFeedRequestDto } from '@feed/dto/request/manageFeed.dto';
 import { Feed } from '@feed/entity/feed.entity';
@@ -103,8 +103,8 @@ describe(`GET ${URL}/{feedId} E2E Test`, () => {
       blog: {
         id: feedList[0].blog.id,
         name: feedList[0].blog.name,
-        ownerName: feedList[0].blog.userName,
-        isOwnerCertified: false,
+        userName: feedList[0].blog.userName,
+        owner: null,
         platform: 'etc',
         image: feedList[0].blog.blogImage ?? null,
       },
@@ -140,8 +140,8 @@ describe(`GET ${URL}/{feedId} E2E Test`, () => {
       blog: {
         id: feedList[1].blog.id,
         name: feedList[1].blog.name,
-        ownerName: feedList[1].blog.userName,
-        isOwnerCertified: false,
+        userName: feedList[1].blog.userName,
+        owner: null,
         platform: feedList[1].blog.blogPlatform,
         image: feedList[1].blog.blogImage ?? null,
       },
@@ -329,7 +329,8 @@ describe(`GET ${URL}/{feedId} E2E Test`, () => {
           activityRepository.find({ where: { user: { id: user.id } } }),
         ]);
       } while (
-        (updatedUser.totalViews === user.totalViews || activities.length === 0) &&
+        (updatedUser.totalViews === user.totalViews ||
+          activities.length === 0) &&
         Date.now() < deadline
       );
 

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -3,6 +3,8 @@ import { ConflictException, NotFoundException } from '@nestjs/common';
 import axios from 'axios';
 import { Request, Response } from 'express';
 
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 
@@ -15,8 +17,6 @@ import {
   FeedViewRepository,
 } from '@feed/repository/feed.repository';
 import { FeedService } from '@feed/service/feed.service';
-
-import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
@@ -122,12 +122,19 @@ describe(`${FeedService.name} Unit Test`, () => {
   describe('getPublicFeed', () => {
     it('존재하지 않으면 NotFoundException을 던진다.', async () => {
       feedRepository.findOneBy.mockResolvedValue(null);
-      await expect(feedService.getPublicFeed(1)).rejects.toThrow(NotFoundException);
+      await expect(feedService.getPublicFeed(1)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('비공개 게시글이면 NotFoundException을 던진다.', async () => {
-      feedRepository.findOneBy.mockResolvedValue({ id: 1, isPublic: false } as any);
-      await expect(feedService.getPublicFeed(1)).rejects.toThrow(NotFoundException);
+      feedRepository.findOneBy.mockResolvedValue({
+        id: 1,
+        isPublic: false,
+      } as any);
+      await expect(feedService.getPublicFeed(1)).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('공개 게시글이면 피드를 반환한다.', async () => {
@@ -417,7 +424,11 @@ describe(`${FeedService.name} Unit Test`, () => {
   });
 
   describe('getFeedDetail', () => {
-    const blogMeta = { id: 1, userName: '조민석', userId: 5 };
+    const blogMeta = {
+      id: 1,
+      userName: '조민석',
+      owner: { id: 5, userName: '조민석', profileImage: null },
+    };
 
     it('피드 뷰를 조회하고 상세 응답으로 변환한다.', async () => {
       // given

--- a/server/test/notification/unit/comment.listener.unit.spec.ts
+++ b/server/test/notification/unit/comment.listener.unit.spec.ts
@@ -45,7 +45,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: null,
+        owner: null,
       });
 
       // when
@@ -64,7 +64,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 2,
+        owner: { id: 2, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -83,7 +83,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -105,7 +105,9 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        commentListener.handleCommentCreated(new CommentCreatedEvent(10, 2, null)),
+        commentListener.handleCommentCreated(
+          new CommentCreatedEvent(10, 2, null),
+        ),
       ).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
     });
@@ -115,7 +117,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -134,7 +136,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -153,7 +155,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -162,9 +164,10 @@ describe(`${CommentListener.name} Unit Test`, () => {
       );
 
       // then
-      expect(
-        notificationService.upsertReplyNotification,
-      ).toHaveBeenCalledWith(5, 10);
+      expect(notificationService.upsertReplyNotification).toHaveBeenCalledWith(
+        5,
+        10,
+      );
     });
 
     it('내 게시글의 내 댓글에 답글이 달리면 답글 알림만 생성하고 댓글 알림은 생성하지 않는다.', async () => {
@@ -172,7 +175,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -195,7 +198,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
       notificationService.upsertReplyNotification.mockRejectedValue(
         new Error('db down'),
@@ -203,9 +206,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        commentListener.handleCommentCreated(
-          new CommentCreatedEvent(10, 2, 5),
-        ),
+        commentListener.handleCommentCreated(new CommentCreatedEvent(10, 2, 5)),
       ).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
     });
@@ -217,11 +218,13 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: null,
+        owner: null,
       });
 
       // when
-      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10, null));
+      await commentListener.handleCommentDeleted(
+        new CommentDeletedEvent(10, null),
+      );
 
       // then
       expect(
@@ -234,11 +237,13 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
-      await commentListener.handleCommentDeleted(new CommentDeletedEvent(10, null));
+      await commentListener.handleCommentDeleted(
+        new CommentDeletedEvent(10, null),
+      );
 
       // then
       expect(
@@ -264,7 +269,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -283,7 +288,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
 
       // when
@@ -302,7 +307,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'owner', profileImage: null },
       });
       notificationService.removeReplyNotificationIfEmpty.mockRejectedValue(
         new Error('db down'),
@@ -310,9 +315,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        commentListener.handleCommentDeleted(
-          new CommentDeletedEvent(10, 5),
-        ),
+        commentListener.handleCommentDeleted(new CommentDeletedEvent(10, 5)),
       ).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
     });

--- a/server/test/notification/unit/like.listener.unit.spec.ts
+++ b/server/test/notification/unit/like.listener.unit.spec.ts
@@ -1,12 +1,12 @@
-import { LikeListener } from '@notification/listener/like.listener';
-import { NotificationService } from '@notification/service/notification.service';
-
 import { WinstonLoggerService } from '@common/logger/logger.service';
 
 import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { LikeCreatedEvent } from '@like/event/like-created.event';
 import { LikeDeletedEvent } from '@like/event/like-deleted.event';
+
+import { LikeListener } from '@notification/listener/like.listener';
+import { NotificationService } from '@notification/service/notification.service';
 
 describe(`${LikeListener.name} Unit Test`, () => {
   let likeListener: LikeListener;
@@ -42,7 +42,7 @@ describe(`${LikeListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: null,
+        owner: null,
       });
 
       // when
@@ -57,7 +57,7 @@ describe(`${LikeListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 2,
+        owner: { id: 2, userName: 'blog-owner', profileImage: null },
       });
 
       // when
@@ -72,7 +72,7 @@ describe(`${LikeListener.name} Unit Test`, () => {
       feedRepository.getBlogMetaByFeedId.mockResolvedValue({
         id: 1,
         userName: 'blog',
-        userId: 99,
+        owner: { id: 99, userName: 'blog-owner', profileImage: null },
       });
 
       // when


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #888

### 소주제1

-   댓글/게시글/유저 신고 각 화면마다 다른 신고+차단 UX(신고 다이얼로그 내 차단 스위치)를 쓰고 있어서 일관성이 없었음. `ReportDialog`에서 차단 옵션을 제거하고, 신고 성공 후 공통 `BlockConfirmDialog`를 띄우는 방식으로 통일함.
-   유저를 차단할 때 그 유저 소유의 RSS를 함께 차단할 수 있어야 한다는 인수조건이 있어서, `BlockConfirmDialog`에 소유 RSS 목록을 보여주고 개별/전체 선택해서 함께 차단하는 UI를 추가함.

### 소주제2

-   `BlockConfirmDialog`에서 "소유주도 차단"을 고르면 프론트가 `ownerId`로 유저를 알아야 하는데, 서버 응답의 `blog.ownerId`가 RssAccept 컬럼값 그대로라 실제 연동된 User 정보(프로필 이미지 등)를 못 받아오고 있었음.
-   `blog.ownerId` / `blog.ownerName` / `blog.isOwnerCertified` 3개 필드로 흩어져 있던 소유자 정보를 `owner: { id, userName, profileImage } | null` 하나로 묶음 (`isOwnerCertified`는 `owner !== null`로 대체되어 삭제). 기존에 이미 존재하던 `GetRssInfoResponseDto.owner` 패턴과 동일한 구조로 맞춤.
-   레포지토리에서 `blog.user` relation을 join하도록 바꿔서, 등록 신청자 이름(`blog.userName`, 항상 존재)과 실제 연동된 User 정보(`blog.owner`, 미인증 시 null)를 명확히 분리함.

# 📋 작업 내용

-   RSS(게시글) 신고 시 신고 접수 후 RSS/소유자 차단 다이얼로그 노출 (`RssPage.tsx`)
-   댓글 신고 시 신고 접수 후 작성자/작성자 소유 RSS 차단 다이얼로그로 통일 (`PostComment.tsx`)
-   유저 프로필 신고·차단 시에도 해당 유저 소유 RSS를 함께 차단 가능하도록 구현 (`ProfileHeader.tsx`)
-   `ReportDialog`에서 차단 스위치(`withBlockOption`) 제거, `BlockConfirmDialog` 신규 컴포넌트로 차단 UX 통일
-   게시글 상세 응답(`GetFeedDetailResponseDto.blog`)의 `ownerId`/`ownerName`/`isOwnerCertified`를 `owner: { id, userName, profileImage } | null`로 통합, 실제 User relation을 join하도록 레포지토리 쿼리 수정
-   좋아요/댓글 알림 리스너(`like.listener.ts`, `comment.listener.ts`)를 변경된 `blogMeta.owner` 구조에 맞게 수정
-   관련 유닛/e2e 테스트, storybook fixture 업데이트

# 📷 스크린 샷(선택 사항)

<img width="516" height="349" alt="image" src="https://github.com/user-attachments/assets/3d2fc3f7-91e8-46e4-ab35-096905365167" />