### PR TITLE
✨ feat: RSS 등록 모달 드롭다운 아이템 아이콘 설정

### DIFF
--- a/client/src/components/RssRegistration/PlatformSelector.tsx
+++ b/client/src/components/RssRegistration/PlatformSelector.tsx
@@ -1,3 +1,4 @@
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -22,13 +23,23 @@ export const BlogPlatformSelector = ({ platforms, value, onChange }: BlogPlatfor
       <Select value={value} onValueChange={onChange}>
         <SelectTrigger className="w-full">
           <SelectValue placeholder="플랫폼을 선택하세요">
-            {selectedPlatform?.label || "플랫폼을 선택하세요"}
+            {selectedPlatform ? (
+              <span className="flex items-center gap-2">
+                <PlatformIcon platform={selectedPlatform.value} className="w-4 h-4" />
+                {selectedPlatform.label}
+              </span>
+            ) : (
+              "플랫폼을 선택하세요"
+            )}
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {platforms.map((platform) => (
-            <SelectItem key={platform.value} value={platform.value}>
-              {platform.label}
+            <SelectItem key={platform.value} value={platform.value} className="py-2.5 pl-5 pr-1 text-base">
+              <span className="flex items-center gap-3">
+                <PlatformIcon platform={platform.value} className="w-5 h-5" />
+                {platform.label}
+              </span>
             </SelectItem>
           ))}
         </SelectContent>

--- a/client/src/components/profile/rss/PlatformIcon.tsx
+++ b/client/src/components/profile/rss/PlatformIcon.tsx
@@ -1,6 +1,6 @@
 import { Rss } from "lucide-react";
 
-const KNOWN_PLATFORMS = ["tistory", "velog", "medium", "naver"];
+const KNOWN_PLATFORMS = ["tistory", "velog", "medium", "naver", "github"];
 
 interface PlatformIconProps {
   platform: string;


### PR DESCRIPTION
# 🔨 테스크

### RSS 등록 모달 플랫폼 선택 아이콘 표시

-   RSS 등록 모달의 플랫폼 Select 컴포넌트에서 선택된 값과 드롭다운 각 항목에 `PlatformIcon`을 함께 표시하도록 개선
-   `PlatformIcon`의 `KNOWN_PLATFORMS`에 `github`을 추가

# 📋 작업 내용

-   `BlogPlatformSelector`의 `SelectValue`, `SelectItem`에 `PlatformIcon` 렌더링 추가
-   `KNOWN_PLATFORMS` 목록에 `github` 플랫폼 추가

# 📷 스크린 샷(선택 사항)
<img width="426" height="450" alt="image" src="https://github.com/user-attachments/assets/96f07aa0-6fca-43d8-a7a2-143be2f5fa91" />
