### PR TITLE
♻️ refactor: 게시글 에디터 TinyMCE 마이그레이션 및 이미지 업로드 기능 추가

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/lang-html": "^6.4.12",
         "@emotion/is-prop-valid": "^1.3.1",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-alert-dialog": "^1.1.2",
@@ -29,6 +30,8 @@
         "@tailwindcss/typography": "^0.5.16",
         "@tanstack/react-query": "^5.100.9",
         "@tanstack/react-query-devtools": "^5.100.9",
+        "@tinymce/tinymce-react": "^6.3.0",
+        "@uiw/react-codemirror": "^4.25.11",
         "avvvatars-react": "^0.4.2",
         "axios": "^1.16.0",
         "class-variance-authority": "^0.7.0",
@@ -44,12 +47,12 @@
         "react-ga4": "^3.0.1",
         "react-helmet": "^6.1.0",
         "react-markdown": "^9.0.3",
-        "react-quill-new": "^3.8.3",
         "react-router-dom": "^6.30.3",
         "recharts": "^2.13.3",
         "socket.io-client": "^4.8.3",
         "tailwind-merge": "^2.6.1",
         "tailwindcss-animate": "^1.0.7",
+        "tinymce": "^8.8.2",
         "zustand": "^5.0.13"
       },
       "devDependencies": {
@@ -95,6 +98,7 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.2",
         "vite": "^5.4.10",
+        "vite-plugin-static-copy": "^3.3.0",
         "vitest": "^2.1.4"
       }
     },
@@ -875,6 +879,144 @@
         "@chromatic-com/vitest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.12",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.12.tgz",
+      "integrity": "sha512-pw2ReWKUqSkbvh76RAT4NYxiogRu+PWkR2ukAwO9uOgrm8uipkzjtKKtNpyeAQwHOqxEeSvAXZ6vr3AfyB9y/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
+      "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1947,6 +2089,63 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.6.tgz",
+      "integrity": "sha512-YJE78Wcg+zX8f10hiHWQ4Az48Qr/c13eId0VtRQYLBpxHDmDeSrXIlkbl+fJGW42rWC/uoUco9mhBZeVWP/A1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
     "node_modules/@lhci/cli": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/@lhci/cli/-/cli-0.15.1.tgz",
@@ -2201,6 +2400,12 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@mdx-js/react": {
       "version": "3.1.1",
@@ -5509,6 +5714,25 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tinymce/tinymce-react": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@tinymce/tinymce-react/-/tinymce-react-6.3.0.tgz",
+      "integrity": "sha512-E++xnn0XzDzpKr40jno2Kj7umfAE6XfINZULEBBeNjTMvbACWzA6CjiR6V8eTDc9yVmdVhIPqVzV4PqD5TZ/4g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0 || ^18.0.0 || ^17.0.1 || ^16.7.0",
+        "react-dom": "^19.0.0 || ^18.0.0 || ^17.0.1 || ^16.7.0",
+        "tinymce": "^8.0.0 || ^7.0.0 || ^6.0.0 || ^5.5.1"
+      },
+      "peerDependenciesMeta": {
+        "tinymce": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tmcp/adapter-valibot": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@tmcp/adapter-valibot/-/adapter-valibot-0.1.6.tgz",
@@ -6167,6 +6391,59 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@uiw/codemirror-extensions-basic-setup": {
+      "version": "4.25.11",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.11.tgz",
+      "integrity": "sha512-otyFa+n9IOYtEjaKOxPedHkj15fTPUF21wdR9pv0GpZPfuGl27cvmcv6+tognbRu9VvEcsHKE+ESoszeo3KfTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@codemirror/autocomplete": ">=6.0.0",
+        "@codemirror/commands": ">=6.0.0",
+        "@codemirror/language": ">=6.0.0",
+        "@codemirror/lint": ">=6.0.0",
+        "@codemirror/search": ">=6.0.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0"
+      }
+    },
+    "node_modules/@uiw/react-codemirror": {
+      "version": "4.25.11",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.11.tgz",
+      "integrity": "sha512-DYVFAKLX+F/4JS9N/7xexh+TICrlncwkX9HKKInrP1bwO0tSfc3k0GB6oawTYhelVKh20cX3TuRx+NJSkVXuMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "@codemirror/commands": "^6.1.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/theme-one-dark": "^6.0.0",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.11",
+        "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
+      },
+      "peerDependencies": {
+        "@babel/runtime": ">=7.11.0",
+        "@codemirror/state": ">=6.0.0",
+        "@codemirror/theme-one-dark": ">=6.0.0",
+        "@codemirror/view": ">=6.0.0",
+        "codemirror": ">=6.0.0",
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -7562,6 +7839,21 @@
         "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7758,6 +8050,12 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -9375,6 +9673,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
       "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/fast-equals": {
@@ -11735,19 +12034,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
       "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -13172,6 +13459,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -13246,12 +13546,6 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
-    },
-    "node_modules/parchment": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-3.0.0.tgz",
-      "integrity": "sha512-HUrJFQ/StvgmXRcQ1ftY6VEZUq3jA2t9ncFN4F84J/vN0/FPpQF+8FKXb3l6fLces6q0uOHj6NJn+2xvZnxO6A==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -13950,41 +14244,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/quill": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
-      "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "lodash-es": "^4.17.21",
-        "parchment": "^3.0.0",
-        "quill-delta": "^5.1.0"
-      },
-      "engines": {
-        "npm": ">=8.2.3"
-      }
-    },
-    "node_modules/quill-delta": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-5.1.0.tgz",
-      "integrity": "sha512-X74oCeRI4/p0ucjb5Ma8adTXd9Scumz367kkMK5V/IatcX6A0vlgLgKbzXWy5nZmCGeNJm2oQX0d2Eqj+ZIlCA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-diff": "^1.3.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/quill/node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -14251,21 +14510,6 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
-      }
-    },
-    "node_modules/react-quill-new": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/react-quill-new/-/react-quill-new-3.8.3.tgz",
-      "integrity": "sha512-c96PYqFTo0pI4R3e79B3rH9LUIce1kIQbmTBu/imJQZk8305ogyLyBqKKjG2UoInDlquXqePSzmBo2aVia3ttw==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash-es": "^4.17.21",
-        "quill": "~2.0.3"
-      },
-      "peerDependencies": {
-        "quill-delta": "^5.1.0",
-        "react": "^16 || ^17 || ^18 || ^19",
-        "react-dom": "^16 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-remove-scroll": {
@@ -15886,6 +16130,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -16227,6 +16477,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinymce": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.8.2.tgz",
+      "integrity": "sha512-wcUGaaAf4XFrQtbZtClbDN/QCqklXLlPt3+7UWliEoosuhnTOJUkXwf7Fzlq7agPnwkKKp1e4JGOhx3O1gWH3g==",
+      "license": "SEE LICENSE IN license.md"
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
@@ -17127,6 +17383,29 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-3.3.0.tgz",
+      "integrity": "sha512-XiAtZcev7nppxNFgKoD55rfL+ukVp/RtrnTJONRwRuzv/B2FK2h2ZRCYjvxhwBV/Oarse83SiyXBSxMTfeEM0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.6.0",
+        "p-map": "^7.0.4",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.15"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/sapphi-red"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/vite/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -17207,6 +17486,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@codemirror/lang-html": "^6.4.12",
     "@emotion/is-prop-valid": "^1.3.1",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
@@ -41,6 +42,8 @@
     "@tailwindcss/typography": "^0.5.16",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-query-devtools": "^5.100.9",
+    "@tinymce/tinymce-react": "^6.3.0",
+    "@uiw/react-codemirror": "^4.25.11",
     "avvvatars-react": "^0.4.2",
     "axios": "^1.16.0",
     "class-variance-authority": "^0.7.0",
@@ -56,12 +59,12 @@
     "react-ga4": "^3.0.1",
     "react-helmet": "^6.1.0",
     "react-markdown": "^9.0.3",
-    "react-quill-new": "^3.8.3",
     "react-router-dom": "^6.30.3",
     "recharts": "^2.13.3",
     "socket.io-client": "^4.8.3",
     "tailwind-merge": "^2.6.1",
     "tailwindcss-animate": "^1.0.7",
+    "tinymce": "^8.8.2",
     "zustand": "^5.0.13"
   },
   "devDependencies": {
@@ -107,6 +110,7 @@
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.2",
     "vite": "^5.4.10",
+    "vite-plugin-static-copy": "^3.3.0",
     "vitest": "^2.1.4"
   }
 }

--- a/client/src/__tests__/components/admin/board/AdminBoardTab.test.tsx
+++ b/client/src/__tests__/components/admin/board/AdminBoardTab.test.tsx
@@ -1,9 +1,7 @@
-import { forwardRef, useImperativeHandle } from "react";
 import type { ReactNode } from "react";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import AdminBoardTab from "@/components/admin/board/AdminBoardTab.tsx";
 
 import { BoardDetail, BoardPage, BoardSummary } from "@/types/board";
@@ -18,16 +16,16 @@ const toastMock = vi.hoisted(() => vi.fn());
 const getDetailMock = vi.hoisted(() => vi.fn());
 const uploadImageMock = vi.hoisted(() => vi.fn());
 
-// react-quill-new mock의 fake 에디터: toolbar/uploader 핸들러 등록 여부를 테스트에서 검증하기 위한 스파이 모음.
-const toolbarAddHandlerMock = vi.hoisted(() => vi.fn());
-const editorInsertEmbedMock = vi.hoisted(() => vi.fn());
-const editorSetSelectionMock = vi.hoisted(() => vi.fn());
-const editorGetSelectionMock = vi.hoisted(() => vi.fn(() => ({ index: 5 })));
-const uploaderModule = vi.hoisted(
-  () => ({ options: {} }) as { options: { handler?: (range: { index: number; length: number }, files: File[]) => void } }
-);
+// @tinymce/tinymce-react mock: 실제 에디터 대신 textarea로 대체하고, 컴포넌트가 넘긴 props(특히
+// init.images_upload_handler / init.file_picker_callback)를 테스트에서 직접 호출하기 위해 스파이로 기록.
+const editorPropsSpy = vi.hoisted(() => vi.fn());
 
-vi.mock("lucide-react", () => lucideProxy());
+// AdminBoardTab import(위 5번째 줄)가 lucide-react를 로드하는 시점보다 lucideProxy 바인딩이
+// 늦게 초기화되어 TDZ ReferenceError가 나므로, 동적 import로 참조 시점을 팩토리 실행 시점까지 늦춘다.
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
 
 vi.mock("@/hooks/common/useCustomToast", () => ({
   useCustomToast: () => ({ toast: toastMock }),
@@ -44,20 +42,11 @@ vi.mock("@/api/services/admin/board", () => ({
   adminBoard: { getDetail: getDetailMock, uploadImage: uploadImageMock },
 }));
 
-vi.mock("react-quill-new", () => ({
-  default: forwardRef<{ getEditor: () => unknown }, { value: string; onChange: (v: string) => void }>(
-    ({ value, onChange }, ref) => {
-      useImperativeHandle(ref, () => ({
-        getEditor: () => ({
-          getModule: (name: string) => (name === "toolbar" ? { addHandler: toolbarAddHandlerMock } : uploaderModule),
-          insertEmbed: editorInsertEmbedMock,
-          setSelection: editorSetSelectionMock,
-          getSelection: editorGetSelectionMock,
-        }),
-      }));
-      return <textarea aria-label="본문" value={value} onChange={(e) => onChange(e.target.value)} />;
-    }
-  ),
+vi.mock("@tinymce/tinymce-react", () => ({
+  Editor: (props: { value: string; onEditorChange: (content: string) => void; init?: Record<string, unknown> }) => {
+    editorPropsSpy(props);
+    return <textarea aria-label="본문" value={props.value} onChange={(e) => props.onEditorChange(e.target.value)} />;
+  },
 }));
 
 vi.mock("@/components/ui/select", () => {
@@ -120,7 +109,6 @@ describe("AdminBoardTab", () => {
     createMutateMock.mockImplementation((_payload, opts) => opts?.onSuccess?.());
     updateMutateMock.mockImplementation((_vars, opts) => opts?.onSuccess?.());
     deleteMutateMock.mockImplementation((_id, opts) => opts?.onSuccess?.());
-    uploaderModule.options.handler = undefined;
   });
 
   it("로딩 중이면 로딩 문구를 표시한다", () => {
@@ -308,16 +296,22 @@ describe("AdminBoardTab", () => {
     expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ description: "삭제를 완료했습니다." }));
   });
 
-  it("에디터 이미지 툴바 버튼으로 파일 선택 시 업로드 후 커서 위치에 이미지를 삽입한다", async () => {
+  type EditorInit = {
+    file_picker_callback: (callback: (url: string, meta?: Record<string, string>) => void) => void;
+    images_upload_handler: (blobInfo: { blob: () => Blob; filename: () => string }) => Promise<string>;
+  };
+  const latestEditorInit = () => (editorPropsSpy.mock.calls.at(-1)?.[0].init as EditorInit) ?? undefined;
+
+  it("에디터 이미지 툴바 버튼으로 파일 선택 시 업로드 후 삽입 콜백에 URL을 전달한다", async () => {
     uploadImageMock.mockResolvedValue("https://cdn.example.com/board/a.png");
     renderTab();
     fireEvent.click(screen.getByRole("button", { name: "공지사항 작성" }));
 
-    await waitFor(() => expect(toolbarAddHandlerMock).toHaveBeenCalledWith("image", expect.any(Function)));
-    const imageButtonHandler = toolbarAddHandlerMock.mock.calls[0][1] as () => void;
+    await waitFor(() => expect(latestEditorInit()).toBeDefined());
+    const insertCallback = vi.fn();
 
     const createElementSpy = vi.spyOn(document, "createElement");
-    imageButtonHandler();
+    latestEditorInit().file_picker_callback(insertCallback);
     const input = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
     createElementSpy.mockRestore();
 
@@ -326,20 +320,21 @@ describe("AdminBoardTab", () => {
     input.dispatchEvent(new Event("change"));
 
     await waitFor(() => expect(uploadImageMock).toHaveBeenCalledWith(file));
-    expect(editorInsertEmbedMock).toHaveBeenCalledWith(5, "image", "https://cdn.example.com/board/a.png", "user");
-    expect(editorSetSelectionMock).toHaveBeenCalledWith(6, 0, "user");
+    await waitFor(() =>
+      expect(insertCallback).toHaveBeenCalledWith("https://cdn.example.com/board/a.png", { alt: "photo.png" })
+    );
   });
 
-  it("이미지 업로드 실패 시 오류 toast를 띄우고 삽입하지 않는다", async () => {
+  it("이미지 업로드 실패 시 오류 toast를 띄우고 삽입 콜백을 호출하지 않는다", async () => {
     uploadImageMock.mockRejectedValue(new Error("network error"));
     renderTab();
     fireEvent.click(screen.getByRole("button", { name: "공지사항 작성" }));
 
-    await waitFor(() => expect(toolbarAddHandlerMock).toHaveBeenCalledWith("image", expect.any(Function)));
-    const imageButtonHandler = toolbarAddHandlerMock.mock.calls[0][1] as () => void;
+    await waitFor(() => expect(latestEditorInit()).toBeDefined());
+    const insertCallback = vi.fn();
 
     const createElementSpy = vi.spyOn(document, "createElement");
-    imageButtonHandler();
+    latestEditorInit().file_picker_callback(insertCallback);
     const input = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
     createElementSpy.mockRestore();
 
@@ -352,26 +347,30 @@ describe("AdminBoardTab", () => {
         expect.objectContaining({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" })
       )
     );
-    expect(editorInsertEmbedMock).not.toHaveBeenCalled();
+    expect(insertCallback).not.toHaveBeenCalled();
   });
 
-  it("붙여넣기/드래그로 여러 이미지를 넣으면 각각 업로드 후 같은 위치에 삽입한다", async () => {
+  it("붙여넣기/드래그로 들어온 이미지는 images_upload_handler로 업로드하고 URL을 반환한다", async () => {
     uploadImageMock.mockResolvedValueOnce("https://cdn.example.com/board/1.png");
     uploadImageMock.mockResolvedValueOnce("https://cdn.example.com/board/2.png");
     renderTab();
     fireEvent.click(screen.getByRole("button", { name: "공지사항 작성" }));
 
-    await waitFor(() => expect(uploaderModule.options.handler).toBeTypeOf("function"));
+    await waitFor(() => expect(latestEditorInit()).toBeDefined());
 
-    const file1 = new File(["a"], "a.png", { type: "image/png" });
-    const file2 = new File(["b"], "b.png", { type: "image/png" });
-    uploaderModule.options.handler?.({ index: 2, length: 0 }, [file1, file2]);
-
-    await waitFor(() => {
-      expect(uploadImageMock).toHaveBeenCalledWith(file1);
-      expect(uploadImageMock).toHaveBeenCalledWith(file2);
+    const blob1 = new Blob(["a"], { type: "image/png" });
+    const blob2 = new Blob(["b"], { type: "image/png" });
+    const url1 = await latestEditorInit().images_upload_handler({
+      blob: () => blob1,
+      filename: () => "a.png",
     });
-    expect(editorInsertEmbedMock).toHaveBeenCalledWith(2, "image", "https://cdn.example.com/board/1.png", "user");
-    expect(editorInsertEmbedMock).toHaveBeenCalledWith(2, "image", "https://cdn.example.com/board/2.png", "user");
+    const url2 = await latestEditorInit().images_upload_handler({
+      blob: () => blob2,
+      filename: () => "b.png",
+    });
+
+    expect(url1).toBe("https://cdn.example.com/board/1.png");
+    expect(url2).toBe("https://cdn.example.com/board/2.png");
+    expect(uploadImageMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/client/src/__tests__/components/admin/board/AdminBoardTab.test.tsx
+++ b/client/src/__tests__/components/admin/board/AdminBoardTab.test.tsx
@@ -1,9 +1,9 @@
+import { forwardRef, useImperativeHandle } from "react";
 import type { ReactNode } from "react";
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
-
 import AdminBoardTab from "@/components/admin/board/AdminBoardTab.tsx";
 
 import { BoardDetail, BoardPage, BoardSummary } from "@/types/board";
@@ -16,6 +16,16 @@ const updateMutateMock = vi.hoisted(() => vi.fn());
 const deleteMutateMock = vi.hoisted(() => vi.fn());
 const toastMock = vi.hoisted(() => vi.fn());
 const getDetailMock = vi.hoisted(() => vi.fn());
+const uploadImageMock = vi.hoisted(() => vi.fn());
+
+// react-quill-new mock의 fake 에디터: toolbar/uploader 핸들러 등록 여부를 테스트에서 검증하기 위한 스파이 모음.
+const toolbarAddHandlerMock = vi.hoisted(() => vi.fn());
+const editorInsertEmbedMock = vi.hoisted(() => vi.fn());
+const editorSetSelectionMock = vi.hoisted(() => vi.fn());
+const editorGetSelectionMock = vi.hoisted(() => vi.fn(() => ({ index: 5 })));
+const uploaderModule = vi.hoisted(
+  () => ({ options: {} }) as { options: { handler?: (range: { index: number; length: number }, files: File[]) => void } }
+);
 
 vi.mock("lucide-react", () => lucideProxy());
 
@@ -31,12 +41,22 @@ vi.mock("@/hooks/queries/useAdminBoards", () => ({
 }));
 
 vi.mock("@/api/services/admin/board", () => ({
-  adminBoard: { getDetail: getDetailMock },
+  adminBoard: { getDetail: getDetailMock, uploadImage: uploadImageMock },
 }));
 
 vi.mock("react-quill-new", () => ({
-  default: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
-    <textarea aria-label="본문" value={value} onChange={(e) => onChange(e.target.value)} />
+  default: forwardRef<{ getEditor: () => unknown }, { value: string; onChange: (v: string) => void }>(
+    ({ value, onChange }, ref) => {
+      useImperativeHandle(ref, () => ({
+        getEditor: () => ({
+          getModule: (name: string) => (name === "toolbar" ? { addHandler: toolbarAddHandlerMock } : uploaderModule),
+          insertEmbed: editorInsertEmbedMock,
+          setSelection: editorSetSelectionMock,
+          getSelection: editorGetSelectionMock,
+        }),
+      }));
+      return <textarea aria-label="본문" value={value} onChange={(e) => onChange(e.target.value)} />;
+    }
   ),
 }));
 
@@ -100,6 +120,7 @@ describe("AdminBoardTab", () => {
     createMutateMock.mockImplementation((_payload, opts) => opts?.onSuccess?.());
     updateMutateMock.mockImplementation((_vars, opts) => opts?.onSuccess?.());
     deleteMutateMock.mockImplementation((_id, opts) => opts?.onSuccess?.());
+    uploaderModule.options.handler = undefined;
   });
 
   it("로딩 중이면 로딩 문구를 표시한다", () => {
@@ -285,5 +306,72 @@ describe("AdminBoardTab", () => {
 
     expect(deleteMutateMock).toHaveBeenCalledWith(11, expect.any(Object));
     expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ description: "삭제를 완료했습니다." }));
+  });
+
+  it("에디터 이미지 툴바 버튼으로 파일 선택 시 업로드 후 커서 위치에 이미지를 삽입한다", async () => {
+    uploadImageMock.mockResolvedValue("https://cdn.example.com/board/a.png");
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "공지사항 작성" }));
+
+    await waitFor(() => expect(toolbarAddHandlerMock).toHaveBeenCalledWith("image", expect.any(Function)));
+    const imageButtonHandler = toolbarAddHandlerMock.mock.calls[0][1] as () => void;
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+    imageButtonHandler();
+    const input = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    createElementSpy.mockRestore();
+
+    const file = new File(["binary"], "photo.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
+    input.dispatchEvent(new Event("change"));
+
+    await waitFor(() => expect(uploadImageMock).toHaveBeenCalledWith(file));
+    expect(editorInsertEmbedMock).toHaveBeenCalledWith(5, "image", "https://cdn.example.com/board/a.png", "user");
+    expect(editorSetSelectionMock).toHaveBeenCalledWith(6, 0, "user");
+  });
+
+  it("이미지 업로드 실패 시 오류 toast를 띄우고 삽입하지 않는다", async () => {
+    uploadImageMock.mockRejectedValue(new Error("network error"));
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "공지사항 작성" }));
+
+    await waitFor(() => expect(toolbarAddHandlerMock).toHaveBeenCalledWith("image", expect.any(Function)));
+    const imageButtonHandler = toolbarAddHandlerMock.mock.calls[0][1] as () => void;
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+    imageButtonHandler();
+    const input = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    createElementSpy.mockRestore();
+
+    const file = new File(["binary"], "photo.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
+    input.dispatchEvent(new Event("change"));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" })
+      )
+    );
+    expect(editorInsertEmbedMock).not.toHaveBeenCalled();
+  });
+
+  it("붙여넣기/드래그로 여러 이미지를 넣으면 각각 업로드 후 같은 위치에 삽입한다", async () => {
+    uploadImageMock.mockResolvedValueOnce("https://cdn.example.com/board/1.png");
+    uploadImageMock.mockResolvedValueOnce("https://cdn.example.com/board/2.png");
+    renderTab();
+    fireEvent.click(screen.getByRole("button", { name: "공지사항 작성" }));
+
+    await waitFor(() => expect(uploaderModule.options.handler).toBeTypeOf("function"));
+
+    const file1 = new File(["a"], "a.png", { type: "image/png" });
+    const file2 = new File(["b"], "b.png", { type: "image/png" });
+    uploaderModule.options.handler?.({ index: 2, length: 0 }, [file1, file2]);
+
+    await waitFor(() => {
+      expect(uploadImageMock).toHaveBeenCalledWith(file1);
+      expect(uploadImageMock).toHaveBeenCalledWith(file2);
+    });
+    expect(editorInsertEmbedMock).toHaveBeenCalledWith(2, "image", "https://cdn.example.com/board/1.png", "user");
+    expect(editorInsertEmbedMock).toHaveBeenCalledWith(2, "image", "https://cdn.example.com/board/2.png", "user");
   });
 });

--- a/client/src/api/services/admin/board.ts
+++ b/client/src/api/services/admin/board.ts
@@ -36,6 +36,14 @@ export const adminBoard = {
     const response = await axiosInstance.patch<ApiData<BoardDetail>>(BOARD.ADMIN_DETAIL(id), payload);
     return response.data.data;
   },
+  uploadImage: async (file: File): Promise<string> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await axiosInstance.post<ApiData<{ url: string }>>(BOARD.ADMIN_UPLOAD_IMAGE, formData, {
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return response.data.data.url;
+  },
   remove: async (id: number): Promise<void> => {
     await axiosInstance.delete(BOARD.ADMIN_DETAIL(id));
   },

--- a/client/src/components/admin/board/AdminBoardTab.tsx
+++ b/client/src/components/admin/board/AdminBoardTab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ReactQuill from "react-quill-new";
 import "react-quill-new/dist/quill.snow.css";
 
@@ -115,6 +115,7 @@ export default function AdminBoardTab() {
   const [loadingEditId, setLoadingEditId] = useState<number | null>(null);
   const { toast } = useCustomToast();
   const queryClient = useQueryClient();
+  const quillRef = useRef<ReactQuill>(null);
 
   const { data, isLoading, isError } = useAdminBoards({
     page,
@@ -159,6 +160,42 @@ export default function AdminBoardTab() {
       setLoadingEditId(null);
     }
   };
+
+  useEffect(() => {
+    if (mode !== "form") return;
+    const editor = quillRef.current?.getEditor();
+    if (!editor) return;
+
+    const insertUploadedImage = async (file: File, index: number) => {
+      try {
+        const url = await adminBoard.uploadImage(file);
+        editor.insertEmbed(index, "image", url, "user");
+        editor.setSelection(index + 1, 0, "user");
+      } catch {
+        toast({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" });
+      }
+    };
+
+    const toolbar = editor.getModule("toolbar") as { addHandler: (name: string, handler: () => void) => void };
+    toolbar.addHandler("image", () => {
+      const input = document.createElement("input");
+      input.setAttribute("type", "file");
+      input.setAttribute("accept", "image/png,image/jpeg,image/webp,image/gif");
+      input.onchange = () => {
+        const file = input.files?.[0];
+        if (!file) return;
+        void insertUploadedImage(file, editor.getSelection(true).index);
+      };
+      input.click();
+    });
+
+    const uploader = editor.getModule("uploader") as {
+      options: { handler: (range: { index: number; length: number }, files: File[]) => void };
+    };
+    uploader.options.handler = (range, files) => {
+      files.forEach((file) => void insertUploadedImage(file, range.index));
+    };
+  }, [mode, toast]);
 
   const handleSubmit = () => {
     const onSuccess = () => {
@@ -244,6 +281,7 @@ export default function AdminBoardTab() {
             <Label>본문</Label>
             <div className="[&_.ql-container]:min-h-[480px] [&_.ql-editor]:min-h-[480px] [&_.ql-editor]:text-base">
               <ReactQuill
+                ref={quillRef}
                 theme="snow"
                 value={form.content}
                 onChange={(content) => setForm((prev) => ({ ...prev, content }))}

--- a/client/src/components/admin/board/AdminBoardTab.tsx
+++ b/client/src/components/admin/board/AdminBoardTab.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useRef, useState } from "react";
-import ReactQuill from "react-quill-new";
-import "react-quill-new/dist/quill.snow.css";
+import { useRef, useState } from "react";
 
 import { ArrowLeft, Loader2, Pencil, Pin, Plus, Trash2 } from "lucide-react";
+import type { Editor as TinyMCEEditor } from "tinymce";
 
 import {
   AlertDialog,
@@ -18,6 +17,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
@@ -29,7 +29,10 @@ import { useCreateBoard, useAdminBoards, useDeleteBoard, useUpdateBoard } from "
 
 import { adminBoard } from "@/api/services/admin/board";
 import { BoardCategory, BoardStatus, BoardSummary } from "@/types/board";
+import { html } from "@codemirror/lang-html";
 import { useQueryClient } from "@tanstack/react-query";
+import { Editor } from "@tinymce/tinymce-react";
+import CodeMirror from "@uiw/react-codemirror";
 
 type StatusFilter = BoardStatus | "ALL";
 type CategoryFilter = BoardCategory | "ALL";
@@ -58,16 +61,17 @@ const CATEGORY_LABELS: Record<BoardCategory, string> = {
 
 const PAGE_SIZE = 10;
 
-// Quill 인스턴스가 modules 객체 identity 변경마다 재생성되는 것을 막기 위해 모듈 스코프 상수로 분리.
-const QUILL_MODULES = {
-  toolbar: [
-    [{ header: [1, 2, 3, false] }],
-    ["bold", "italic", "underline", "strike"],
-    [{ color: [] }, { background: [] }],
-    [{ list: "ordered" }, { list: "bullet" }],
-    ["link", "image"],
-    ["clean"],
-  ],
+const EDITOR_INIT = {
+  min_height: 480,
+  menubar: false,
+  branding: false,
+  plugins: "link image lists",
+  toolbar:
+    "blocks | bold italic underline strikethrough | forecolor backcolor | bullist numlist | link image | removeformat | code",
+  block_formats: "본문=p; 제목1=h1; 제목2=h2; 제목3=h3",
+  file_picker_types: "image",
+  automatic_uploads: true,
+  paste_data_images: true,
 };
 
 const toDatetimeLocal = (iso: string | null): string => {
@@ -115,7 +119,6 @@ export default function AdminBoardTab() {
   const [loadingEditId, setLoadingEditId] = useState<number | null>(null);
   const { toast } = useCustomToast();
   const queryClient = useQueryClient();
-  const quillRef = useRef<ReactQuill>(null);
 
   const { data, isLoading, isError } = useAdminBoards({
     page,
@@ -161,41 +164,39 @@ export default function AdminBoardTab() {
     }
   };
 
-  useEffect(() => {
-    if (mode !== "form") return;
-    const editor = quillRef.current?.getEditor();
-    if (!editor) return;
+  const handleImageUpload = async (blobInfo: { blob: () => Blob; filename: () => string }): Promise<string> => {
+    const file = new File([blobInfo.blob()], blobInfo.filename(), { type: blobInfo.blob().type });
+    try {
+      return await adminBoard.uploadImage(file);
+    } catch {
+      toast({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" });
+      throw new Error("이미지 업로드 실패");
+    }
+  };
 
-    const insertUploadedImage = async (file: File, index: number) => {
-      try {
-        const url = await adminBoard.uploadImage(file);
-        editor.insertEmbed(index, "image", url, "user");
-        editor.setSelection(index + 1, 0, "user");
-      } catch {
-        toast({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" });
-      }
+  const handleFilePick = (callback: (url: string, meta?: Record<string, string>) => void) => {
+    const input = document.createElement("input");
+    input.setAttribute("type", "file");
+    input.setAttribute("accept", "image/png,image/jpeg,image/webp,image/gif");
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      adminBoard
+        .uploadImage(file)
+        .then((url) => callback(url, { alt: file.name }))
+        .catch(() => toast({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" }));
     };
+    input.click();
+  };
 
-    const toolbar = editor.getModule("toolbar") as { addHandler: (name: string, handler: () => void) => void };
-    toolbar.addHandler("image", () => {
-      const input = document.createElement("input");
-      input.setAttribute("type", "file");
-      input.setAttribute("accept", "image/png,image/jpeg,image/webp,image/gif");
-      input.onchange = () => {
-        const file = input.files?.[0];
-        if (!file) return;
-        void insertUploadedImage(file, editor.getSelection(true).index);
-      };
-      input.click();
-    });
+  const editorRef = useRef<TinyMCEEditor | null>(null);
+  const [isSourceOpen, setIsSourceOpen] = useState(false);
+  const [sourceDraft, setSourceDraft] = useState("");
 
-    const uploader = editor.getModule("uploader") as {
-      options: { handler: (range: { index: number; length: number }, files: File[]) => void };
-    };
-    uploader.options.handler = (range, files) => {
-      files.forEach((file) => void insertUploadedImage(file, range.index));
-    };
-  }, [mode, toast]);
+  const applySourceDraft = () => {
+    editorRef.current?.setContent(sourceDraft);
+    setIsSourceOpen(false);
+  };
 
   const handleSubmit = () => {
     const onSuccess = () => {
@@ -279,16 +280,44 @@ export default function AdminBoardTab() {
 
           <div className="flex flex-col gap-2">
             <Label>본문</Label>
-            <div className="[&_.ql-container]:min-h-[480px] [&_.ql-editor]:min-h-[480px] [&_.ql-editor]:text-base">
-              <ReactQuill
-                ref={quillRef}
-                theme="snow"
-                value={form.content}
-                onChange={(content) => setForm((prev) => ({ ...prev, content }))}
-                modules={QUILL_MODULES}
-              />
-            </div>
+            <Editor
+              tinymceScriptSrc="/tinymce/tinymce.min.js"
+              licenseKey="gpl"
+              value={form.content}
+              onEditorChange={(content) => setForm((prev) => ({ ...prev, content }))}
+              init={{
+                ...EDITOR_INIT,
+                images_upload_handler: handleImageUpload,
+                file_picker_callback: handleFilePick,
+                setup: (editor: TinyMCEEditor) => {
+                  editorRef.current = editor;
+                  editor.ui.registry.addButton("code", {
+                    icon: "sourcecode",
+                    tooltip: "HTML 소스 편집",
+                    onAction: () => {
+                      setSourceDraft(editor.getContent({ format: "html" }));
+                      setIsSourceOpen(true);
+                    },
+                  });
+                },
+              }}
+            />
           </div>
+
+          <Dialog open={isSourceOpen} onOpenChange={setIsSourceOpen}>
+            <DialogContent className="max-w-3xl">
+              <DialogHeader>
+                <DialogTitle>HTML 소스 편집</DialogTitle>
+              </DialogHeader>
+              <CodeMirror value={sourceDraft} height="480px" extensions={[html()]} onChange={setSourceDraft} />
+              <DialogFooter>
+                <Button variant="outline" onClick={() => setIsSourceOpen(false)}>
+                  취소
+                </Button>
+                <Button onClick={applySourceDraft}>적용</Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
 
           <div className="grid grid-cols-2 gap-4">
             <div className="flex flex-col gap-2">

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -130,6 +130,7 @@ export const BOARD = {
   DETAIL: (id: number) => `/api/boards/${id}`,
   ADMIN_LIST: "/api/admins/boards",
   ADMIN_DETAIL: (id: number) => `/api/admins/boards/${id}`,
+  ADMIN_UPLOAD_IMAGE: "/api/admins/boards/images",
 };
 
 export const QNA = {

--- a/docker-compose/docker-compose.dev.yml
+++ b/docker-compose/docker-compose.dev.yml
@@ -73,6 +73,7 @@ services:
     volumes:
       - ../server:/var/web05-Denamu/server
       - /var/web05-Denamu/server/node_modules
+      - ../objects:/app/objects
     environment:
       NODE_ENV: 'DEV'
       TZ: 'Asia/Seoul'

--- a/docker-compose/docker-compose.local.yml
+++ b/docker-compose/docker-compose.local.yml
@@ -18,6 +18,7 @@ services:
       - app
     volumes:
       - ../nginx/logs:/var/log/nginx
+      - ../objects:/var/web05-Denamu/objects
     environment:
       TZ: 'Asia/Seoul'
 
@@ -40,6 +41,7 @@ services:
         condition: service_healthy
     volumes:
       - ../server/logs:/var/web05-Denamu/server/logs
+      - ../objects:/app/objects
     environment:
       NODE_ENV: 'LOCAL'
       TZ: 'Asia/Seoul'

--- a/server/src/board/api-docs/uploadBoardImage.api-docs.ts
+++ b/server/src/board/api-docs/uploadBoardImage.api-docs.ts
@@ -1,0 +1,44 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiCookieAuth,
+  ApiOperation,
+} from '@nestjs/swagger';
+
+import { UploadBoardImageResponseDto } from '@board/dto/response/uploadBoardImage.dto';
+
+import {
+  ApiBadRequestDoc,
+  ApiCreatedDataResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+export function ApiUploadBoardImage() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '게시글 본문 이미지 업로드 API' }),
+    ApiConsumes('multipart/form-data'),
+    ApiBody({
+      description: '업로드할 이미지 파일',
+      schema: {
+        type: 'object',
+        properties: {
+          file: {
+            type: 'string',
+            format: 'binary',
+            description: '업로드할 이미지 (png, jpg, jpeg, webp, gif)',
+          },
+        },
+        required: ['file'],
+      },
+    }),
+    ApiCreatedDataResponse(
+      UploadBoardImageResponseDto,
+      false,
+      '이미지 업로드 성공',
+    ),
+    ApiBadRequestDoc('잘못된 요청'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/board/controller/adminBoard.controller.ts
+++ b/server/src/board/controller/adminBoard.controller.ts
@@ -2,15 +2,21 @@ import {
   Body,
   Controller,
   Delete,
+  FileTypeValidator,
   Get,
   HttpCode,
   HttpStatus,
+  MaxFileSizeValidator,
   Param,
+  ParseFilePipe,
   Patch,
   Post,
   Query,
+  UploadedFile,
   UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags } from '@nestjs/swagger';
 
 import { ApiCreateBoard } from '@board/api-docs/createBoard.api-docs';
@@ -18,21 +24,60 @@ import { ApiDeleteBoard } from '@board/api-docs/deleteBoard.api-docs';
 import { ApiGetAdminBoard } from '@board/api-docs/getAdminBoard.api-docs';
 import { ApiGetAdminBoards } from '@board/api-docs/getAdminBoards.api-docs';
 import { ApiUpdateBoard } from '@board/api-docs/updateBoard.api-docs';
+import { ApiUploadBoardImage } from '@board/api-docs/uploadBoardImage.api-docs';
 import { CreateBoardRequestDto } from '@board/dto/request/createBoard.dto';
 import { GetAdminBoardsRequestDto } from '@board/dto/request/getAdminBoards.dto';
 import { GetBoardRequestDto } from '@board/dto/request/getBoard.dto';
 import { UpdateBoardRequestDto } from '@board/dto/request/updateBoard.dto';
+import { UploadBoardImageResponseDto } from '@board/dto/response/uploadBoardImage.dto';
 import { BoardService } from '@board/service/board.service';
 
 import { CurrentAdmin } from '@common/decorator/current-admin.decorator';
 import { AdminAuthGuard } from '@common/guard/session.guard';
 import { ApiResponse } from '@common/response/common.response';
 
+import { FILE_SIZE_LIMITS, FileUploadType } from '@file/constant/file.constant';
+import { FileService } from '@file/service/file.service';
+
 @ApiTags('Admin')
 @Controller('admins/boards')
 @UseGuards(AdminAuthGuard)
 export class AdminBoardController {
-  constructor(private readonly boardService: BoardService) {}
+  constructor(
+    private readonly boardService: BoardService,
+    private readonly fileService: FileService,
+  ) {}
+
+  @ApiUploadBoardImage()
+  @Post('images')
+  @HttpCode(HttpStatus.CREATED)
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadImage(
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({
+            maxSize: FILE_SIZE_LIMITS.IMAGE,
+            message: `파일 크기는 ${FILE_SIZE_LIMITS.IMAGE / (1024 * 1024)}MB를 초과할 수 없습니다.`,
+          }),
+          new FileTypeValidator({
+            fileType: /image\/(png|jpg|jpeg|webp|gif)/,
+            skipMagicNumbersValidation: true,
+          }),
+        ],
+      }),
+    )
+    file: Express.Multer.File,
+  ) {
+    const url = await this.fileService.saveWithoutOwner(
+      file,
+      FileUploadType.BOARD_IMAGE,
+    );
+    return ApiResponse.responseWithData(
+      '이미지 업로드에 성공했습니다.',
+      new UploadBoardImageResponseDto(url),
+    );
+  }
 
   @ApiGetAdminBoards()
   @Get()

--- a/server/src/board/dto/response/uploadBoardImage.dto.ts
+++ b/server/src/board/dto/response/uploadBoardImage.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UploadBoardImageResponseDto {
+  @ApiProperty({
+    example: '/objects/BOARD_IMAGE/2026-08-06/example.jpg',
+    description: '업로드된 이미지 접근 URL',
+  })
+  url: string;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+}

--- a/server/src/board/module/board.module.ts
+++ b/server/src/board/module/board.module.ts
@@ -7,10 +7,12 @@ import { BoardService } from '@board/service/board.service';
 
 import { AdminModule } from '@admin/module/admin.module';
 
+import { FileModule } from '@file/module/file.module';
+
 import { UserRepository } from '@user/repository/user.repository';
 
 @Module({
-  imports: [AdminModule],
+  imports: [AdminModule, FileModule],
   controllers: [BoardController, AdminBoardController],
   providers: [BoardService, BoardRepository, UserRepository],
   exports: [],

--- a/server/src/board/service/board.service.ts
+++ b/server/src/board/service/board.service.ts
@@ -11,12 +11,15 @@ import {
 } from '@board/dto/response/board.dto';
 import { Board } from '@board/entity/board.entity';
 import { BoardRepository } from '@board/repository/board.repository';
+import { extractBoardImageUrls } from '@board/util/extractBoardImageUrls';
 import { validateWindow } from '@board/util/validateWindow';
 
 import { AdminRepository } from '@admin/repository/admin.repository';
 
 import { EmailProducer } from '@common/email/email.producer';
 import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { FileService } from '@file/service/file.service';
 
 import { UserRepository } from '@user/repository/user.repository';
 
@@ -29,6 +32,7 @@ export class BoardService {
     private readonly adminRepository: AdminRepository,
     private readonly userRepository: UserRepository,
     private readonly emailProducer: EmailProducer,
+    private readonly fileService: FileService,
     private readonly logger: WinstonLoggerService,
   ) {}
 
@@ -168,6 +172,8 @@ export class BoardService {
         : board.endAt;
     validateWindow(startAt, endAt);
 
+    const previousContent = board.content;
+
     if (dto.title !== undefined) board.title = dto.title;
     if (dto.content !== undefined) board.content = dto.content;
     if (dto.isPinned !== undefined) board.isPinned = dto.isPinned;
@@ -177,13 +183,30 @@ export class BoardService {
     board.endAt = endAt;
 
     await this.boardRepository.save(board);
+
+    if (dto.content !== undefined) {
+      const removedUrls = extractBoardImageUrls(previousContent).filter(
+        (url) => !extractBoardImageUrls(dto.content).includes(url),
+      );
+      await this.deleteBoardImages(removedUrls);
+    }
+
     return BoardDetailDto.fromDetail(board);
   }
 
   async deleteBoard(id: number): Promise<void> {
-    const result = await this.boardRepository.delete(id);
-    if (!result.affected) {
+    const board = await this.boardRepository.findOneBy({ id });
+    if (!board) {
       throw new NotFoundException(NOT_FOUND_MESSAGE);
     }
+
+    await this.boardRepository.delete(id);
+    await this.deleteBoardImages(extractBoardImageUrls(board.content));
+  }
+
+  private async deleteBoardImages(urls: string[]): Promise<void> {
+    await Promise.allSettled(
+      urls.map((url) => this.fileService.deleteUntracked(url)),
+    );
   }
 }

--- a/server/src/board/util/extractBoardImageUrls.ts
+++ b/server/src/board/util/extractBoardImageUrls.ts
@@ -1,0 +1,5 @@
+const BOARD_IMAGE_SRC_PATTERN = /<img[^>]+src="(\/objects\/BOARD_IMAGE\/[^"]+)"/g;
+
+export function extractBoardImageUrls(content: string): string[] {
+  return [...content.matchAll(BOARD_IMAGE_SRC_PATTERN)].map((match) => match[1]);
+}

--- a/server/src/file/constant/file.constant.ts
+++ b/server/src/file/constant/file.constant.ts
@@ -1,5 +1,6 @@
 export enum FileUploadType {
   PROFILE_IMAGE = 'PROFILE_IMAGE',
+  BOARD_IMAGE = 'BOARD_IMAGE',
   // 추후 추가될 타입들 명시
 }
 

--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -30,16 +30,7 @@ export class FileService {
     uploadType: FileUploadType,
     userId: number,
   ) {
-    const today = this.getDateString();
-    const targetDir = path.join(this.basePath, uploadType, today);
-
-    await this.ensureDirectory(targetDir);
-
-    const ext = path.extname(file.originalname);
-    const fileName = `${uuid.v4()}${ext}`;
-    const filePath = path.join(targetDir, fileName);
-
-    await fs.writeFile(filePath, file.buffer);
+    const filePath = await this.writeToDisk(file, uploadType);
 
     const { originalname, mimetype, size } = file;
     const savedFile = await this.fileRepository.save({
@@ -52,6 +43,32 @@ export class FileService {
     const accessUrl = this.generateAccessUrl(filePath);
 
     return UploadFileResponseDto.toResponseDto(savedFile, accessUrl);
+  }
+
+  async saveWithoutOwner(
+    file: Express.Multer.File,
+    uploadType: FileUploadType,
+  ): Promise<string> {
+    const filePath = await this.writeToDisk(file, uploadType);
+    return this.generateAccessUrl(filePath);
+  }
+
+  private async writeToDisk(
+    file: Express.Multer.File,
+    uploadType: FileUploadType,
+  ): Promise<string> {
+    const today = this.getDateString();
+    const targetDir = path.join(this.basePath, uploadType, today);
+
+    await this.ensureDirectory(targetDir);
+
+    const ext = path.extname(file.originalname);
+    const fileName = `${uuid.v4()}${ext}`;
+    const filePath = path.join(targetDir, fileName);
+
+    await fs.writeFile(filePath, file.buffer);
+
+    return filePath;
   }
 
   private async ensureDirectory(dir: string) {
@@ -103,6 +120,16 @@ export class FileService {
 
   async getFileInfo(id: number): Promise<File> {
     return this.findById(id);
+  }
+
+  async deleteUntracked(accessUrl: string): Promise<void> {
+    const filePath = this.resolveInternalPath(accessUrl);
+    try {
+      await access(filePath);
+      await unlink(filePath);
+    } catch {
+      this.logger.warn(`파일 삭제 실패: ${filePath}`, 'FileService');
+    }
   }
 
   async deleteByPath(accessUrl: string): Promise<void> {

--- a/server/test/board/unit/board.service.unit.spec.ts
+++ b/server/test/board/unit/board.service.unit.spec.ts
@@ -14,6 +14,8 @@ import { AdminRepository } from '@admin/repository/admin.repository';
 import { EmailProducer } from '@common/email/email.producer';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 
+import { FileService } from '@file/service/file.service';
+
 import { UserRepository } from '@user/repository/user.repository';
 
 import { BoardFixture } from '@test/config/common/fixture/board.fixture';
@@ -25,6 +27,7 @@ describe(`${BoardService.name} Unit Test`, () => {
     | 'findPublicById'
     | 'findAdminList'
     | 'findOne'
+    | 'findOneBy'
     | 'create'
     | 'save'
     | 'delete',
@@ -35,6 +38,7 @@ describe(`${BoardService.name} Unit Test`, () => {
     Pick<UserRepository, 'findNoticeAgreedUsers'>
   >;
   let emailProducer: jest.Mocked<Pick<EmailProducer, 'produceNoticePublished'>>;
+  let fileService: jest.Mocked<Pick<FileService, 'deleteUntracked'>>;
   let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
 
   const createBoard = (overwrites: Partial<Board> = {}): Board =>
@@ -51,6 +55,7 @@ describe(`${BoardService.name} Unit Test`, () => {
       findPublicById: jest.fn(),
       findAdminList: jest.fn(),
       findOne: jest.fn(),
+      findOneBy: jest.fn(),
       create: jest.fn((entityLike) => entityLike),
       save: jest.fn((entity) => entity),
       delete: jest.fn(),
@@ -64,6 +69,9 @@ describe(`${BoardService.name} Unit Test`, () => {
     emailProducer = {
       produceNoticePublished: jest.fn(),
     };
+    fileService = {
+      deleteUntracked: jest.fn().mockResolvedValue(undefined),
+    };
     logger = { error: jest.fn() };
 
     boardService = new BoardService(
@@ -71,6 +79,7 @@ describe(`${BoardService.name} Unit Test`, () => {
       adminRepository as unknown as AdminRepository,
       userRepository as unknown as UserRepository,
       emailProducer as unknown as EmailProducer,
+      fileService as unknown as FileService,
       logger as unknown as WinstonLoggerService,
     );
   });
@@ -630,28 +639,77 @@ describe(`${BoardService.name} Unit Test`, () => {
       expect(result.isPinned).toBe(true);
       expect(boardRepository.save).toHaveBeenCalled();
     });
+
+    it('본문에서 제거된 이미지 파일을 삭제한다.', async () => {
+      // given
+      boardRepository.findOne.mockResolvedValue(
+        createBoard({
+          content:
+            '<p>본문</p><img src="/objects/BOARD_IMAGE/2026-08-06/old.jpg">',
+        }),
+      );
+
+      // when
+      await boardService.updateBoard(
+        1,
+        new UpdateBoardRequestDto({
+          content:
+            '<p>본문</p><img src="/objects/BOARD_IMAGE/2026-08-06/new.jpg">',
+        }),
+      );
+
+      // then
+      expect(fileService.deleteUntracked).toHaveBeenCalledWith(
+        '/objects/BOARD_IMAGE/2026-08-06/old.jpg',
+      );
+      expect(fileService.deleteUntracked).not.toHaveBeenCalledWith(
+        '/objects/BOARD_IMAGE/2026-08-06/new.jpg',
+      );
+    });
   });
 
   describe('deleteBoard', () => {
-    it('삭제된 행이 없을 경우 NotFoundException을 던진다.', async () => {
+    it('게시글이 존재하지 않을 경우 NotFoundException을 던진다.', async () => {
       // given
-      boardRepository.delete.mockResolvedValue({ affected: 0 });
+      boardRepository.findOneBy.mockResolvedValue(null);
 
       // when & then
       await expect(boardService.deleteBoard(1)).rejects.toThrow(
         NotFoundException,
       );
+      expect(boardRepository.delete).not.toHaveBeenCalled();
     });
 
     it('게시글 삭제에 성공한다.', async () => {
       // given
-      boardRepository.delete.mockResolvedValue({ affected: 1 });
+      boardRepository.findOneBy.mockResolvedValue(
+        createBoard({ content: '<p>본문</p>' }),
+      );
 
       // when
       await boardService.deleteBoard(1);
 
       // then
       expect(boardRepository.delete).toHaveBeenCalledWith(1);
+      expect(fileService.deleteUntracked).not.toHaveBeenCalled();
+    });
+
+    it('본문에 포함된 이미지 파일도 함께 삭제한다.', async () => {
+      // given
+      boardRepository.findOneBy.mockResolvedValue(
+        createBoard({
+          content:
+            '<p>본문</p><img src="/objects/BOARD_IMAGE/2026-08-06/a.jpg">',
+        }),
+      );
+
+      // when
+      await boardService.deleteBoard(1);
+
+      // then
+      expect(fileService.deleteUntracked).toHaveBeenCalledWith(
+        '/objects/BOARD_IMAGE/2026-08-06/a.jpg',
+      );
     });
   });
 });


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #906 

### 소주제1 - 에디터 라이브러리 교체 (react-quill → TinyMCE)

- react-quill 기반 에디터를 TinyMCE로 교체했습니다.
- Tistory 블로그 작성 시 사용하는 에디터가 TinyMCE라서 찾아봤고, 이미지 크기 조정 기능들도 있어서 좋을듯 하여 마이그레이션 했습니다.
<img width="457" height="68" alt="image" src="https://github.com/user-attachments/assets/8151585f-8c86-4f0a-8dfb-9ad6c3ee4c42" />

### 소주제2 - 게시글 이미지 업로드 기능

- 관리자 게시글 작성/수정 시 에디터 내 이미지 업로드가 가능하도록 API와 클라이언트를 연동했습니다.
- 이미지는 소유자(User) 없이 업로드되며(`FileService.saveWithoutOwner`), 게시글 저장/수정 시점에 본문(content)에서 실제 사용된 이미지 URL만 추출(`extractBoardImageUrls`)해 대조합니다.
- 게시글 수정/삭제로 더 이상 참조되지 않는 이미지는 자동으로 정리(`deleteUntracked`)되어 고아 파일이 쌓이지 않도록 했습니다.

# 📋 작업 내용

- `POST /admins/boards/images` 게시글 이미지 업로드 API 추가 (파일 크기/타입 검증 포함)
- `FileService`에 소유자 없는 업로드(`saveWithoutOwner`) 및 미추적 파일 삭제(`deleteUntracked`) 로직 추가
- `BoardService`에서 게시글 생성/수정/삭제 시 본문에 남아있는 이미지 URL만 유지하고 나머지는 정리하도록 반영
- 클라이언트 `AdminBoardTab`에 TinyMCE 에디터 적용 및 이미지 업로드 연동
- 관련 유닛 테스트 보강 (`board.service.unit.spec.ts`, `AdminBoardTab.test.tsx`)

# 📷 스크린 샷(선택 사항)

<img width="1278" height="775" alt="image" src="https://github.com/user-attachments/assets/42b5fc4d-edf2-4446-a478-135872d30409" />