### PR TITLE
⚡️ perf: 이미지 업로드 시 webp 변환

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -43,6 +43,7 @@
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "sanitize-html": "^2.17.6",
+        "sharp": "^0.35.3",
         "typeorm": "^0.3.29",
         "uuid": "^11.1.0",
         "winston": "^3.16.0",
@@ -788,6 +789,16 @@
         "kuler": "^2.0.0"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -1143,6 +1154,506 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -12129,9 +12640,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12241,6 +12752,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {

--- a/server/package.json
+++ b/server/package.json
@@ -66,6 +66,7 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "sanitize-html": "^2.17.6",
+    "sharp": "^0.35.3",
     "typeorm": "^0.3.29",
     "uuid": "^11.1.0",
     "winston": "^3.16.0",

--- a/server/src/file/constant/file.constant.ts
+++ b/server/src/file/constant/file.constant.ts
@@ -9,3 +9,5 @@ export const FILE_SIZE_LIMITS = {
   IMAGE: 5 * 1024 * 1024,
   DEFAULT: 10 * 1024 * 1024,
 };
+
+export const IMAGE_WEBP_QUALITY = 80;

--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -8,10 +9,14 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as uuid from 'uuid';
 import { access, unlink } from 'fs/promises';
+import sharp from 'sharp';
 
 import { WinstonLoggerService } from '@common/logger/logger.service';
 
-import { FileUploadType } from '@file/constant/file.constant';
+import {
+  FileUploadType,
+  IMAGE_WEBP_QUALITY,
+} from '@file/constant/file.constant';
 import { UploadFileResponseDto } from '@file/dto/response/uploadFile.dto';
 import { File } from '@file/entity/file.entity';
 import { FileRepository } from '@file/repository/file.repository';
@@ -30,11 +35,13 @@ export class FileService {
     uploadType: FileUploadType,
     userId: number,
   ) {
-    const filePath = await this.writeToDisk(file, uploadType);
+    const { filePath, mimetype, size } = await this.writeToDisk(
+      file,
+      uploadType,
+    );
 
-    const { originalname, mimetype, size } = file;
     const savedFile = await this.fileRepository.save({
-      originalName: originalname,
+      originalName: file.originalname,
       mimetype,
       size,
       path: filePath,
@@ -49,26 +56,42 @@ export class FileService {
     file: Express.Multer.File,
     uploadType: FileUploadType,
   ): Promise<string> {
-    const filePath = await this.writeToDisk(file, uploadType);
+    const { filePath } = await this.writeToDisk(file, uploadType);
     return this.generateAccessUrl(filePath);
   }
 
   private async writeToDisk(
     file: Express.Multer.File,
     uploadType: FileUploadType,
-  ): Promise<string> {
+  ) {
     const today = this.getDateString();
     const targetDir = path.join(this.basePath, uploadType, today);
 
     await this.ensureDirectory(targetDir);
 
-    const ext = path.extname(file.originalname);
+    const webpBuffer = await this.convertToWebp(file.buffer);
+    const useWebp = webpBuffer.length < file.buffer.length;
+
+    const buffer = useWebp ? webpBuffer : file.buffer;
+    const ext = useWebp ? '.webp' : path.extname(file.originalname);
+    const mimetype = useWebp ? 'image/webp' : file.mimetype;
+
     const fileName = `${uuid.v4()}${ext}`;
     const filePath = path.join(targetDir, fileName);
 
-    await fs.writeFile(filePath, file.buffer);
+    await fs.writeFile(filePath, buffer);
 
-    return filePath;
+    return { filePath, mimetype, size: buffer.length };
+  }
+
+  private async convertToWebp(buffer: Buffer): Promise<Buffer> {
+    try {
+      return await sharp(buffer, { animated: true })
+        .webp({ quality: IMAGE_WEBP_QUALITY })
+        .toBuffer();
+    } catch {
+      throw new BadRequestException('올바르지 않은 이미지 파일입니다.');
+    }
   }
 
   private async ensureDirectory(dir: string) {

--- a/server/test/file/e2e/upload.e2e-spec.ts
+++ b/server/test/file/e2e/upload.e2e-spec.ts
@@ -18,6 +18,12 @@ import { testApp } from '@test/config/e2e/env/jest.setup';
 
 const URL = '/api/files';
 
+// 100x100 단색 PNG: webp 변환 시 원본보다 확실히 작아지는 케이스 (353B -> 106B)
+const PNG_FIXTURE_BUFFER = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABE0lEQVR4nO3WUQ0DAQzD0CExfygHaxTuZ0onPakILCfN5yn3vIPwQep5rQtYgdUvEsOswIpZbd+RGAZWzEoM+5dhrLMCK2Ylhs3LSGcFVsxqHjHTIbBiVvfPgg+smJUYNi8jnRVYMat5xEyHwIpZ3T8LPrBiVmLYvIx0VmDFrOYRMx0CK2Z1/yz4wIpZiWHzMtJZgRWzmkfMdAismNX9s+ADK2Ylhs3LSGcFVsxqHjHTIbBiVvfPgg+smJUYNi8jnRVYMat5xEyHwIpZ3T8LPrBiVmLYvIx0VmDFrOYRMx0CK2Z1/yz4wIpZiWHzMtJZgRWzmkfMdAismNX9s+ADK2Ylhs3LSGcFVsxqHjHTIbBamfUFgy2uiqggRS0AAAAASUVORK5CYII=',
+  'base64',
+);
+
 describe(`POST ${URL} E2E Test`, () => {
   let agent: TestAgent;
   let user: User;
@@ -147,7 +153,7 @@ describe(`POST ${URL} E2E Test`, () => {
       .post(URL)
       .query(requestDto)
       .set('Authorization', `Bearer ${accessToken}`)
-      .attach('file', Buffer.alloc(1024, 0), 'test.png');
+      .attach('file', PNG_FIXTURE_BUFFER, 'test.png');
 
     // Http then
     const { data } = response.body;
@@ -155,9 +161,9 @@ describe(`POST ${URL} E2E Test`, () => {
     expect(data).toStrictEqual({
       id: expect.any(Number),
       originalName: 'test.png',
-      mimetype: 'image/png',
-      size: 1024,
-      url: expect.stringContaining(fileRandomName),
+      mimetype: 'image/webp',
+      size: expect.any(Number),
+      url: expect.stringContaining(`${fileRandomName}.webp`),
       userId: user.id,
       createdAt: expect.any(String),
     });
@@ -165,7 +171,7 @@ describe(`POST ${URL} E2E Test`, () => {
     // DB, Redis when
     const savedFile = await fileRepository.findOneBy({
       originalName: 'test.png',
-      mimetype: 'image/png',
+      mimetype: 'image/webp',
     });
 
     // DB, Redis then

--- a/server/test/file/unit/file.service.unit.spec.ts
+++ b/server/test/file/unit/file.service.unit.spec.ts
@@ -1,6 +1,11 @@
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 
 import * as fs from 'fs/promises';
+import sharp from 'sharp';
 
 import { WinstonLoggerService } from '@common/logger/logger.service';
 
@@ -11,8 +16,10 @@ import { FileService } from '@file/service/file.service';
 import { FileFixture } from '@test/config/common/fixture/file.fixture';
 
 jest.mock('fs/promises');
+jest.mock('sharp');
 
 const mockedFs = fs as jest.Mocked<typeof fs>;
+const mockedSharp = sharp as jest.MockedFunction<typeof sharp>;
 
 describe(`${FileService.name} Unit Test`, () => {
   let fileService: FileService;
@@ -33,14 +40,20 @@ describe(`${FileService.name} Unit Test`, () => {
   });
 
   describe('handleUpload', () => {
-    it('디렉터리를 생성하고 파일을 쓴 뒤 메타데이터를 저장한다.', async () => {
+    it('webp 변환 결과가 원본보다 작으면 webp로 재인코딩한 파일을 쓴 뒤 메타데이터를 저장한다.', async () => {
       // given
       const multerFile = {
         originalname: 'avatar.png',
         mimetype: 'image/png',
         size: 2048,
-        buffer: Buffer.from('data'),
+        buffer: Buffer.from('original-png-data-longer-than-webp'),
       } as Express.Multer.File;
+      const webpBuffer = Buffer.from('webp');
+      mockedSharp.mockReturnValue({
+        webp: jest.fn().mockReturnValue({
+          toBuffer: jest.fn().mockResolvedValue(webpBuffer),
+        }),
+      } as any);
       const savedFile = FileFixture.createFileFixture({
         id: 1,
         user: { id: 7 } as any,
@@ -55,24 +68,89 @@ describe(`${FileService.name} Unit Test`, () => {
       );
 
       // then
+      expect(mockedSharp).toHaveBeenCalledWith(multerFile.buffer, {
+        animated: true,
+      });
       expect(mockedFs.mkdir).toHaveBeenCalledWith(expect.any(String), {
         recursive: true,
       });
       expect(mockedFs.writeFile).toHaveBeenCalledWith(
-        expect.any(String),
-        multerFile.buffer,
+        expect.stringMatching(/\.webp$/),
+        webpBuffer,
       );
       expect(fileRepository.save).toHaveBeenCalledWith(
         expect.objectContaining({
           originalName: 'avatar.png',
-          mimetype: 'image/png',
-          size: 2048,
+          mimetype: 'image/webp',
+          size: webpBuffer.length,
           user: { id: 7 },
         }),
       );
       expect(result.id).toBe(savedFile.id);
       expect(result.userId).toBe(7);
       expect(typeof result.url).toBe('string');
+    });
+
+    it('이미지 변환에 실패하면 BadRequestException을 던진다.', async () => {
+      // given
+      const multerFile = {
+        originalname: 'broken.png',
+        mimetype: 'image/png',
+        size: 10,
+        buffer: Buffer.from('broken'),
+      } as Express.Multer.File;
+      mockedSharp.mockReturnValue({
+        webp: jest.fn().mockReturnValue({
+          toBuffer: jest.fn().mockRejectedValue(new Error('invalid image')),
+        }),
+      } as any);
+
+      // when & then
+      await expect(
+        fileService.handleUpload(multerFile, FileUploadType.PROFILE_IMAGE, 7),
+      ).rejects.toThrow(BadRequestException);
+      expect(fileRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('webp 변환 결과가 원본보다 크거나 같으면 원본을 그대로 저장한다.', async () => {
+      // given
+      const multerFile = {
+        originalname: 'tiny.gif',
+        mimetype: 'image/gif',
+        size: 4,
+        buffer: Buffer.from('data'),
+      } as Express.Multer.File;
+      const largerWebpBuffer = Buffer.from('webp-is-bigger-than-original');
+      mockedSharp.mockReturnValue({
+        webp: jest.fn().mockReturnValue({
+          toBuffer: jest.fn().mockResolvedValue(largerWebpBuffer),
+        }),
+      } as any);
+      const savedFile = FileFixture.createFileFixture({
+        id: 2,
+        user: { id: 7 } as any,
+      });
+      fileRepository.save.mockResolvedValue(savedFile);
+
+      // when
+      await fileService.handleUpload(
+        multerFile,
+        FileUploadType.PROFILE_IMAGE,
+        7,
+      );
+
+      // then
+      expect(mockedFs.writeFile).toHaveBeenCalledWith(
+        expect.stringMatching(/\.gif$/),
+        multerFile.buffer,
+      );
+      expect(fileRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          originalName: 'tiny.gif',
+          mimetype: 'image/gif',
+          size: multerFile.buffer.length,
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #908

### 이미지 webp 변환

- 이미지 업로드 시 원본을 그대로 저장하지 않고, `sharp`로 webp 인코딩 후 원본과 크기를 비교해 더 작은 쪽을 저장하도록 변경
- 예시: 512KB PNG 업로드 시 33.32KB webp로 변환 (약 93% 절감)
- `sharp`는 libvips 기반 Node.js 이미지 처리 라이브러리로, C 바인딩을 사용해 Node 진영에서 가장 빠른 축에 속하는 리사이즈/인코딩 성능을 제공. 별도 네이티브 빌드 없이 대부분의 포맷(JPEG/PNG/WebP/GIF/AVIF 등) 인코딩·디코딩을 지원해 이번 변환 로직의 유일한 의존성으로 채택
- GIF는 `animated: true` 옵션으로 프레임 전체를 유지한 채 애니메이션 webp로 변환. 정적 이미지 대비 프레임 수만큼 압축 이득이 크지 않을 수 있어, 변환 결과가 원본보다 작을 때만 webp를 채택하고 그렇지 않으면 원본 GIF를 그대로 저장 (테스트로 검증)
- 변환 실패(손상된 이미지 등) 시 `BadRequestException`으로 명확히 응답하도록 예외 처리 추가

# 📋 작업 내용

- `sharp` 의존성 추가
- `FileService.writeToDisk`에서 업로드 파일을 webp로 인코딩 후 원본과 크기 비교, 더 작은 쪽을 채택하여 저장
- 변환 실패 시 `BadRequestException` 발생
- 단위/E2E 테스트에 webp 변환 성공/실패/원본 유지 케이스 추가

# 📷 스크린 샷(선택 사항)

512KB PNG → 33.32KB WebP 변환 확인
<img width="440" height="94" alt="image" src="https://github.com/user-attachments/assets/fda391ae-564c-4258-aedc-77218e3d170e" />
