### PR TITLE
✨ feat: 관리자 단체(마케팅) 이메일 발송 기능

### DIFF
--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -6,6 +6,7 @@ import type { ChildAdmin } from "@/types/admin";
 import type { BoardDetail, BoardPage, BoardSummary } from "@/types/board";
 import type { ChartPlatform, ChartType } from "@/types/chart";
 import type { AdminChatRoom, ChatType } from "@/types/chat";
+import type { MarketingEmailDetail, MarketingEmailPage, MarketingEmailSummary } from "@/types/marketingEmail";
 import type { FeedDetail, FeedList } from "@/types/post";
 import type {
   BlockedRss,
@@ -518,6 +519,36 @@ export const mockFaqBoardDetail: BoardDetail = {
   authorName: "테스트 계정",
   updatedAt: "2026-07-22T09:00:00.000Z",
 };
+
+const mockMarketingEmailSummaries: MarketingEmailSummary[] = [
+  {
+    id: 2,
+    subject: "여름 신기능 소식",
+    recipientCount: 1240,
+    authorName: "관리자",
+    createdAt: "2026-07-20T09:00:00.000Z",
+  },
+  {
+    id: 1,
+    subject: "데나무 서비스 오픈 안내",
+    recipientCount: 980,
+    authorName: "메인 관리자",
+    createdAt: "2026-06-25T09:00:00.000Z",
+  },
+];
+
+export const mockMarketingEmailsPage: MarketingEmailPage<MarketingEmailSummary> = {
+  result: mockMarketingEmailSummaries,
+  page: 1,
+  limit: 10,
+  totalCount: mockMarketingEmailSummaries.length,
+  hasMore: false,
+};
+
+export const mockMarketingEmailDetails: MarketingEmailDetail[] = mockMarketingEmailSummaries.map((summary) => ({
+  ...summary,
+  content: `<p>안녕하세요! <b>${summary.subject}</b> 소식을 전해드립니다.</p>`,
+}));
 
 const mockQnaSummaries: QnaSummary[] = [
   {

--- a/client/src/__tests__/api/services/admin/marketingEmail.test.ts
+++ b/client/src/__tests__/api/services/admin/marketingEmail.test.ts
@@ -1,0 +1,94 @@
+import MockAdapter from "axios-mock-adapter";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FILE, MARKETING_EMAIL } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+import { adminMarketingEmail } from "@/api/services/admin/marketingEmail";
+
+let mock: MockAdapter;
+
+describe("adminMarketingEmail service", () => {
+  beforeEach(() => {
+    mock = new MockAdapter(axiosInstance);
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("getList는 관리자 목록 엔드포인트를 page/limit 파라미터로 GET하고 data.data를 언랩한다", async () => {
+    const payload = {
+      result: [
+        {
+          id: 1,
+          subject: "여름 소식",
+          recipientCount: 120,
+          authorName: "관리자",
+          createdAt: "2026-07-20T09:00:00.000Z",
+        },
+      ],
+      page: 1,
+      limit: 10,
+      totalCount: 1,
+      hasMore: false,
+    };
+    mock.onGet(MARKETING_EMAIL.ADMIN_LIST).reply(200, { message: "성공", data: payload });
+
+    const result = await adminMarketingEmail.getList({ page: 1, limit: 10 });
+
+    expect(result).toEqual(payload);
+    expect(mock.history.get[0].params).toEqual({ page: 1, limit: 10 });
+  });
+
+  it("getDetail은 관리자 상세 엔드포인트를 GET하고 data.data를 언랩한다", async () => {
+    const payload = {
+      id: 1,
+      subject: "여름 소식",
+      content: "<p>안녕하세요</p>",
+      recipientCount: 120,
+      authorName: "관리자",
+      createdAt: "2026-07-20T09:00:00.000Z",
+    };
+    mock.onGet(MARKETING_EMAIL.ADMIN_DETAIL(1)).reply(200, { message: "성공", data: payload });
+
+    const result = await adminMarketingEmail.getDetail(1);
+
+    expect(result).toEqual(payload);
+    expect(mock.history.get[0].url).toBe(MARKETING_EMAIL.ADMIN_DETAIL(1));
+  });
+
+  it("send는 관리자 목록 엔드포인트로 POST하고 payload를 body로 전달하며 data.data를 언랩한다", async () => {
+    const payload = { subject: "새 소식", content: "<p>내용</p>" };
+    const responseData = {
+      id: 1,
+      subject: "새 소식",
+      recipientCount: 120,
+      authorName: "관리자",
+      createdAt: "2026-07-20T09:00:00.000Z",
+    };
+    mock.onPost(MARKETING_EMAIL.ADMIN_LIST).reply(201, { message: "성공", data: responseData });
+
+    const result = await adminMarketingEmail.send(payload);
+
+    expect(result).toEqual(responseData);
+    expect(mock.history.post).toHaveLength(1);
+    expect(mock.history.post[0].url).toBe(MARKETING_EMAIL.ADMIN_LIST);
+    expect(JSON.parse(mock.history.post[0].data)).toEqual(payload);
+  });
+
+  it("uploadImage는 uploadType=MARKETING_EMAIL_IMAGE 파라미터로 파일을 업로드하고 url을 반환한다", async () => {
+    mock
+      .onPost(FILE.ADMIN_UPLOAD_IMAGE)
+      .reply(200, { message: "성공", data: { url: "https://cdn.example.com/marketing/a.png" } });
+
+    const file = new File(["binary"], "a.png", { type: "image/png" });
+    const url = await adminMarketingEmail.uploadImage(file);
+
+    expect(url).toBe("https://cdn.example.com/marketing/a.png");
+    expect(mock.history.post).toHaveLength(1);
+    expect(mock.history.post[0].url).toBe(FILE.ADMIN_UPLOAD_IMAGE);
+    expect(mock.history.post[0].params).toEqual({ uploadType: "MARKETING_EMAIL_IMAGE" });
+    expect(mock.history.post[0].headers?.["Content-Type"]).toContain("multipart/form-data");
+  });
+});

--- a/client/src/__tests__/components/admin/marketingEmail/AdminMarketingEmailTab.test.tsx
+++ b/client/src/__tests__/components/admin/marketingEmail/AdminMarketingEmailTab.test.tsx
@@ -1,0 +1,351 @@
+import type { ReactNode } from "react";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import AdminMarketingEmailTab from "@/components/admin/marketingEmail/AdminMarketingEmailTab.tsx";
+
+import { MarketingEmailPage, MarketingEmailSummary } from "@/types/marketingEmail";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const useAdminMarketingEmailsMock = vi.hoisted(() => vi.fn());
+const sendMutateMock = vi.hoisted(() => vi.fn());
+const toastMock = vi.hoisted(() => vi.fn());
+const uploadImageMock = vi.hoisted(() => vi.fn());
+const getDetailMock = vi.hoisted(() => vi.fn());
+
+// @tinymce/tinymce-react mock: 실제 에디터 대신 textarea로 대체하고, 컴포넌트가 넘긴 props(특히
+// init.images_upload_handler / init.file_picker_callback)를 테스트에서 직접 호출하기 위해 스파이로 기록.
+const editorPropsSpy = vi.hoisted(() => vi.fn());
+
+// AdminMarketingEmailTab import(위 5번째 줄)가 lucide-react를 로드하는 시점보다 lucideProxy 바인딩이
+// 늦게 초기화되어 TDZ ReferenceError가 나므로, 동적 import로 참조 시점을 팩토리 실행 시점까지 늦춘다.
+vi.mock("lucide-react", async () => {
+  const { lucideProxy } = await import("@/__tests__/__mocks__/external/lucide-proxy.tsx");
+  return lucideProxy();
+});
+
+vi.mock("@/hooks/common/useCustomToast", () => ({
+  useCustomToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock("@/hooks/queries/useAdminMarketingEmail", () => ({
+  useAdminMarketingEmails: (params: unknown) => useAdminMarketingEmailsMock(params),
+  useSendMarketingEmail: () => ({ mutate: sendMutateMock, isPending: false }),
+}));
+
+vi.mock("@/api/services/admin/marketingEmail", () => ({
+  adminMarketingEmail: { uploadImage: uploadImageMock, getDetail: getDetailMock },
+}));
+
+vi.mock("@tinymce/tinymce-react", () => ({
+  Editor: (props: { value: string; onEditorChange: (content: string) => void; init?: Record<string, unknown> }) => {
+    editorPropsSpy(props);
+    return <textarea aria-label="본문" value={props.value} onChange={(e) => props.onEditorChange(e.target.value)} />;
+  },
+}));
+
+vi.mock("@/components/ui/alert-dialog", () => {
+  const pass = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return {
+    AlertDialog: pass,
+    AlertDialogTrigger: pass,
+    AlertDialogContent: pass,
+    AlertDialogHeader: pass,
+    AlertDialogFooter: pass,
+    AlertDialogTitle: pass,
+    AlertDialogDescription: pass,
+    AlertDialogCancel: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+    AlertDialogAction: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+      <button data-testid="confirm-send" onClick={onClick}>
+        {children}
+      </button>
+    ),
+  };
+});
+
+const makeItem = (overrides: Partial<MarketingEmailSummary> = {}): MarketingEmailSummary => ({
+  id: 1,
+  subject: "여름 신기능 소식",
+  recipientCount: 120,
+  authorName: "관리자",
+  createdAt: "2026-07-20T09:00:00.000Z",
+  ...overrides,
+});
+
+const makePage = (
+  result: MarketingEmailSummary[],
+  totalCount = result.length
+): MarketingEmailPage<MarketingEmailSummary> => ({
+  result,
+  page: 1,
+  limit: 10,
+  totalCount,
+  hasMore: false,
+});
+
+const renderTab = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AdminMarketingEmailTab />
+    </QueryClientProvider>
+  );
+};
+
+describe("AdminMarketingEmailTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAdminMarketingEmailsMock.mockReturnValue({ data: makePage([]), isLoading: false, isError: false });
+    sendMutateMock.mockImplementation((_payload, opts) =>
+      opts?.onSuccess?.({
+        id: 1,
+        subject: "새 소식",
+        recipientCount: 10,
+        authorName: null,
+        createdAt: "2026-07-20T09:00:00.000Z",
+      })
+    );
+  });
+
+  it("로딩 중이면 로딩 문구를 표시한다", () => {
+    useAdminMarketingEmailsMock.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    renderTab();
+
+    expect(screen.getByText("불러오는 중...")).toBeInTheDocument();
+  });
+
+  it("에러 시 에러 문구를 표시한다", () => {
+    useAdminMarketingEmailsMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    renderTab();
+
+    expect(screen.getByText("이력을 불러오지 못했습니다.")).toBeInTheDocument();
+  });
+
+  it("발송 이력이 없으면 안내 문구를 표시한다", () => {
+    renderTab();
+
+    expect(screen.getByText("발송 이력이 없습니다.")).toBeInTheDocument();
+  });
+
+  it("발송 이력을 수신자 수 배지와 함께 카드로 렌더링한다", () => {
+    useAdminMarketingEmailsMock.mockReturnValue({
+      data: makePage([makeItem({ id: 1, subject: "여름 신기능 소식", recipientCount: 120, authorName: "관리자" })]),
+      isLoading: false,
+      isError: false,
+    });
+    renderTab();
+
+    expect(screen.getByText("여름 신기능 소식")).toBeInTheDocument();
+    expect(screen.getByText("수신 120명")).toBeInTheDocument();
+    expect(screen.getByText("관리자")).toBeInTheDocument();
+  });
+
+  it("totalCount가 페이지 크기를 초과하면 다음 클릭 시 page 파라미터를 증가시킨다", () => {
+    useAdminMarketingEmailsMock.mockReturnValue({ data: makePage([makeItem()], 25), isLoading: false, isError: false });
+    renderTab();
+
+    expect(useAdminMarketingEmailsMock).toHaveBeenLastCalledWith({ page: 1, limit: 10 });
+
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+    expect(useAdminMarketingEmailsMock).toHaveBeenLastCalledWith({ page: 2, limit: 10 });
+  });
+
+  it("발송 이력 카드를 클릭하면 상세를 조회해 본문을 펼쳐서 보여준다", async () => {
+    useAdminMarketingEmailsMock.mockReturnValue({
+      data: makePage([makeItem({ id: 1, subject: "여름 신기능 소식" })]),
+      isLoading: false,
+      isError: false,
+    });
+    getDetailMock.mockResolvedValue({
+      id: 1,
+      subject: "여름 신기능 소식",
+      content: "<p>안녕하세요, 회원님!</p>",
+      recipientCount: 120,
+      authorName: "관리자",
+      createdAt: "2026-07-20T09:00:00.000Z",
+    });
+    renderTab();
+
+    fireEvent.click(screen.getByText("여름 신기능 소식"));
+
+    expect(getDetailMock).toHaveBeenCalledWith(1);
+    await waitFor(() => expect(screen.getByText("안녕하세요, 회원님!")).toBeInTheDocument());
+  });
+
+  it("펼쳐진 카드를 다시 클릭하면 접히고, 또 클릭해도 캐시된 본문이라 재조회하지 않는다", async () => {
+    useAdminMarketingEmailsMock.mockReturnValue({
+      data: makePage([makeItem({ id: 1, subject: "여름 신기능 소식" })]),
+      isLoading: false,
+      isError: false,
+    });
+    getDetailMock.mockResolvedValue({
+      id: 1,
+      subject: "여름 신기능 소식",
+      content: "<p>안녕하세요, 회원님!</p>",
+      recipientCount: 120,
+      authorName: "관리자",
+      createdAt: "2026-07-20T09:00:00.000Z",
+    });
+    renderTab();
+
+    fireEvent.click(screen.getByText("여름 신기능 소식"));
+    await waitFor(() => expect(screen.getByText("안녕하세요, 회원님!")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("여름 신기능 소식"));
+    expect(screen.queryByText("안녕하세요, 회원님!")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("여름 신기능 소식"));
+    await waitFor(() => expect(screen.getByText("안녕하세요, 회원님!")).toBeInTheDocument());
+    expect(getDetailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("상세 조회 실패 시 오류 toast를 띄우고 펼쳐진 상태를 유지하지 않는다", async () => {
+    useAdminMarketingEmailsMock.mockReturnValue({
+      data: makePage([makeItem({ id: 1, subject: "여름 신기능 소식" })]),
+      isLoading: false,
+      isError: false,
+    });
+    getDetailMock.mockRejectedValue(new Error("network error"));
+    renderTab();
+
+    fireEvent.click(screen.getByText("여름 신기능 소식"));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "발송 내역을 불러오지 못했습니다.", variant: "destructive" })
+      )
+    );
+  });
+
+  // AlertDialog를 flatten mock했기 때문에 트리거 버튼과 AlertDialogAction("발송")이 동시에
+  // DOM에 존재해 이름이 충돌한다. 트리거는 항상 첫 번째로 렌더링되는 "발송" 버튼이다.
+  const getSendTriggerButton = () => screen.getAllByRole("button", { name: "발송" })[0];
+
+  it("제목/본문이 비어 있으면 발송 버튼이 비활성화된다", () => {
+    renderTab();
+
+    expect(getSendTriggerButton()).toBeDisabled();
+  });
+
+  it("제목만 입력하고 본문이 비어 있으면 발송 버튼이 비활성화된다", () => {
+    renderTab();
+
+    fireEvent.change(screen.getByLabelText("제목"), { target: { value: "새 소식" } });
+
+    expect(getSendTriggerButton()).toBeDisabled();
+  });
+
+  it("제목과 본문을 모두 입력하면 발송 버튼이 활성화된다", () => {
+    renderTab();
+
+    fireEvent.change(screen.getByLabelText("제목"), { target: { value: "새 소식" } });
+    fireEvent.change(screen.getByLabelText("본문"), { target: { value: "<p>내용</p>" } });
+
+    expect(getSendTriggerButton()).toBeEnabled();
+  });
+
+  it("제목과 본문을 입력하고 발송 확인 시 sendMarketingEmail을 호출하고 성공 toast를 띄운 뒤 입력값을 초기화한다", () => {
+    renderTab();
+
+    fireEvent.change(screen.getByLabelText("제목"), { target: { value: "새 소식" } });
+    fireEvent.change(screen.getByLabelText("본문"), { target: { value: "<p>내용</p>" } });
+    fireEvent.click(getSendTriggerButton());
+    fireEvent.click(screen.getByTestId("confirm-send"));
+
+    expect(sendMutateMock).toHaveBeenCalledWith({ subject: "새 소식", content: "<p>내용</p>" }, expect.any(Object));
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ description: "10명에게 발송을 완료했습니다." }));
+    expect(screen.getByLabelText("제목")).toHaveValue("");
+    expect(screen.getByLabelText("본문")).toHaveValue("");
+  });
+
+  it("발송 실패 시 오류 toast를 띄운다", () => {
+    sendMutateMock.mockImplementation((_payload, opts) => opts?.onError?.());
+    renderTab();
+
+    fireEvent.change(screen.getByLabelText("제목"), { target: { value: "새 소식" } });
+    fireEvent.change(screen.getByLabelText("본문"), { target: { value: "<p>내용</p>" } });
+    fireEvent.click(getSendTriggerButton());
+    fireEvent.click(screen.getByTestId("confirm-send"));
+
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "발송 중 오류가 발생했습니다.", variant: "destructive" })
+    );
+  });
+
+  type EditorInit = {
+    file_picker_callback: (callback: (url: string, meta?: Record<string, string>) => void) => void;
+    images_upload_handler: (blobInfo: { blob: () => Blob; filename: () => string }) => Promise<string>;
+  };
+  const latestEditorInit = () => (editorPropsSpy.mock.calls.at(-1)?.[0].init as EditorInit) ?? undefined;
+
+  it("에디터 이미지 툴바 버튼으로 파일 선택 시 업로드 후 삽입 콜백에 URL을 전달한다", async () => {
+    uploadImageMock.mockResolvedValue("https://cdn.example.com/marketing/a.png");
+    renderTab();
+
+    await waitFor(() => expect(latestEditorInit()).toBeDefined());
+    const insertCallback = vi.fn();
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+    latestEditorInit().file_picker_callback(insertCallback);
+    const input = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    createElementSpy.mockRestore();
+
+    const file = new File(["binary"], "photo.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
+    input.dispatchEvent(new Event("change"));
+
+    await waitFor(() => expect(uploadImageMock).toHaveBeenCalledWith(file));
+    await waitFor(() =>
+      expect(insertCallback).toHaveBeenCalledWith("https://cdn.example.com/marketing/a.png", { alt: "photo.png" })
+    );
+  });
+
+  it("이미지 업로드 실패 시 오류 toast를 띄우고 삽입 콜백을 호출하지 않는다", async () => {
+    uploadImageMock.mockRejectedValue(new Error("network error"));
+    renderTab();
+
+    await waitFor(() => expect(latestEditorInit()).toBeDefined());
+    const insertCallback = vi.fn();
+
+    const createElementSpy = vi.spyOn(document, "createElement");
+    latestEditorInit().file_picker_callback(insertCallback);
+    const input = createElementSpy.mock.results.at(-1)?.value as HTMLInputElement;
+    createElementSpy.mockRestore();
+
+    const file = new File(["binary"], "photo.png", { type: "image/png" });
+    Object.defineProperty(input, "files", { value: [file] });
+    input.dispatchEvent(new Event("change"));
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" })
+      )
+    );
+    expect(insertCallback).not.toHaveBeenCalled();
+  });
+
+  it("붙여넣기/드래그로 들어온 이미지는 images_upload_handler로 업로드하고 URL을 반환한다", async () => {
+    uploadImageMock.mockResolvedValueOnce("https://cdn.example.com/marketing/1.png");
+    uploadImageMock.mockResolvedValueOnce("https://cdn.example.com/marketing/2.png");
+    renderTab();
+
+    await waitFor(() => expect(latestEditorInit()).toBeDefined());
+
+    const blob1 = new Blob(["a"], { type: "image/png" });
+    const blob2 = new Blob(["b"], { type: "image/png" });
+    const url1 = await latestEditorInit().images_upload_handler({
+      blob: () => blob1,
+      filename: () => "a.png",
+    });
+    const url2 = await latestEditorInit().images_upload_handler({
+      blob: () => blob2,
+      filename: () => "b.png",
+    });
+
+    expect(url1).toBe("https://cdn.example.com/marketing/1.png");
+    expect(url2).toBe("https://cdn.example.com/marketing/2.png");
+    expect(uploadImageMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/client/src/__tests__/hooks/queries/useAdminMarketingEmail.test.tsx
+++ b/client/src/__tests__/hooks/queries/useAdminMarketingEmail.test.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAdminMarketingEmails, useSendMarketingEmail } from "@/hooks/queries/useAdminMarketingEmail";
+
+import { adminMarketingEmail } from "@/api/services/admin/marketingEmail";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("@/api/services/admin/marketingEmail", () => ({
+  adminMarketingEmail: {
+    getList: vi.fn(),
+    send: vi.fn(),
+    uploadImage: vi.fn(),
+  },
+}));
+
+const mocked = vi.mocked(adminMarketingEmail);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+describe("useAdminMarketingEmails", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocked.getList.mockResolvedValue({ result: [], page: 1, limit: 10, totalCount: 0, hasMore: false });
+  });
+
+  it("params를 그대로 전달해 adminMarketingEmail.getList를 호출한다", async () => {
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useAdminMarketingEmails({ page: 2, limit: 10 }), { wrapper });
+
+    await waitFor(() => expect(mocked.getList).toHaveBeenCalledWith({ page: 2, limit: 10 }));
+  });
+});
+
+describe("useSendMarketingEmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocked.send.mockResolvedValue({
+      id: 1,
+      subject: "새 소식",
+      recipientCount: 120,
+      authorName: "관리자",
+      createdAt: "2026-07-20T09:00:00.000Z",
+    });
+  });
+
+  it("mutate 시 adminMarketingEmail.send를 호출하고 성공하면 adminMarketingEmails 캐시를 무효화한다", async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useSendMarketingEmail(), { wrapper });
+
+    result.current.mutate({ subject: "새 소식", content: "<p>내용</p>" });
+
+    await waitFor(() => expect(mocked.send).toHaveBeenCalledWith({ subject: "새 소식", content: "<p>내용</p>" }));
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["adminMarketingEmails"] }));
+  });
+});

--- a/client/src/api/services/admin/board.ts
+++ b/client/src/api/services/admin/board.ts
@@ -1,4 +1,4 @@
-import { BOARD } from "@/constants/endpoints";
+import { BOARD, FILE } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
 import { ApiData } from "@/types/api";
@@ -39,7 +39,8 @@ export const adminBoard = {
   uploadImage: async (file: File): Promise<string> => {
     const formData = new FormData();
     formData.append("file", file);
-    const response = await axiosInstance.post<ApiData<{ url: string }>>(BOARD.ADMIN_UPLOAD_IMAGE, formData, {
+    const response = await axiosInstance.post<ApiData<{ url: string }>>(FILE.ADMIN_UPLOAD_IMAGE, formData, {
+      params: { uploadType: "BOARD_IMAGE" },
       headers: { "Content-Type": "multipart/form-data" },
     });
     return response.data.data.url;

--- a/client/src/api/services/admin/marketingEmail.ts
+++ b/client/src/api/services/admin/marketingEmail.ts
@@ -1,0 +1,33 @@
+import { FILE, MARKETING_EMAIL } from "@/constants/endpoints";
+
+import { axiosInstance } from "@/api/instance";
+import { ApiData } from "@/types/api";
+import { MarketingEmailPage, MarketingEmailSummary, SendMarketingEmailPayload } from "@/types/marketingEmail";
+
+export interface GetAdminMarketingEmailsParams {
+  page?: number;
+  limit?: number;
+}
+
+export const adminMarketingEmail = {
+  getList: async (params: GetAdminMarketingEmailsParams): Promise<MarketingEmailPage<MarketingEmailSummary>> => {
+    const response = await axiosInstance.get<ApiData<MarketingEmailPage<MarketingEmailSummary>>>(
+      MARKETING_EMAIL.ADMIN_LIST,
+      { params }
+    );
+    return response.data.data;
+  },
+  send: async (payload: SendMarketingEmailPayload): Promise<MarketingEmailSummary> => {
+    const response = await axiosInstance.post<ApiData<MarketingEmailSummary>>(MARKETING_EMAIL.ADMIN_LIST, payload);
+    return response.data.data;
+  },
+  uploadImage: async (file: File): Promise<string> => {
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await axiosInstance.post<ApiData<{ url: string }>>(FILE.ADMIN_UPLOAD_IMAGE, formData, {
+      params: { uploadType: "MARKETING_EMAIL_IMAGE" },
+      headers: { "Content-Type": "multipart/form-data" },
+    });
+    return response.data.data.url;
+  },
+};

--- a/client/src/api/services/admin/marketingEmail.ts
+++ b/client/src/api/services/admin/marketingEmail.ts
@@ -2,7 +2,12 @@ import { FILE, MARKETING_EMAIL } from "@/constants/endpoints";
 
 import { axiosInstance } from "@/api/instance";
 import { ApiData } from "@/types/api";
-import { MarketingEmailPage, MarketingEmailSummary, SendMarketingEmailPayload } from "@/types/marketingEmail";
+import {
+  MarketingEmailDetail,
+  MarketingEmailPage,
+  MarketingEmailSummary,
+  SendMarketingEmailPayload,
+} from "@/types/marketingEmail";
 
 export interface GetAdminMarketingEmailsParams {
   page?: number;
@@ -15,6 +20,10 @@ export const adminMarketingEmail = {
       MARKETING_EMAIL.ADMIN_LIST,
       { params }
     );
+    return response.data.data;
+  },
+  getDetail: async (id: number): Promise<MarketingEmailDetail> => {
+    const response = await axiosInstance.get<ApiData<MarketingEmailDetail>>(MARKETING_EMAIL.ADMIN_DETAIL(id));
     return response.data.data;
   },
   send: async (payload: SendMarketingEmailPayload): Promise<MarketingEmailSummary> => {

--- a/client/src/components/admin/layout/AdminHeader.tsx
+++ b/client/src/components/admin/layout/AdminHeader.tsx
@@ -19,7 +19,7 @@ export const AdminHeader = ({
   name,
 }: {
   setLogin: () => void;
-  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT" | "REPORT" | "BOARD" | "QNA") => void;
+  handleTap: (tap: "RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT" | "REPORT" | "BOARD" | "QNA" | "EMAIL") => void;
   name?: string;
 }) => {
   const handleLogout = () => {

--- a/client/src/components/admin/layout/AdminNavigationMenu.tsx
+++ b/client/src/components/admin/layout/AdminNavigationMenu.tsx
@@ -9,6 +9,7 @@ export const TAB_TYPES = {
   REPORT: "REPORT",
   BOARD: "BOARD",
   QNA: "QNA",
+  EMAIL: "EMAIL",
 } as const;
 
 type TabType = (typeof TAB_TYPES)[keyof typeof TAB_TYPES];
@@ -50,6 +51,11 @@ export const AdminNavigationMenu = ({ handleTap }: { handleTap: (tabType: TabTyp
         <NavigationMenuItem>
           <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("QNA")}>
             Q&A 관리
+          </Button>
+        </NavigationMenuItem>
+        <NavigationMenuItem>
+          <Button variant="ghost" className="w-full justify-start" onClick={() => handleTap("EMAIL")}>
+            이메일 관리
           </Button>
         </NavigationMenuItem>
       </NavigationMenuList>

--- a/client/src/components/admin/marketingEmail/AdminMarketingEmailTab.stories.tsx
+++ b/client/src/components/admin/marketingEmail/AdminMarketingEmailTab.stories.tsx
@@ -1,0 +1,84 @@
+import AdminMarketingEmailTab from "@/components/admin/marketingEmail/AdminMarketingEmailTab";
+
+import { MARKETING_EMAIL } from "@/constants/endpoints";
+
+import { mockMarketingEmailDetails, mockMarketingEmailsPage } from "@/__storybook__/fixtures";
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+const meta = {
+  title: "admin/marketingEmail/AdminMarketingEmailTab",
+  component: AdminMarketingEmailTab,
+} satisfies Meta<typeof AdminMarketingEmailTab>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithHistory: Story = {
+  name: "발송 이력 있음",
+  beforeEach: () => {
+    mockApi.onGet(MARKETING_EMAIL.ADMIN_LIST).reply(...ok(mockMarketingEmailsPage));
+    mockMarketingEmailDetails.forEach((detail) => {
+      mockApi.onGet(MARKETING_EMAIL.ADMIN_DETAIL(detail.id)).reply(...ok(detail));
+    });
+  },
+};
+
+export const HistoryDetail: Story = {
+  name: "발송 이력 카드를 펼쳐 본문 확인",
+  beforeEach: () => {
+    mockApi.onGet(MARKETING_EMAIL.ADMIN_LIST).reply(...ok(mockMarketingEmailsPage));
+    mockMarketingEmailDetails.forEach((detail) => {
+      mockApi.onGet(MARKETING_EMAIL.ADMIN_DETAIL(detail.id)).reply(...ok(detail));
+    });
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const target = mockMarketingEmailDetails[0];
+
+    await userEvent.click(await canvas.findByText(target.subject));
+
+    await waitFor(() => expect(canvas.getByText(/안녕하세요!/)).toBeInTheDocument());
+  },
+};
+
+export const Empty: Story = {
+  name: "발송 이력 없음",
+  beforeEach: () => {
+    mockApi
+      .onGet(MARKETING_EMAIL.ADMIN_LIST)
+      .reply(...ok({ result: [], page: 1, limit: 10, totalCount: 0, hasMore: false }));
+  },
+};
+
+export const Loading: Story = {
+  name: "로딩 중",
+  beforeEach: () => {
+    mockApi.onGet(MARKETING_EMAIL.ADMIN_LIST).reply(() => new Promise(() => {}));
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(MARKETING_EMAIL.ADMIN_LIST).reply(...fail());
+  },
+};
+
+export const SendDisabledUntilBothFilled: Story = {
+  name: "제목만 입력해도 발송 버튼은 비활성 상태 유지",
+  beforeEach: () => {
+    mockApi
+      .onGet(MARKETING_EMAIL.ADMIN_LIST)
+      .reply(...ok({ result: [], page: 1, limit: 10, totalCount: 0, hasMore: false }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(await canvas.findByRole("button", { name: "발송" })).toBeDisabled();
+
+    await userEvent.type(canvas.getByLabelText("제목"), "새 소식");
+    await waitFor(() => expect(canvas.getByRole("button", { name: "발송" })).toBeDisabled());
+  },
+};

--- a/client/src/components/admin/marketingEmail/AdminMarketingEmailTab.tsx
+++ b/client/src/components/admin/marketingEmail/AdminMarketingEmailTab.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 
-import { Mail } from "lucide-react";
+import DOMPurify from "dompurify";
+import { ChevronDown, ChevronUp, Loader2, Mail } from "lucide-react";
 import type { Editor as TinyMCEEditor } from "tinymce";
 
 import {
@@ -24,6 +25,8 @@ import { useCustomToast } from "@/hooks/common/useCustomToast";
 import { useAdminMarketingEmails, useSendMarketingEmail } from "@/hooks/queries/useAdminMarketingEmail";
 
 import { adminMarketingEmail } from "@/api/services/admin/marketingEmail";
+import { MarketingEmailDetail, MarketingEmailSummary } from "@/types/marketingEmail";
+import { useQueryClient } from "@tanstack/react-query";
 import { Editor } from "@tinymce/tinymce-react";
 
 const EDITOR_INIT = {
@@ -45,8 +48,12 @@ export default function AdminMarketingEmailTab() {
   const [subject, setSubject] = useState("");
   const [content, setContent] = useState("");
   const [page, setPage] = useState(1);
+  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [detailsById, setDetailsById] = useState<Record<number, MarketingEmailDetail>>({});
+  const [loadingDetailId, setLoadingDetailId] = useState<number | null>(null);
   const { toast } = useCustomToast();
   const editorRef = useRef<TinyMCEEditor | null>(null);
+  const queryClient = useQueryClient();
 
   const { data, isLoading, isError } = useAdminMarketingEmails({ page, limit: PAGE_SIZE });
   const { mutate: sendMarketingEmail, isPending } = useSendMarketingEmail();
@@ -98,6 +105,29 @@ export default function AdminMarketingEmailTab() {
   };
 
   const canSend = subject.trim().length > 0 && content.trim().length > 0 && !isPending;
+
+  const toggleDetail = async (item: MarketingEmailSummary) => {
+    if (expandedId === item.id) {
+      setExpandedId(null);
+      return;
+    }
+    setExpandedId(item.id);
+    if (detailsById[item.id]) return;
+
+    setLoadingDetailId(item.id);
+    try {
+      const result = await queryClient.fetchQuery({
+        queryKey: ["adminMarketingEmail", item.id],
+        queryFn: () => adminMarketingEmail.getDetail(item.id),
+      });
+      setDetailsById((prev) => ({ ...prev, [item.id]: result }));
+    } catch {
+      toast({ description: "발송 내역을 불러오지 못했습니다.", variant: "destructive" });
+      setExpandedId(null);
+    } finally {
+      setLoadingDetailId(null);
+    }
+  };
 
   return (
     <section className="flex flex-col gap-6 min-h-[300px]">
@@ -172,18 +202,47 @@ export default function AdminMarketingEmailTab() {
           <p className="py-12 text-center text-sm text-gray-400">발송 이력이 없습니다.</p>
         ) : (
           <div className="flex flex-col gap-3">
-            {history.map((item) => (
-              <Card key={item.id}>
-                <CardContent className="flex items-center gap-3 p-4">
-                  <Badge variant="secondary" className="shrink-0">
-                    수신 {item.recipientCount}명
-                  </Badge>
-                  <span className="flex-1 truncate font-medium">{item.subject}</span>
-                  {item.authorName && <span className="shrink-0 text-xs text-gray-400">{item.authorName}</span>}
-                  <span className="shrink-0 text-xs text-gray-400">{new Date(item.createdAt).toLocaleString()}</span>
-                </CardContent>
-              </Card>
-            ))}
+            {history.map((item) => {
+              const isExpanded = expandedId === item.id;
+              const detail = detailsById[item.id];
+              return (
+                <Card key={item.id}>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    className="cursor-pointer"
+                    onClick={() => toggleDetail(item)}
+                    onKeyDown={(e) => e.key === "Enter" && toggleDetail(item)}
+                  >
+                    <CardContent className="flex items-center gap-3 p-4">
+                      <Badge variant="secondary" className="shrink-0">
+                        수신 {item.recipientCount}명
+                      </Badge>
+                      <span className="flex-1 truncate font-medium">{item.subject}</span>
+                      {item.authorName && <span className="shrink-0 text-xs text-gray-400">{item.authorName}</span>}
+                      <span className="shrink-0 text-xs text-gray-400">
+                        {new Date(item.createdAt).toLocaleString()}
+                      </span>
+                      {loadingDetailId === item.id ? (
+                        <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+                      ) : isExpanded ? (
+                        <ChevronUp className="h-4 w-4 shrink-0 text-gray-400" />
+                      ) : (
+                        <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
+                      )}
+                    </CardContent>
+                  </div>
+                  {isExpanded && detail && (
+                    <CardContent className="border-t pt-4">
+                      <div
+                        className="prose max-w-full prose-p:my-2 prose-a:text-primary prose-a:no-underline hover:prose-a:underline"
+                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(detail.content) }}
+                      />
+                    </CardContent>
+                  )}
+                </Card>
+              );
+            })}
           </div>
         )}
 

--- a/client/src/components/admin/marketingEmail/AdminMarketingEmailTab.tsx
+++ b/client/src/components/admin/marketingEmail/AdminMarketingEmailTab.tsx
@@ -1,0 +1,206 @@
+import { useRef, useState } from "react";
+
+import { Mail } from "lucide-react";
+import type { Editor as TinyMCEEditor } from "tinymce";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+import { useCustomToast } from "@/hooks/common/useCustomToast";
+import { useAdminMarketingEmails, useSendMarketingEmail } from "@/hooks/queries/useAdminMarketingEmail";
+
+import { adminMarketingEmail } from "@/api/services/admin/marketingEmail";
+import { Editor } from "@tinymce/tinymce-react";
+
+const EDITOR_INIT = {
+  min_height: 400,
+  menubar: false,
+  branding: false,
+  plugins: "link image lists",
+  toolbar:
+    "blocks | bold italic underline strikethrough | forecolor backcolor | bullist numlist | link image | removeformat",
+  block_formats: "본문=p; 제목1=h1; 제목2=h2; 제목3=h3",
+  file_picker_types: "image",
+  automatic_uploads: true,
+  paste_data_images: true,
+};
+
+const PAGE_SIZE = 10;
+
+export default function AdminMarketingEmailTab() {
+  const [subject, setSubject] = useState("");
+  const [content, setContent] = useState("");
+  const [page, setPage] = useState(1);
+  const { toast } = useCustomToast();
+  const editorRef = useRef<TinyMCEEditor | null>(null);
+
+  const { data, isLoading, isError } = useAdminMarketingEmails({ page, limit: PAGE_SIZE });
+  const { mutate: sendMarketingEmail, isPending } = useSendMarketingEmail();
+
+  const history = data?.result ?? [];
+  const totalPages = Math.max(1, Math.ceil((data?.totalCount ?? 0) / PAGE_SIZE));
+
+  const handleImageUpload = async (blobInfo: { blob: () => Blob; filename: () => string }): Promise<string> => {
+    const file = new File([blobInfo.blob()], blobInfo.filename(), { type: blobInfo.blob().type });
+    try {
+      return await adminMarketingEmail.uploadImage(file);
+    } catch {
+      toast({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" });
+      throw new Error("이미지 업로드 실패");
+    }
+  };
+
+  const handleFilePick = (callback: (url: string, meta?: Record<string, string>) => void) => {
+    const input = document.createElement("input");
+    input.setAttribute("type", "file");
+    input.setAttribute("accept", "image/png,image/jpeg,image/webp,image/gif");
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      adminMarketingEmail
+        .uploadImage(file)
+        .then((url) => callback(url, { alt: file.name }))
+        .catch(() => toast({ description: "이미지 업로드에 실패했습니다.", variant: "destructive" }));
+    };
+    input.click();
+  };
+
+  const handleSend = () => {
+    sendMarketingEmail(
+      { subject, content },
+      {
+        onSuccess: (result) => {
+          toast({ description: `${result.recipientCount}명에게 발송을 완료했습니다.` });
+          setSubject("");
+          setContent("");
+          editorRef.current?.setContent("");
+          setPage(1);
+        },
+        onError: () => {
+          toast({ description: "발송 중 오류가 발생했습니다.", variant: "destructive" });
+        },
+      }
+    );
+  };
+
+  const canSend = subject.trim().length > 0 && content.trim().length > 0 && !isPending;
+
+  return (
+    <section className="flex flex-col gap-6 min-h-[300px]">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Mail className="h-5 w-5" />
+            마케팅 이메일 작성
+          </CardTitle>
+          <p className="text-sm text-gray-400">
+            광고성 정보 수신에 동의한 회원에게만 발송됩니다. 제목 맨 앞에 "(광고)"가 자동으로 붙습니다.
+          </p>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="marketing-subject">제목</Label>
+            <Input
+              id="marketing-subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="제목을 입력하세요"
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label>본문</Label>
+            <Editor
+              tinymceScriptSrc="/tinymce/tinymce.min.js"
+              licenseKey="gpl"
+              value={content}
+              onEditorChange={setContent}
+              init={{
+                ...EDITOR_INIT,
+                images_upload_handler: handleImageUpload,
+                file_picker_callback: handleFilePick,
+                setup: (editor: TinyMCEEditor) => {
+                  editorRef.current = editor;
+                },
+              }}
+            />
+          </div>
+
+          <div className="flex justify-end border-t pt-4">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button disabled={!canSend}>{isPending ? "발송 중..." : "발송"}</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>마케팅 이메일을 발송하시겠습니까?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    광고성 정보 수신에 동의한 회원 전체에게 즉시 발송되며, 되돌릴 수 없습니다.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>취소</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleSend}>발송</AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="flex flex-col gap-3">
+        <h3 className="text-sm font-semibold text-gray-500">발송 이력</h3>
+        {isLoading ? (
+          <p className="py-12 text-center text-sm text-gray-400">불러오는 중...</p>
+        ) : isError ? (
+          <p className="py-12 text-center text-sm text-red-500">이력을 불러오지 못했습니다.</p>
+        ) : history.length === 0 ? (
+          <p className="py-12 text-center text-sm text-gray-400">발송 이력이 없습니다.</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {history.map((item) => (
+              <Card key={item.id}>
+                <CardContent className="flex items-center gap-3 p-4">
+                  <Badge variant="secondary" className="shrink-0">
+                    수신 {item.recipientCount}명
+                  </Badge>
+                  <span className="flex-1 truncate font-medium">{item.subject}</span>
+                  {item.authorName && <span className="shrink-0 text-xs text-gray-400">{item.authorName}</span>}
+                  <span className="shrink-0 text-xs text-gray-400">{new Date(item.createdAt).toLocaleString()}</span>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-center gap-2">
+            <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+              이전
+            </Button>
+            <span className="text-sm text-gray-500">
+              {page} / {totalPages}
+            </span>
+            <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+              다음
+            </Button>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -123,6 +123,7 @@ export const REPORT = {
 
 export const FILE = {
   UPLOAD: "/api/files",
+  ADMIN_UPLOAD_IMAGE: "/api/admins/images",
 };
 
 export const BOARD = {
@@ -130,7 +131,10 @@ export const BOARD = {
   DETAIL: (id: number) => `/api/boards/${id}`,
   ADMIN_LIST: "/api/admins/boards",
   ADMIN_DETAIL: (id: number) => `/api/admins/boards/${id}`,
-  ADMIN_UPLOAD_IMAGE: "/api/admins/boards/images",
+};
+
+export const MARKETING_EMAIL = {
+  ADMIN_LIST: "/api/admins/marketing-emails",
 };
 
 export const QNA = {

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -135,6 +135,7 @@ export const BOARD = {
 
 export const MARKETING_EMAIL = {
   ADMIN_LIST: "/api/admins/marketing-emails",
+  ADMIN_DETAIL: (id: number) => `/api/admins/marketing-emails/${id}`,
 };
 
 export const QNA = {

--- a/client/src/hooks/queries/useAdminMarketingEmail.ts
+++ b/client/src/hooks/queries/useAdminMarketingEmail.ts
@@ -1,0 +1,22 @@
+import { adminMarketingEmail, GetAdminMarketingEmailsParams } from "@/api/services/admin/marketingEmail";
+import { SendMarketingEmailPayload } from "@/types/marketingEmail";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+const LIST_KEY = "adminMarketingEmails";
+
+export const useAdminMarketingEmails = (params: GetAdminMarketingEmailsParams) => {
+  return useQuery({
+    queryKey: [LIST_KEY, params],
+    queryFn: () => adminMarketingEmail.getList(params),
+  });
+};
+
+export const useSendMarketingEmail = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: SendMarketingEmailPayload) => adminMarketingEmail.send(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [LIST_KEY] });
+    },
+  });
+};

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -9,6 +9,7 @@ import AdminMember from "@/components/admin/layout/AdminMember";
 import AdminMyPage from "@/components/admin/layout/AdminMyPage";
 import { AdminTabs } from "@/components/admin/layout/AdminTabs";
 import AdminLogin from "@/components/admin/login/AdminLoginModal";
+import AdminMarketingEmailTab from "@/components/admin/marketingEmail/AdminMarketingEmailTab";
 import AdminPostTab from "@/components/admin/post/AdminPostTab";
 import AdminQnaTab from "@/components/admin/qna/AdminQnaTab";
 import AdminReportTab from "@/components/admin/report/AdminReportTab";
@@ -19,7 +20,9 @@ import { useAdminCheck } from "@/hooks/queries/useAdminAuth";
 export default function Admin() {
   const [isLogin, setIsLogin] = useState<boolean>(false);
   const { status, isLoading, data } = useAdminCheck();
-  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT" | "REPORT" | "BOARD" | "QNA">("RSS");
+  const [tap, setTap] = useState<"RSS" | "MEMBER" | "MYPAGE" | "POST" | "CHAT" | "REPORT" | "BOARD" | "QNA" | "EMAIL">(
+    "RSS"
+  );
 
   useEffect(() => {
     setIsLogin(status === "success");
@@ -51,6 +54,9 @@ export default function Admin() {
     }
     if (tap === "QNA") {
       return <AdminQnaTab />;
+    }
+    if (tap === "EMAIL") {
+      return <AdminMarketingEmailTab />;
     }
     return <AdminMember />;
   };

--- a/client/src/types/marketingEmail.ts
+++ b/client/src/types/marketingEmail.ts
@@ -6,6 +6,10 @@ export interface MarketingEmailSummary {
   createdAt: string;
 }
 
+export interface MarketingEmailDetail extends MarketingEmailSummary {
+  content: string;
+}
+
 export interface MarketingEmailPage<T> {
   result: T[];
   page: number;

--- a/client/src/types/marketingEmail.ts
+++ b/client/src/types/marketingEmail.ts
@@ -1,0 +1,20 @@
+export interface MarketingEmailSummary {
+  id: number;
+  subject: string;
+  recipientCount: number;
+  authorName: string | null;
+  createdAt: string;
+}
+
+export interface MarketingEmailPage<T> {
+  result: T[];
+  page: number;
+  limit: number;
+  totalCount: number;
+  hasMore: boolean;
+}
+
+export interface SendMarketingEmailPayload {
+  subject: string;
+  content: string;
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
+import { viteStaticCopy } from "vite-plugin-static-copy";
 
 import react from "@vitejs/plugin-react-swc";
 
@@ -11,6 +12,9 @@ export default defineConfig({
     visualizer({
       open: !process.env.VITE_VISUALIZE,
       brotliSize: true,
+    }),
+    viteStaticCopy({
+      targets: [{ src: "node_modules/tinymce", dest: "." }],
     }),
   ],
   resolve: {

--- a/docker-compose/db/init.sql
+++ b/docker-compose/db/init.sql
@@ -341,6 +341,18 @@ CREATE TABLE `board` (
   CONSTRAINT `FK_board_author_admin_id` FOREIGN KEY (`author_admin_id`) REFERENCES `admin` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
+CREATE TABLE `marketing_email` (
+  `id` int NOT NULL AUTO_INCREMENT,
+  `subject` varchar(255) NOT NULL,
+  `content` longtext NOT NULL,
+  `recipient_count` int NOT NULL,
+  `author_admin_id` int DEFAULT NULL,
+  `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `FK_marketing_email_author_admin_id` (`author_admin_id`),
+  CONSTRAINT `FK_marketing_email_author_admin_id` FOREIGN KEY (`author_admin_id`) REFERENCES `admin` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+);
+
 -- denamu.qna definition
 
 CREATE TABLE `qna` (

--- a/email-worker/scripts/preview-email.ts
+++ b/email-worker/scripts/preview-email.ts
@@ -5,6 +5,7 @@ import {
   createAdminDeleteAccountContent,
   createAdminVerificationMailContent,
   createDeleteAccountContent,
+  createMarketingBroadcastContent,
   createNoticePublishedContent,
   createPasswordResetMailContent,
   createQnaAnsweredContent,
@@ -109,6 +110,15 @@ const previews: [string, string, string][] = [
       '김데나무',
       '서비스 점검 안내',
       1,
+      SERVICE_ADDRESS,
+    ),
+  ],
+  [
+    'marketing-broadcast',
+    '마케팅 이메일(광고)',
+    createMarketingBroadcastContent(
+      '김데나무',
+      '<p>이번 달 새로운 기능을 소개합니다.</p>',
       SERVICE_ADDRESS,
     ),
   ],

--- a/email-worker/src/common/types.ts
+++ b/email-worker/src/common/types.ts
@@ -56,3 +56,10 @@ export interface NoticePublished {
   boardId: number;
   title: string;
 }
+
+export interface MarketingBroadcast {
+  email: string;
+  userName: string;
+  subject: string;
+  content: string;
+}

--- a/email-worker/src/email/constant.ts
+++ b/email-worker/src/email/constant.ts
@@ -11,4 +11,5 @@ export const EmailPayloadConstant = {
   ADMIN_PASSWORD_RESET: 'adminPasswordReset',
   QNA_ANSWERED: 'qnaAnswered',
   NOTICE_PUBLISHED: 'noticePublished',
+  MARKETING_BROADCAST: 'marketingBroadcast',
 } as const;

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -133,6 +133,10 @@ export class EmailConsumer implements Lifecycle {
         await this.emailService.sendNoticePublishedMail(payload.data);
         break;
 
+      case EmailPayloadConstant.MARKETING_BROADCAST:
+        await this.emailService.sendMarketingBroadcastMail(payload.data);
+        break;
+
       case EmailPayloadConstant.ADMIN_CERTIFICATION:
         await this.emailService.sendAdminCertificationMail(payload.data);
         break;

--- a/email-worker/src/email/email.content.ts
+++ b/email-worker/src/email/email.content.ts
@@ -5,7 +5,11 @@ export const PRODUCT_DOMAIN =
 
 const LOGO_URL = 'https://denamu.dev/files/Denamu_Logo_KOR.png';
 
-function mailLayout(bodyContent: string, serviceAddress: string) {
+function mailLayout(
+  bodyContent: string,
+  serviceAddress: string,
+  consentNotice?: string,
+) {
   return `
   <div style="font-family: 'Apple SD Gothic Neo', 'Malgun Gothic', '맑은 고딕', sans-serif; margin: 0; padding: 1px; background-color: #f4f4f4;">
     <div style="max-width: 600px; margin: 20px auto; background-color: #ffffff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);">
@@ -15,9 +19,10 @@ function mailLayout(bodyContent: string, serviceAddress: string) {
       <div style="padding: 20px 0;">
         ${bodyContent}
       </div>
-      <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; border-top: 2px solid #f0f0f0; color: #6c757d; font-size: 14px; height: 100px;">
-        <p>본 메일은 발신전용입니다.</p>
-        <p>문의사항이 있으시다면 <a href="mailto:${serviceAddress}" style="color: #007bff; text-decoration: none;">${serviceAddress}</a>로 연락주세요.</p>
+      <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; border-top: 2px solid #f0f0f0; color: #6c757d; font-size: 14px; padding: 10px 0;">
+        <p style="margin: 4px 0;">본 메일은 발신전용입니다.</p>
+        ${consentNotice ?? ''}
+        <p style="margin: 4px 0;">문의사항이 있으시다면 <a href="mailto:${serviceAddress}" style="color: #007bff; text-decoration: none;">${serviceAddress}</a>로 연락주세요.</p>
       </div>
     </div>
   </div>
@@ -303,7 +308,25 @@ export function createNoticePublishedContent(
           ${fallbackLink(noticeLink)}
         `)}
   `;
-  return mailLayout(body, serviceAddress);
+  const consentNotice = `
+        <p style="margin: 4px 0;">본 메일은 [마이페이지 → 정보 수정 → 공지사항 이메일 수신 동의]에서 수신에 동의하신 분께 발송되었습니다.</p>
+        <p style="margin: 4px 0;">해당 메뉴에서 언제든 수신 동의 또는 거절을 다시 선택하실 수 있습니다.</p>`;
+  return mailLayout(body, serviceAddress, consentNotice);
+}
+
+export function createMarketingBroadcastContent(
+  userName: string,
+  content: string,
+  serviceAddress: string,
+) {
+  const body = `
+        <p>안녕하세요, <b>${userName}</b>님!</p>
+        ${content}
+  `;
+  const consentNotice = `
+        <p style="margin: 4px 0;">본 메일은 [마이페이지 → 정보 수정 → 마케팅 활용 및 광고성 정보 수신 동의]에서 수신에 동의하신 분께 발송되었습니다.</p>
+        <p style="margin: 4px 0;">해당 메뉴에서 언제든 수신 동의 또는 거절을 다시 선택하실 수 있습니다.</p>`;
+  return mailLayout(body, serviceAddress, consentNotice);
 }
 
 export function createDeleteAccountContent(

--- a/email-worker/src/email/email.service.ts
+++ b/email-worker/src/email/email.service.ts
@@ -7,6 +7,7 @@ import logger from '@common/logger/logger';
 import { EmailMetrics } from '@common/metrics/email-metrics';
 import {
   AdminCertification,
+  MarketingBroadcast,
   NoticePublished,
   QnaAnswered,
   Rss,
@@ -21,6 +22,7 @@ import {
   createAdminDeleteAccountContent,
   createAdminVerificationMailContent,
   createDeleteAccountContent,
+  createMarketingBroadcastContent,
   createNoticePublishedContent,
   createPasswordResetMailContent,
   createQnaAnsweredContent,
@@ -350,6 +352,29 @@ export class EmailService {
         notice.userName,
         notice.title,
         notice.boardId,
+        this.emailUser,
+      ),
+    };
+  }
+
+  async sendMarketingBroadcastMail(
+    marketingBroadcast: MarketingBroadcast,
+  ): Promise<void> {
+    const mailOptions = this.createMarketingBroadcastMail(marketingBroadcast);
+
+    await this.sendMail(mailOptions);
+  }
+
+  private createMarketingBroadcastMail(
+    marketingBroadcast: MarketingBroadcast,
+  ): nodemailer.SendMailOptions {
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: `${marketingBroadcast.userName}<${marketingBroadcast.email}>`,
+      subject: `(광고) [🎋 Denamu] ${marketingBroadcast.subject}`,
+      html: createMarketingBroadcastContent(
+        marketingBroadcast.userName,
+        marketingBroadcast.content,
         this.emailUser,
       ),
     };

--- a/email-worker/src/email/types.ts
+++ b/email-worker/src/email/types.ts
@@ -1,5 +1,6 @@
 import {
   AdminCertification,
+  MarketingBroadcast,
   NoticePublished,
   QnaAnswered,
   RssCertification,
@@ -44,6 +45,10 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.NOTICE_PUBLISHED;
       data: NoticePublished;
+    }
+  | {
+      type: typeof EmailPayloadConstant.MARKETING_BROADCAST;
+      data: MarketingBroadcast;
     };
 
 export type NodeMailerError = Error & {

--- a/email-worker/test/unit/consumer.spec.ts
+++ b/email-worker/test/unit/consumer.spec.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 
 import {
   AdminCertification,
+  MarketingBroadcast,
   RssCertification,
   RssRegistration,
   RssRegistrationRequest,
@@ -41,6 +42,7 @@ describe('email consumer unit test', () => {
     let sendAdminCertificationMail: jest.Mock;
     let sendAdminDeleteAccountMail: jest.Mock;
     let sendAdminPasswordResetEmail: jest.Mock;
+    let sendMarketingBroadcastMail: jest.Mock;
 
     beforeEach(() => {
       sendUserCertificationMail = jest.fn().mockResolvedValue(undefined);
@@ -53,6 +55,7 @@ describe('email consumer unit test', () => {
       sendAdminCertificationMail = jest.fn().mockResolvedValue(undefined);
       sendAdminDeleteAccountMail = jest.fn().mockResolvedValue(undefined);
       sendAdminPasswordResetEmail = jest.fn().mockResolvedValue(undefined);
+      sendMarketingBroadcastMail = jest.fn().mockResolvedValue(undefined);
 
       emailService = {
         sendUserCertificationMail,
@@ -65,6 +68,7 @@ describe('email consumer unit test', () => {
         sendAdminCertificationMail,
         sendAdminDeleteAccountMail,
         sendAdminPasswordResetEmail,
+        sendMarketingBroadcastMail,
       } as any;
       rabbitmqService = {
         sendMessageToQueue: jest.fn().mockResolvedValue(null),
@@ -264,6 +268,27 @@ describe('email consumer unit test', () => {
 
       expect(sendAdminPasswordResetEmail).toHaveBeenCalledTimes(1);
       expect(sendAdminPasswordResetEmail).toHaveBeenCalledWith(adminData);
+    });
+
+    it('MARKETING_BROADCAST 타입일 때 sendMarketingBroadcastMail을 호출한다', async () => {
+      //given
+      const marketingData: MarketingBroadcast = {
+        email: 'test@test.com',
+        userName: 'tester',
+        subject: '9월 신규 기능 소식',
+        content: '<p>이번 달 업데이트를 확인해보세요.</p>',
+      };
+      const payload: EmailPayload = {
+        type: EmailPayloadConstant.MARKETING_BROADCAST,
+        data: marketingData,
+      };
+
+      //when
+      await emailConsumer.handleEmailByType(payload);
+
+      //then
+      expect(sendMarketingBroadcastMail).toHaveBeenCalledTimes(1);
+      expect(sendMarketingBroadcastMail).toHaveBeenCalledWith(marketingData);
     });
 
     it('알 수 없는 타입일 때 아무 메서드도 호출하지 않는다', async () => {
@@ -682,7 +707,11 @@ describe('email consumer unit test', () => {
       } as any;
       emailService = { sendUserCertificationMail } as any;
       notifier = { start: jest.fn(), publish: jest.fn() };
-      emailConsumer = new EmailConsumer(rabbitmqService, emailService, notifier);
+      emailConsumer = new EmailConsumer(
+        rabbitmqService,
+        emailService,
+        notifier,
+      );
     });
 
     it('start 호출 시 EMAIL_SEND 큐를 consume 한다', async () => {
@@ -733,7 +762,9 @@ describe('email consumer unit test', () => {
     });
 
     it('대기 중인 작업이 없으면 waitForPendingTasks는 즉시 반환한다', async () => {
-      await expect(emailConsumer.waitForPendingTasks()).resolves.toBeUndefined();
+      await expect(
+        emailConsumer.waitForPendingTasks(),
+      ).resolves.toBeUndefined();
     });
 
     it('stop은 진행 중인 작업이 모두 끝날 때까지 대기한 후 종료한다', async () => {

--- a/email-worker/test/unit/emailService.spec.ts
+++ b/email-worker/test/unit/emailService.spec.ts
@@ -5,6 +5,8 @@ import * as nodemailer from 'nodemailer';
 import { EmailMetrics } from '@common/metrics/email-metrics';
 import {
   AdminCertification,
+  MarketingBroadcast,
+  NoticePublished,
   RssCertification,
   RssRegistration,
   RssRegistrationRequest,
@@ -442,6 +444,95 @@ describe('EmailService unit test', () => {
       const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
       expect(callArgs.html).toContain(request.rss.name);
       expect(callArgs.html).toContain(request.rss.rssUrl);
+    });
+  });
+
+  describe('sendNoticePublishedMail unit test', () => {
+    it('공지사항 등록 메일을 공지 수신동의 안내와 함께 올바르게 전송한다', async () => {
+      //given
+      const notice: NoticePublished = {
+        email: 'tester@test.com',
+        userName: 'tester',
+        boardId: 42,
+        title: '서비스 점검 안내',
+      };
+
+      //when
+      await emailService.sendNoticePublishedMail(notice);
+
+      //then
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: `${notice.userName}<${notice.email}>`,
+          subject: '[🎋 Denamu] 새로운 공지사항이 등록되었습니다.',
+        }),
+      );
+
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(notice.userName);
+      expect(callArgs.html).toContain(notice.title);
+      expect(callArgs.html).toContain(
+        `${PRODUCT_DOMAIN}/board/${notice.boardId}`,
+      );
+      expect(callArgs.html).toContain('공지사항 이메일 수신 동의');
+      expect(callArgs.html).not.toContain(
+        '마케팅 활용 및 광고성 정보 수신 동의',
+      );
+    });
+  });
+
+  describe('sendMarketingBroadcastMail unit test', () => {
+    const marketingBroadcast: MarketingBroadcast = {
+      email: 'tester@test.com',
+      userName: 'tester',
+      subject: '9월 신규 기능 소식',
+      content: '<p>이번 달 업데이트를 확인해보세요.</p>',
+    };
+
+    it('광고성 단체 메일을 (광고) 접두사가 붙은 제목으로 전송한다', async () => {
+      //given
+      const expectedSubject = `(광고) [🎋 Denamu] ${marketingBroadcast.subject}`;
+
+      //when
+      await emailService.sendMarketingBroadcastMail(marketingBroadcast);
+
+      //then
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: `${marketingBroadcast.userName}<${marketingBroadcast.email}>`,
+          subject: expectedSubject,
+        }),
+      );
+    });
+
+    it('본문에 수신자 이름, 전달 내용, 마케팅 수신동의 안내가 포함된다', async () => {
+      //given
+      //when
+      await emailService.sendMarketingBroadcastMail(marketingBroadcast);
+
+      //then
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(marketingBroadcast.userName);
+      expect(callArgs.html).toContain(marketingBroadcast.content);
+      expect(callArgs.html).toContain('마케팅 활용 및 광고성 정보 수신 동의');
+      expect(callArgs.html).not.toContain('공지사항 이메일 수신 동의');
+    });
+
+    it('메일 전송 실패 시 에러를 그대로 전파한다', async () => {
+      //given
+      const error = new Error('SMTP connection failed');
+      mockSendMail.mockRejectedValue(error);
+
+      //when
+      const sending =
+        emailService.sendMarketingBroadcastMail(marketingBroadcast);
+
+      //then
+      await expect(sending).rejects.toThrow('SMTP connection failed');
     });
   });
 });

--- a/server/.prettierrc.js
+++ b/server/.prettierrc.js
@@ -21,7 +21,7 @@ module.exports = {
     '^@file/(.*)?$',
     '^@health/(.*)?$',
     '^@like/(.*)?$',
-    '^@notice/(.*)?$',
+    '^@marketingEmail/(.*)?$',
     '^@notification/(.*)?$',
     '^@qna/(.*)?$',
     '^@report/(.*)?$',

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -33,6 +33,8 @@ import { HealthController } from '@health/health.controller';
 
 import { LikeModule } from '@like/module/like.module';
 
+import { MarketingEmailModule } from '@marketingEmail/module/marketingEmail.module';
+
 import { NotificationModule } from '@notification/module/notification.module';
 
 import { QnaModule } from '@qna/module/qna.module';
@@ -100,6 +102,7 @@ const exists = !!chosen && fs.existsSync(chosen);
     CommentModule,
     LikeModule,
     BoardModule,
+    MarketingEmailModule,
     QnaModule,
     NotificationModule,
     BlockModule,

--- a/server/src/board/controller/adminBoard.controller.ts
+++ b/server/src/board/controller/adminBoard.controller.ts
@@ -2,21 +2,15 @@ import {
   Body,
   Controller,
   Delete,
-  FileTypeValidator,
   Get,
   HttpCode,
   HttpStatus,
-  MaxFileSizeValidator,
   Param,
-  ParseFilePipe,
   Patch,
   Post,
   Query,
-  UploadedFile,
   UseGuards,
-  UseInterceptors,
 } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags } from '@nestjs/swagger';
 
 import { ApiCreateBoard } from '@board/api-docs/createBoard.api-docs';
@@ -24,60 +18,21 @@ import { ApiDeleteBoard } from '@board/api-docs/deleteBoard.api-docs';
 import { ApiGetAdminBoard } from '@board/api-docs/getAdminBoard.api-docs';
 import { ApiGetAdminBoards } from '@board/api-docs/getAdminBoards.api-docs';
 import { ApiUpdateBoard } from '@board/api-docs/updateBoard.api-docs';
-import { ApiUploadBoardImage } from '@board/api-docs/uploadBoardImage.api-docs';
 import { CreateBoardRequestDto } from '@board/dto/request/createBoard.dto';
 import { GetAdminBoardsRequestDto } from '@board/dto/request/getAdminBoards.dto';
 import { GetBoardRequestDto } from '@board/dto/request/getBoard.dto';
 import { UpdateBoardRequestDto } from '@board/dto/request/updateBoard.dto';
-import { UploadBoardImageResponseDto } from '@board/dto/response/uploadBoardImage.dto';
 import { BoardService } from '@board/service/board.service';
 
 import { CurrentAdmin } from '@common/decorator/current-admin.decorator';
 import { AdminAuthGuard } from '@common/guard/session.guard';
 import { ApiResponse } from '@common/response/common.response';
 
-import { FILE_SIZE_LIMITS, FileUploadType } from '@file/constant/file.constant';
-import { FileService } from '@file/service/file.service';
-
 @ApiTags('Admin')
 @Controller('admins/boards')
 @UseGuards(AdminAuthGuard)
 export class AdminBoardController {
-  constructor(
-    private readonly boardService: BoardService,
-    private readonly fileService: FileService,
-  ) {}
-
-  @ApiUploadBoardImage()
-  @Post('images')
-  @HttpCode(HttpStatus.CREATED)
-  @UseInterceptors(FileInterceptor('file'))
-  async uploadImage(
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [
-          new MaxFileSizeValidator({
-            maxSize: FILE_SIZE_LIMITS.IMAGE,
-            message: `파일 크기는 ${FILE_SIZE_LIMITS.IMAGE / (1024 * 1024)}MB를 초과할 수 없습니다.`,
-          }),
-          new FileTypeValidator({
-            fileType: /image\/(png|jpg|jpeg|webp|gif)/,
-            skipMagicNumbersValidation: true,
-          }),
-        ],
-      }),
-    )
-    file: Express.Multer.File,
-  ) {
-    const url = await this.fileService.saveWithoutOwner(
-      file,
-      FileUploadType.BOARD_IMAGE,
-    );
-    return ApiResponse.responseWithData(
-      '이미지 업로드에 성공했습니다.',
-      new UploadBoardImageResponseDto(url),
-    );
-  }
+  constructor(private readonly boardService: BoardService) {}
 
   @ApiGetAdminBoards()
   @Get()

--- a/server/src/common/database/migration/1785500000000-CreateMarketingEmail.ts
+++ b/server/src/common/database/migration/1785500000000-CreateMarketingEmail.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateMarketingEmail1785500000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+    CREATE TABLE \`marketing_email\` (
+      \`id\` int NOT NULL AUTO_INCREMENT,
+      \`subject\` varchar(255) NOT NULL,
+      \`content\` longtext NOT NULL,
+      \`recipient_count\` int NOT NULL,
+      \`author_admin_id\` int DEFAULT NULL,
+      \`created_at\` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      PRIMARY KEY (\`id\`),
+      KEY \`FK_marketing_email_author_admin_id\` (\`author_admin_id\`),
+      CONSTRAINT \`FK_marketing_email_author_admin_id\` FOREIGN KEY (\`author_admin_id\`) REFERENCES \`admin\` (\`id\`) ON DELETE SET NULL ON UPDATE CASCADE
+    );
+        `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE marketing_email;');
+  }
+}

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@nestjs/common';
 import {
   EmailPayload,
   EmailPayloadConstant,
+  MarketingBroadcast,
   NoticePublished,
   QnaAnswered,
 } from '@common/email/email.type';
@@ -200,6 +201,13 @@ export class EmailProducer {
   async produceNoticePublished(payload: NoticePublished) {
     await this.produceMessage({
       type: EmailPayloadConstant.NOTICE_PUBLISHED,
+      data: payload,
+    });
+  }
+
+  async produceMarketingBroadcast(payload: MarketingBroadcast) {
+    await this.produceMessage({
+      type: EmailPayloadConstant.MARKETING_BROADCAST,
       data: payload,
     });
   }

--- a/server/src/common/email/email.type.ts
+++ b/server/src/common/email/email.type.ts
@@ -56,6 +56,13 @@ export interface NoticePublished {
   title: string;
 }
 
+export interface MarketingBroadcast {
+  email: string;
+  userName: string;
+  subject: string;
+  content: string;
+}
+
 export const EmailPayloadConstant = {
   USER_CERTIFICATION: 'userCertification',
   RSS_REMOVAL: 'rssRemoval',
@@ -69,6 +76,7 @@ export const EmailPayloadConstant = {
   ADMIN_PASSWORD_RESET: 'adminPasswordReset',
   QNA_ANSWERED: 'qnaAnswered',
   NOTICE_PUBLISHED: 'noticePublished',
+  MARKETING_BROADCAST: 'marketingBroadcast',
 } as const;
 
 export type EmailPayload =
@@ -104,4 +112,8 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.NOTICE_PUBLISHED;
       data: NoticePublished;
+    }
+  | {
+      type: typeof EmailPayloadConstant.MARKETING_BROADCAST;
+      data: MarketingBroadcast;
     };

--- a/server/src/file/api-docs/uploadAdminImage.api-docs.ts
+++ b/server/src/file/api-docs/uploadAdminImage.api-docs.ts
@@ -6,18 +6,18 @@ import {
   ApiOperation,
 } from '@nestjs/swagger';
 
-import { UploadBoardImageResponseDto } from '@board/dto/response/uploadBoardImage.dto';
-
 import {
   ApiBadRequestDoc,
   ApiCreatedDataResponse,
   ApiUnauthorizedDoc,
 } from '@common/swagger/swagger.helper';
 
-export function ApiUploadBoardImage() {
+import { UploadImageResponseDto } from '@file/dto/response/uploadImage.dto';
+
+export function ApiUploadAdminImage() {
   return applyDecorators(
     ApiCookieAuth('sessionId'),
-    ApiOperation({ summary: '게시글 본문 이미지 업로드 API' }),
+    ApiOperation({ summary: '관리자 이미지 업로드 API' }),
     ApiConsumes('multipart/form-data'),
     ApiBody({
       description: '업로드할 이미지 파일',
@@ -33,11 +33,7 @@ export function ApiUploadBoardImage() {
         required: ['file'],
       },
     }),
-    ApiCreatedDataResponse(
-      UploadBoardImageResponseDto,
-      false,
-      '이미지 업로드 성공',
-    ),
+    ApiCreatedDataResponse(UploadImageResponseDto, false, '이미지 업로드 성공'),
     ApiBadRequestDoc('잘못된 요청'),
     ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
   );

--- a/server/src/file/constant/file.constant.ts
+++ b/server/src/file/constant/file.constant.ts
@@ -1,8 +1,13 @@
 export enum FileUploadType {
   PROFILE_IMAGE = 'PROFILE_IMAGE',
   BOARD_IMAGE = 'BOARD_IMAGE',
-  // 추후 추가될 타입들 명시
+  MARKETING_EMAIL_IMAGE = 'MARKETING_EMAIL_IMAGE',
 }
+
+export const ADMIN_UPLOADABLE_IMAGE_TYPES = [
+  FileUploadType.BOARD_IMAGE,
+  FileUploadType.MARKETING_EMAIL_IMAGE,
+] as const;
 
 export const FILE_SIZE_LIMITS = {
   // MB 단위

--- a/server/src/file/controller/adminFile.controller.ts
+++ b/server/src/file/controller/adminFile.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Controller,
+  FileTypeValidator,
+  HttpCode,
+  HttpStatus,
+  MaxFileSizeValidator,
+  ParseFilePipe,
+  Post,
+  Query,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiTags } from '@nestjs/swagger';
+
+import { AdminAuthGuard } from '@common/guard/session.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiUploadAdminImage } from '@file/api-docs/uploadAdminImage.api-docs';
+import { FILE_SIZE_LIMITS } from '@file/constant/file.constant';
+import { UploadAdminImageRequestDto } from '@file/dto/request/uploadAdminImage.dto';
+import { UploadImageResponseDto } from '@file/dto/response/uploadImage.dto';
+import { FileService } from '@file/service/file.service';
+
+@ApiTags('Admin')
+@Controller('admins/images')
+@UseGuards(AdminAuthGuard)
+export class AdminFileController {
+  constructor(private readonly fileService: FileService) {}
+
+  @ApiUploadAdminImage()
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @UseInterceptors(FileInterceptor('file'))
+  async uploadImage(
+    @UploadedFile(
+      new ParseFilePipe({
+        validators: [
+          new MaxFileSizeValidator({
+            maxSize: FILE_SIZE_LIMITS.IMAGE,
+            message: `파일 크기는 ${FILE_SIZE_LIMITS.IMAGE / (1024 * 1024)}MB를 초과할 수 없습니다.`,
+          }),
+          new FileTypeValidator({
+            fileType: /image\/(png|jpg|jpeg|webp|gif)/,
+            skipMagicNumbersValidation: true,
+          }),
+        ],
+      }),
+    )
+    file: Express.Multer.File,
+    @Query() query: UploadAdminImageRequestDto,
+  ) {
+    const url = await this.fileService.saveWithoutOwner(file, query.uploadType);
+    return ApiResponse.responseWithData(
+      '이미지 업로드에 성공했습니다.',
+      new UploadImageResponseDto(url),
+    );
+  }
+}

--- a/server/src/file/dto/request/uploadAdminImage.dto.ts
+++ b/server/src/file/dto/request/uploadAdminImage.dto.ts
@@ -1,0 +1,21 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { IsIn } from 'class-validator';
+
+import {
+  ADMIN_UPLOADABLE_IMAGE_TYPES,
+  FileUploadType,
+} from '@file/constant/file.constant';
+
+export class UploadAdminImageRequestDto {
+  @ApiProperty({
+    description: '이미지 업로드 타입',
+    enum: ADMIN_UPLOADABLE_IMAGE_TYPES,
+    example: FileUploadType.BOARD_IMAGE,
+    required: true,
+  })
+  @IsIn(ADMIN_UPLOADABLE_IMAGE_TYPES, {
+    message: '지원하지 않는 파일 타입입니다.',
+  })
+  uploadType: FileUploadType;
+}

--- a/server/src/file/dto/response/uploadImage.dto.ts
+++ b/server/src/file/dto/response/uploadImage.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class UploadBoardImageResponseDto {
+export class UploadImageResponseDto {
   @ApiProperty({
     example: '/objects/BOARD_IMAGE/2026-08-06/example.jpg',
     description: '업로드된 이미지 접근 URL',

--- a/server/src/file/module/file.module.ts
+++ b/server/src/file/module/file.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 
 import { BoardRepository } from '@board/repository/board.repository';
 
+import { AdminFileController } from '@file/controller/adminFile.controller';
 import { FileController } from '@file/controller/file.controller';
 import { FileRepository } from '@file/repository/file.repository';
 import { FileScheduler } from '@file/scheduler/file.scheduler';
@@ -10,7 +11,7 @@ import { FileService } from '@file/service/file.service';
 import { UserRepository } from '@user/repository/user.repository';
 
 @Module({
-  controllers: [FileController],
+  controllers: [FileController, AdminFileController],
   providers: [
     FileService,
     FileRepository,

--- a/server/src/marketingEmail/api-docs/getAdminMarketingEmail.api-docs.ts
+++ b/server/src/marketingEmail/api-docs/getAdminMarketingEmail.api-docs.ts
@@ -1,0 +1,20 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiDataResponse,
+  ApiNotFoundDoc,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+import { MarketingEmailDetailDto } from '@marketingEmail/dto/response/marketingEmail.dto';
+
+export function ApiGetAdminMarketingEmail() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '마케팅 이메일 발송 상세 조회 API' }),
+    ApiDataResponse(MarketingEmailDetailDto, false, '발송 상세 조회 성공'),
+    ApiNotFoundDoc('존재하지 않는 발송 이력입니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/marketingEmail/api-docs/getAdminMarketingEmails.api-docs.ts
+++ b/server/src/marketingEmail/api-docs/getAdminMarketingEmails.api-docs.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+import { MarketingEmailListResponseDto } from '@marketingEmail/dto/response/marketingEmail.dto';
+
+export function ApiGetAdminMarketingEmails() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({ summary: '마케팅 이메일 발송 이력 조회 API' }),
+    ApiDataResponse(
+      MarketingEmailListResponseDto,
+      false,
+      '발송 이력 조회 성공',
+    ),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/marketingEmail/api-docs/sendMarketingEmail.api-docs.ts
+++ b/server/src/marketingEmail/api-docs/sendMarketingEmail.api-docs.ts
@@ -1,0 +1,24 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiCookieAuth, ApiOperation } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiCreatedDataResponse,
+  ApiUnauthorizedDoc,
+} from '@common/swagger/swagger.helper';
+
+import { MarketingEmailSummaryDto } from '@marketingEmail/dto/response/marketingEmail.dto';
+
+export function ApiSendMarketingEmail() {
+  return applyDecorators(
+    ApiCookieAuth('sessionId'),
+    ApiOperation({
+      summary: '마케팅 이메일 발송 API',
+      description:
+        '광고성 정보 수신에 동의한 회원에게만 발송됩니다. 제목 맨 앞에 "(광고)"가 자동으로 붙습니다.',
+    }),
+    ApiCreatedDataResponse(MarketingEmailSummaryDto, false, '이메일 발송 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+    ApiUnauthorizedDoc('인증되지 않은 요청입니다.'),
+  );
+}

--- a/server/src/marketingEmail/controller/adminMarketingEmail.controller.ts
+++ b/server/src/marketingEmail/controller/adminMarketingEmail.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+
+import { CurrentAdmin } from '@common/decorator/current-admin.decorator';
+import { AdminAuthGuard } from '@common/guard/session.guard';
+import { ApiResponse } from '@common/response/common.response';
+
+import { ApiGetAdminMarketingEmails } from '@marketingEmail/api-docs/getAdminMarketingEmails.api-docs';
+import { ApiSendMarketingEmail } from '@marketingEmail/api-docs/sendMarketingEmail.api-docs';
+import { GetAdminMarketingEmailsRequestDto } from '@marketingEmail/dto/request/getAdminMarketingEmails.dto';
+import { SendMarketingEmailRequestDto } from '@marketingEmail/dto/request/sendMarketingEmail.dto';
+import { MarketingEmailService } from '@marketingEmail/service/marketingEmail.service';
+
+@ApiTags('Admin')
+@Controller('admins/marketing-emails')
+@UseGuards(AdminAuthGuard)
+export class AdminMarketingEmailController {
+  constructor(private readonly marketingEmailService: MarketingEmailService) {}
+
+  @ApiGetAdminMarketingEmails()
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getAdminMarketingEmails(
+    @Query() queryDto: GetAdminMarketingEmailsRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '발송 이력 조회를 성공했습니다.',
+      await this.marketingEmailService.getAdminMarketingEmails(queryDto),
+    );
+  }
+
+  @ApiSendMarketingEmail()
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async sendMarketingEmail(
+    @CurrentAdmin() email: string,
+    @Body() bodyDto: SendMarketingEmailRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '이메일이 성공적으로 발송되었습니다.',
+      await this.marketingEmailService.sendMarketingEmail(email, bodyDto),
+    );
+  }
+}

--- a/server/src/marketingEmail/controller/adminMarketingEmail.controller.ts
+++ b/server/src/marketingEmail/controller/adminMarketingEmail.controller.ts
@@ -4,6 +4,7 @@ import {
   Get,
   HttpCode,
   HttpStatus,
+  Param,
   Post,
   Query,
   UseGuards,
@@ -14,9 +15,11 @@ import { CurrentAdmin } from '@common/decorator/current-admin.decorator';
 import { AdminAuthGuard } from '@common/guard/session.guard';
 import { ApiResponse } from '@common/response/common.response';
 
+import { ApiGetAdminMarketingEmail } from '@marketingEmail/api-docs/getAdminMarketingEmail.api-docs';
 import { ApiGetAdminMarketingEmails } from '@marketingEmail/api-docs/getAdminMarketingEmails.api-docs';
 import { ApiSendMarketingEmail } from '@marketingEmail/api-docs/sendMarketingEmail.api-docs';
 import { GetAdminMarketingEmailsRequestDto } from '@marketingEmail/dto/request/getAdminMarketingEmails.dto';
+import { GetMarketingEmailRequestDto } from '@marketingEmail/dto/request/getMarketingEmail.dto';
 import { SendMarketingEmailRequestDto } from '@marketingEmail/dto/request/sendMarketingEmail.dto';
 import { MarketingEmailService } from '@marketingEmail/service/marketingEmail.service';
 
@@ -35,6 +38,16 @@ export class AdminMarketingEmailController {
     return ApiResponse.responseWithData(
       '발송 이력 조회를 성공했습니다.',
       await this.marketingEmailService.getAdminMarketingEmails(queryDto),
+    );
+  }
+
+  @ApiGetAdminMarketingEmail()
+  @Get('/:id')
+  @HttpCode(HttpStatus.OK)
+  async getAdminMarketingEmail(@Param() paramDto: GetMarketingEmailRequestDto) {
+    return ApiResponse.responseWithData(
+      '발송 상세 조회를 성공했습니다.',
+      await this.marketingEmailService.getAdminMarketingEmail(paramDto.id),
     );
   }
 

--- a/server/src/marketingEmail/dto/request/getAdminMarketingEmails.dto.ts
+++ b/server/src/marketingEmail/dto/request/getAdminMarketingEmails.dto.ts
@@ -1,0 +1,24 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class GetAdminMarketingEmailsRequestDto {
+  @ApiPropertyOptional({ example: 1, description: '조회할 페이지 번호' })
+  @IsOptional()
+  @Min(1, { message: 'page 값은 1 이상이어야 합니다.' })
+  @IsInt({ message: '정수를 입력해주세요.' })
+  @Type(() => Number)
+  page: number = 1;
+
+  @ApiPropertyOptional({ example: 10, description: '페이지당 개수' })
+  @IsOptional()
+  @Min(1, { message: 'limit 값은 1 이상이어야 합니다.' })
+  @IsInt({ message: '정수를 입력해주세요.' })
+  @Type(() => Number)
+  limit: number = 10;
+
+  constructor(partial: Partial<GetAdminMarketingEmailsRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/marketingEmail/dto/request/getMarketingEmail.dto.ts
+++ b/server/src/marketingEmail/dto/request/getMarketingEmail.dto.ts
@@ -1,0 +1,16 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsInt, Min } from 'class-validator';
+
+export class GetMarketingEmailRequestDto {
+  @ApiProperty({ example: 1, description: '마케팅 이메일 발송 ID' })
+  @IsInt({ message: '정수를 입력해주세요.' })
+  @Min(1, { message: 'id 값은 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  id: number;
+
+  constructor(partial: Partial<GetMarketingEmailRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/marketingEmail/dto/request/sendMarketingEmail.dto.ts
+++ b/server/src/marketingEmail/dto/request/sendMarketingEmail.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { Transform } from 'class-transformer';
+import { IsString, MaxLength } from 'class-validator';
+
+import { sanitizeBoardContent } from '@common/util/sanitizeHtml';
+
+export class SendMarketingEmailRequestDto {
+  @ApiProperty({
+    description: '제목 (발송 시 제목 맨 앞에 "(광고)"가 자동으로 붙습니다)',
+    example: '8월 신규 기능 소식을 전해드려요',
+    maxLength: 255,
+  })
+  @IsString({ message: '문자열로 입력해주세요.' })
+  @MaxLength(255, { message: '제목은 255자 이하로 입력해주세요.' })
+  subject: string;
+
+  @ApiProperty({
+    description: '본문 (에디터에서 작성된 HTML)',
+    example: '<p>이번 달 새로운 기능을 소개합니다.</p>',
+  })
+  @IsString({ message: '문자열로 입력해주세요.' })
+  @Transform(({ value }) => sanitizeBoardContent(value))
+  content: string;
+
+  constructor(partial: Partial<SendMarketingEmailRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/marketingEmail/dto/response/marketingEmail.dto.ts
+++ b/server/src/marketingEmail/dto/response/marketingEmail.dto.ts
@@ -48,6 +48,53 @@ export class MarketingEmailSummaryDto {
   }
 }
 
+export class MarketingEmailDetailDto {
+  @ApiProperty({ example: 1, description: '발송 ID' })
+  id: number;
+
+  @ApiProperty({
+    example: '8월 신규 기능 소식을 전해드려요',
+    description: '제목',
+  })
+  subject: string;
+
+  @ApiProperty({
+    example: '<p>안녕하세요, 회원님!</p>',
+    description: '본문 (HTML)',
+  })
+  content: string;
+
+  @ApiProperty({ example: 128, description: '수신자 수' })
+  recipientCount: number;
+
+  @ApiProperty({
+    example: '테스트 계정',
+    description: '발송한 관리자 이름 (탈퇴 등으로 계정이 없으면 null)',
+    nullable: true,
+  })
+  authorName: string | null;
+
+  @ApiProperty({ example: '2026-08-06T12:00:00.000Z', description: '발송일시' })
+  createdAt: Date;
+
+  constructor(partial: Partial<MarketingEmailDetailDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(
+    marketingEmail: MarketingEmail,
+  ): MarketingEmailDetailDto {
+    return new MarketingEmailDetailDto({
+      id: marketingEmail.id,
+      subject: marketingEmail.subject,
+      content: marketingEmail.content,
+      recipientCount: marketingEmail.recipientCount,
+      authorName: marketingEmail.author?.name ?? null,
+      createdAt: marketingEmail.createdAt,
+    });
+  }
+}
+
 export class MarketingEmailListResponseDto {
   @ApiProperty({
     type: [MarketingEmailSummaryDto],

--- a/server/src/marketingEmail/dto/response/marketingEmail.dto.ts
+++ b/server/src/marketingEmail/dto/response/marketingEmail.dto.ts
@@ -1,0 +1,88 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+import { MarketingEmail } from '@marketingEmail/entity/marketingEmail.entity';
+
+export class MarketingEmailSummaryDto {
+  @ApiProperty({ example: 1, description: '발송 ID' })
+  id: number;
+
+  @ApiProperty({
+    example: '8월 신규 기능 소식을 전해드려요',
+    description: '제목',
+  })
+  subject: string;
+
+  @ApiProperty({ example: 128, description: '수신자 수' })
+  recipientCount: number;
+
+  @ApiProperty({
+    example: '테스트 계정',
+    description: '발송한 관리자 이름 (탈퇴 등으로 계정이 없으면 null)',
+    nullable: true,
+  })
+  authorName: string | null;
+
+  @ApiProperty({ example: '2026-08-06T12:00:00.000Z', description: '발송일시' })
+  createdAt: Date;
+
+  constructor(partial: Partial<MarketingEmailSummaryDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResultDto(marketingEmail: MarketingEmail): MarketingEmailSummaryDto {
+    return new MarketingEmailSummaryDto({
+      id: marketingEmail.id,
+      subject: marketingEmail.subject,
+      recipientCount: marketingEmail.recipientCount,
+      authorName: marketingEmail.author?.name ?? null,
+      createdAt: marketingEmail.createdAt,
+    });
+  }
+
+  static toResultDtoArray(
+    marketingEmails: MarketingEmail[],
+  ): MarketingEmailSummaryDto[] {
+    return marketingEmails.map((marketingEmail) =>
+      this.toResultDto(marketingEmail),
+    );
+  }
+}
+
+export class MarketingEmailListResponseDto {
+  @ApiProperty({
+    type: [MarketingEmailSummaryDto],
+    description: '발송 이력 목록',
+  })
+  result: MarketingEmailSummaryDto[];
+
+  @ApiProperty({ example: 1, description: '현재 페이지 번호' })
+  page: number;
+
+  @ApiProperty({ example: 10, description: '페이지당 개수' })
+  limit: number;
+
+  @ApiProperty({ example: 1, description: '전체 개수' })
+  totalCount: number;
+
+  @ApiProperty({ example: false, description: '다음 페이지 존재 여부' })
+  hasMore: boolean;
+
+  constructor(partial: Partial<MarketingEmailListResponseDto>) {
+    Object.assign(this, partial);
+  }
+
+  static toResponseDto(
+    marketingEmails: MarketingEmail[],
+    page: number,
+    limit: number,
+    totalCount: number,
+  ): MarketingEmailListResponseDto {
+    return new MarketingEmailListResponseDto({
+      result: MarketingEmailSummaryDto.toResultDtoArray(marketingEmails),
+      page,
+      limit,
+      totalCount,
+      hasMore: page * limit < totalCount,
+    });
+  }
+}

--- a/server/src/marketingEmail/entity/marketingEmail.entity.ts
+++ b/server/src/marketingEmail/entity/marketingEmail.entity.ts
@@ -1,0 +1,40 @@
+import {
+  BaseEntity,
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+
+import { Admin } from '@admin/entity/admin.entity';
+
+@Entity({ name: 'marketing_email' })
+export class MarketingEmail extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ length: 255, nullable: false })
+  subject: string;
+
+  @Column({ type: 'longtext', nullable: false })
+  content: string;
+
+  @Column({ name: 'recipient_count', type: 'int', nullable: false })
+  recipientCount: number;
+
+  @ManyToOne(() => Admin, {
+    nullable: true,
+    onUpdate: 'CASCADE',
+    onDelete: 'SET NULL',
+  })
+  @JoinColumn({
+    name: 'author_admin_id',
+    foreignKeyConstraintName: 'FK_marketing_email_author_admin_id',
+  })
+  author: Admin | null;
+
+  @CreateDateColumn({ name: 'created_at', type: 'datetime', nullable: false })
+  createdAt: Date;
+}

--- a/server/src/marketingEmail/module/marketingEmail.module.ts
+++ b/server/src/marketingEmail/module/marketingEmail.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+
+import { AdminModule } from '@admin/module/admin.module';
+
+import { AdminMarketingEmailController } from '@marketingEmail/controller/adminMarketingEmail.controller';
+import { MarketingEmailRepository } from '@marketingEmail/repository/marketingEmail.repository';
+import { MarketingEmailService } from '@marketingEmail/service/marketingEmail.service';
+
+import { UserRepository } from '@user/repository/user.repository';
+
+@Module({
+  imports: [AdminModule],
+  controllers: [AdminMarketingEmailController],
+  providers: [MarketingEmailService, MarketingEmailRepository, UserRepository],
+  exports: [],
+})
+export class MarketingEmailModule {}

--- a/server/src/marketingEmail/repository/marketingEmail.repository.ts
+++ b/server/src/marketingEmail/repository/marketingEmail.repository.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+
+import { DataSource, Repository } from 'typeorm';
+
+import { MarketingEmail } from '@marketingEmail/entity/marketingEmail.entity';
+
+@Injectable()
+export class MarketingEmailRepository extends Repository<MarketingEmail> {
+  constructor(private dataSource: DataSource) {
+    super(MarketingEmail, dataSource.createEntityManager());
+  }
+
+  async findAdminList(page: number, limit: number) {
+    const [items, totalCount] = await this.findAndCount({
+      relations: ['author'],
+      order: { id: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { items, totalCount };
+  }
+}

--- a/server/src/marketingEmail/service/marketingEmail.service.ts
+++ b/server/src/marketingEmail/service/marketingEmail.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@nestjs/common';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { EmailProducer } from '@common/email/email.producer';
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { GetAdminMarketingEmailsRequestDto } from '@marketingEmail/dto/request/getAdminMarketingEmails.dto';
+import { SendMarketingEmailRequestDto } from '@marketingEmail/dto/request/sendMarketingEmail.dto';
+import {
+  MarketingEmailListResponseDto,
+  MarketingEmailSummaryDto,
+} from '@marketingEmail/dto/response/marketingEmail.dto';
+import { MarketingEmailRepository } from '@marketingEmail/repository/marketingEmail.repository';
+
+import { UserRepository } from '@user/repository/user.repository';
+
+@Injectable()
+export class MarketingEmailService {
+  constructor(
+    private readonly marketingEmailRepository: MarketingEmailRepository,
+    private readonly adminRepository: AdminRepository,
+    private readonly userRepository: UserRepository,
+    private readonly emailProducer: EmailProducer,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  async getAdminMarketingEmails(queryDto: GetAdminMarketingEmailsRequestDto) {
+    const { page, limit } = queryDto;
+    const { items, totalCount } =
+      await this.marketingEmailRepository.findAdminList(page, limit);
+    return MarketingEmailListResponseDto.toResponseDto(
+      items,
+      page,
+      limit,
+      totalCount,
+    );
+  }
+
+  async sendMarketingEmail(
+    authorEmail: string,
+    dto: SendMarketingEmailRequestDto,
+  ) {
+    const recipients = await this.userRepository.findMarketingAgreedUsers();
+    const author = await this.adminRepository.findOneBy({
+      email: authorEmail,
+    });
+
+    const marketingEmail = this.marketingEmailRepository.create({
+      subject: dto.subject,
+      content: dto.content,
+      recipientCount: recipients.length,
+      author,
+    });
+    await this.marketingEmailRepository.save(marketingEmail);
+
+    const results = await Promise.allSettled(
+      recipients.map((recipient) =>
+        this.emailProducer.produceMarketingBroadcast({
+          email: recipient.email,
+          userName: recipient.userName,
+          subject: dto.subject,
+          content: dto.content,
+        }),
+      ),
+    );
+
+    const failedCount = results.filter(
+      (result) => result.status === 'rejected',
+    ).length;
+    if (failedCount > 0) {
+      this.logger.error(
+        `마케팅 이메일 발행 중 일부가 실패했습니다.: marketingEmailId=${marketingEmail.id}, failed=${failedCount}/${recipients.length}`,
+      );
+    }
+
+    return MarketingEmailSummaryDto.toResultDto(marketingEmail);
+  }
+}

--- a/server/src/marketingEmail/service/marketingEmail.service.ts
+++ b/server/src/marketingEmail/service/marketingEmail.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 
 import { AdminRepository } from '@admin/repository/admin.repository';
 
@@ -8,12 +8,15 @@ import { WinstonLoggerService } from '@common/logger/logger.service';
 import { GetAdminMarketingEmailsRequestDto } from '@marketingEmail/dto/request/getAdminMarketingEmails.dto';
 import { SendMarketingEmailRequestDto } from '@marketingEmail/dto/request/sendMarketingEmail.dto';
 import {
+  MarketingEmailDetailDto,
   MarketingEmailListResponseDto,
   MarketingEmailSummaryDto,
 } from '@marketingEmail/dto/response/marketingEmail.dto';
 import { MarketingEmailRepository } from '@marketingEmail/repository/marketingEmail.repository';
 
 import { UserRepository } from '@user/repository/user.repository';
+
+const NOT_FOUND_MESSAGE = '존재하지 않는 발송 이력입니다.';
 
 @Injectable()
 export class MarketingEmailService {
@@ -35,6 +38,17 @@ export class MarketingEmailService {
       limit,
       totalCount,
     );
+  }
+
+  async getAdminMarketingEmail(id: number): Promise<MarketingEmailDetailDto> {
+    const marketingEmail = await this.marketingEmailRepository.findOne({
+      where: { id },
+      relations: ['author'],
+    });
+    if (!marketingEmail) {
+      throw new NotFoundException(NOT_FOUND_MESSAGE);
+    }
+    return MarketingEmailDetailDto.toResponseDto(marketingEmail);
   }
 
   async sendMarketingEmail(

--- a/server/src/user/repository/user.repository.ts
+++ b/server/src/user/repository/user.repository.ts
@@ -54,4 +54,11 @@ export class UserRepository extends Repository<User> {
       select: ['email', 'userName'],
     });
   }
+
+  async findMarketingAgreedUsers() {
+    return this.find({
+      where: { marketingEmailAgreed: true },
+      select: ['email', 'userName'],
+    });
+  }
 }

--- a/server/test/config/common/fixture/marketingEmail.fixture.ts
+++ b/server/test/config/common/fixture/marketingEmail.fixture.ts
@@ -1,0 +1,28 @@
+import * as uuid from 'uuid';
+
+import { MarketingEmail } from '@marketingEmail/entity/marketingEmail.entity';
+
+export const MARKETING_EMAIL_DEFAULT_CONTENT =
+  '<p>테스트 마케팅 이메일 본문입니다.</p>';
+
+export class MarketingEmailFixture {
+  static createGeneralMarketingEmail() {
+    return {
+      subject: `marketing${uuid.v4()}`,
+      content: MARKETING_EMAIL_DEFAULT_CONTENT,
+      recipientCount: 0,
+      author: null,
+    };
+  }
+
+  static createMarketingEmailFixture(
+    overwrites: Partial<MarketingEmail> = {},
+  ): MarketingEmail {
+    const marketingEmail = new MarketingEmail();
+    return Object.assign(
+      marketingEmail,
+      this.createGeneralMarketingEmail(),
+      overwrites,
+    );
+  }
+}

--- a/server/test/file/dto/uploadAdminImage.dto.spec.ts
+++ b/server/test/file/dto/uploadAdminImage.dto.spec.ts
@@ -1,0 +1,82 @@
+import { validate } from 'class-validator';
+
+import { FileUploadType } from '@file/constant/file.constant';
+import { UploadAdminImageRequestDto } from '@file/dto/request/uploadAdminImage.dto';
+
+describe(`${UploadAdminImageRequestDto.name} Test`, () => {
+  let dto: UploadAdminImageRequestDto;
+
+  beforeEach(() => {
+    dto = new UploadAdminImageRequestDto();
+    dto.uploadType = FileUploadType.BOARD_IMAGE;
+  });
+
+  it('이미지 타입이 관리자 업로드 허용 목록에 있을 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('이미지 타입이 마케팅 이메일 이미지일 경우 유효성 검사에 성공한다.', async () => {
+    // given
+    dto.uploadType = FileUploadType.MARKETING_EMAIL_IMAGE;
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('uploadType', () => {
+    it('이미지 타입이 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.uploadType = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isIn');
+    });
+
+    it('이미지 타입이 프로필 이미지처럼 관리자 업로드 허용 목록에 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.uploadType = FileUploadType.PROFILE_IMAGE;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isIn');
+    });
+
+    it('이미지 타입이 타입 목록에 없는 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.uploadType = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isIn');
+    });
+
+    it('이미지 타입이 문자열이 아닌 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.uploadType = 1 as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isIn');
+    });
+  });
+});

--- a/server/test/file/e2e/admin-upload.e2e-spec.ts
+++ b/server/test/file/e2e/admin-upload.e2e-spec.ts
@@ -1,0 +1,166 @@
+import { HttpStatus } from '@nestjs/common';
+
+import * as uuid from 'uuid';
+import fs from 'fs/promises';
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { FILE_SIZE_LIMITS, FileUploadType } from '@file/constant/file.constant';
+import { FileRepository } from '@file/repository/file.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/admins/images';
+
+// 100x100 단색 PNG: webp 변환 시 원본보다 확실히 작아지는 케이스 (353B -> 106B)
+const PNG_FIXTURE_BUFFER = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAGQAAABkCAIAAAD/gAIDAAAACXBIWXMAAAPoAAAD6AG1e1JrAAABE0lEQVR4nO3WUQ0DAQzD0CExfygHaxTuZ0onPakILCfN5yn3vIPwQep5rQtYgdUvEsOswIpZbd+RGAZWzEoM+5dhrLMCK2Ylhs3LSGcFVsxqHjHTIbBiVvfPgg+smJUYNi8jnRVYMat5xEyHwIpZ3T8LPrBiVmLYvIx0VmDFrOYRMx0CK2Z1/yz4wIpZiWHzMtJZgRWzmkfMdAismNX9s+ADK2Ylhs3LSGcFVsxqHjHTIbBiVvfPgg+smJUYNi8jnRVYMat5xEyHwIpZ3T8LPrBiVmLYvIx0VmDFrOYRMx0CK2Z1/yz4wIpZiWHzMtJZgRWzmkfMdAismNX9s+ADK2Ylhs3LSGcFVsxqHjHTIbBamfUFgy2uiqggRS0AAAAASUVORK5CYII=',
+  'base64',
+);
+
+describe(`POST ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let fileRepository: FileRepository;
+
+  const sessionKey = 'admin-image-upload-session-key';
+  const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+  const fileRandomName = 'test-random-uuid-file-name';
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+    fileRepository = testApp.get(FileRepository);
+  });
+
+  beforeEach(async () => {
+    jest.spyOn(fs, 'writeFile').mockResolvedValue(undefined);
+    jest.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+    jest.spyOn(uuid, 'v4').mockReturnValue(fileRandomName as any);
+
+    const admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(redisKeyMake(sessionKey), admin.email);
+  });
+
+  it('[401] 관리자 세션 쿠키가 없을 경우 이미지 업로드를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query({ uploadType: FileUploadType.BOARD_IMAGE })
+      .attach('file', PNG_FIXTURE_BUFFER, 'test.png');
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+
+    // DB then
+    expect(await fileRepository.count()).toBe(0);
+  });
+
+  it('[201] 게시글 이미지 타입으로 파일을 첨부할 경우 이미지 업로드를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query({ uploadType: FileUploadType.BOARD_IMAGE })
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .attach('file', PNG_FIXTURE_BUFFER, 'test.png');
+
+    // Http then
+    const { message, data } = response.body as {
+      message: string;
+      data: { url: string };
+    };
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(message).toBe('이미지 업로드에 성공했습니다.');
+    expect(data).toStrictEqual({
+      url: expect.stringContaining(`${fileRandomName}.webp`),
+    });
+    expect(data.url).toContain(FileUploadType.BOARD_IMAGE);
+
+    // DB then
+    expect(await fileRepository.count()).toBe(0);
+  });
+
+  it('[201] 마케팅 이메일 이미지 타입으로 파일을 첨부할 경우 이미지 업로드를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query({ uploadType: FileUploadType.MARKETING_EMAIL_IMAGE })
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .attach('file', PNG_FIXTURE_BUFFER, 'test.png');
+
+    // Http then
+    const { data } = response.body as { data: { url: string } };
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(data.url).toContain(FileUploadType.MARKETING_EMAIL_IMAGE);
+
+    // DB then
+    expect(await fileRepository.count()).toBe(0);
+  });
+
+  it('[400] 이미지 타입이 관리자 업로드 허용 목록에 없을 경우 이미지 업로드를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query({ uploadType: FileUploadType.PROFILE_IMAGE })
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .attach('file', PNG_FIXTURE_BUFFER, 'test.png');
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+  });
+
+  it('[400] 파일이 포함되어 있지 않을 경우 이미지 업로드를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query({ uploadType: FileUploadType.BOARD_IMAGE })
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+  });
+
+  it('[400] 파일 타입이 이미지가 아닐 경우 이미지 업로드를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query({ uploadType: FileUploadType.BOARD_IMAGE })
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .attach('file', Buffer.alloc(1024, 0), 'test.txt');
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+  });
+
+  it('[400] 파일 크기가 제한을 초과할 경우 이미지 업로드를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .post(URL)
+      .query({ uploadType: FileUploadType.BOARD_IMAGE })
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .attach('file', Buffer.alloc(FILE_SIZE_LIMITS.IMAGE + 1, 0), 'test.png');
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+    expect(data).toBeUndefined();
+  });
+});

--- a/server/test/marketingEmail/dto/getAdminMarketingEmails.dto.spec.ts
+++ b/server/test/marketingEmail/dto/getAdminMarketingEmails.dto.spec.ts
@@ -1,0 +1,84 @@
+import { validate } from 'class-validator';
+
+import { GetAdminMarketingEmailsRequestDto } from '@marketingEmail/dto/request/getAdminMarketingEmails.dto';
+
+describe(`${GetAdminMarketingEmailsRequestDto.name} Test`, () => {
+  let dto: GetAdminMarketingEmailsRequestDto;
+
+  beforeEach(() => {
+    dto = new GetAdminMarketingEmailsRequestDto({ page: 1, limit: 10 });
+  });
+
+  it('page와 limit이 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('page와 limit이 입력되지 않을 경우 기본값이 적용되어 유효성 검사에 성공한다.', async () => {
+    // given
+    const defaultDto = new GetAdminMarketingEmailsRequestDto({});
+
+    // when
+    const errors = await validate(defaultDto);
+
+    // then
+    expect(errors).toHaveLength(0);
+    expect(defaultDto.page).toBe(1);
+    expect(defaultDto.limit).toBe(10);
+  });
+
+  describe('page', () => {
+    it('page가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+
+    it('page가 정수가 아닌 실수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 1.5;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+  });
+
+  describe('limit', () => {
+    it('limit이 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+
+    it('limit이 정수가 아닌 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+  });
+});

--- a/server/test/marketingEmail/dto/getMarketingEmail.dto.spec.ts
+++ b/server/test/marketingEmail/dto/getMarketingEmail.dto.spec.ts
@@ -1,0 +1,59 @@
+import { validate } from 'class-validator';
+
+import { GetMarketingEmailRequestDto } from '@marketingEmail/dto/request/getMarketingEmail.dto';
+
+describe(`${GetMarketingEmailRequestDto.name} Test`, () => {
+  let dto: GetMarketingEmailRequestDto;
+
+  beforeEach(() => {
+    dto = new GetMarketingEmailRequestDto({
+      id: 1,
+    });
+  });
+
+  it('발송 ID가 1 이상의 정수일 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('id', () => {
+    it('발송 ID가 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = null;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('발송 ID가 정수가 아닌 문자열일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = 'test' as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('발송 ID가 1 미만의 정수일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.id = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+});

--- a/server/test/marketingEmail/dto/sendMarketingEmail.dto.spec.ts
+++ b/server/test/marketingEmail/dto/sendMarketingEmail.dto.spec.ts
@@ -1,0 +1,97 @@
+import { validate } from 'class-validator';
+
+import { SendMarketingEmailRequestDto } from '@marketingEmail/dto/request/sendMarketingEmail.dto';
+
+describe(`${SendMarketingEmailRequestDto.name} Test`, () => {
+  let dto: SendMarketingEmailRequestDto;
+
+  beforeEach(() => {
+    dto = new SendMarketingEmailRequestDto({
+      subject: '8월 신규 기능 소식을 전해드려요',
+      content: '<p>이번 달 새로운 기능을 소개합니다.</p>',
+    });
+  });
+
+  it('제목과 본문이 모두 올바를 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('제목이 255자 경계값일 경우 유효성 검사에 성공한다.', async () => {
+    // given
+    dto.subject = 'a'.repeat(255);
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('subject', () => {
+    it('제목이 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.subject = undefined;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+
+    it('제목이 문자열이 아닌 숫자일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.subject = 1 as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+
+    it('제목이 255자를 초과할 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.subject = 'a'.repeat(256);
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('maxLength');
+    });
+  });
+
+  describe('content', () => {
+    it('본문이 없을 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.content = undefined;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+
+    it('본문이 문자열이 아닌 객체일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.content = { text: 'test' } as any;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isString');
+    });
+  });
+});

--- a/server/test/marketingEmail/e2e/admin-detail.e2e-spec.ts
+++ b/server/test/marketingEmail/e2e/admin-detail.e2e-spec.ts
@@ -1,0 +1,102 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Admin } from '@admin/entity/admin.entity';
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { MarketingEmail } from '@marketingEmail/entity/marketingEmail.entity';
+import { MarketingEmailRepository } from '@marketingEmail/repository/marketingEmail.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { MarketingEmailFixture } from '@test/config/common/fixture/marketingEmail.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = (id: number | string) => `/api/admins/marketing-emails/${id}`;
+
+describe(`GET /api/admins/marketing-emails/:id E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let marketingEmailRepository: MarketingEmailRepository;
+
+  const sessionKey = 'admin-marketing-email-detail-session-key';
+  const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+
+  let admin: Admin;
+  let marketingEmail: MarketingEmail;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+    marketingEmailRepository = testApp.get(MarketingEmailRepository);
+  });
+
+  beforeEach(async () => {
+    admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(redisKeyMake(sessionKey), admin.email);
+
+    marketingEmail = await marketingEmailRepository.save(
+      MarketingEmailFixture.createMarketingEmailFixture({
+        author: admin,
+        recipientCount: 5,
+      }),
+    );
+  });
+
+  it('[401] 관리자 세션 쿠키가 없을 경우 상세 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(URL(marketingEmail.id));
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 발송 이력의 본문을 포함하여 상세 조회를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL(marketingEmail.id))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    const { message, data } = response.body;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(message).toBe('발송 상세 조회를 성공했습니다.');
+    expect(data).toMatchObject({
+      id: marketingEmail.id,
+      subject: marketingEmail.subject,
+      content: marketingEmail.content,
+      recipientCount: 5,
+      authorName: admin.name,
+    });
+  });
+
+  it('[404] 존재하지 않는 발송 이력일 경우 상세 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL(999999))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.NOT_FOUND);
+  });
+
+  it('[400] id가 정수가 아닐 경우 상세 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL('abc'))
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+});

--- a/server/test/marketingEmail/e2e/admin-get.e2e-spec.ts
+++ b/server/test/marketingEmail/e2e/admin-get.e2e-spec.ts
@@ -1,0 +1,184 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Admin } from '@admin/entity/admin.entity';
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { MarketingEmail } from '@marketingEmail/entity/marketingEmail.entity';
+import { MarketingEmailRepository } from '@marketingEmail/repository/marketingEmail.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { MarketingEmailFixture } from '@test/config/common/fixture/marketingEmail.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/admins/marketing-emails';
+
+type MarketingEmailListResponseBody = {
+  message: string;
+  data: {
+    page: number;
+    limit: number;
+    totalCount: number;
+    hasMore: boolean;
+    result: { id: number; authorName: string | null }[];
+  };
+};
+
+describe(`GET ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let marketingEmailRepository: MarketingEmailRepository;
+
+  const sessionKey = 'admin-marketing-email-get-session-key';
+  const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+
+  let admin: Admin;
+  let first: MarketingEmail;
+  let second: MarketingEmail;
+  let orphan: MarketingEmail;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+    marketingEmailRepository = testApp.get(MarketingEmailRepository);
+  });
+
+  beforeEach(async () => {
+    admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(redisKeyMake(sessionKey), admin.email);
+
+    first = await marketingEmailRepository.save(
+      MarketingEmailFixture.createMarketingEmailFixture({
+        author: admin,
+        recipientCount: 3,
+      }),
+    );
+    second = await marketingEmailRepository.save(
+      MarketingEmailFixture.createMarketingEmailFixture({ author: admin }),
+    );
+    orphan = await marketingEmailRepository.save(
+      MarketingEmailFixture.createMarketingEmailFixture({ author: null }),
+    );
+  });
+
+  it('[401] 관리자 세션 쿠키가 없을 경우 이력 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent.get(URL);
+
+    // Http then
+    const { data } = response.body;
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+    expect(data).toBeUndefined();
+  });
+
+  it('[200] 쿼리 파라미터가 없을 경우 기본 페이지네이션으로 이력 조회를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    const { message, data } = response.body as MarketingEmailListResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(message).toBe('발송 이력 조회를 성공했습니다.');
+    expect(data.page).toBe(1);
+    expect(data.limit).toBe(10);
+    expect(data.totalCount).toBe(3);
+    expect(data.hasMore).toBe(false);
+    expect(data.result.map((item) => item.id).sort()).toStrictEqual(
+      [first.id, second.id, orphan.id].sort(),
+    );
+  });
+
+  it('[200] 최신 발송 이력이 목록 최상단으로 정렬되어 조회를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    const { data } = response.body as MarketingEmailListResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result.map((item) => item.id)).toStrictEqual([
+      orphan.id,
+      second.id,
+      first.id,
+    ]);
+  });
+
+  it('[200] 발송한 관리자 이름과 수신자 수를 포함하여 조회를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    const { data } = response.body as MarketingEmailListResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result[2]).toMatchObject({
+      id: first.id,
+      subject: first.subject,
+      recipientCount: 3,
+      authorName: admin.name,
+    });
+    expect(data.result[2]).not.toHaveProperty('content');
+  });
+
+  it('[200] 발송한 관리자가 없는 이력일 경우 관리자 이름을 null로 조회를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    const { data } = response.body as MarketingEmailListResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result[0].authorName).toBeNull();
+  });
+
+  it('[200] 페이지네이션을 입력할 경우 해당 페이지 조회를 성공한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .query({ page: 1, limit: 2 })
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    const { data } = response.body as MarketingEmailListResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result).toHaveLength(2);
+    expect(data.totalCount).toBe(3);
+    expect(data.hasMore).toBe(true);
+  });
+
+  it('[400] page가 1 미만일 경우 이력 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .query({ page: 0 })
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[400] limit이 정수가 아닐 경우 이력 조회를 실패한다.', async () => {
+    // Http when
+    const response = await agent
+      .get(URL)
+      .query({ limit: 'test' })
+      .set('Cookie', `sessionId=${sessionKey}`);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+});

--- a/server/test/marketingEmail/e2e/admin-send.e2e-spec.ts
+++ b/server/test/marketingEmail/e2e/admin-send.e2e-spec.ts
@@ -1,0 +1,209 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { Admin } from '@admin/entity/admin.entity';
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { SendMarketingEmailRequestDto } from '@marketingEmail/dto/request/sendMarketingEmail.dto';
+import { MarketingEmailRepository } from '@marketingEmail/repository/marketingEmail.repository';
+
+import { UserRepository } from '@user/repository/user.repository';
+
+import { AdminFixture } from '@test/config/common/fixture/admin.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/admins/marketing-emails';
+
+describe(`POST ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let adminRepository: AdminRepository;
+  let userRepository: UserRepository;
+  let marketingEmailRepository: MarketingEmailRepository;
+
+  const sessionKey = 'admin-marketing-email-send-session-key';
+  const redisKeyMake = (data: string) => `${REDIS_KEYS.ADMIN_AUTH_KEY}:${data}`;
+
+  let admin: Admin;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    adminRepository = testApp.get(AdminRepository);
+    userRepository = testApp.get(UserRepository);
+    marketingEmailRepository = testApp.get(MarketingEmailRepository);
+  });
+
+  beforeEach(async () => {
+    admin = await adminRepository.save(
+      await AdminFixture.createAdminCryptFixture(),
+    );
+    await redisService.set(redisKeyMake(sessionKey), admin.email);
+
+    await userRepository.save(
+      await UserFixture.createUserCryptFixture({ marketingEmailAgreed: true }),
+    );
+    await userRepository.save(
+      await UserFixture.createUserCryptFixture({ marketingEmailAgreed: false }),
+    );
+  });
+
+  it('[401] 관리자 세션 쿠키가 없을 경우 발송을 실패한다.', async () => {
+    // given
+    const requestDto = new SendMarketingEmailRequestDto({
+      subject: '8월 소식',
+      content: '<p>본문</p>',
+    });
+
+    // Http when
+    const response = await agent.post(URL).send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.UNAUTHORIZED);
+
+    // DB then
+    expect(await marketingEmailRepository.count()).toBe(0);
+  });
+
+  it('[201] 제목과 본문을 입력할 경우 수신 동의한 사용자에게만 발송을 성공한다.', async () => {
+    // given
+    const requestDto = new SendMarketingEmailRequestDto({
+      subject: '8월 소식',
+      content: '<p>본문</p>',
+    });
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send(requestDto);
+
+    // Http then
+    const { message, data } = response.body as {
+      message: string;
+      data: { id: number; recipientCount: number; authorName: string };
+    };
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(message).toBe('이메일이 성공적으로 발송되었습니다.');
+    expect(data).toMatchObject({
+      subject: requestDto.subject,
+      recipientCount: 1,
+      authorName: admin.name,
+    });
+
+    // DB then
+    const saved = await marketingEmailRepository.findOne({
+      where: { id: data.id },
+      relations: ['author'],
+    });
+    expect(saved.subject).toBe(requestDto.subject);
+    expect(saved.content).toBe(requestDto.content);
+    expect(saved.recipientCount).toBe(1);
+    expect(saved.author.id).toBe(admin.id);
+  });
+
+  it('[201] 수신 동의한 사용자가 없을 경우 수신자 수 0으로 발송을 성공한다.', async () => {
+    // given
+    await userRepository.delete({ marketingEmailAgreed: true });
+    const requestDto = new SendMarketingEmailRequestDto({
+      subject: '8월 소식',
+      content: '<p>본문</p>',
+    });
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send(requestDto);
+
+    // Http then
+    const { data } = response.body as { data: { recipientCount: number } };
+    expect(response.status).toBe(HttpStatus.CREATED);
+    expect(data.recipientCount).toBe(0);
+
+    // DB then
+    expect(await marketingEmailRepository.count()).toBe(1);
+  });
+
+  it('[201] 본문에 허용되지 않은 태그가 포함될 경우 제거된 상태로 발송을 성공한다.', async () => {
+    // given
+    const requestDto = new SendMarketingEmailRequestDto({
+      subject: '8월 소식',
+      content: '<p>본문</p><script>alert(1)</script>',
+    });
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send(requestDto);
+
+    // Http then
+    const { data } = response.body as { data: { id: number } };
+    expect(response.status).toBe(HttpStatus.CREATED);
+
+    // DB then
+    const saved = await marketingEmailRepository.findOneBy({ id: data.id });
+    expect(saved.content).toBe('<p>본문</p>');
+  });
+
+  it('[400] 제목이 255자를 초과할 경우 발송을 실패한다.', async () => {
+    // given
+    const requestDto = new SendMarketingEmailRequestDto({
+      subject: 'a'.repeat(256),
+      content: '<p>본문</p>',
+    });
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+
+    // DB then
+    expect(await marketingEmailRepository.count()).toBe(0);
+  });
+
+  it('[400] 제목이 없을 경우 발송을 실패한다.', async () => {
+    // given
+    const requestDto = { content: '<p>본문</p>' };
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+
+    // DB then
+    expect(await marketingEmailRepository.count()).toBe(0);
+  });
+
+  it('[400] 본문이 없을 경우 발송을 실패한다.', async () => {
+    // given
+    const requestDto = { subject: '8월 소식' };
+
+    // Http when
+    const response = await agent
+      .post(URL)
+      .set('Cookie', `sessionId=${sessionKey}`)
+      .send(requestDto);
+
+    // Http then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+
+    // DB then
+    expect(await marketingEmailRepository.count()).toBe(0);
+  });
+});

--- a/server/test/marketingEmail/unit/marketingEmail.service.unit.spec.ts
+++ b/server/test/marketingEmail/unit/marketingEmail.service.unit.spec.ts
@@ -1,0 +1,279 @@
+import { AdminRepository } from '@admin/repository/admin.repository';
+
+import { EmailProducer } from '@common/email/email.producer';
+import { WinstonLoggerService } from '@common/logger/logger.service';
+
+import { GetAdminMarketingEmailsRequestDto } from '@marketingEmail/dto/request/getAdminMarketingEmails.dto';
+import { SendMarketingEmailRequestDto } from '@marketingEmail/dto/request/sendMarketingEmail.dto';
+import { MarketingEmail } from '@marketingEmail/entity/marketingEmail.entity';
+import { MarketingEmailRepository } from '@marketingEmail/repository/marketingEmail.repository';
+import { MarketingEmailService } from '@marketingEmail/service/marketingEmail.service';
+
+import { UserRepository } from '@user/repository/user.repository';
+
+import { MarketingEmailFixture } from '@test/config/common/fixture/marketingEmail.fixture';
+
+describe(`${MarketingEmailService.name} Unit Test`, () => {
+  let marketingEmailService: MarketingEmailService;
+  let marketingEmailRepository: Record<
+    'findAdminList' | 'create' | 'save' | 'findOne',
+    jest.Mock
+  >;
+  let adminRepository: Record<'findOneBy', jest.Mock>;
+  let userRepository: jest.Mocked<
+    Pick<UserRepository, 'findMarketingAgreedUsers'>
+  >;
+  let emailProducer: jest.Mocked<
+    Pick<EmailProducer, 'produceMarketingBroadcast'>
+  >;
+  let logger: jest.Mocked<Pick<WinstonLoggerService, 'error'>>;
+
+  const createMarketingEmail = (
+    overwrites: Partial<MarketingEmail> = {},
+  ): MarketingEmail =>
+    MarketingEmailFixture.createMarketingEmailFixture({
+      id: 1,
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+      ...overwrites,
+    });
+
+  beforeEach(() => {
+    marketingEmailRepository = {
+      findAdminList: jest.fn(),
+      create: jest.fn((entityLike) => entityLike),
+      save: jest.fn((entity) => entity),
+      findOne: jest.fn(),
+    };
+    adminRepository = {
+      findOneBy: jest.fn(),
+    };
+    userRepository = {
+      findMarketingAgreedUsers: jest.fn().mockResolvedValue([]),
+    };
+    emailProducer = {
+      produceMarketingBroadcast: jest.fn().mockResolvedValue(undefined),
+    };
+    logger = { error: jest.fn() };
+
+    marketingEmailService = new MarketingEmailService(
+      marketingEmailRepository as unknown as MarketingEmailRepository,
+      adminRepository as unknown as AdminRepository,
+      userRepository as unknown as UserRepository,
+      emailProducer as unknown as EmailProducer,
+      logger as unknown as WinstonLoggerService,
+    );
+  });
+
+  describe('getAdminMarketingEmails', () => {
+    it('페이지네이션 값을 리포지토리에 위임하고 목록을 반환한다.', async () => {
+      // given
+      marketingEmailRepository.findAdminList.mockResolvedValue({
+        items: [createMarketingEmail({ id: 2 }), createMarketingEmail()],
+        totalCount: 25,
+      });
+
+      // when
+      const result = await marketingEmailService.getAdminMarketingEmails(
+        new GetAdminMarketingEmailsRequestDto({ page: 2, limit: 10 }),
+      );
+
+      // then
+      expect(marketingEmailRepository.findAdminList).toHaveBeenCalledWith(
+        2,
+        10,
+      );
+      expect(result.page).toBe(2);
+      expect(result.limit).toBe(10);
+      expect(result.totalCount).toBe(25);
+      expect(result.hasMore).toBe(true);
+      expect(result.result).toHaveLength(2);
+    });
+
+    it('마지막 페이지일 경우 hasMore가 false로 반환된다.', async () => {
+      // given
+      marketingEmailRepository.findAdminList.mockResolvedValue({
+        items: [createMarketingEmail()],
+        totalCount: 10,
+      });
+
+      // when
+      const result = await marketingEmailService.getAdminMarketingEmails(
+        new GetAdminMarketingEmailsRequestDto({ page: 1, limit: 10 }),
+      );
+
+      // then
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('목록 응답에는 본문이 포함되지 않는다.', async () => {
+      // given
+      marketingEmailRepository.findAdminList.mockResolvedValue({
+        items: [createMarketingEmail()],
+        totalCount: 1,
+      });
+
+      // when
+      const result = await marketingEmailService.getAdminMarketingEmails(
+        new GetAdminMarketingEmailsRequestDto({ page: 1, limit: 10 }),
+      );
+
+      // then
+      expect(result.result[0]).not.toHaveProperty('content');
+    });
+
+    it('발송한 관리자가 없는 이력일 경우 관리자 이름을 null로 반환한다.', async () => {
+      // given
+      marketingEmailRepository.findAdminList.mockResolvedValue({
+        items: [createMarketingEmail({ author: null })],
+        totalCount: 1,
+      });
+
+      // when
+      const result = await marketingEmailService.getAdminMarketingEmails(
+        new GetAdminMarketingEmailsRequestDto({ page: 1, limit: 10 }),
+      );
+
+      // then
+      expect(result.result[0].authorName).toBeNull();
+    });
+  });
+
+  describe('getAdminMarketingEmail', () => {
+    it('id로 조회된 발송 이력을 본문 포함하여 반환한다.', async () => {
+      // given
+      marketingEmailRepository.findOne.mockResolvedValue(
+        createMarketingEmail({ id: 5 }),
+      );
+
+      // when
+      const result = await marketingEmailService.getAdminMarketingEmail(5);
+
+      // then
+      expect(marketingEmailRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 5 },
+        relations: ['author'],
+      });
+      expect(result).toHaveProperty('content');
+      expect(result.id).toBe(5);
+    });
+
+    it('존재하지 않는 id일 경우 NotFoundException을 던진다.', async () => {
+      // given
+      marketingEmailRepository.findOne.mockResolvedValue(null);
+
+      // when, then
+      await expect(
+        marketingEmailService.getAdminMarketingEmail(999),
+      ).rejects.toThrow('존재하지 않는 발송 이력입니다.');
+    });
+  });
+
+  describe('sendMarketingEmail', () => {
+    const requestDto = new SendMarketingEmailRequestDto({
+      subject: '8월 소식',
+      content: '<p>본문</p>',
+    });
+
+    it('수신 동의한 사용자 수를 수신자 수로 저장하고 각 사용자에게 이메일을 발행한다.', async () => {
+      // given
+      const author = { id: 1, name: '관리자', email: 'admin@test.com' };
+      adminRepository.findOneBy.mockResolvedValue(author);
+      userRepository.findMarketingAgreedUsers.mockResolvedValue([
+        { email: 'a@test.com', userName: 'a' },
+        { email: 'b@test.com', userName: 'b' },
+      ] as any);
+
+      // when
+      const result = await marketingEmailService.sendMarketingEmail(
+        'admin@test.com',
+        requestDto,
+      );
+
+      // then
+      expect(adminRepository.findOneBy).toHaveBeenCalledWith({
+        email: 'admin@test.com',
+      });
+      expect(marketingEmailRepository.create).toHaveBeenCalledWith({
+        subject: '8월 소식',
+        content: '<p>본문</p>',
+        recipientCount: 2,
+        author,
+      });
+      expect(marketingEmailRepository.save).toHaveBeenCalled();
+      expect(emailProducer.produceMarketingBroadcast).toHaveBeenCalledTimes(2);
+      expect(emailProducer.produceMarketingBroadcast).toHaveBeenCalledWith({
+        email: 'a@test.com',
+        userName: 'a',
+        subject: '8월 소식',
+        content: '<p>본문</p>',
+      });
+      expect(result.recipientCount).toBe(2);
+      expect(result.authorName).toBe('관리자');
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('수신 동의한 사용자가 없을 경우 수신자 수 0으로 저장하고 이메일을 발행하지 않는다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+
+      // when
+      const result = await marketingEmailService.sendMarketingEmail(
+        'admin@test.com',
+        requestDto,
+      );
+
+      // then
+      expect(emailProducer.produceMarketingBroadcast).not.toHaveBeenCalled();
+      expect(result.recipientCount).toBe(0);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
+    it('발송한 관리자를 찾지 못할 경우 관리자 이름을 null로 반환한다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+
+      // when
+      const result = await marketingEmailService.sendMarketingEmail(
+        'admin@test.com',
+        requestDto,
+      );
+
+      // then
+      expect(marketingEmailRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ author: null }),
+      );
+      expect(result.authorName).toBeNull();
+    });
+
+    it('일부 이메일 발행이 실패해도 에러를 기록하고 발송 결과를 반환한다.', async () => {
+      // given
+      adminRepository.findOneBy.mockResolvedValue(null);
+      marketingEmailRepository.save.mockImplementation(
+        (entity: MarketingEmail) => {
+          entity.id = 1;
+          return entity;
+        },
+      );
+      userRepository.findMarketingAgreedUsers.mockResolvedValue([
+        { email: 'a@test.com', userName: 'a' },
+        { email: 'b@test.com', userName: 'b' },
+      ] as any);
+      emailProducer.produceMarketingBroadcast
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('RabbitMQ 오류'));
+
+      // when
+      const result = await marketingEmailService.sendMarketingEmail(
+        'admin@test.com',
+        requestDto,
+      );
+
+      // then
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('marketingEmailId=1, failed=1/2'),
+      );
+      expect(result.id).toBe(1);
+      expect(result.recipientCount).toBe(2);
+    });
+  });
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -29,6 +29,7 @@
       "@file/*": ["./src/file/*"],
       "@health/*": ["./src/health/*"],
       "@like/*": ["./src/like/*"],
+      "@marketingEmail/*": ["./src/marketingEmail/*"],
       "@notification/*": ["./src/notification/*"],
       "@qna/*": ["./src/qna/*"],
       "@report/*": ["./src/report/*"],


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #915

### 단체(마케팅) 이메일 발송

- 관리자가 광고성 정보 수신에 동의한 회원 전체에게 이메일을 발송할 수 있는 기능이 필요했습니다.
- 발송 이력을 별도 테이블(`marketing_email`)로 관리해 언제, 누구에게, 어떤 내용을 보냈는지 추적 가능하도록 했습니다.
- 광고 메일 규제 대응을 위해 제목에 `(광고)` 접두사를 자동으로 붙이고, 본문 하단에 수신 동의 안내 문구(마이페이지에서 동의 여부 변경 가능)를 포함했습니다.
- 공지 이메일(NOTICE_PUBLISHED)에도 동일한 수신 동의 안내 문구를 추가해 형평성을 맞췄습니다.

### 이메일 본문 이미지 첨부

- 관리자가 TinyMCE 에디터로 이메일 본문을 작성할 때 이미지를 삽입할 수 있도록 이미지 업로드 API(`POST /admins/images`)를 추가했습니다.
- 기존 게시글 이미지 업로드 로직과 분리해 소유자(owner) 없이 저장하는 `saveWithoutOwner` 경로를 별도로 구성했습니다.

# 📋 작업 내용

- **server**
  - `marketingEmail` 도메인 추가 (entity, repository, service, controller, dto, api-docs)
  - `MarketingEmail` 테이블 마이그레이션 추가
  - 단체 이메일 발송 API (`POST /admins/marketing-emails`), 발송 이력 조회 API (`GET /admins/marketing-emails`) 구현
  - 관리자용 이미지 업로드 API (`POST /admins/images`) 및 관련 DTO/파일 상수 추가
  - `EmailProducer`에 마케팅 이메일 발행 로직 추가
- **email-worker**
  - `MARKETING_BROADCAST` 이메일 타입 및 컨슈머 핸들러 추가
  - `mailLayout`에 수신 동의 안내 문구(`consentNotice`) 옵션 추가, 공지/마케팅 메일에 적용
  - 마케팅 광고 메일 콘텐츠(`createMarketingBroadcastContent`) 및 발송 로직 추가
- **client**
  - 관리자 페이지에 단체 이메일 탭(`AdminMarketingEmailTab`) 추가 (TinyMCE 에디터, 발송 이력 조회)
  - 관련 API 서비스, react-query 훅, 타입 추가
  - vite에 tinymce 정적 자산 등록

# 📷 스크린 샷(선택 사항)

<img width="1253" height="892" alt="image" src="https://github.com/user-attachments/assets/7d92cb0a-b8ae-4b47-b1e8-3f65d2b6b3f9" />
<img width="1596" height="248" alt="image" src="https://github.com/user-attachments/assets/f918609c-57bc-489c-a4e1-6a759f7f721b" />
