### PR TITLE
🐛 fix: feed crawler entity expansion 상한선 확장

### DIFF
--- a/feed-crawler/src/common/parser/base-feed-parser.ts
+++ b/feed-crawler/src/common/parser/base-feed-parser.ts
@@ -24,6 +24,11 @@ export abstract class BaseFeedParser {
     attributeNamePrefix: '@_',
     parseAttributeValue: true,
     trimValues: true,
+    processEntities: {
+      maxEntityCount: 200000,
+      maxTotalExpansions: 200000,
+      maxExpandedLength: 5_000_000,
+    },
   });
   protected readonly parserUtil: ParserUtil;
   protected readonly notifier: Notifier;

--- a/feed-crawler/test/config/constant/parser-fixtures.ts
+++ b/feed-crawler/test/config/constant/parser-fixtures.ts
@@ -89,6 +89,23 @@ export const ATOM_10_SINGLE_ENTRY = `<?xml version="1.0" encoding="UTF-8"?>
   </entry>
 </feed>`;
 
+// entity 참조가 많은 대용량 피드 (tistory/wordpress처럼 본문 전체가 escape된 HTML인 경우 재현)
+// fast-xml-parser 기본 상한(maxTotalExpansions/maxEntityCount: 1000)을 넘는 1500개 entity 참조 포함
+const ENTITY_HEAVY_DESCRIPTION = '&amp;&lt;'.repeat(750);
+export const RSS_20_ENTITY_HEAVY = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>대용량 블로그</title>
+    <link>https://rssfeed.com</link>
+    <item>
+      <title>entity가 많은 글</title>
+      <description>${ENTITY_HEAVY_DESCRIPTION}</description>
+      <link>https://rssfeed.com/entity-heavy</link>
+      <pubDate>${FIXED_DATE_UTC}</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
 // 잘못된 형식의 XML 데이터
 export const INVALID_XML = `<?xml version="1.0"?>
 <invalid>

--- a/feed-crawler/test/unit/parser.spec.ts
+++ b/feed-crawler/test/unit/parser.spec.ts
@@ -6,6 +6,7 @@ import {
   FIXED_DATE,
   INVALID_XML,
   MOCK_RSS_OBJ,
+  RSS_20_ENTITY_HEAVY,
   RSS_20_SAMPLE,
   RSS_20_SINGLE_ITEM,
 } from '@test/config/constant/parser-fixtures';
@@ -185,6 +186,11 @@ describe('Parser 모듈 테스트', () => {
         const result = rss20Parser.canParse(INVALID_XML);
         expect(result).toBe(false);
       });
+
+      it('entity 참조가 1000개를 초과하는 대용량 피드도 지원 형식으로 식별해야 한다 (tistory/wordpress 유사 케이스)', () => {
+        const result = rss20Parser.canParse(RSS_20_ENTITY_HEAVY);
+        expect(result).toBe(true);
+      });
     });
 
     describe('extractRawFeeds', () => {
@@ -219,6 +225,16 @@ describe('Parser 모듈 테스트', () => {
         expect(rawFeeds[0]).toMatchObject({
           title: '유일한 글',
           link: 'https://rssfeed.com/only',
+        });
+      });
+
+      it('entity 참조가 1000개를 초과하는 대용량 피드도 예외 없이 파싱해야 한다', () => {
+        const rawFeeds = rss20Parser['extractRawFeeds'](RSS_20_ENTITY_HEAVY);
+
+        expect(rawFeeds).toHaveLength(1);
+        expect(rawFeeds[0]).toMatchObject({
+          title: 'entity가 많은 글',
+          link: 'https://rssfeed.com/entity-heavy',
         });
       });
     });


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #899

### RSS 파싱 실패 원인

-   tistory/wordpress 계열처럼 게시글 본문 전체를 escape된 HTML로 담는 RSS 피드는 `&amp;`, `&lt;`, `&nbsp;` 등 표준 entity 참조가 매우 많음.
-   `fast-xml-parser`는 4.5.x부터 entity bomb(billion laughs) 방어를 위해 `processEntities` 상한을 기본 적용함(`maxTotalExpansions: 1000`, `maxEntityCount: 1000` 등). 이 값을 넘으면 파싱 자체가 예외를 던짐.
-   `FeedParserManager.findSuitableParser`는 각 파서의 `canParse()`가 파싱 예외를 내부에서 삼키고 `false`를 반환하도록 되어 있어, 실제로는 entity 상한 초과인데 "지원하지 않는 피드 형식"이라는 엉뚱한 에러로 보고됨.
-   실측: 승인된 RSS 21개 중 tistory 다수 + `jinlee.kr`, `dev.gmarket.com` 등에서 재현. `jinlee.kr/feed`는 entity 참조가 111,206개로 훨씬 큼.

### 왜 완전히 제거하지 않았는지

-   기본 1000이라는 값은 임의로 작아서 정상적인 대용량 피드까지 막는 게 문제였지만, 상한 자체를 없애면 향후 악성 DOCTYPE 커스텀 entity(재귀 확장) 방어가 약해짐.
-   재귀 확장(billion laughs)의 실질 방어선은 `maxExpansionDepth`(기본 10, 미변경)이므로, `maxTotalExpansions` 등은 실사용 최대치(111k)에 여유를 둔 200,000으로 상향하는 선에서 마무리함.

# 📋 작업 내용

-   `feed-crawler/src/common/parser/base-feed-parser.ts`: 공용 `XMLParser`에 `processEntities.maxEntityCount / maxTotalExpansions / maxExpandedLength` 상한을 상향 조정.
-   승인된 RSS 21개 전체 실제 fetch + `FeedParserManager` 실행으로 파싱 성공 확인 (`jacky0831`, `laurent`, `tunaspace`, `asn6878`, `dev.gmarket.com`, `oraciondev`, `skdltn210`, `seok3765`, `g-db`, `newcodes`, `jinlee.kr` 등 포함).