### PR TITLE
✨ feat: 이미지 첨부/변경 제한 및 미사용 이미지 자동 정리 구현

### DIFF
--- a/client/src/__tests__/components/profile/sections/ProfileEditTab.test.tsx
+++ b/client/src/__tests__/components/profile/sections/ProfileEditTab.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/hooks/queries/useOAuthLinks.ts", () => ({
 vi.mock("@/hooks/queries/useProfileSettings.ts", () => ({
   useUpdateProfile: () => ({ mutate: updateProfileMutate, isPending: false }),
   useUploadProfileImage: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useUpdateProfileImage: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useChangePassword: () => ({ mutate: changePasswordMutate, isPending: false }),
   useRequestDeleteAccount: () => ({ mutate: requestDeleteMutate, isPending: false }),
 }));

--- a/client/src/api/services/profile.ts
+++ b/client/src/api/services/profile.ts
@@ -61,6 +61,11 @@ export const updateProfile = async (payload: UpdateProfilePayload): Promise<ApiM
   return response.data;
 };
 
+export const updateProfileImage = async (profileImage: string): Promise<ApiMessage> => {
+  const response = await axiosInstance.patch<ApiMessage>(PROFILE.UPDATE_IMAGE, { profileImage });
+  return response.data;
+};
+
 export const checkUserNameAvailability = async (userName: string): Promise<boolean> => {
   const response = await axiosInstance.get<ApiData<{ exists: boolean }>>(USER.USERNAME_AVAILABILITY, {
     params: { userName },

--- a/client/src/components/profile/sections/ProfileEditTab.tsx
+++ b/client/src/components/profile/sections/ProfileEditTab.tsx
@@ -36,6 +36,7 @@ import {
   useChangePassword,
   useRequestDeleteAccount,
   useUpdateProfile,
+  useUpdateProfileImage,
   useUploadProfileImage,
 } from "@/hooks/queries/useProfileSettings.ts";
 
@@ -96,6 +97,7 @@ export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
 
   const updateProfile = useUpdateProfile(userId);
   const uploadImage = useUploadProfileImage();
+  const updateProfileImage = useUpdateProfileImage(userId);
   const changePassword = useChangePassword();
   const requestDelete = useRequestDeleteAccount();
 
@@ -188,12 +190,13 @@ export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
     if (!file) return;
     try {
       const result = await uploadImage.mutateAsync(file);
+      await updateProfileImage.mutateAsync(result.url);
       setProfileImage(result.url);
-      toast({ title: "이미지 업로드 성공", description: "저장을 눌러 변경사항을 반영하세요." });
+      toast({ title: "프로필 이미지 변경 성공", description: "프로필 이미지가 변경되었습니다." });
     } catch (error) {
       toast({
-        title: "이미지 업로드 실패",
-        description: getErrorMessage(error, "이미지 업로드에 실패했습니다."),
+        title: "프로필 이미지 변경 실패",
+        description: getErrorMessage(error, "프로필 이미지 변경에 실패했습니다."),
         variant: "destructive",
       });
     }
@@ -236,9 +239,6 @@ export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
     }
     if (introduction !== (profile?.introduction ?? "")) {
       payload.introduction = introduction;
-    }
-    if (profileImage && profileImage !== (profile?.profileImage ?? null)) {
-      payload.profileImage = profileImage;
     }
 
     if (Object.keys(payload).length === 0) {
@@ -355,10 +355,10 @@ export const ProfileEditTab = ({ userId, email }: ProfileEditTabProps) => {
               />
               <Button
                 variant="outline"
-                disabled={uploadImage.isPending}
+                disabled={uploadImage.isPending || updateProfileImage.isPending}
                 onClick={() => fileInputRef.current?.click()}
               >
-                {uploadImage.isPending ? "업로드 중..." : "이미지 변경"}
+                {uploadImage.isPending || updateProfileImage.isPending ? "변경 중..." : "이미지 변경"}
               </Button>
               <p className="mt-2 text-xs text-gray-400">PNG, JPG, WEBP, GIF (최대 5MB)</p>
             </div>

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -152,6 +152,7 @@ export const NOTIFICATION = {
 export const PROFILE = {
   PROFILE: (id: number) => `/api/users/${id}/profile`,
   UPDATE: "/api/users/profile",
+  UPDATE_IMAGE: "/api/users/profile-image",
   RSS: (id: number) => `/api/users/${id}/rss`,
   LIKES: (id: number) => `/api/users/${id}/likes`,
   COMMENTS: (id: number) => `/api/users/${id}/comments`,

--- a/client/src/hooks/queries/useProfileSettings.ts
+++ b/client/src/hooks/queries/useProfileSettings.ts
@@ -4,6 +4,7 @@ import {
   changePassword,
   requestDeleteAccount,
   updateProfile,
+  updateProfileImage,
   uploadProfileImage,
 } from "@/api/services/profile";
 import { ApiMessage } from "@/types/api";
@@ -26,6 +27,16 @@ export const useUploadProfileImage = () =>
   useMutation<UploadResult, ApiError, File>({
     mutationFn: uploadProfileImage,
   });
+
+export const useUpdateProfileImage = (userId: number) => {
+  const queryClient = useQueryClient();
+  return useMutation<ApiMessage, ApiError, string>({
+    mutationFn: updateProfileImage,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userProfile", userId] });
+    },
+  });
+};
 
 export const useChangePassword = () =>
   useMutation<ApiMessage, ApiError, ChangePasswordPayload>({

--- a/client/src/types/profile.ts
+++ b/client/src/types/profile.ts
@@ -67,7 +67,6 @@ export interface ProfileActivity {
 
 export interface UpdateProfilePayload {
   userName?: string;
-  profileImage?: string;
   introduction?: string;
   marketingEmailAgreed?: boolean;
   inactivityEmailAgreed?: boolean;

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -53,6 +53,7 @@ CREATE TABLE `user` (
   `inactivity_email_agreed_at` datetime DEFAULT NULL,
   `notice_email_agreed` tinyint NOT NULL DEFAULT 0,
   `notice_email_agreed_at` datetime DEFAULT NULL,
+  `profile_image_change_count` int NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `UQ_user_user_name` (`user_name`),
   UNIQUE KEY `UQ_user_email` (`email`)

--- a/server/src/board/constant/board.constant.ts
+++ b/server/src/board/constant/board.constant.ts
@@ -7,3 +7,5 @@ export enum BoardCategory {
   NOTICE = 'NOTICE',
   FAQ = 'FAQ',
 }
+
+export const MAX_BOARD_IMAGE_COUNT = 5;

--- a/server/src/board/dto/request/createBoard.dto.ts
+++ b/server/src/board/dto/request/createBoard.dto.ts
@@ -1,5 +1,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
+import { MaxBoardImageCount } from '@board/validator/maxBoardImageCount.validator';
 import { Transform } from 'class-transformer';
 import {
   IsBoolean,
@@ -11,8 +13,6 @@ import {
 } from 'class-validator';
 
 import { sanitizeBoardContent } from '@common/util/sanitizeHtml';
-
-import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
 
 export class CreateBoardRequestDto {
   @ApiProperty({
@@ -30,6 +30,7 @@ export class CreateBoardRequestDto {
   })
   @IsString({ message: '문자열로 입력해주세요.' })
   @Transform(({ value }) => sanitizeBoardContent(value))
+  @MaxBoardImageCount()
   content: string;
 
   @ApiPropertyOptional({ description: '상단 고정 여부', default: false })

--- a/server/src/board/dto/request/updateBoard.dto.ts
+++ b/server/src/board/dto/request/updateBoard.dto.ts
@@ -1,5 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
+import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
+import { MaxBoardImageCount } from '@board/validator/maxBoardImageCount.validator';
 import { Transform } from 'class-transformer';
 import {
   IsBoolean,
@@ -11,8 +13,6 @@ import {
 } from 'class-validator';
 
 import { sanitizeBoardContent } from '@common/util/sanitizeHtml';
-
-import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
 
 export class UpdateBoardRequestDto {
   @ApiPropertyOptional({
@@ -31,7 +31,10 @@ export class UpdateBoardRequestDto {
   })
   @IsOptional()
   @IsString({ message: '문자열로 입력해주세요.' })
-  @Transform(({ value }) => (value === undefined ? value : sanitizeBoardContent(value)))
+  @Transform(({ value }) =>
+    value === undefined ? value : sanitizeBoardContent(value),
+  )
+  @MaxBoardImageCount()
   content?: string;
 
   @ApiPropertyOptional({ description: '상단 고정 여부' })

--- a/server/src/board/validator/maxBoardImageCount.validator.ts
+++ b/server/src/board/validator/maxBoardImageCount.validator.ts
@@ -1,0 +1,25 @@
+import { MAX_BOARD_IMAGE_COUNT } from '@board/constant/board.constant';
+import { extractBoardImageUrls } from '@board/util/extractBoardImageUrls';
+import { registerDecorator, ValidationOptions } from 'class-validator';
+
+export function MaxBoardImageCount(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'maxBoardImageCount',
+      target: object.constructor,
+      propertyName,
+      options: {
+        message: `이미지는 최대 ${MAX_BOARD_IMAGE_COUNT}장까지 첨부할 수 있습니다.`,
+        ...validationOptions,
+      },
+      validator: {
+        validate(value: unknown): boolean {
+          return (
+            typeof value === 'string' &&
+            extractBoardImageUrls(value).length <= MAX_BOARD_IMAGE_COUNT
+          );
+        },
+      },
+    });
+  };
+}

--- a/server/src/common/database/migration/1785400000000-AddProfileImageChangeCount.ts
+++ b/server/src/common/database/migration/1785400000000-AddProfileImageChangeCount.ts
@@ -1,0 +1,18 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProfileImageChangeCount1785400000000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE \`user\`
+        ADD COLUMN \`profile_image_change_count\` int NOT NULL DEFAULT 0;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      'ALTER TABLE `user` DROP COLUMN `profile_image_change_count`;',
+    );
+  }
+}

--- a/server/src/file/constant/file.constant.ts
+++ b/server/src/file/constant/file.constant.ts
@@ -11,3 +11,5 @@ export const FILE_SIZE_LIMITS = {
 };
 
 export const IMAGE_WEBP_QUALITY = 80;
+
+export const ORPHAN_FILE_GRACE_PERIOD_MS = 1000 * 60 * 60 * 24;

--- a/server/src/file/module/file.module.ts
+++ b/server/src/file/module/file.module.ts
@@ -1,12 +1,23 @@
 import { Module } from '@nestjs/common';
 
+import { BoardRepository } from '@board/repository/board.repository';
+
 import { FileController } from '@file/controller/file.controller';
 import { FileRepository } from '@file/repository/file.repository';
+import { FileScheduler } from '@file/scheduler/file.scheduler';
 import { FileService } from '@file/service/file.service';
+
+import { UserRepository } from '@user/repository/user.repository';
 
 @Module({
   controllers: [FileController],
-  providers: [FileService, FileRepository],
+  providers: [
+    FileService,
+    FileRepository,
+    UserRepository,
+    BoardRepository,
+    FileScheduler,
+  ],
   exports: [FileService],
 })
 export class FileModule {}

--- a/server/src/file/repository/file.repository.ts
+++ b/server/src/file/repository/file.repository.ts
@@ -1,12 +1,22 @@
 import { Injectable } from '@nestjs/common';
 
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, LessThan, Like, Repository } from 'typeorm';
 
+import { FileUploadType } from '@file/constant/file.constant';
 import { File } from '@file/entity/file.entity';
 
 @Injectable()
 export class FileRepository extends Repository<File> {
   constructor(private dataSource: DataSource) {
     super(File, dataSource.createEntityManager());
+  }
+
+  async findOldByUploadType(uploadType: FileUploadType, before: Date) {
+    return this.find({
+      where: {
+        path: Like(`%/${uploadType}/%`),
+        createdAt: LessThan(before),
+      },
+    });
   }
 }

--- a/server/src/file/scheduler/file.scheduler.ts
+++ b/server/src/file/scheduler/file.scheduler.ts
@@ -1,0 +1,139 @@
+import { Injectable } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { BoardRepository } from '@board/repository/board.repository';
+import { extractBoardImageUrls } from '@board/util/extractBoardImageUrls';
+import { IsNull, Not } from 'typeorm';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import {
+  FileUploadType,
+  ORPHAN_FILE_GRACE_PERIOD_MS,
+} from '@file/constant/file.constant';
+import { FileRepository } from '@file/repository/file.repository';
+import { FileService } from '@file/service/file.service';
+import { canonicalizeUrl } from '@file/util/canonicalizeUrl';
+
+import { UserRepository } from '@user/repository/user.repository';
+
+@Injectable()
+export class FileScheduler {
+  constructor(
+    private readonly fileRepository: FileRepository,
+    private readonly userRepository: UserRepository,
+    private readonly boardRepository: BoardRepository,
+    private readonly fileService: FileService,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_3AM)
+  async cleanupOrphanFiles(): Promise<void> {
+    await this.cleanupOrphanProfileImages();
+    await this.cleanupOrphanBoardImages();
+  }
+
+  private async cleanupOrphanProfileImages(): Promise<void> {
+    const cutoff = new Date(Date.now() - ORPHAN_FILE_GRACE_PERIOD_MS);
+
+    try {
+      const candidates = await this.fileRepository.findOldByUploadType(
+        FileUploadType.PROFILE_IMAGE,
+        cutoff,
+      );
+      if (candidates.length === 0) {
+        return;
+      }
+
+      const totalUserCount = await this.userRepository.count();
+      if (totalUserCount === 0) {
+        this.logger.warn(
+          '[FileScheduler]: 유저 조회 결과가 비정상적으로 비어 있어 정리를 중단합니다.',
+        );
+        return;
+      }
+
+      const users = await this.userRepository.find({
+        where: { profileImage: Not(IsNull()) },
+        select: ['profileImage'],
+      });
+      const referenced = new Set(
+        users.map((user) => canonicalizeUrl(user.profileImage)),
+      );
+
+      let deletedCount = 0;
+      for (const candidate of candidates) {
+        const accessUrl = this.fileService.toAccessUrl(candidate.path);
+        if (referenced.has(canonicalizeUrl(accessUrl))) {
+          continue;
+        }
+        try {
+          await this.fileService.deleteByPath(accessUrl);
+          deletedCount += 1;
+        } catch (error) {
+          this.logger.error(
+            `[FileScheduler]: 프로필 고아 이미지 삭제 실패: ${accessUrl}, error=${error}`,
+          );
+        }
+      }
+      this.logger.log(
+        `[FileScheduler]: 프로필 고아 이미지 ${deletedCount}개 삭제 완료.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[FileScheduler]: 프로필 고아 이미지 정리 중 오류 발생: ${error}`,
+      );
+    }
+  }
+
+  private async cleanupOrphanBoardImages(): Promise<void> {
+    const cutoff = Date.now() - ORPHAN_FILE_GRACE_PERIOD_MS;
+
+    try {
+      const candidates = await this.fileService.findOldBoardImagePaths(cutoff);
+      if (candidates.length === 0) {
+        return;
+      }
+
+      const boards = await this.boardRepository.find({
+        select: ['content'],
+      });
+
+      if (boards.length === 0) {
+        this.logger.warn(
+          '[FileScheduler]: 게시글 조회 결과가 비정상적으로 비어 있어 정리를 중단합니다.',
+        );
+        return;
+      }
+
+      const referenced = new Set(
+        boards.flatMap((board) =>
+          extractBoardImageUrls(board.content).map(canonicalizeUrl),
+        ),
+      );
+
+      let deletedCount = 0;
+      for (const internalPath of candidates) {
+        const accessUrl = this.fileService.toAccessUrl(internalPath);
+        if (referenced.has(canonicalizeUrl(accessUrl))) {
+          continue;
+        }
+        try {
+          await this.fileService.deleteUntracked(accessUrl);
+          deletedCount += 1;
+        } catch (error) {
+          this.logger.error(
+            `[FileScheduler]: 게시글 고아 이미지 삭제 실패: ${accessUrl}, error=${error}`,
+          );
+        }
+      }
+      this.logger.log(
+        `[FileScheduler]: 게시글 고아 이미지 ${deletedCount}개 삭제 완료.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[FileScheduler]: 게시글 고아 이미지 정리 중 오류 발생: ${error}`,
+      );
+    }
+  }
+}

--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -180,4 +180,35 @@ export class FileService {
 
     await this.fileRepository.delete(file.id);
   }
+
+  async findOldBoardImagePaths(cutoff: number): Promise<string[]> {
+    const boardImageDir = path.join(this.basePath, FileUploadType.BOARD_IMAGE);
+
+    let dateDirs: string[];
+    try {
+      dateDirs = await fs.readdir(boardImageDir);
+    } catch {
+      return [];
+    }
+
+    const files: string[] = [];
+    for (const dateDir of dateDirs) {
+      const dateDirPath = path.join(boardImageDir, dateDir);
+      let fileNames: string[];
+      try {
+        fileNames = await fs.readdir(dateDirPath);
+      } catch {
+        continue;
+      }
+
+      for (const fileName of fileNames) {
+        const filePath = path.join(dateDirPath, fileName);
+        const stat = await fs.stat(filePath);
+        if (stat.isFile() && stat.mtimeMs < cutoff) {
+          files.push(filePath);
+        }
+      }
+    }
+    return files;
+  }
 }

--- a/server/src/file/service/file.service.ts
+++ b/server/src/file/service/file.service.ts
@@ -103,6 +103,14 @@ export class FileService {
     return now.toISOString().split('T')[0];
   }
 
+  get objectsBasePath(): string {
+    return this.basePath;
+  }
+
+  toAccessUrl(internalPath: string): string {
+    return this.generateAccessUrl(internalPath);
+  }
+
   private generateAccessUrl(filePath: string): string {
     return filePath.replace(this.basePath, '/objects');
   }

--- a/server/src/file/util/canonicalizeUrl.ts
+++ b/server/src/file/util/canonicalizeUrl.ts
@@ -1,0 +1,4 @@
+export function canonicalizeUrl(url: string): string {
+  const index = url.indexOf('/objects/');
+  return index === -1 ? url : url.slice(index);
+}

--- a/server/src/user/api-docs/updateProfileImage.api-docs.ts
+++ b/server/src/user/api-docs/updateProfileImage.api-docs.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiBody, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiMessageResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+import { UpdateProfileImageRequestDto } from '@user/dto/request/updateProfileImage.dto';
+
+export function ApiUpdateProfileImage() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '프로필 이미지 변경 API',
+      description:
+        '사용자의 프로필 이미지를 변경합니다. 하루 최대 변경 횟수 제한이 있습니다.',
+    }),
+    ApiBearerAuth(),
+    ApiBody({ type: UpdateProfileImageRequestDto }),
+    ApiMessageResponse('프로필 이미지 변경 성공'),
+    ApiBadRequestDoc('하루 변경 한도를 초과했습니다.'),
+    ApiUnauthorizedDoc('로그인이 필요합니다.'),
+  );
+}

--- a/server/src/user/api-docs/updateUser.api-docs.ts
+++ b/server/src/user/api-docs/updateUser.api-docs.ts
@@ -13,7 +13,7 @@ export function ApiUpdateUser() {
     ApiOperation({
       summary: '사용자 정보 수정 API',
       description:
-        '사용자의 이름, 프로필 이미지, 자기소개, 이메일 수신 동의(마케팅/미접속 알림/공지사항)를 수정합니다.',
+        '사용자의 이름, 자기소개, 이메일 수신 동의(마케팅/미접속 알림/공지사항)를 수정합니다.',
     }),
     ApiBearerAuth(),
     ApiBody({ type: UpdateUserRequestDto }),

--- a/server/src/user/constant/user.constants.ts
+++ b/server/src/user/constant/user.constants.ts
@@ -1,1 +1,3 @@
 export const REFRESH_TOKEN_TTL = 1000 * 60 * 60 * 24 * 7;
+
+export const PROFILE_IMAGE_DAILY_LIMIT = 3;

--- a/server/src/user/controller/user.controller.ts
+++ b/server/src/user/controller/user.controller.ts
@@ -47,6 +47,7 @@ import { ApiRegisterUser } from '@user/api-docs/registerUser.api-docs';
 import { ApiRequestDeleteAccount } from '@user/api-docs/requestDeleteAccount.api-docs';
 import { ApiResetPassword } from '@user/api-docs/resetPassword.api-docs';
 import { ApiSearchUser } from '@user/api-docs/searchUser.api-docs';
+import { ApiUpdateProfileImage } from '@user/api-docs/updateProfileImage.api-docs';
 import { ApiUpdateUser } from '@user/api-docs/updateUser.api-docs';
 import { CertificateUserRequestDto } from '@user/dto/request/certificateUser.dto';
 import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
@@ -61,6 +62,7 @@ import { RequestDeleteAccountRequestDto } from '@user/dto/request/requestDeleteA
 import { ResetPasswordRequestDto } from '@user/dto/request/resetPassword.dto';
 import { ResetPasswordParamRequestDto } from '@user/dto/request/resetPasswordParam.dto';
 import { SearchUserRequestDto } from '@user/dto/request/searchUser.dto';
+import { UpdateProfileImageRequestDto } from '@user/dto/request/updateProfileImage.dto';
 import { UpdateUserRequestDto } from '@user/dto/request/updateUser.dto';
 import { UserService } from '@user/service/user.service';
 
@@ -209,6 +211,23 @@ export class UserController {
     await this.userService.updateUser(user.id, updateUserDto);
     return ApiResponse.responseWithNoContent(
       '사용자 프로필 정보가 성공적으로 수정되었습니다.',
+    );
+  }
+
+  @ApiUpdateProfileImage()
+  @Patch('/profile-image')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtGuard)
+  async updateProfileImage(
+    @Body() updateProfileImageDto: UpdateProfileImageRequestDto,
+    @CurrentUser() user: Payload,
+  ) {
+    await this.userService.updateProfileImage(
+      user.id,
+      updateProfileImageDto.profileImage,
+    );
+    return ApiResponse.responseWithNoContent(
+      '프로필 이미지가 성공적으로 변경되었습니다.',
     );
   }
 

--- a/server/src/user/dto/request/updateProfileImage.dto.ts
+++ b/server/src/user/dto/request/updateProfileImage.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsString } from 'class-validator';
+
+export class UpdateProfileImageRequestDto {
+  @ApiProperty({
+    example: 'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+    description: '변경할 프로필 이미지 path',
+  })
+  @IsString({
+    message: '프로필 이미지는 문자열이어야 합니다.',
+  })
+  profileImage: string;
+}

--- a/server/src/user/dto/request/updateUser.dto.ts
+++ b/server/src/user/dto/request/updateUser.dto.ts
@@ -18,17 +18,6 @@ export class UpdateUserRequestDto {
   userName?: string;
 
   @ApiPropertyOptional({
-    example: 'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
-    description: '변경할 프로필 이미지 path',
-    required: false,
-  })
-  @IsOptional()
-  @IsString({
-    message: '프로필 이미지는 문자열이어야 합니다.',
-  })
-  profileImage?: string;
-
-  @ApiPropertyOptional({
     example: '안녕하세요! 김개발입니다.',
     description: '변경할 자기소개',
     required: false,

--- a/server/src/user/entity/user.entity.ts
+++ b/server/src/user/entity/user.entity.ts
@@ -124,6 +124,14 @@ export class User extends BaseEntity {
   })
   noticeEmailAgreedAt: Date | null;
 
+  @Column({
+    name: 'profile_image_change_count',
+    type: 'int',
+    nullable: false,
+    default: 0,
+  })
+  profileImageChangeCount: number;
+
   @OneToMany(() => Activity, (activity) => activity.user)
   activities: Activity[];
 

--- a/server/src/user/scheduler/user.scheduler.ts
+++ b/server/src/user/scheduler/user.scheduler.ts
@@ -55,4 +55,21 @@ export class UserScheduler {
       );
     }
   }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async resetProfileImageChangeCounts() {
+    try {
+      const result = await this.userRepository.update(
+        { profileImageChangeCount: Not(0) },
+        { profileImageChangeCount: 0 },
+      );
+      this.logger.log(
+        `[UserScheduler]: 프로필 이미지 변경 횟수 초기화 완료. ${result.affected ?? 0}명.`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[UserScheduler]: 프로필 이미지 변경 횟수 초기화 중 오류 발생: ${error}`,
+      );
+    }
+  }
 }

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   Injectable,
   NotFoundException,
@@ -10,7 +11,7 @@ import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import * as uuid from 'uuid';
 import { Response } from 'express';
-import { DataSource, IsNull } from 'typeorm';
+import { DataSource, IsNull, LessThan } from 'typeorm';
 
 import { cookieConfig } from '@common/cookie/cookie.config';
 import { EmailProducer } from '@common/email/email.producer';
@@ -28,7 +29,10 @@ import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
-import { REFRESH_TOKEN_TTL } from '@user/constant/user.constants';
+import {
+  PROFILE_IMAGE_DAILY_LIMIT,
+  REFRESH_TOKEN_TTL,
+} from '@user/constant/user.constants';
 import { ChangePasswordRequestDto } from '@user/dto/request/changePassword.dto';
 import { LoginUserRequestDto } from '@user/dto/request/loginUser.dto';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
@@ -309,6 +313,7 @@ export class UserService {
       updateData.profileImage !== undefined &&
       user.profileImage !== updateData.profileImage
     ) {
+      await this.consumeProfileImageChangeQuota(userId);
       if (user.profileImage) {
         await this.fileService.deleteByPath(user.profileImage);
       }
@@ -337,6 +342,22 @@ export class UserService {
         throw new ConflictException('이미 존재하는 닉네임입니다.');
       }
       throw error;
+    }
+  }
+
+  private async consumeProfileImageChangeQuota(userId: number): Promise<void> {
+    const result = await this.userRepository.update(
+      {
+        id: userId,
+        profileImageChangeCount: LessThan(PROFILE_IMAGE_DAILY_LIMIT),
+      },
+      { profileImageChangeCount: () => 'profile_image_change_count + 1' },
+    );
+
+    if (result.affected === 0) {
+      throw new BadRequestException(
+        `프로필 이미지는 하루 최대 ${PROFILE_IMAGE_DAILY_LIMIT}회까지 변경할 수 있습니다.`,
+      );
     }
   }
 

--- a/server/src/user/service/user.service.ts
+++ b/server/src/user/service/user.service.ts
@@ -11,7 +11,8 @@ import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import * as uuid from 'uuid';
 import { Response } from 'express';
-import { DataSource, IsNull, LessThan } from 'typeorm';
+import { DataSource, FindOptionsWhere, IsNull, LessThan } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 import { cookieConfig } from '@common/cookie/cookie.config';
 import { EmailProducer } from '@common/email/email.producer';
@@ -295,48 +296,35 @@ export class UserService {
     userId: number,
     updateData: Partial<UpdateUserRequestDto>,
   ): Promise<void> {
-    const user = await this.getUser(userId);
+    await this.getUser(userId);
 
-    if (
-      updateData.userName !== undefined &&
-      updateData.userName !== user.userName
-    ) {
-      const existingName = await this.userRepository.findOne({
-        where: { userName: updateData.userName },
-      });
-      if (existingName) {
-        throw new ConflictException('이미 존재하는 닉네임입니다.');
-      }
-      user.userName = updateData.userName;
-    }
-    if (
-      updateData.profileImage !== undefined &&
-      user.profileImage !== updateData.profileImage
-    ) {
-      await this.consumeProfileImageChangeQuota(userId);
-      if (user.profileImage) {
-        await this.fileService.deleteByPath(user.profileImage);
-      }
-      user.profileImage = updateData.profileImage;
+    const partialUpdate: Partial<User> = {};
+
+    if (updateData.userName !== undefined) {
+      partialUpdate.userName = updateData.userName;
     }
     if (updateData.introduction !== undefined) {
-      user.introduction = updateData.introduction;
+      partialUpdate.introduction = updateData.introduction;
     }
     if (updateData.marketingEmailAgreed !== undefined) {
-      user.marketingEmailAgreed = updateData.marketingEmailAgreed;
-      user.marketingEmailAgreedAt = new Date();
+      partialUpdate.marketingEmailAgreed = updateData.marketingEmailAgreed;
+      partialUpdate.marketingEmailAgreedAt = new Date();
     }
     if (updateData.inactivityEmailAgreed !== undefined) {
-      user.inactivityEmailAgreed = updateData.inactivityEmailAgreed;
-      user.inactivityEmailAgreedAt = new Date();
+      partialUpdate.inactivityEmailAgreed = updateData.inactivityEmailAgreed;
+      partialUpdate.inactivityEmailAgreedAt = new Date();
     }
     if (updateData.noticeEmailAgreed !== undefined) {
-      user.noticeEmailAgreed = updateData.noticeEmailAgreed;
-      user.noticeEmailAgreedAt = new Date();
+      partialUpdate.noticeEmailAgreed = updateData.noticeEmailAgreed;
+      partialUpdate.noticeEmailAgreedAt = new Date();
+    }
+
+    if (Object.keys(partialUpdate).length === 0) {
+      return;
     }
 
     try {
-      await this.userRepository.save(user);
+      await this.userRepository.update({ id: userId }, partialUpdate);
     } catch (error) {
       if ((error as { code?: string })?.code === 'ER_DUP_ENTRY') {
         throw new ConflictException('이미 존재하는 닉네임입니다.');
@@ -345,19 +333,31 @@ export class UserService {
     }
   }
 
-  private async consumeProfileImageChangeQuota(userId: number): Promise<void> {
-    const result = await this.userRepository.update(
-      {
-        id: userId,
-        profileImageChangeCount: LessThan(PROFILE_IMAGE_DAILY_LIMIT),
-      },
-      { profileImageChangeCount: () => 'profile_image_change_count + 1' },
-    );
+  async updateProfileImage(userId: number, profileImage: string) {
+    const user = await this.getUser(userId);
 
+    if (profileImage === user.profileImage) {
+      return;
+    }
+
+    const criteria: FindOptionsWhere<User> = {
+      id: userId,
+      profileImageChangeCount: LessThan(PROFILE_IMAGE_DAILY_LIMIT),
+    };
+    const partialUpdate: QueryDeepPartialEntity<User> = {
+      profileImage,
+      profileImageChangeCount: () => 'profile_image_change_count + 1',
+    };
+
+    const result = await this.userRepository.update(criteria, partialUpdate);
     if (result.affected === 0) {
       throw new BadRequestException(
         `프로필 이미지는 하루 최대 ${PROFILE_IMAGE_DAILY_LIMIT}회까지 변경할 수 있습니다.`,
       );
+    }
+
+    if (user.profileImage) {
+      await this.fileService.deleteByPath(user.profileImage);
     }
   }
 

--- a/server/test/board/dto/createBoard.dto.spec.ts
+++ b/server/test/board/dto/createBoard.dto.spec.ts
@@ -1,7 +1,6 @@
-import { validate } from 'class-validator';
-
 import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
 import { CreateBoardRequestDto } from '@board/dto/request/createBoard.dto';
+import { validate } from 'class-validator';
 
 describe(`${CreateBoardRequestDto.name} Test`, () => {
   let dto: CreateBoardRequestDto;
@@ -100,6 +99,35 @@ describe(`${CreateBoardRequestDto.name} Test`, () => {
       // then
       expect(errors).toHaveLength(1);
       expect(errors[0].constraints).toHaveProperty('isString');
+    });
+
+    it('첨부 이미지가 최대 개수(5장)까지면 유효성 검사에 성공한다.', async () => {
+      // given
+      dto.content = Array.from(
+        { length: 5 },
+        (_, i) => `<img src="/objects/BOARD_IMAGE/2026-08-01/${i}.png">`,
+      ).join('');
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(0);
+    });
+
+    it('첨부 이미지가 최대 개수(5장)를 초과하면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.content = Array.from(
+        { length: 6 },
+        (_, i) => `<img src="/objects/BOARD_IMAGE/2026-08-01/${i}.png">`,
+      ).join('');
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('maxBoardImageCount');
     });
   });
 

--- a/server/test/board/dto/updateBoard.dto.spec.ts
+++ b/server/test/board/dto/updateBoard.dto.spec.ts
@@ -1,7 +1,6 @@
-import { validate } from 'class-validator';
-
 import { BoardCategory, BoardStatus } from '@board/constant/board.constant';
 import { UpdateBoardRequestDto } from '@board/dto/request/updateBoard.dto';
+import { validate } from 'class-validator';
 
 describe(`${UpdateBoardRequestDto.name} Test`, () => {
   let dto: UpdateBoardRequestDto;
@@ -85,6 +84,35 @@ describe(`${UpdateBoardRequestDto.name} Test`, () => {
       // then
       expect(errors).toHaveLength(1);
       expect(errors[0].constraints).toHaveProperty('isString');
+    });
+
+    it('첨부 이미지가 최대 개수(5장)까지면 유효성 검사에 성공한다.', async () => {
+      // given
+      dto.content = Array.from(
+        { length: 5 },
+        (_, i) => `<img src="/objects/BOARD_IMAGE/2026-08-01/${i}.png">`,
+      ).join('');
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(0);
+    });
+
+    it('첨부 이미지가 최대 개수(5장)를 초과하면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.content = Array.from(
+        { length: 6 },
+        (_, i) => `<img src="/objects/BOARD_IMAGE/2026-08-01/${i}.png">`,
+      ).join('');
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('maxBoardImageCount');
     });
   });
 

--- a/server/test/file/unit/file.scheduler.unit.spec.ts
+++ b/server/test/file/unit/file.scheduler.unit.spec.ts
@@ -1,0 +1,223 @@
+import { BoardRepository } from '@board/repository/board.repository';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { FileRepository } from '@file/repository/file.repository';
+import { FileScheduler } from '@file/scheduler/file.scheduler';
+import { FileService } from '@file/service/file.service';
+
+import { UserRepository } from '@user/repository/user.repository';
+
+import { BoardFixture } from '@test/config/common/fixture/board.fixture';
+import { FileFixture } from '@test/config/common/fixture/file.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+
+describe(`${FileScheduler.name} Unit Test`, () => {
+  let fileScheduler: FileScheduler;
+  let fileRepository: jest.Mocked<Pick<FileRepository, 'findOldByUploadType'>>;
+  let userRepository: jest.Mocked<Pick<UserRepository, 'count' | 'find'>>;
+  let boardRepository: jest.Mocked<Pick<BoardRepository, 'find'>>;
+  let fileService: jest.Mocked<
+    Pick<
+      FileService,
+      | 'findOldBoardImagePaths'
+      | 'toAccessUrl'
+      | 'deleteByPath'
+      | 'deleteUntracked'
+    >
+  >;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'log' | 'warn' | 'error'>>;
+
+  beforeEach(() => {
+    fileRepository = { findOldByUploadType: jest.fn().mockResolvedValue([]) };
+    userRepository = {
+      count: jest.fn(),
+      find: jest.fn(),
+    };
+    boardRepository = { find: jest.fn() };
+    fileService = {
+      findOldBoardImagePaths: jest.fn().mockResolvedValue([]),
+      toAccessUrl: jest.fn((p: string) => p),
+      deleteByPath: jest.fn(),
+      deleteUntracked: jest.fn(),
+    };
+    logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    fileScheduler = new FileScheduler(
+      fileRepository as unknown as FileRepository,
+      userRepository as unknown as UserRepository,
+      boardRepository as unknown as BoardRepository,
+      fileService as unknown as FileService,
+      logger as unknown as WinstonLoggerService,
+    );
+  });
+
+  describe('cleanupOrphanProfileImages', () => {
+    it('오래된 후보가 없으면 유저 조회 없이 종료한다.', async () => {
+      // given
+      fileRepository.findOldByUploadType.mockResolvedValue([]);
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(userRepository.count).not.toHaveBeenCalled();
+    });
+
+    it('유저 전체 조회 결과가 비어 있으면 정리를 중단한다.', async () => {
+      // given
+      fileRepository.findOldByUploadType.mockResolvedValue([
+        FileFixture.createFileFixture({ path: '/app/objects/a.png' }),
+      ]);
+      userRepository.count.mockResolvedValue(0);
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(userRepository.find).not.toHaveBeenCalled();
+      expect(fileService.deleteByPath).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('참조되지 않는 후보만 삭제하고, 참조되는 후보는 남긴다.', async () => {
+      // given
+      fileRepository.findOldByUploadType.mockResolvedValue([
+        FileFixture.createFileFixture({
+          path: '/objects/PROFILE_IMAGE/used.png',
+        }),
+        FileFixture.createFileFixture({
+          path: '/objects/PROFILE_IMAGE/unused.png',
+        }),
+      ]);
+      userRepository.count.mockResolvedValue(1);
+      userRepository.find.mockResolvedValue([
+        UserFixture.createUserFixture({
+          profileImage: '/objects/PROFILE_IMAGE/used.png',
+        }),
+      ]);
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(fileService.deleteByPath).toHaveBeenCalledTimes(1);
+      expect(fileService.deleteByPath).toHaveBeenCalledWith(
+        '/objects/PROFILE_IMAGE/unused.png',
+      );
+    });
+
+    it('삭제 중 오류가 발생해도 나머지 후보를 계속 처리한다.', async () => {
+      // given
+      fileRepository.findOldByUploadType.mockResolvedValue([
+        FileFixture.createFileFixture({ path: '/objects/PROFILE_IMAGE/a.png' }),
+        FileFixture.createFileFixture({ path: '/objects/PROFILE_IMAGE/b.png' }),
+      ]);
+      userRepository.count.mockResolvedValue(1);
+      userRepository.find.mockResolvedValue([]);
+      fileService.deleteByPath.mockRejectedValueOnce(
+        new Error('unlink failed'),
+      );
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(fileService.deleteByPath).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('조회 중 예외가 발생하면 잡아서 에러로 남기고 전파하지 않는다.', async () => {
+      // given
+      fileRepository.findOldByUploadType.mockRejectedValue(
+        new Error('DB down'),
+      );
+
+      // when & then
+      await expect(fileScheduler.cleanupOrphanFiles()).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanupOrphanBoardImages', () => {
+    it('오래된 후보가 없으면 게시글 조회 없이 종료한다.', async () => {
+      // given
+      fileService.findOldBoardImagePaths.mockResolvedValue([]);
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(boardRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('게시글 조회 결과가 비어 있으면 정리를 중단한다.', async () => {
+      // given
+      fileService.findOldBoardImagePaths.mockResolvedValue([
+        '/app/objects/BOARD_IMAGE/2026-08-01/a.png',
+      ]);
+      boardRepository.find.mockResolvedValue([]);
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(fileService.deleteUntracked).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it('본문에 참조되지 않는 후보만 삭제한다.', async () => {
+      // given
+      fileService.findOldBoardImagePaths.mockResolvedValue([
+        '/objects/BOARD_IMAGE/used.png',
+        '/objects/BOARD_IMAGE/unused.png',
+      ]);
+      boardRepository.find.mockResolvedValue([
+        BoardFixture.createBoardFixture({
+          content: '<p><img src="/objects/BOARD_IMAGE/used.png"></p>',
+        }),
+      ]);
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(fileService.deleteUntracked).toHaveBeenCalledTimes(1);
+      expect(fileService.deleteUntracked).toHaveBeenCalledWith(
+        '/objects/BOARD_IMAGE/unused.png',
+      );
+    });
+
+    it('삭제 중 오류가 발생해도 나머지 후보를 계속 처리한다.', async () => {
+      // given
+      fileService.findOldBoardImagePaths.mockResolvedValue([
+        '/objects/BOARD_IMAGE/a.png',
+        '/objects/BOARD_IMAGE/b.png',
+      ]);
+      boardRepository.find.mockResolvedValue([
+        BoardFixture.createBoardFixture({ content: '<p>no images</p>' }),
+      ]);
+      fileService.deleteUntracked.mockRejectedValueOnce(
+        new Error('unlink failed'),
+      );
+
+      // when
+      await fileScheduler.cleanupOrphanFiles();
+
+      // then
+      expect(fileService.deleteUntracked).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('조회 중 예외가 발생하면 잡아서 에러로 남기고 전파하지 않는다.', async () => {
+      // given
+      fileService.findOldBoardImagePaths.mockRejectedValue(
+        new Error('disk error'),
+      );
+
+      // when & then
+      await expect(fileScheduler.cleanupOrphanFiles()).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/test/file/unit/file.service.unit.spec.ts
+++ b/server/test/file/unit/file.service.unit.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@nestjs/common';
 
 import * as fs from 'fs/promises';
+import * as path from 'path';
 import sharp from 'sharp';
 
 import { WinstonLoggerService } from '@common/logger/logger.service';
@@ -254,6 +255,139 @@ describe(`${FileService.name} Unit Test`, () => {
       // then
       expect(mockedFs.unlink).toHaveBeenCalledWith(file.path);
       expect(fileRepository.delete).toHaveBeenCalledWith(file.id);
+    });
+  });
+
+  describe('saveWithoutOwner', () => {
+    it('파일을 디스크에 저장만 하고 File 레코드는 생성하지 않는다.', async () => {
+      // given
+      const multerFile = {
+        originalname: 'board.png',
+        mimetype: 'image/png',
+        size: 2048,
+        buffer: Buffer.from('original-png-data-longer-than-webp'),
+      } as Express.Multer.File;
+      const webpBuffer = Buffer.from('webp');
+      mockedSharp.mockReturnValue({
+        webp: jest.fn().mockReturnValue({
+          toBuffer: jest.fn().mockResolvedValue(webpBuffer),
+        }),
+      } as any);
+
+      // when
+      const url = await fileService.saveWithoutOwner(
+        multerFile,
+        FileUploadType.BOARD_IMAGE,
+      );
+
+      // then
+      expect(mockedFs.writeFile).toHaveBeenCalledWith(
+        expect.stringMatching(/\.webp$/),
+        webpBuffer,
+      );
+      expect(url).toContain('BOARD_IMAGE');
+      expect(fileRepository.save).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteUntracked', () => {
+    it('물리 파일만 삭제하고 File 레코드는 건드리지 않는다.', async () => {
+      // given
+      const accessUrl = '/objects/BOARD_IMAGE/2026-08-01/a.png';
+
+      // when
+      await fileService.deleteUntracked(accessUrl);
+
+      // then
+      expect(mockedFs.unlink).toHaveBeenCalledWith(
+        '/app/objects/BOARD_IMAGE/2026-08-01/a.png',
+      );
+      expect(fileRepository.findOne).not.toHaveBeenCalled();
+      expect(fileRepository.delete).not.toHaveBeenCalled();
+    });
+
+    it('물리 파일 삭제에 실패해도 경고만 남기고 예외를 던지지 않는다.', async () => {
+      // given
+      mockedFs.access.mockRejectedValue(new Error('ENOENT'));
+
+      // when & then
+      await expect(
+        fileService.deleteUntracked('/objects/BOARD_IMAGE/missing.png'),
+      ).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('findOldBoardImagePaths', () => {
+    const boardImageDir = path.join('/app/objects', FileUploadType.BOARD_IMAGE);
+    const dateDir1 = path.join(boardImageDir, '2026-08-01');
+    const dateDir2 = path.join(boardImageDir, '2026-08-02');
+    const cutoff = new Date('2026-08-05').getTime();
+
+    it('board image 디렉터리 자체가 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      mockedFs.readdir.mockRejectedValue(new Error('ENOENT'));
+
+      // when
+      const result = await fileService.findOldBoardImagePaths(cutoff);
+
+      // then
+      expect(result).toEqual([]);
+    });
+
+    it('cutoff보다 오래된 파일만 모으고, 읽기 실패한 날짜 디렉터리는 건너뛴다.', async () => {
+      // given
+      mockedFs.readdir.mockImplementation((dir) => {
+        if (dir === boardImageDir)
+          return Promise.resolve(['2026-08-01', '2026-08-02'] as any);
+        if (dir === dateDir1)
+          return Promise.resolve(['old.png', 'new.png'] as any);
+        if (dir === dateDir2) return Promise.reject(new Error('ENOENT'));
+        return Promise.reject(new Error(`unexpected dir: ${String(dir)}`));
+      });
+      mockedFs.stat.mockImplementation((filePath) => {
+        if (filePath === path.join(dateDir1, 'old.png')) {
+          return Promise.resolve({
+            isFile: () => true,
+            mtimeMs: cutoff - 1000,
+          } as any);
+        }
+        if (filePath === path.join(dateDir1, 'new.png')) {
+          return Promise.resolve({
+            isFile: () => true,
+            mtimeMs: cutoff + 1000,
+          } as any);
+        }
+        return Promise.reject(
+          new Error(`unexpected file: ${String(filePath)}`),
+        );
+      });
+
+      // when
+      const result = await fileService.findOldBoardImagePaths(cutoff);
+
+      // then
+      expect(result).toEqual([path.join(dateDir1, 'old.png')]);
+    });
+
+    it('디렉터리 엔트리는 결과에서 제외한다.', async () => {
+      // given
+      mockedFs.readdir.mockImplementation((dir) => {
+        if (dir === boardImageDir)
+          return Promise.resolve(['2026-08-01'] as any);
+        if (dir === dateDir1) return Promise.resolve(['sub-dir'] as any);
+        return Promise.reject(new Error(`unexpected dir: ${String(dir)}`));
+      });
+      mockedFs.stat.mockResolvedValue({
+        isFile: () => false,
+        mtimeMs: cutoff - 1000,
+      } as any);
+
+      // when
+      const result = await fileService.findOldBoardImagePaths(cutoff);
+
+      // then
+      expect(result).toEqual([]);
     });
   });
 });

--- a/server/test/user/dto/update.dto.spec.ts
+++ b/server/test/user/dto/update.dto.spec.ts
@@ -8,7 +8,6 @@ describe(`${UpdateUserRequestDto.name} Test`, () => {
   beforeEach(() => {
     dto = new UpdateUserRequestDto({
       userName: 'test',
-      profileImage: 'test',
       introduction: 'test',
     });
   });
@@ -66,20 +65,6 @@ describe(`${UpdateUserRequestDto.name} Test`, () => {
       // then
       expect(errors).toHaveLength(1);
       expect(errors[0].constraints).toHaveProperty('maxLength');
-    });
-  });
-
-  describe('profileImage', () => {
-    it('프로필 이미지 경로가 문자열이 아니고 정수일 경우 유효성 검사에 실패한다.', async () => {
-      // given
-      dto.profileImage = 123 as any;
-
-      // when
-      const errors = await validate(dto);
-
-      // then
-      expect(errors).toHaveLength(1);
-      expect(errors[0].constraints).toHaveProperty('isString');
     });
   });
 
@@ -155,14 +140,13 @@ describe(`${UpdateUserRequestDto.name} Test`, () => {
     it('여러 필드가 유효하지 않을 경우 여러 유효성 검사에 실패한다.', async () => {
       // given
       dto.userName = 123 as any;
-      dto.profileImage = 456 as any;
       dto.introduction = 789 as any;
 
       // when
       const errors = await validate(dto);
 
       // then
-      expect(errors).toHaveLength(3);
+      expect(errors).toHaveLength(2);
 
       const constraintTypes = errors.flatMap((error) =>
         Object.keys(error.constraints || {}),

--- a/server/test/user/dto/updateProfileImage.dto.spec.ts
+++ b/server/test/user/dto/updateProfileImage.dto.spec.ts
@@ -1,0 +1,32 @@
+import { validate } from 'class-validator';
+
+import { UpdateProfileImageRequestDto } from '@user/dto/request/updateProfileImage.dto';
+
+describe(`${UpdateProfileImageRequestDto.name} Test`, () => {
+  let dto: UpdateProfileImageRequestDto;
+
+  beforeEach(() => {
+    dto = new UpdateProfileImageRequestDto();
+    dto.profileImage = 'test';
+  });
+
+  it('프로필 이미지 경로가 문자열이면 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('프로필 이미지 경로가 문자열이 아니고 정수일 경우 유효성 검사에 실패한다.', async () => {
+    // given
+    dto.profileImage = 123 as any;
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(1);
+    expect(errors[0].constraints).toHaveProperty('isString');
+  });
+});

--- a/server/test/user/e2e/update-profile-image.e2e-spec.ts
+++ b/server/test/user/e2e/update-profile-image.e2e-spec.ts
@@ -1,0 +1,121 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { FileService } from '@file/service/file.service';
+
+import { PROFILE_IMAGE_DAILY_LIMIT } from '@user/constant/user.constants';
+import { UpdateProfileImageRequestDto } from '@user/dto/request/updateProfileImage.dto';
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken } from '@test/config/e2e/env/jest.setup';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/users/profile-image';
+
+describe(`PATCH ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let userRepository: UserRepository;
+  let fileService: FileService;
+  let deleteByPathSpy: jest.SpyInstance;
+  let user: User;
+  let accessToken: string;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    fileService = testApp.get(FileService);
+    userRepository = testApp.get(UserRepository);
+  });
+
+  beforeEach(async () => {
+    deleteByPathSpy = jest
+      .spyOn(fileService, 'deleteByPath')
+      .mockResolvedValue(undefined);
+    user = await userRepository.save(
+      await UserFixture.createUserCryptFixture({
+        userName: '기존이름',
+        profileImage: 'https://url/objects/PROFILE_IMAGE/20000902/uuid_old.png',
+      }),
+    );
+    accessToken = createAccessToken(user);
+  });
+
+  it('[401] 로그인하지 않은 유저가 프로필 이미지 변경 요청을 할 경우 실패한다.', async () => {
+    // given
+    const requestDto: UpdateProfileImageRequestDto = {
+      profileImage: 'https://url/objects/PROFILE_IMAGE/20000902/uuid.png',
+    };
+
+    // Http when
+    const response = await agent.patch(URL).send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+
+    // DB when
+    const savedUser = await userRepository.findOneBy({ id: user.id });
+
+    // DB then
+    expect(savedUser.profileImage).toBe(user.profileImage);
+  });
+
+  it('[200] 프로필 이미지 변경 요청을 하면 기존 파일을 삭제하고 변경에 성공한다.', async () => {
+    // given
+    const requestDto: UpdateProfileImageRequestDto = {
+      profileImage: 'https://url/objects/PROFILE_IMAGE/20000902/uuid_new.png',
+    };
+
+    // Http when
+    const response = await agent
+      .patch(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data).toBeUndefined();
+    expect(deleteByPathSpy).toHaveBeenCalledWith(user.profileImage);
+
+    // DB when
+    const savedUser = await userRepository.findOneBy({ id: user.id });
+
+    // DB then
+    expect(savedUser.profileImage).toBe(requestDto.profileImage);
+    expect(savedUser.profileImageChangeCount).toBe(1);
+  });
+
+  it('[400] 하루 최대 변경 횟수를 초과하면 변경에 실패한다.', async () => {
+    // given
+    await userRepository.update(
+      { id: user.id },
+      { profileImageChangeCount: PROFILE_IMAGE_DAILY_LIMIT },
+    );
+    const requestDto: UpdateProfileImageRequestDto = {
+      profileImage: 'https://url/objects/PROFILE_IMAGE/20000902/uuid_new.png',
+    };
+
+    // Http when
+    const response = await agent
+      .patch(URL)
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send(requestDto);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+    expect(deleteByPathSpy).not.toHaveBeenCalled();
+
+    // DB when
+    const savedUser = await userRepository.findOneBy({ id: user.id });
+
+    // DB then
+    expect(savedUser.profileImage).toBe(user.profileImage);
+  });
+});

--- a/server/test/user/e2e/update-profile.e2e-spec.ts
+++ b/server/test/user/e2e/update-profile.e2e-spec.ts
@@ -44,7 +44,6 @@ describe(`PATCH ${URL} E2E Test`, () => {
     // given
     const requestDto = new UpdateUserRequestDto({
       userName: '변경된이름',
-      profileImage: 'https://url/objects/PROFILE_IMAGE/20000902/uuid.png',
       introduction: '변경된 소개글입니다.',
     });
 
@@ -69,7 +68,6 @@ describe(`PATCH ${URL} E2E Test`, () => {
     // given
     const requestDto = new UpdateUserRequestDto({
       userName: '변경된이름',
-      profileImage: 'https://url/objects/PROFILE_IMAGE/20000902/uuid.png',
       introduction: '변경된 소개글입니다.',
     });
     accessToken = createAccessToken({ id: Number.MAX_SAFE_INTEGER });
@@ -98,7 +96,6 @@ describe(`PATCH ${URL} E2E Test`, () => {
     // given
     const requestDto = new UpdateUserRequestDto({
       userName: '변경된이름',
-      profileImage: 'https://url/objects/PROFILE_IMAGE/20000902/uuid.png',
       introduction: '변경된 소개글입니다.',
     });
 
@@ -118,7 +115,6 @@ describe(`PATCH ${URL} E2E Test`, () => {
 
     // DB, Redis then
     expect(savedUser.userName).toBe(requestDto.userName);
-    expect(savedUser.profileImage).toBe(requestDto.profileImage);
     expect(savedUser.introduction).toBe(requestDto.introduction);
   });
 

--- a/server/test/user/unit/user.scheduler.unit.spec.ts
+++ b/server/test/user/unit/user.scheduler.unit.spec.ts
@@ -1,0 +1,61 @@
+import { Not } from 'typeorm';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { UserRepository } from '@user/repository/user.repository';
+import { UserScheduler } from '@user/scheduler/user.scheduler';
+
+describe(`${UserScheduler.name} Unit Test`, () => {
+  let userScheduler: UserScheduler;
+  let userRepository: jest.Mocked<Pick<UserRepository, 'update'>>;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'log' | 'error'>>;
+
+  beforeEach(() => {
+    userRepository = { update: jest.fn() };
+    logger = { log: jest.fn(), error: jest.fn() };
+
+    userScheduler = new UserScheduler(
+      userRepository as unknown as UserRepository,
+      logger as unknown as WinstonLoggerService,
+    );
+  });
+
+  describe('resetProfileImageChangeCounts', () => {
+    it('변경 횟수가 0이 아닌 유저를 전부 0으로 초기화한다.', async () => {
+      // given
+      userRepository.update.mockResolvedValue({ affected: 3 } as any);
+
+      // when
+      await userScheduler.resetProfileImageChangeCounts();
+
+      // then
+      expect(userRepository.update).toHaveBeenCalledWith(
+        { profileImageChangeCount: Not(0) },
+        { profileImageChangeCount: 0 },
+      );
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('3명'));
+    });
+
+    it('affected가 없으면 0명으로 로그를 남긴다.', async () => {
+      // given
+      userRepository.update.mockResolvedValue({ affected: undefined } as any);
+
+      // when
+      await userScheduler.resetProfileImageChangeCounts();
+
+      // then
+      expect(logger.log).toHaveBeenCalledWith(expect.stringContaining('0명'));
+    });
+
+    it('초기화 중 오류가 발생하면 잡아서 에러로 남기고 전파하지 않는다.', async () => {
+      // given
+      userRepository.update.mockRejectedValue(new Error('DB down'));
+
+      // when & then
+      await expect(
+        userScheduler.resetProfileImageChangeCounts(),
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   ConflictException,
   NotFoundException,
   UnauthorizedException,
@@ -7,7 +8,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 
 import { Response } from 'express';
-import { DataSource } from 'typeorm';
+import { DataSource, LessThan } from 'typeorm';
 
 import { EmailProducer } from '@common/email/email.producer';
 import { Payload } from '@common/guard/jwt.guard';
@@ -23,6 +24,7 @@ import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
+import { PROFILE_IMAGE_DAILY_LIMIT } from '@user/constant/user.constants';
 import { RegisterUserRequestDto } from '@user/dto/request/registerUser.dto';
 import { SearchUserRequestDto } from '@user/dto/request/searchUser.dto';
 import { CheckEmailDuplicationResponseDto } from '@user/dto/response/checkEmailDuplication.dto';
@@ -48,6 +50,7 @@ describe(`${UserService.name} Unit Test`, () => {
       | 'findOne'
       | 'save'
       | 'remove'
+      | 'update'
       | 'searchUserList'
       | 'isUserBlocked'
     >
@@ -95,6 +98,7 @@ describe(`${UserService.name} Unit Test`, () => {
       findOne: jest.fn(),
       save: jest.fn(),
       remove: jest.fn(),
+      update: jest.fn().mockResolvedValue({ affected: 1 }),
       searchUserList: jest.fn(),
       isUserBlocked: jest.fn(),
     };
@@ -585,39 +589,7 @@ describe(`${UserService.name} Unit Test`, () => {
   describe('updateUser', () => {
     const userId = 1;
 
-    it('프로필 이미지가 변경되면 기존 파일을 삭제하고 교체한다.', async () => {
-      // given
-      const user = UserFixture.createUserFixture({
-        profileImage: 'old.png',
-      });
-      userRepository.findOneBy.mockResolvedValue(user);
-
-      // when
-      await userService.updateUser(userId, {
-        profileImage: 'new.png',
-      });
-
-      // then
-      expect(fileService.deleteByPath).toHaveBeenCalledWith('old.png');
-      expect(user.profileImage).toBe('new.png');
-      expect(userRepository.save).toHaveBeenCalledWith(user);
-    });
-
-    it('동일한 프로필 이미지면 파일을 삭제하지 않는다.', async () => {
-      // given
-      const user = UserFixture.createUserFixture({ profileImage: 'same.png' });
-      userRepository.findOneBy.mockResolvedValue(user);
-
-      // when
-      await userService.updateUser(userId, {
-        profileImage: 'same.png',
-      });
-
-      // then
-      expect(fileService.deleteByPath).not.toHaveBeenCalled();
-    });
-
-    it('userName만 들어오면 이름만 변경한다.', async () => {
+    it('userName만 들어오면 해당 필드만 갱신한다.', async () => {
       // given
       const user = UserFixture.createUserFixture({ userName: 'old' });
       userRepository.findOneBy.mockResolvedValue(user);
@@ -628,44 +600,29 @@ describe(`${UserService.name} Unit Test`, () => {
       });
 
       // then
-      expect(user.userName).toBe('new');
+      expect(userRepository.update).toHaveBeenCalledWith(
+        { id: userId },
+        { userName: 'new' },
+      );
       expect(fileService.deleteByPath).not.toHaveBeenCalled();
     });
 
-    it('변경하려는 userName이 이미 존재하면 ConflictException을 던진다.', async () => {
+    it('존재하지 않는 사용자면 NotFoundException을 던지고 갱신하지 않는다.', async () => {
       // given
-      const user = UserFixture.createUserFixture({ userName: 'old' });
-      userRepository.findOneBy.mockResolvedValue(user);
-      userRepository.findOne.mockResolvedValue(
-        UserFixture.createUserFixture({ userName: 'taken' }),
-      );
+      userRepository.findOneBy.mockResolvedValue(null);
 
       // when & then
       await expect(
-        userService.updateUser(userId, { userName: 'taken' }),
-      ).rejects.toThrow(ConflictException);
-      expect(userRepository.save).not.toHaveBeenCalled();
+        userService.updateUser(userId, { userName: 'new' }),
+      ).rejects.toThrow(NotFoundException);
+      expect(userRepository.update).not.toHaveBeenCalled();
     });
 
-    it('동일한 userName이면 중복 조회 없이 통과한다.', async () => {
+    it('갱신 시 unique 제약 위반(ER_DUP_ENTRY)이면 ConflictException으로 변환한다.', async () => {
       // given
-      const user = UserFixture.createUserFixture({ userName: 'same' });
-      userRepository.findOneBy.mockResolvedValue(user);
-
-      // when
-      await userService.updateUser(userId, { userName: 'same' });
-
-      // then
-      expect(userRepository.findOne).not.toHaveBeenCalled();
-      expect(userRepository.save).toHaveBeenCalledWith(user);
-    });
-
-    it('사전 조회를 통과해도 저장 시 unique 제약 위반(ER_DUP_ENTRY)이면 ConflictException으로 변환한다.', async () => {
-      // given: 사전 조회는 비어 있지만(TOCTOU) 저장 시점에 중복이 발생하는 경합 상황
       const user = UserFixture.createUserFixture({ userName: 'old' });
       userRepository.findOneBy.mockResolvedValue(user);
-      userRepository.findOne.mockResolvedValue(null);
-      userRepository.save.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
+      userRepository.update.mockRejectedValue({ code: 'ER_DUP_ENTRY' });
 
       // when & then
       await expect(
@@ -673,13 +630,9 @@ describe(`${UserService.name} Unit Test`, () => {
       ).rejects.toThrow(ConflictException);
     });
 
-    it('이메일 수신 동의 값이 들어오면 해당 필드만 변경한다.', async () => {
+    it('이메일 수신 동의 값이 들어오면 해당 필드만 갱신한다.', async () => {
       // given
-      const user = UserFixture.createUserFixture({
-        marketingEmailAgreed: false,
-        inactivityEmailAgreed: true,
-        noticeEmailAgreed: true,
-      });
+      const user = UserFixture.createUserFixture();
       userRepository.findOneBy.mockResolvedValue(user);
 
       // when
@@ -689,28 +642,96 @@ describe(`${UserService.name} Unit Test`, () => {
       });
 
       // then
-      expect(user.marketingEmailAgreed).toBe(true);
-      expect(user.inactivityEmailAgreed).toBe(false);
-      expect(user.noticeEmailAgreed).toBe(true);
-      expect(userRepository.save).toHaveBeenCalledWith(user);
+      expect(userRepository.update).toHaveBeenCalledWith(
+        { id: userId },
+        {
+          marketingEmailAgreed: true,
+          marketingEmailAgreedAt: expect.any(Date),
+          inactivityEmailAgreed: false,
+          inactivityEmailAgreedAt: expect.any(Date),
+        },
+      );
     });
 
-    it('이메일 수신 동의 값이 없으면 기존 값을 유지한다.', async () => {
+    it('이메일 수신 동의 값이 없으면 갱신 대상에 포함하지 않는다.', async () => {
       // given
-      const user = UserFixture.createUserFixture({
-        marketingEmailAgreed: false,
-        inactivityEmailAgreed: true,
-        noticeEmailAgreed: true,
-      });
+      const user = UserFixture.createUserFixture();
       userRepository.findOneBy.mockResolvedValue(user);
 
       // when
       await userService.updateUser(userId, { introduction: '변경' });
 
       // then
-      expect(user.marketingEmailAgreed).toBe(false);
-      expect(user.inactivityEmailAgreed).toBe(true);
-      expect(user.noticeEmailAgreed).toBe(true);
+      expect(userRepository.update).toHaveBeenCalledWith(
+        { id: userId },
+        { introduction: '변경' },
+      );
+    });
+
+    it('갱신할 필드가 없으면 update를 호출하지 않는다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture();
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.updateUser(userId, {});
+
+      // then
+      expect(userRepository.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateProfileImage', () => {
+    const userId = 1;
+
+    it('프로필 이미지가 변경되면 기존 파일을 삭제하고 한도 가드와 함께 원자적으로 갱신한다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({
+        profileImage: 'old.png',
+      });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.updateProfileImage(userId, 'new.png');
+
+      // then
+      expect(fileService.deleteByPath).toHaveBeenCalledWith('old.png');
+      expect(userRepository.update).toHaveBeenCalledWith(
+        {
+          id: userId,
+          profileImageChangeCount: LessThan(PROFILE_IMAGE_DAILY_LIMIT),
+        },
+        expect.objectContaining({
+          profileImage: 'new.png',
+          profileImageChangeCount: expect.any(Function),
+        }),
+      );
+    });
+
+    it('동일한 프로필 이미지면 파일을 삭제하지 않고 한도 가드도 걸지 않는다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ profileImage: 'same.png' });
+      userRepository.findOneBy.mockResolvedValue(user);
+
+      // when
+      await userService.updateProfileImage(userId, 'same.png');
+
+      // then
+      expect(fileService.deleteByPath).not.toHaveBeenCalled();
+      expect(userRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('하루 변경 한도를 초과하면 BadRequestException을 던지고 파일을 삭제하지 않는다.', async () => {
+      // given
+      const user = UserFixture.createUserFixture({ profileImage: 'old.png' });
+      userRepository.findOneBy.mockResolvedValue(user);
+      userRepository.update.mockResolvedValue({ affected: 0 } as any);
+
+      // when & then
+      await expect(
+        userService.updateProfileImage(userId, 'new.png'),
+      ).rejects.toThrow(BadRequestException);
+      expect(fileService.deleteByPath).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #912 
- close #913 

### 게시글/프로필 이미지 첨부 개수 제한

-   게시글 본문(`content`)에 첨부 가능한 이미지 개수를 5장으로 제한하는 커스텀 validator(`maxBoardImageCount`)를 DTO 레벨에 추가함.
-   API 호출 전 유효성 검사 단계에서 걸러지도록 해서, 불필요한 이미지 저장/DB write가 발생하지 않게 함.

### 프로필 이미지 변경 횟수 제한 (하루 3회) — race condition 대응

-   `user.profileImageChangeCount`를 하루 최대 3회(`PROFILE_IMAGE_DAILY_LIMIT`)로 제한.
-   처음엔 "엔티티 조회 → 카운트 검사 → 카운트+1 → save" 방식을 고려했으나, 이 방식은 read-modify-write 구조라 동시 요청 시 TOCTOU race가 발생함. 두 요청이 동시에 카운트 2를 읽고 각자 3으로 증가시켜 저장하면, 실제로는 이미지가 2번 바뀌었는데도 DB엔 1번 증가한 것처럼 기록되어 하루 제한이 조용히 뚫림.
-   그래서 조회-후-갱신이 아니라, **단일 UPDATE 문에서 조건과 증가를 동시에 처리**하도록 구현함.
    ```sql
    UPDATE user
    SET profile_image_change_count = profile_image_change_count + 1, profile_image = ?
    WHERE id = ? AND profile_image_change_count < 3
    ```
-   `profile_image_change_count + 1`은 TypeORM의 raw SQL 표현식(`() => string`)으로 넘겨서, 애플리케이션 메모리 값이 아니라 **UPDATE 실행 시점의 실제 DB 값 기준**으로 증가하게 함. WHERE 조건도 같은 문장 안에서 평가되므로 MySQL의 row-level 락 안에서 원자적으로 처리됨.
-   `affected === 0`이면 한도 초과로 판단해 `BadRequestException`을 던짐. 동일한 이미지로 재요청하는 경우는 카운트 소모 없이 조기 반환하도록 처리함.
-   매일 자정, `UserScheduler.resetProfileImageChangeCounts()`가 전체 유저의 카운트를 0으로 초기화함.

### 프로필/프로필 이미지 갱신 API 분리

-   `UserService`가 여러 기능(인증, RSS, 활동, 프로필, 비밀번호, 탈퇴 등)이 한 파일에 몰려있어 계속 비대해지는 상태였음. 그중에서도 `updateUser`는 일반 프로필 필드(닉네임/소개/이메일 수신동의)와 프로필 이미지(원자적 카운트 증가, 한도 가드, 기존 파일 정리)라는 서로 다른 성격의 로직이 한 메서드에 섞여있어 가장 먼저 정리 대상이 됨.
-   `PATCH /users/profile` (일반 필드, `UserService.updateUser`)와 `PATCH /users/profile-image` (이미지 전용, `UserService.updateProfileImage`)로 엔드포인트/서비스 메서드를 분리함.
-   분리 후 `updateUser`는 raw SQL 카운터 증가 로직이 없어져서 `QueryDeepPartialEntity<User>` 대신 `Partial<User>` 타입으로 단순화됐고, 프론트엔드도 아바타 이미지를 선택 즉시 반영하는 액션으로 바꿔서 "저장" 버튼과의 결합을 없앰.

### 매일 새벽 3시 미사용 이미지 정리 스케줄러

-   업로드는 됐지만 어떤 게시글/프로필에도 참조되지 않는 "고아 이미지"가 스토리지에 계속 쌓이는 문제가 있어서 `FileScheduler.cleanupOrphanFiles()`를 추가함 (`@Cron(CronExpression.EVERY_DAY_AT_3AM)`).
-   프로필 이미지: `FileUploadType.PROFILE_IMAGE`로 업로드된 파일 중 생성 후 24시간(`ORPHAN_FILE_GRACE_PERIOD_MS`) 이상 지난 것을 후보로 조회하고, 전체 유저의 `profileImage` 값을 모아 참조 여부를 대조해서 어디에도 안 쓰이는 파일만 삭제.
-   게시글 이미지: 마찬가지로 24시간 지난 board 이미지 후보를 조회하고, 전체 게시글의 `content`에서 이미지 URL을 파싱(`extractBoardImageUrls`)해 참조 집합을 만든 뒤 미참조 파일만 삭제.
-   24시간 유예 기간을 둔 이유: 업로드 직후 ~ 게시글/프로필 저장 완료 사이의 시간차 때문에, 업로드는 됐지만 아직 참조가 걸리기 전인 파일이 정상 케이스인데도 삭제되는 걸 방지하기 위함.
-   URL 형식 차이(스킴, trailing slash 등)로 인한 오탐 비교를 막기 위해 `canonicalizeUrl`로 정규화 후 비교함.
-   유저/게시글 조회 결과가 비정상적으로 0건이면(장애 상황 등) 삭제를 중단하고 경고 로그만 남기도록 해서, 조회 실패가 전체 삭제로 이어지는 사고를 방지함.

# 📋 작업 내용

-   게시글 이미지 첨부 개수 제한 DTO validator 추가
-   `user.profileImageChangeCount` 컬럼 추가 + 마이그레이션
-   프로필 이미지 변경 하루 3회 제한 (원자적 UPDATE 기반)
-   프로필 이미지 변경 횟수 매일 자정 초기화 크론 추가
-   `updateUser` / `updateProfileImage` API 분리 (서버 + 클라이언트)
-   미사용 프로필/게시글 이미지 매일 새벽 3시 자동 정리 스케줄러 추가
-   `FileService` 함수 접근 지정자 캡슐화
-   관련 유닛/DTO/E2E 테스트 추가

# 📷 스크린 샷(선택 사항)

-   해당 사항 없음 (백엔드 API/스케줄러 변경)