### PR TITLE
💄 style: DTO 변환 함수 이름 변경

### DIFF
--- a/server/src/board/dto/response/board.dto.ts
+++ b/server/src/board/dto/response/board.dto.ts
@@ -32,7 +32,7 @@ export class BoardSummaryDto {
     Object.assign(this, partial);
   }
 
-  static fromSummary(board: Board): BoardSummaryDto {
+  static toResultDto(board: Board): BoardSummaryDto {
     return new BoardSummaryDto({
       id: board.id,
       title: board.title,
@@ -45,8 +45,8 @@ export class BoardSummaryDto {
     });
   }
 
-  static fromSummaryArray(boards: Board[]): BoardSummaryDto[] {
-    return boards.map((board) => this.fromSummary(board));
+  static toResultDtoArray(boards: Board[]): BoardSummaryDto[] {
+    return boards.map((board) => this.toResultDto(board));
   }
 }
 
@@ -72,7 +72,7 @@ export class BoardDetailDto extends BoardSummaryDto {
     Object.assign(this, partial);
   }
 
-  static fromDetail(board: Board): BoardDetailDto {
+  static toResponseDto(board: Board): BoardDetailDto {
     return new BoardDetailDto({
       id: board.id,
       title: board.title,
@@ -109,14 +109,14 @@ export class BoardListResponseDto {
     Object.assign(this, partial);
   }
 
-  static of(
+  static toResponseDto(
     boards: Board[],
     page: number,
     limit: number,
     totalCount: number,
   ): BoardListResponseDto {
     return new BoardListResponseDto({
-      result: BoardSummaryDto.fromSummaryArray(boards),
+      result: BoardSummaryDto.toResultDtoArray(boards),
       page,
       limit,
       totalCount,

--- a/server/src/board/service/board.service.ts
+++ b/server/src/board/service/board.service.ts
@@ -40,7 +40,7 @@ export class BoardService {
       new Date(),
       category,
     );
-    return BoardListResponseDto.of(items, page, limit, totalCount);
+    return BoardListResponseDto.toResponseDto(items, page, limit, totalCount);
   }
 
   async getPublicBoard(id: number): Promise<BoardDetailDto> {
@@ -48,7 +48,7 @@ export class BoardService {
     if (!board) {
       throw new NotFoundException(NOT_FOUND_MESSAGE);
     }
-    return BoardDetailDto.fromDetail(board);
+    return BoardDetailDto.toResponseDto(board);
   }
 
   async getAdminBoards(queryDto: GetAdminBoardsRequestDto) {
@@ -59,7 +59,7 @@ export class BoardService {
       status,
       category,
     );
-    return BoardListResponseDto.of(items, page, limit, totalCount);
+    return BoardListResponseDto.toResponseDto(items, page, limit, totalCount);
   }
 
   async getAdminBoard(id: number): Promise<BoardDetailDto> {
@@ -70,7 +70,7 @@ export class BoardService {
     if (!board) {
       throw new NotFoundException(NOT_FOUND_MESSAGE);
     }
-    return BoardDetailDto.fromDetail(board);
+    return BoardDetailDto.toResponseDto(board);
   }
 
   async createBoard(
@@ -99,7 +99,7 @@ export class BoardService {
       await this.notifyNoticePublished(board);
     }
 
-    return BoardDetailDto.fromDetail(board);
+    return BoardDetailDto.toResponseDto(board);
   }
 
   private isNoticeVisibleNow(board: Board): boolean {
@@ -177,7 +177,7 @@ export class BoardService {
     board.endAt = endAt;
 
     await this.boardRepository.save(board);
-    return BoardDetailDto.fromDetail(board);
+    return BoardDetailDto.toResponseDto(board);
   }
 
   async deleteBoard(id: number): Promise<void> {

--- a/server/src/qna/dto/response/qna.dto.ts
+++ b/server/src/qna/dto/response/qna.dto.ts
@@ -12,7 +12,7 @@ export class QnaCreatedDto {
     Object.assign(this, partial);
   }
 
-  static of(id: number): QnaCreatedDto {
+  static toResponseDto(id: number): QnaCreatedDto {
     return new QnaCreatedDto({ id });
   }
 }
@@ -43,7 +43,7 @@ export class QnaSummaryDto {
     Object.assign(this, partial);
   }
 
-  static fromSummary(qna: Qna): QnaSummaryDto {
+  static toResultDto(qna: Qna): QnaSummaryDto {
     return new QnaSummaryDto({
       id: qna.id,
       title: qna.title,
@@ -54,8 +54,8 @@ export class QnaSummaryDto {
     });
   }
 
-  static fromSummaryArray(qnas: Qna[]): QnaSummaryDto[] {
-    return qnas.map((qna) => this.fromSummary(qna));
+  static toResultDtoArray(qnas: Qna[]): QnaSummaryDto[] {
+    return qnas.map((qna) => this.toResultDto(qna));
   }
 }
 
@@ -79,14 +79,14 @@ export class QnaListResponseDto {
     Object.assign(this, partial);
   }
 
-  static of(
+  static toResponseDto(
     qnas: Qna[],
     page: number,
     limit: number,
     totalCount: number,
   ): QnaListResponseDto {
     return new QnaListResponseDto({
-      result: QnaSummaryDto.fromSummaryArray(qnas),
+      result: QnaSummaryDto.toResultDtoArray(qnas),
       page,
       limit,
       totalCount,
@@ -119,7 +119,7 @@ export class QnaMessageResponseDto {
     Object.assign(this, partial);
   }
 
-  static from(message: QnaMessage): QnaMessageResponseDto {
+  static toResultDto(message: QnaMessage): QnaMessageResponseDto {
     return new QnaMessageResponseDto({
       type: message.type,
       content: message.content,
@@ -144,7 +144,7 @@ export class QnaDetailDto extends QnaSummaryDto {
     Object.assign(this, partial);
   }
 
-  static fromDetail(qna: Qna): QnaDetailDto {
+  static toResponseDto(qna: Qna): QnaDetailDto {
     return new QnaDetailDto({
       id: qna.id,
       title: qna.title,
@@ -154,7 +154,7 @@ export class QnaDetailDto extends QnaSummaryDto {
       createdAt: qna.createdAt,
       updatedAt: qna.updatedAt,
       messages: (qna.messages ?? []).map((message) =>
-        QnaMessageResponseDto.from(message),
+        QnaMessageResponseDto.toResultDto(message),
       ),
     });
   }
@@ -180,7 +180,7 @@ export class QnaLockedDto {
     Object.assign(this, partial);
   }
 
-  static of(qna: Qna): QnaLockedDto {
+  static toResponseDto(qna: Qna): QnaLockedDto {
     return new QnaLockedDto({
       id: qna.id,
       title: qna.title,

--- a/server/src/qna/service/qna.service.ts
+++ b/server/src/qna/service/qna.service.ts
@@ -115,7 +115,7 @@ export class QnaService {
       { id: qnaId, isSecret: dto.isSecret, content: dto.content },
       false,
     );
-    return QnaCreatedDto.of(qnaId);
+    return QnaCreatedDto.toResponseDto(qnaId);
   }
 
   async getPublicQnas(queryDto: GetQnasRequestDto) {
@@ -124,7 +124,7 @@ export class QnaService {
       page,
       limit,
     );
-    return QnaListResponseDto.of(items, page, limit, totalCount);
+    return QnaListResponseDto.toResponseDto(items, page, limit, totalCount);
   }
 
   async getPublicQna(id: number) {
@@ -134,9 +134,9 @@ export class QnaService {
     }
 
     if (qna.isSecret) {
-      return QnaLockedDto.of(qna);
+      return QnaLockedDto.toResponseDto(qna);
     }
-    return QnaDetailDto.fromDetail(qna);
+    return QnaDetailDto.toResponseDto(qna);
   }
 
   async verifyQna(id: number, password: string) {
@@ -149,7 +149,7 @@ export class QnaService {
       throw new UnauthorizedException(QNA_VERIFY_FAIL_MESSAGE);
     }
 
-    return QnaDetailDto.fromDetail(qna);
+    return QnaDetailDto.toResponseDto(qna);
   }
 
   async createQnaMessage(
@@ -217,7 +217,7 @@ export class QnaService {
       limit,
       status,
     );
-    return QnaListResponseDto.of(items, page, limit, totalCount);
+    return QnaListResponseDto.toResponseDto(items, page, limit, totalCount);
   }
 
   async getAdminQna(id: number) {
@@ -225,7 +225,7 @@ export class QnaService {
     if (!qna) {
       throw new NotFoundException(QNA_NOT_FOUND_MESSAGE);
     }
-    return QnaDetailDto.fromDetail(qna);
+    return QnaDetailDto.toResponseDto(qna);
   }
 
   async createQnaAnswer(


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연결된 이슈 없음

### DTO 변환 함수 네이밍 통일

- `board`, `qna` 도메인의 DTO 정적 변환 함수 이름이 `of`, `from`, `fromSummary`, `fromDetail` 등으로 제각각이라 역할이 한눈에 파악되지 않았습니다.
- 역할에 따라 `toResultDto`(리스트/서머리 요소 변환), `toResponseDto`(최종 응답 DTO 변환)로 네이밍을 통일했습니다.

# 📋 작업 내용

- `board.dto.ts`, `qna.dto.ts`의 정적 변환 메서드 이름 변경 (`fromSummary` → `toResultDto`, `fromSummaryArray` → `toResultDtoArray`, `fromDetail`/`of` → `toResponseDto`, `from` → `toResultDto`)
- 변경된 메서드를 호출하는 `board.service.ts`, `qna.service.ts` 호출부 함께 수정
- 로직 변경 없이 이름만 변경

# 📷 스크린 샷(선택 사항)

해당 없음