### PR TITLE
🐛 fix: Open Graph 이미지 경로 및 메타데이터 개선

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -19,9 +19,10 @@
     <meta name="keywords" content="블로그, 개발자, 데나무, 개발, 개발 블로그, 개발 허브" />
     <meta property="og:title" content="Denamu" />
     <meta property="og:description" content="개발자들의 블로그 허브 데나무" />
-    <meta property="og:image" content="src/assets/logo-denamu-title.svg" />
+    <meta property="og:image" content="https://denamu.dev/files/Denamu_Logo_KOR.png" />
     <meta property="og:url" content="https://denamu.dev" />
     <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
     <script
       src="https://t1.kakaocdn.net/kakao_js_sdk/2.7.4/kakao.min.js"
       integrity="sha384-DKYJZ8NLiK8MN4/C5P2dtSmLQ4KwPaoqAfyA/DfmEc1VDxu4yyC7wy6K1Hs90nka"

--- a/client/src/components/common/Card/PostDetail.tsx
+++ b/client/src/components/common/Card/PostDetail.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useCallback } from "react";
+import { Helmet } from "react-helmet";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { X } from "lucide-react";
@@ -56,6 +57,9 @@ export default function PostDetail() {
       style={{ paddingRight: scrollbarWidth }}
       onClick={handleClickOutside}
     >
+      <Helmet>
+        <title>{data.data.title} - 데나무</title>
+      </Helmet>
       <div ref={modalRef} className="bg-white rounded-md w-[90%] max-w-4xl h-auto relative">
         {!isHeaderVisible && (
           <FixedHeader title={data.data.title} onClose={closeDetail} scrollbarWidth={scrollbarWidth} />

--- a/client/src/pages/PostDetailPage.tsx
+++ b/client/src/pages/PostDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { Helmet } from "react-helmet";
 import { useLocation, useParams } from "react-router-dom";
 
 import { BlockedFeedNotice } from "@/components/common/Card/detail/BlockedFeedNotice";
@@ -49,6 +50,9 @@ export default function PostDetailPage() {
 
   return (
     <div ref={modalRef} className="bg-white overflow-y-auto relative">
+      <Helmet>
+        <title>{data.data.title} - 데나무</title>
+      </Helmet>
       <Header />
       <div className="mt-5 px-10 md:px-40 flex flex-col gap-2 max-w-7xl mx-auto">
         <PostHeader data={data.data} />

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,6 +6,22 @@ upstream denamu_backend {
     include /etc/nginx/conf.d/denamu_active_backend.conf;
 }
 
+# OG(Open Graph) 스크래퍼 감지 - 게시글 상세 경로에서 봇에게만 서버 렌더링 메타태그를 응답
+map $http_user_agent $is_og_bot {
+    default 0;
+    ~*facebookexternalhit 1;
+    ~*Twitterbot 1;
+    ~*Slackbot 1;
+    ~*TelegramBot 1;
+    ~*Discordbot 1;
+    ~*LinkedInBot 1;
+    ~*KakaoTalk-Scrap 1;
+    ~*Googlebot 1;
+    ~*bingbot 1;
+    ~*Yeti 1;
+    ~*bot 1;
+}
+
 # HTTP로 들어오는 요청을 HTTPS로 Redirect
 server {
     listen 80;
@@ -90,6 +106,54 @@ server {
     location / {
         root /var/dist;
         index index.html;
+        try_files $uri /index.html;
+    }
+
+    # 게시글 상세 경로 - OG 스크래퍼 봇이면 서버 렌더링 메타태그 HTML로, 아니면 기존 SPA로
+    location ~ ^/[0-9]+$ {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        if ($is_og_bot) {
+            proxy_pass http://denamu_backend/api/feeds$uri/og;
+            break;
+        }
+
+        root /var/dist;
+        try_files $uri /index.html;
+    }
+
+    # 프로필 상세 경로 - OG 스크래퍼 봇이면 서버 렌더링 메타태그 HTML로, 아니면 기존 SPA로
+    location ~ ^/profile/([0-9]+)$ {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        if ($is_og_bot) {
+            proxy_pass http://denamu_backend/api/users/$1/profile/og;
+            break;
+        }
+
+        root /var/dist;
+        try_files $uri /index.html;
+    }
+
+    # RSS(블로그) 상세 경로 - OG 스크래퍼 봇이면 서버 렌더링 메타태그 HTML로, 아니면 기존 SPA로
+    location ~ ^/rss/([0-9]+)$ {
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        if ($is_og_bot) {
+            proxy_pass http://denamu_backend/api/rss/$1/og;
+            break;
+        }
+
+        root /var/dist;
         try_files $uri /index.html;
     }
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,6 +35,24 @@ http {
 	error_log /var/log/nginx/error.log error;
 
 	##
+	# OG(Open Graph) 스크래퍼 감지 - 게시글 상세 경로에서 봇에게만 서버 렌더링 메타태그를 응답
+	##
+	map $http_user_agent $is_og_bot {
+		default 0;
+		~*facebookexternalhit 1;
+		~*Twitterbot 1;
+		~*Slackbot 1;
+		~*TelegramBot 1;
+		~*Discordbot 1;
+		~*LinkedInBot 1;
+		~*KakaoTalk-Scrap 1;
+		~*Googlebot 1;
+		~*bingbot 1;
+		~*Yeti 1;
+		~*bot 1;
+	}
+
+	##
 	# Gzip Settings
 	##
 
@@ -73,6 +91,54 @@ http {
 		location / {
 			root /var/web05-Denamu/client/dist;
 			index index.html;
+			try_files $uri /index.html;
+		}
+
+		# 게시글 상세 경로 - OG 스크래퍼 봇이면 서버 렌더링 메타태그 HTML로, 아니면 기존 SPA로
+		location ~ ^/[0-9]+$ {
+			proxy_set_header Host $host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+
+			if ($is_og_bot) {
+				proxy_pass http://app:8080/api/feeds$uri/og;
+				break;
+			}
+
+			root /var/web05-Denamu/client/dist;
+			try_files $uri /index.html;
+		}
+
+		# 프로필 상세 경로 - OG 스크래퍼 봇이면 서버 렌더링 메타태그 HTML로, 아니면 기존 SPA로
+		location ~ ^/profile/([0-9]+)$ {
+			proxy_set_header Host $host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+
+			if ($is_og_bot) {
+				proxy_pass http://app:8080/api/users/$1/profile/og;
+				break;
+			}
+
+			root /var/web05-Denamu/client/dist;
+			try_files $uri /index.html;
+		}
+
+		# RSS(블로그) 상세 경로 - OG 스크래퍼 봇이면 서버 렌더링 메타태그 HTML로, 아니면 기존 SPA로
+		location ~ ^/rss/([0-9]+)$ {
+			proxy_set_header Host $host;
+			proxy_set_header X-Real-IP $remote_addr;
+			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+			proxy_set_header X-Forwarded-Proto $scheme;
+
+			if ($is_og_bot) {
+				proxy_pass http://app:8080/api/rss/$1/og;
+				break;
+			}
+
+			root /var/web05-Denamu/client/dist;
 			try_files $uri /index.html;
 		}
 

--- a/server/src/common/util/renderOgHtml.ts
+++ b/server/src/common/util/renderOgHtml.ts
@@ -1,0 +1,98 @@
+const DEFAULT_OG_TITLE = 'Denamu';
+const DEFAULT_OG_DESCRIPTION = '개발자들의 블로그 허브 데나무';
+const DEFAULT_OG_IMAGE = 'https://denamu.dev/files/Denamu_Logo_KOR.png';
+const SITE_URL = 'https://denamu.dev';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function renderDefaultOgHtml(): string {
+  return renderOgHtml({
+    title: DEFAULT_OG_TITLE,
+    description: DEFAULT_OG_DESCRIPTION,
+    image: DEFAULT_OG_IMAGE,
+    url: SITE_URL,
+    type: 'website',
+  });
+}
+
+export function renderFeedOgHtml(feed: {
+  feedId: number;
+  title: string;
+  summary: string | null;
+  thumbnail: string | null;
+}): string {
+  return renderOgHtml({
+    title: `Denamu - ${feed.title}`,
+    description: feed.summary ?? DEFAULT_OG_DESCRIPTION,
+    image: feed.thumbnail ?? DEFAULT_OG_IMAGE,
+    url: `${SITE_URL}/${feed.feedId}`,
+    type: 'article',
+  });
+}
+
+export function renderProfileOgHtml(profile: {
+  userId: number;
+  userName: string;
+  introduction: string | null;
+  profileImage: string | null;
+}): string {
+  return renderOgHtml({
+    title: `Denamu - ${profile.userName}`,
+    description: profile.introduction ?? DEFAULT_OG_DESCRIPTION,
+    image: profile.profileImage ?? DEFAULT_OG_IMAGE,
+    url: `${SITE_URL}/profile/${profile.userId}`,
+    type: 'profile',
+  });
+}
+
+export function renderRssOgHtml(rss: {
+  rssId: number;
+  name: string;
+  blogImage: string | null;
+}): string {
+  return renderOgHtml({
+    title: `Denamu - ${rss.name}`,
+    description: DEFAULT_OG_DESCRIPTION,
+    image: rss.blogImage ?? DEFAULT_OG_IMAGE,
+    url: `${SITE_URL}/rss/${rss.rssId}`,
+    type: 'website',
+  });
+}
+
+function renderOgHtml(params: {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+  type: string;
+}): string {
+  const title = escapeHtml(params.title);
+  const description = escapeHtml(params.description);
+  const image = escapeHtml(params.image);
+  const url = escapeHtml(params.url);
+  const type = escapeHtml(params.type);
+
+  return `<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8" />
+<title>${title}</title>
+<meta property="og:title" content="${title}" />
+<meta property="og:description" content="${description}" />
+<meta property="og:image" content="${image}" />
+<meta property="og:url" content="${url}" />
+<meta property="og:type" content="${type}" />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="canonical" href="${url}" />
+</head>
+<body></body>
+</html>
+`;
+}

--- a/server/src/common/util/renderOgHtml.ts
+++ b/server/src/common/util/renderOgHtml.ts
@@ -19,6 +19,7 @@ export function renderDefaultOgHtml(): string {
     image: DEFAULT_OG_IMAGE,
     url: SITE_URL,
     type: 'website',
+    twitterCard: 'summary',
   });
 }
 
@@ -34,6 +35,7 @@ export function renderFeedOgHtml(feed: {
     image: feed.thumbnail ?? DEFAULT_OG_IMAGE,
     url: `${SITE_URL}/${feed.feedId}`,
     type: 'article',
+    twitterCard: 'summary_large_image',
   });
 }
 
@@ -49,6 +51,7 @@ export function renderProfileOgHtml(profile: {
     image: profile.profileImage ?? DEFAULT_OG_IMAGE,
     url: `${SITE_URL}/profile/${profile.userId}`,
     type: 'profile',
+    twitterCard: 'summary',
   });
 }
 
@@ -63,6 +66,7 @@ export function renderRssOgHtml(rss: {
     image: rss.blogImage ?? DEFAULT_OG_IMAGE,
     url: `${SITE_URL}/rss/${rss.rssId}`,
     type: 'website',
+    twitterCard: 'summary',
   });
 }
 
@@ -72,6 +76,7 @@ function renderOgHtml(params: {
   image: string;
   url: string;
   type: string;
+  twitterCard: 'summary' | 'summary_large_image';
 }): string {
   const title = escapeHtml(params.title);
   const description = escapeHtml(params.description);
@@ -89,7 +94,7 @@ function renderOgHtml(params: {
 <meta property="og:image" content="${image}" />
 <meta property="og:url" content="${url}" />
 <meta property="og:type" content="${type}" />
-<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:card" content="${params.twitterCard}" />
 <link rel="canonical" href="${url}" />
 </head>
 <body></body>

--- a/server/src/feed/controller/feed.controller.ts
+++ b/server/src/feed/controller/feed.controller.ts
@@ -2,8 +2,10 @@ import {
   Controller,
   Get,
   Head,
+  Header,
   HttpCode,
   HttpStatus,
+  NotFoundException,
   Param,
   Post,
   Query,
@@ -13,7 +15,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 
 import { Request, Response } from 'express';
 import { Observable } from 'rxjs';
@@ -21,6 +23,10 @@ import { Observable } from 'rxjs';
 import { CurrentUser } from '@common/decorator/current-user.decorator';
 import { JwtGuard, OptionalJwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
+import {
+  renderDefaultOgHtml,
+  renderFeedOgHtml,
+} from '@common/util/renderOgHtml';
 
 import { ApiDeleteCheckFeed } from '@feed/api-docs/deleteCheckFeed.api-docs';
 import { ApiGetFeedDetail } from '@feed/api-docs/getFeedDetail.api-docs';
@@ -180,5 +186,29 @@ export class FeedController {
       '요청이 성공적으로 처리되었습니다.',
       await this.feedService.getFeedDetail(feedDetailRequestDto, user?.id),
     );
+  }
+
+  @ApiExcludeEndpoint()
+  @Get(':feedId/og')
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/html; charset=utf-8')
+  async getFeedOg(@Param() feedDetailRequestDto: ManageFeedRequestDto) {
+    try {
+      const feed = await this.feedService.getFeedDetail(
+        feedDetailRequestDto,
+        undefined,
+      );
+      return renderFeedOgHtml({
+        feedId: feed.id,
+        title: feed.title,
+        summary: feed.summary,
+        thumbnail: feed.thumbnail,
+      });
+    } catch (err) {
+      if (err instanceof NotFoundException) {
+        return renderDefaultOgHtml();
+      }
+      throw err;
+    }
   }
 }

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -3,21 +3,27 @@ import {
   Controller,
   Delete,
   Get,
+  Header,
   HttpCode,
   HttpStatus,
+  NotFoundException,
   Param,
   Patch,
   Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 
 import { ReadActivityQueryRequestDto } from '@activity/dto/request/readActivity.dto';
 
 import { CurrentUser } from '@common/decorator';
 import { JwtGuard, OptionalJwtGuard, Payload } from '@common/guard/jwt.guard';
 import { ApiResponse } from '@common/response/common.response';
+import {
+  renderDefaultOgHtml,
+  renderRssOgHtml,
+} from '@common/util/renderOgHtml';
 
 import { ApiCreateRss } from '@rss/api-docs/createRss.api-docs';
 import { ApiCreateRssCertification } from '@rss/api-docs/createRssCertification.api-docs';
@@ -273,5 +279,25 @@ export class RssController {
       'RSS 게시글 목록 조회를 처리했습니다.',
       await this.rssService.getRssFeeds(paramDto.rssId, queryDto),
     );
+  }
+
+  @ApiExcludeEndpoint()
+  @Get(':rssId/og')
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/html; charset=utf-8')
+  async getRssOg(@Param() paramDto: GetRssInfoParamRequestDto) {
+    try {
+      const rss = await this.rssService.getRssInfo(paramDto.rssId);
+      return renderRssOgHtml({
+        rssId: paramDto.rssId,
+        name: rss.name,
+        blogImage: rss.blogImage,
+      });
+    } catch (err) {
+      if (err instanceof NotFoundException) {
+        return renderDefaultOgHtml();
+      }
+      throw err;
+    }
   }
 }

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -3,8 +3,10 @@ import {
   Controller,
   Delete,
   Get,
+  Header,
   HttpCode,
   HttpStatus,
+  NotFoundException,
   Param,
   Patch,
   Post,
@@ -12,7 +14,7 @@ import {
   Res,
   UseGuards,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiExcludeEndpoint, ApiTags } from '@nestjs/swagger';
 
 import { Response } from 'express';
 
@@ -25,6 +27,10 @@ import {
 } from '@common/guard/jwt.guard';
 import { LoginThrottlerGuard } from '@common/guard/login-throttler.guard';
 import { ApiResponse } from '@common/response/common.response';
+import {
+  renderDefaultOgHtml,
+  renderProfileOgHtml,
+} from '@common/util/renderOgHtml';
 
 import { ApiCertificateUser } from '@user/api-docs/certificateUser.api-docs';
 import { ApiChangePassword } from '@user/api-docs/changePassword.api-docs';
@@ -271,5 +277,26 @@ export class UserController {
     return ApiResponse.responseWithNoContent(
       '비밀번호가 성공적으로 수정되었습니다.',
     );
+  }
+
+  @ApiExcludeEndpoint()
+  @Get('/:id/profile/og')
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/html; charset=utf-8')
+  async getUserProfileOg(@Param() paramDto: GetUserProfileParamRequestDto) {
+    try {
+      const profile = await this.userService.getUserProfile(paramDto.id);
+      return renderProfileOgHtml({
+        userId: paramDto.id,
+        userName: profile.userName,
+        introduction: profile.introduction,
+        profileImage: profile.profileImage,
+      });
+    } catch (err) {
+      if (err instanceof NotFoundException) {
+        return renderDefaultOgHtml();
+      }
+      throw err;
+    }
   }
 }


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #889

### Open Graph 이미지 경로 누락 수정

-   `client/index.html`의 `og:image`가 상대 경로(`src/assets/...`)로 설정되어 있어 크롤러가 접근할 수 없었음. 절대 경로(`https://denamu.dev/files/Denamu_Logo_KOR.png`)로 변경.

### Open Graph API 구현

-   피드/RSS/유저 프로필 상세 페이지는 SPA라 크롤러(카카오톡, 트위터 등)가 실제 콘텐츠(썸네일, 제목, 요약)를 읽지 못하는 문제가 있었음.
-   각 리소스별로 서버에서 OG 메타 태그를 렌더링하는 엔드포인트(`/:feedId/og`, `/:rssId/og`, `/:id/profile/og`)를 추가하고, nginx에서 크롤러 User-Agent 요청을 해당 경로로 라우팅하도록 설정.
-   리소스를 찾지 못한 경우(404) 기본 OG(`renderDefaultOgHtml`)로 폴백 처리해 깨진 미리보기가 노출되지 않도록 함.
-   트위터 카드 타입을 리소스 성격에 맞게 구분(`summary` / `summary_large_image`) 적용.

# 📋 작업 내용

-   `server/src/common/util/renderOgHtml.ts`: OG HTML 렌더링 유틸 추가 (default/feed/profile/rss)
-   `server/src/feed/controller/feed.controller.ts`, `rss/controller/rss.controller.ts`, `user/controller/user.controller.ts`: `/og` 엔드포인트 추가 (Swagger 문서에서는 제외)
-   `nginx.conf`, `nginx/nginx.conf`: 크롤러 요청을 OG 엔드포인트로 라우팅
-   `client/index.html`: 기본 og:image 절대 경로로 수정, twitter:card 메타 추가
-   게시글 상세 탭 타이틀을 게시글 제목으로 표시하도록 `Helmet` 적용 (`PostDetail.tsx`, `PostDetailPage.tsx`)

# 📷 스크린 샷(선택 사항)
<img width="244" height="229" alt="image" src="https://github.com/user-attachments/assets/dd76e0d9-0191-4209-b72c-c2a11ecdd214" />