### PR TITLE
♻️ refactor: 채팅 브로드캐스트를 Redis Pub/Sub 방식으로 전환 및 무중단 재접속 처리

### DIFF
--- a/client/src/__tests__/components/chat/layout/ChatHistory.test.tsx
+++ b/client/src/__tests__/components/chat/layout/ChatHistory.test.tsx
@@ -3,9 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import ChatHistory from "@/components/chat/layout/ChatHistory.tsx";
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
-let storeState: { chatHistory: Array<{ message: string; userName: string; timestamp: string }>; isLoading: boolean };
+let storeState: {
+  chatHistory: Array<{ message: string; userName: string; timestamp: string }>;
+  isLoading: boolean;
+  connect: (room?: string) => void;
+  currentRoomId: string;
+};
 
 vi.mock("lucide-react", () => lucideProxy());
 
@@ -30,7 +35,7 @@ vi.mock("@/assets/empty-panda.svg", () => ({ default: "empty.svg" }));
 
 describe("ChatHistory", () => {
   beforeEach(() => {
-    storeState = { chatHistory: [], isLoading: false };
+    storeState = { chatHistory: [], isLoading: false, connect: vi.fn(), currentRoomId: "" };
   });
 
   it("로딩 중이면 ChatSkeleton을 렌더링해야 한다", () => {
@@ -44,6 +49,25 @@ describe("ChatHistory", () => {
     render(<ChatHistory isFull={false} isConnected={false} />);
 
     expect(screen.getByText("채팅이 연결되지 않았습니다.")).toBeInTheDocument();
+  });
+
+  it("연결되지 않았을 때 재연결 버튼 클릭 시 onReconnect가 호출된다", () => {
+    const onReconnect = vi.fn();
+    render(<ChatHistory isFull={false} isConnected={false} onReconnect={onReconnect} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "재연결" }));
+
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    expect(storeState.connect).not.toHaveBeenCalled();
+  });
+
+  it("onReconnect가 없으면 재연결 버튼이 store의 connect를 현재 방으로 호출한다", () => {
+    storeState.currentRoomId = "room-1";
+    render(<ChatHistory isFull={false} isConnected={false} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "재연결" }));
+
+    expect(storeState.connect).toHaveBeenCalledWith("room-1");
   });
 
   it("방이 가득 찼으면 경고를 렌더링해야 한다", () => {

--- a/client/src/__tests__/store/useChatStore.test.ts
+++ b/client/src/__tests__/store/useChatStore.test.ts
@@ -100,4 +100,24 @@ describe("useChatStore", () => {
     expect(mockSocket.listenerCount("chatHistory")).toBe(1);
     expect(mockSocket.listenerCount("connect")).toBe(1);
   });
+
+  it("서버가 명시적으로 끊은 경우(io server disconnect) 소켓을 수동으로 재연결한다", () => {
+    useChatStore.getState().getHistory();
+    mockSocket.connect.mockClear();
+
+    mockSocket.trigger("disconnect", "io server disconnect");
+
+    expect(useChatStore.getState().isConnected).toBe(false);
+    expect(mockSocket.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("네트워크 문제로 끊긴 경우(transport close)는 수동 재연결을 시도하지 않는다", () => {
+    useChatStore.getState().getHistory();
+    mockSocket.connect.mockClear();
+
+    mockSocket.trigger("disconnect", "transport close");
+
+    expect(useChatStore.getState().isConnected).toBe(false);
+    expect(mockSocket.connect).not.toHaveBeenCalled();
+  });
 });

--- a/client/src/components/chat/layout/ChatHistory.stories.tsx
+++ b/client/src/components/chat/layout/ChatHistory.stories.tsx
@@ -1,6 +1,8 @@
-import type { Meta, StoryObj } from "@storybook/react-vite";
-
 import ChatHistory from "@/components/chat/layout/ChatHistory";
+
+import { useChatStore } from "@/store/useChatStore";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn } from "storybook/test";
 
 const meta = {
   title: "chat/layout/ChatHistory",
@@ -12,3 +14,11 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const Disconnected: Story = {
+  args: { isConnected: false, onReconnect: fn() },
+  // isLoading은 store 전역 상태라 args로 제어 안 됨. 실제 disconnect 화면 확인을 위해 강제로 false 처리.
+  play: async () => {
+    useChatStore.setState({ isLoading: false });
+  },
+};

--- a/client/src/components/chat/layout/ChatHistory.tsx
+++ b/client/src/components/chat/layout/ChatHistory.tsx
@@ -2,17 +2,27 @@ import { CircleAlert } from "lucide-react";
 
 import ChatItem from "@/components/chat/ChatItem";
 import ChatSkeleton from "@/components/chat/layout/ChatSkeleton";
+import { Button } from "@/components/ui/button";
 
 import Empty from "@/assets/empty-panda.svg";
 
-import { useChatStore } from "@/store/useChatStore";
 import { getLocalDateString, getLocalMinuteKey } from "@/utils/date";
 
-export default function ChatHistory({ isFull, isConnected }: { isFull: boolean; isConnected: boolean }) {
-  const { chatHistory, isLoading } = useChatStore();
+import { useChatStore } from "@/store/useChatStore";
+
+export default function ChatHistory({
+  isFull,
+  isConnected,
+  onReconnect,
+}: {
+  isFull: boolean;
+  isConnected: boolean;
+  onReconnect?: () => void;
+}) {
+  const { chatHistory, isLoading, connect, currentRoomId } = useChatStore();
 
   if (isLoading) return <ChatSkeleton number={14} />;
-  if (!isConnected) return <NotConnected />;
+  if (!isConnected) return <NotConnected onReconnect={onReconnect ?? (() => connect(currentRoomId || undefined))} />;
   if (isFull) return <FullChatWarning />;
   if (chatHistory.length === 0) return <EmptyChatHistory />;
 
@@ -59,12 +69,15 @@ const EmptyChatHistory = () => (
   </div>
 );
 
-const NotConnected = () => (
+const NotConnected = ({ onReconnect }: { onReconnect: () => void }) => (
   <div className="flex flex-col justify-center items-center h-[70vh] gap-3">
     <CircleAlert color="red" size={200} />
     <div className="flex flex-col items-center gap-1">
       <p className="font-bold">채팅이 연결되지 않았습니다.</p>
       <p>잠시 기다리면 연결이 됩니다.</p>
     </div>
+    <Button variant="default" onClick={onReconnect}>
+      재연결
+    </Button>
   </div>
 );

--- a/client/src/store/useChatStore.ts
+++ b/client/src/store/useChatStore.ts
@@ -29,7 +29,7 @@ type Action = {
 };
 
 export const useChatStore = create<State & Action>((set, get) => {
-  const initializeSocket = (room: string = 'anonymous') => {
+  const initializeSocket = (room: string = "anonymous") => {
     if (socket) return socket;
     socket = io(CHAT_SERVER_URL, {
       transports: ["websocket"],
@@ -70,23 +70,21 @@ export const useChatStore = create<State & Action>((set, get) => {
     socket.on("messageDeleted", (data) => {
       set((state) => ({
         chatHistory: state.chatHistory.map((msg) =>
-          msg.messageId === data.messageId
-            ? { ...msg, message: data.message, userName: data.userName }
-            : msg
+          msg.messageId === data.messageId ? { ...msg, message: data.message, userName: data.userName } : msg
         ),
       }));
     });
 
-    socket.on('assignUserId', ({ userId }: { userId: string }) => {
-      localStorage.setItem('userID', userId);
+    socket.on("assignUserId", ({ userId }: { userId: string }) => {
+      localStorage.setItem("userID", userId);
     });
 
-    socket.on('assignRoom', ({ roomId, roomName }: { roomId: string; roomName: string }) => {
+    socket.on("assignRoom", ({ roomId, roomName }: { roomId: string; roomName: string }) => {
       set({ currentRoomId: roomId, currentRoomName: roomName });
     });
 
-    socket.on('assignUserName', ({ userName }: { userName: string }) => {
-      localStorage.setItem('userName', userName);
+    socket.on("assignUserName", ({ userName }: { userName: string }) => {
+      localStorage.setItem("userName", userName);
       set({ currentUserName: userName });
     });
 
@@ -99,8 +97,11 @@ export const useChatStore = create<State & Action>((set, get) => {
       socket?.emit("register", { userId: localStorage.getItem("userID") });
     });
 
-    socket.on("disconnect", () => {
+    socket.on("disconnect", (reason) => {
       useChatStore.setState({ isConnected: false });
+      if (reason === "io server disconnect") {
+        socket?.connect();
+      }
     });
 
     return socket;
@@ -111,12 +112,12 @@ export const useChatStore = create<State & Action>((set, get) => {
     userCount: 0,
     isLoading: true,
     isConnected: false,
-    currentRoomId: '',
-    currentRoomName: '',
-    currentUserName: localStorage.getItem('userName') ?? '',
+    currentRoomId: "",
+    currentRoomName: "",
+    currentUserName: localStorage.getItem("userName") ?? "",
 
     connect: (room?: string) => {
-      const s = initializeSocket(room ?? 'anonymous');
+      const s = initializeSocket(room ?? "anonymous");
       if (!s.connected) {
         s.connect();
       }
@@ -129,7 +130,7 @@ export const useChatStore = create<State & Action>((set, get) => {
     switchRoom: (roomId: string) => {
       socket?.disconnect();
       socket = null;
-      set({ chatHistory: [], currentRoomId: '', currentRoomName: '', isLoading: true, isConnected: false });
+      set({ chatHistory: [], currentRoomId: "", currentRoomName: "", isLoading: true, isConnected: false });
 
       const s = initializeSocket(roomId);
       s.connect();
@@ -146,7 +147,7 @@ export const useChatStore = create<State & Action>((set, get) => {
         chatHistory: [
           ...state.chatHistory,
           {
-            timestamp: '전송중',
+            timestamp: "전송중",
             userName: state.currentUserName,
             message: message.message,
             messageId: message.messageId,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -24,6 +24,7 @@
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^10.0.2",
         "@nestjs/websockets": "^10.4.22",
+        "@socket.io/redis-adapter": "^8.3.0",
         "@willsoto/nestjs-prometheus": "^6.0.2",
         "@woowa-babble/random-nickname": "^1.0.2",
         "amqplib": "^0.10.9",
@@ -3204,6 +3205,40 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@socket.io/redis-adapter": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/redis-adapter/-/redis-adapter-8.3.0.tgz",
+      "integrity": "sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.1",
+        "notepack.io": "~3.0.1",
+        "uid2": "1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "socket.io-adapter": "^2.5.4"
+      }
+    },
+    "node_modules/@socket.io/redis-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
@@ -10787,6 +10822,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/notepack.io": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/notepack.io/-/notepack.io-3.0.1.tgz",
+      "integrity": "sha512-TKC/8zH5pXIAMVQio2TvVDTtPRX+DJPHDqjRbxogtFiByHyzKmy96RA0JtCQJ+WouyyL4A10xomQzgbUT+1jCg==",
+      "license": "MIT"
+    },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -13891,6 +13932,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/uid2": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-1.0.0.tgz",
+      "integrity": "sha512-+I6aJUv63YAcY9n4mQreLUt0d4lvwkkopDNmpomkAUz0fAkEMV9pRWxN0EjhW1YfRhcuyHg2v3mwddCDW1+LFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/uint8array-extras": {

--- a/server/package.json
+++ b/server/package.json
@@ -47,6 +47,7 @@
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^10.0.2",
     "@nestjs/websockets": "^10.4.22",
+    "@socket.io/redis-adapter": "^8.3.0",
     "@willsoto/nestjs-prometheus": "^6.0.2",
     "@woowa-babble/random-nickname": "^1.0.2",
     "amqplib": "^0.10.9",

--- a/server/src/chat/chat.gateway.ts
+++ b/server/src/chat/chat.gateway.ts
@@ -1,4 +1,9 @@
-import { Injectable, UseFilters, ValidationPipe } from '@nestjs/common';
+import {
+  Injectable,
+  OnApplicationShutdown,
+  UseFilters,
+  ValidationPipe,
+} from '@nestjs/common';
 import {
   ConnectedSocket,
   MessageBody,
@@ -31,7 +36,9 @@ import { SendMessageDto } from './dto/sendMessage.dto';
     origin: '*', // TODO: 연동 할때 보고 확인 후 설정 해보기
   },
 })
-export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class ChatGateway
+  implements OnGatewayConnection, OnGatewayDisconnect, OnApplicationShutdown
+{
   @WebSocketServer()
   server: Server;
 
@@ -158,6 +165,10 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
     await this.chatService.saveMessageToRedis(redisPayload);
     this.server.to(roomId).emit('message', redisPayload);
+  }
+
+  onApplicationShutdown() {
+    this.server?.local.disconnectSockets(true);
   }
 
   getRoomClientCount(roomId: string): number {

--- a/server/src/common/redis/redis-io.adapter.ts
+++ b/server/src/common/redis/redis-io.adapter.ts
@@ -1,0 +1,32 @@
+import { INestApplicationContext } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { IoAdapter } from '@nestjs/platform-socket.io';
+
+import { createAdapter } from '@socket.io/redis-adapter';
+import Redis from 'ioredis';
+import { Server, ServerOptions } from 'socket.io';
+
+export class RedisIoAdapter extends IoAdapter {
+  private adapterConstructor: ReturnType<typeof createAdapter>;
+
+  constructor(app: INestApplicationContext) {
+    super(app);
+
+    const configService = app.get(ConfigService);
+    const pubClient = new Redis({
+      host: configService.get<string>('REDIS_HOST'),
+      port: configService.get<number>('REDIS_PORT'),
+      username: configService.get<string>('REDIS_USER'),
+      password: configService.get<string>('REDIS_PASSWORD'),
+    });
+    const subClient = pubClient.duplicate();
+
+    this.adapterConstructor = createAdapter(pubClient, subClient);
+  }
+
+  createIOServer(port: number, options?: ServerOptions) {
+    const server: Server = super.createIOServer(port, options);
+    server.adapter(this.adapterConstructor);
+    return server;
+  }
+}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -8,6 +8,7 @@ import { InternalExceptionsFilter } from '@common/filters/internal.exceptions.fi
 import { LoggingInterceptor } from '@common/logger/logger.interceptor';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import { MetricsInterceptor } from '@common/metrics/metrics.interceptor';
+import { RedisIoAdapter } from '@common/redis/redis-io.adapter';
 import { setupSwagger } from '@common/swagger/swagger';
 
 import { AppModule } from './app.module';
@@ -15,6 +16,8 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const logger = app.get(WinstonLoggerService);
+  app.enableShutdownHooks();
+  app.useWebSocketAdapter(new RedisIoAdapter(app));
   app.setGlobalPrefix('api');
   app.use(cookieParser());
   app.useGlobalInterceptors(


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #903
  - #762 에서 nginx/docker compose 레벨의 Blue-Green 무중단 배포는 구축되었으나, 이는 HTTP 트래픽 전환에만 유효합니다. Socket.IO는 기본적으로 프로세스 내 인메모리(in-memory) 어댑터로 room을 관리하기 때문에, 배포로 인스턴스가 교체되는 순간 **WebSocket 세션 레벨에서는 무중단이 보장되지 않는** 구조적 공백이 있었습니다. 본 PR은 이 공백을 애플리케이션 레벨에서 메꿉니다.

### 소주제1 — 채팅 브로드캐스트를 Redis Pub/Sub 어댑터로 전환

**문제**
- 기존 Socket.IO 기본 어댑터는 서버 프로세스 내부 인메모리 Map으로 room·소켓 연결을 관리합니다. `server.to(roomId).emit()`은 이 Map을 조회해 **같은 프로세스에 연결된 소켓에게만** 이벤트를 전달합니다.
- 인스턴스를 2대 이상으로 수평 확장하거나, 배포로 신규 인스턴스가 기동되는 과도기에는 인스턴스 A에 연결된 클라이언트의 메시지가 인스턴스 B에 연결된 클라이언트에게 전달되지 않습니다. 즉 인스턴스가 바뀌는 순간 채팅이 끊기거나 메시지가 유실될 수 있는 구조였습니다.

**해결 — 동작 원리**
`@socket.io/redis-adapter`를 도입해 `RedisIoAdapter`(`server/src/common/redis/redis-io.adapter.ts`, 32줄)를 구현하고 `main.ts`에서 `app.useWebSocketAdapter(new RedisIoAdapter(app))`로 교체했습니다.

1. 부트스트랩 시 기존에 이미 사용 중이던 `ioredis` 클라이언트를 `pubClient`로 생성하고, pub/sub은 하나의 커넥션을 겸용할 수 없으므로 `pubClient.duplicate()`로 `subClient`를 분리 생성합니다. → 신규 Redis 인프라 없이 기존 커넥션 패턴만 재사용(신규 npm 의존성은 `@socket.io/redis-adapter` 1개뿐).
2. `createAdapter(pubClient, subClient)`로 만든 어댑터를 `server.adapter()`에 등록합니다.
3. 이후 `server.to(roomId).emit('message', payload)` 호출 시, 어댑터는 로컬 소켓에 이벤트를 전달함과 동시에 해당 room에 대응하는 Redis 채널로 **publish** 합니다.
4. 모든 서버 인스턴스는 기동 시점부터 동일한 Redis 채널을 **subscribe**하고 있으므로, 메시지를 발행한 인스턴스를 포함한 전체 인스턴스가 이벤트를 수신합니다.
5. 각 인스턴스는 수신한 이벤트를 자신에게 실제로 연결되어 있는(local) 소켓 중 해당 room 소속 소켓에게만 재전달합니다.

결과적으로 클라이언트는 어느 인스턴스에 연결되어 있든 같은 room의 메시지를 동일하게 수신하며, 브로드캐스트 비용은 "로컬 emit 1회 + Redis publish 1회"로, 인스턴스 수 N에 비례해 fan-out(O(N)) 되는 구조로 바뀝니다. 현재 서비스 규모(단일 Redis, 소규모 room)에서는 이 오버헤드가 무시할 만한 수준이라고 판단했습니다.

### 소주제2 — 우아한 종료(Graceful Shutdown)와 프론트엔드 재접속

- `app.enableShutdownHooks()`를 활성화하고 `ChatGateway.onApplicationShutdown()`에서 `server.local.disconnectSockets(true)`를 호출합니다. `.local`을 명시해 Redis 어댑터를 거치지 않고 **현재 인스턴스에 물린 소켓만** 명시적으로 끊습니다. 이로써 배포로 인스턴스가 SIGTERM을 받을 때, 클라이언트는 `disconnect` 이벤트를 `io server disconnect` 사유로 즉시 수신합니다.
- 프론트엔드(`useChatStore.ts`)는 `disconnect` 사유를 분기합니다: `io server disconnect`(서버가 명시적으로 끊음)일 때만 `socket.connect()`로 즉시 재연결을 시도하고, `transport close` 등 네트워크 문제로 인한 단절은 Socket.IO 내장 재연결 로직에 맡깁니다. 이 분기가 없으면 서버 측 정상 종료 상황에서 재연결이 지연되거나, 반대로 네트워크 불안정 상황에서 수동 재연결 호출이 중복 발생할 수 있습니다.
- 자동 재연결이 지연되는 경우를 대비해 `ChatHistory.tsx`에 수동 "재연결" 버튼을 추가했습니다(`onReconnect` prop 미전달 시 store의 `connect(currentRoomId)`로 폴백).

# 📋 작업 내용

- (신규) `server/src/common/redis/redis-io.adapter.ts`: Redis Pub/Sub 기반 Socket.IO 어댑터 구현
- `server/src/main.ts`: `enableShutdownHooks()` 활성화, `RedisIoAdapter` 등록
- `server/src/chat/chat.gateway.ts`: `OnApplicationShutdown` 구현, 종료 시 로컬 소켓 명시적 disconnect
- `server/package.json`: `@socket.io/redis-adapter@^8.3.0` 추가 (신규 의존성 1개, 기존 `ioredis` 클라이언트 재사용)
- `client/src/store/useChatStore.ts`: `disconnect` 사유(`io server disconnect` vs 그 외)에 따른 재연결 분기 처리
- `client/src/components/chat/layout/ChatHistory.tsx`: 연결 끊김 화면에 수동 "재연결" 버튼 추가
- 테스트: 재연결 사유 분기 2건(`useChatStore.test.ts`), 재연결 버튼 클릭 동작 2건(`ChatHistory.test.tsx`) — 총 4개 케이스 추가

**변경 규모**: 커밋 4개, 파일 10개 변경 (+193 / -28, 순증 +165줄), 신규 파일 1개, 신규 의존성 1개

# 📷 스크린샷(선택 사항)
<img width="491" height="457" alt="image" src="https://github.com/user-attachments/assets/542d7ceb-6b25-49ba-9890-46a0a761dda0" />