### PR TITLE
✨ feat: 미확인 알림 다이제스트 이메일 발송 기능 구현

### DIFF
--- a/email-worker/scripts/preview-email.ts
+++ b/email-worker/scripts/preview-email.ts
@@ -13,6 +13,7 @@ import {
   createRssRegistrationContent,
   createRssRegistrationRequestContent,
   createRssRemoveCertificateContent,
+  createUnreadNotificationDigestContent,
   createVerificationMailContent,
 } from '@email/email.content';
 
@@ -121,6 +122,11 @@ const previews: [string, string, string][] = [
       '<p>이번 달 새로운 기능을 소개합니다.</p>',
       SERVICE_ADDRESS,
     ),
+  ],
+  [
+    'unread-notification-digest',
+    '미확인 알림 다이제스트',
+    createUnreadNotificationDigestContent('김데나무', 5, SERVICE_ADDRESS),
   ],
 ];
 

--- a/email-worker/src/common/types.ts
+++ b/email-worker/src/common/types.ts
@@ -63,3 +63,9 @@ export interface MarketingBroadcast {
   subject: string;
   content: string;
 }
+
+export interface UnreadNotificationDigest {
+  email: string;
+  userName: string;
+  unreadCount: number;
+}

--- a/email-worker/src/email/constant.ts
+++ b/email-worker/src/email/constant.ts
@@ -12,4 +12,5 @@ export const EmailPayloadConstant = {
   QNA_ANSWERED: 'qnaAnswered',
   NOTICE_PUBLISHED: 'noticePublished',
   MARKETING_BROADCAST: 'marketingBroadcast',
+  UNREAD_NOTIFICATION_DIGEST: 'unreadNotificationDigest',
 } as const;

--- a/email-worker/src/email/email.consumer.ts
+++ b/email-worker/src/email/email.consumer.ts
@@ -149,6 +149,10 @@ export class EmailConsumer implements Lifecycle {
         await this.emailService.sendAdminPasswordResetEmail(payload.data);
         break;
 
+      case EmailPayloadConstant.UNREAD_NOTIFICATION_DIGEST:
+        await this.emailService.sendUnreadNotificationDigestMail(payload.data);
+        break;
+
       default:
         logger.info(`처리할 수 없는 이메일 타입이 입력되었습니다.`);
     }

--- a/email-worker/src/email/email.content.ts
+++ b/email-worker/src/email/email.content.ts
@@ -329,6 +329,26 @@ export function createMarketingBroadcastContent(
   return mailLayout(body, serviceAddress, consentNotice);
 }
 
+export function createUnreadNotificationDigestContent(
+  userName: string,
+  unreadCount: number,
+  serviceAddress: string,
+) {
+  const body = `
+        ${heading('확인하지 않은 알림이 있습니다 🔔', '#007bff')}
+        ${infoBox(`
+          <p><strong>안녕하세요, ${userName}님!</strong></p>
+          <p>일주일 넘게 확인하지 않은 알림이 있습니다.</p>
+        `)}
+        <div style="text-align: center; margin: 20px 0;">
+          <span style="font-size: 64px; font-weight: bold; color: #007bff; line-height: 1;">${unreadCount}</span>
+          <span style="font-size: 20px; color: #007bff; font-weight: bold;">개</span>
+        </div>
+        ${button(PRODUCT_DOMAIN, '알림 확인하러 가기')}
+  `;
+  return mailLayout(body, serviceAddress);
+}
+
 export function createDeleteAccountContent(
   userName: string,
   verificationLink: string,

--- a/email-worker/src/email/email.service.ts
+++ b/email-worker/src/email/email.service.ts
@@ -15,6 +15,7 @@ import {
   RssRegistration,
   RssRegistrationRequest,
   RssRemoval,
+  UnreadNotificationDigest,
   User,
 } from '@common/types';
 
@@ -30,6 +31,7 @@ import {
   createRssRegistrationContent,
   createRssRegistrationRequestContent,
   createRssRemoveCertificateContent,
+  createUnreadNotificationDigestContent,
   createVerificationMailContent,
   PRODUCT_DOMAIN,
 } from '@email/email.content';
@@ -45,6 +47,7 @@ export class EmailService {
   constructor(@inject(EmailMetrics) private readonly metrics: EmailMetrics) {
     this.emailUser = process.env.EMAIL_USER;
     const emailPassword = process.env.EMAIL_PASSWORD;
+
     if (!this.emailUser) {
       throw new Error('EMAIL_USER 환경 변수가 설정되지 않았습니다.');
     }
@@ -52,6 +55,7 @@ export class EmailService {
     if (!emailPassword) {
       throw new Error('EMAIL_PASSWORD 환경 변수가 설정되지 않았습니다.');
     }
+
     this.transporter = nodemailer.createTransport({
       host: process.env.SMTP_HOST || 'smtp.gmail.com',
       port: Number(process.env.SMTP_PORT) || 587,
@@ -365,6 +369,14 @@ export class EmailService {
     await this.sendMail(mailOptions);
   }
 
+  async sendUnreadNotificationDigestMail(
+    digest: UnreadNotificationDigest,
+  ): Promise<void> {
+    const mailOptions = this.createUnreadNotificationDigestMail(digest);
+
+    await this.sendMail(mailOptions);
+  }
+
   private createMarketingBroadcastMail(
     marketingBroadcast: MarketingBroadcast,
   ): nodemailer.SendMailOptions {
@@ -375,6 +387,21 @@ export class EmailService {
       html: createMarketingBroadcastContent(
         marketingBroadcast.userName,
         marketingBroadcast.content,
+        this.emailUser,
+      ),
+    };
+  }
+
+  private createUnreadNotificationDigestMail(
+    digest: UnreadNotificationDigest,
+  ): nodemailer.SendMailOptions {
+    return {
+      from: `Denamu<${this.emailUser}>`,
+      to: `${digest.userName}<${digest.email}>`,
+      subject: `[🎋 Denamu] 확인하지 않은 알림이 ${digest.unreadCount}개 있습니다.`,
+      html: createUnreadNotificationDigestContent(
+        digest.userName,
+        digest.unreadCount,
         this.emailUser,
       ),
     };

--- a/email-worker/src/email/types.ts
+++ b/email-worker/src/email/types.ts
@@ -7,6 +7,7 @@ import {
   RssRegistration,
   RssRegistrationRequest,
   RssRemoval,
+  UnreadNotificationDigest,
   User,
 } from '@common/types';
 
@@ -49,6 +50,10 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.MARKETING_BROADCAST;
       data: MarketingBroadcast;
+    }
+  | {
+      type: typeof EmailPayloadConstant.UNREAD_NOTIFICATION_DIGEST;
+      data: UnreadNotificationDigest;
     };
 
 export type NodeMailerError = Error & {

--- a/email-worker/test/unit/consumer.spec.ts
+++ b/email-worker/test/unit/consumer.spec.ts
@@ -7,6 +7,7 @@ import {
   RssRegistration,
   RssRegistrationRequest,
   RssRemoval,
+  UnreadNotificationDigest,
   User,
 } from '@common/types';
 
@@ -43,6 +44,7 @@ describe('email consumer unit test', () => {
     let sendAdminDeleteAccountMail: jest.Mock;
     let sendAdminPasswordResetEmail: jest.Mock;
     let sendMarketingBroadcastMail: jest.Mock;
+    let sendUnreadNotificationDigestMail: jest.Mock;
 
     beforeEach(() => {
       sendUserCertificationMail = jest.fn().mockResolvedValue(undefined);
@@ -56,6 +58,7 @@ describe('email consumer unit test', () => {
       sendAdminDeleteAccountMail = jest.fn().mockResolvedValue(undefined);
       sendAdminPasswordResetEmail = jest.fn().mockResolvedValue(undefined);
       sendMarketingBroadcastMail = jest.fn().mockResolvedValue(undefined);
+      sendUnreadNotificationDigestMail = jest.fn().mockResolvedValue(undefined);
 
       emailService = {
         sendUserCertificationMail,
@@ -69,6 +72,7 @@ describe('email consumer unit test', () => {
         sendAdminDeleteAccountMail,
         sendAdminPasswordResetEmail,
         sendMarketingBroadcastMail,
+        sendUnreadNotificationDigestMail,
       } as any;
       rabbitmqService = {
         sendMessageToQueue: jest.fn().mockResolvedValue(null),
@@ -289,6 +293,25 @@ describe('email consumer unit test', () => {
       //then
       expect(sendMarketingBroadcastMail).toHaveBeenCalledTimes(1);
       expect(sendMarketingBroadcastMail).toHaveBeenCalledWith(marketingData);
+    });
+
+    it('UNREAD_NOTIFICATION_DIGEST 타입일 때 sendUnreadNotificationDigestMail을 호출한다', async () => {
+      const digestData: UnreadNotificationDigest = {
+        email: 'test@test.com',
+        userName: 'tester',
+        unreadCount: 5,
+      };
+      const payload: EmailPayload = {
+        type: EmailPayloadConstant.UNREAD_NOTIFICATION_DIGEST,
+        data: digestData,
+      };
+
+      await emailConsumer.handleEmailByType(payload);
+
+      expect(sendUnreadNotificationDigestMail).toHaveBeenCalledTimes(1);
+      expect(sendUnreadNotificationDigestMail).toHaveBeenCalledWith(
+        digestData,
+      );
     });
 
     it('알 수 없는 타입일 때 아무 메서드도 호출하지 않는다', async () => {

--- a/email-worker/test/unit/emailService.spec.ts
+++ b/email-worker/test/unit/emailService.spec.ts
@@ -359,7 +359,8 @@ describe('EmailService unit test', () => {
 
       const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
       expect(callArgs.html).toContain(digest.userName);
-      expect(callArgs.html).toContain(`${digest.unreadCount}개`);
+      expect(callArgs.html).toContain(`>${digest.unreadCount}<`);
+      expect(callArgs.html).toContain('개');
       expect(callArgs.html).toContain(PRODUCT_DOMAIN);
     });
   });

--- a/email-worker/test/unit/emailService.spec.ts
+++ b/email-worker/test/unit/emailService.spec.ts
@@ -11,6 +11,7 @@ import {
   RssRegistration,
   RssRegistrationRequest,
   RssRemoval,
+  UnreadNotificationDigest,
   User,
 } from '@common/types';
 
@@ -334,6 +335,32 @@ describe('EmailService unit test', () => {
       expect(callArgs.html).toContain(
         `${PRODUCT_DOMAIN}/users/deletion-requests/confirm?token=${user.uuid}`,
       );
+    });
+  });
+
+  describe('sendUnreadNotificationDigestMail unit test', () => {
+    it('미읽음 알림 다이제스트 메일을 올바르게 전송한다', async () => {
+      const digest: UnreadNotificationDigest = {
+        email: 'tester@test.com',
+        userName: 'tester',
+        unreadCount: 5,
+      };
+
+      await emailService.sendUnreadNotificationDigestMail(digest);
+
+      expect(mockSendMail).toHaveBeenCalledTimes(1);
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          from: `Denamu<${mockEmailUser}>`,
+          to: `${digest.userName}<${digest.email}>`,
+          subject: `[🎋 Denamu] 확인하지 않은 알림이 ${digest.unreadCount}개 있습니다.`,
+        }),
+      );
+
+      const callArgs = (mockSendMail.mock.calls[0] as [{ html: string }])[0];
+      expect(callArgs.html).toContain(digest.userName);
+      expect(callArgs.html).toContain(`${digest.unreadCount}개`);
+      expect(callArgs.html).toContain(PRODUCT_DOMAIN);
     });
   });
 

--- a/server/src/common/email/email.producer.ts
+++ b/server/src/common/email/email.producer.ts
@@ -6,6 +6,7 @@ import {
   MarketingBroadcast,
   NoticePublished,
   QnaAnswered,
+  UnreadNotificationDigest,
 } from '@common/email/email.type';
 import { WinstonLoggerService } from '@common/logger/logger.service';
 import {
@@ -208,6 +209,13 @@ export class EmailProducer {
   async produceMarketingBroadcast(payload: MarketingBroadcast) {
     await this.produceMessage({
       type: EmailPayloadConstant.MARKETING_BROADCAST,
+      data: payload,
+    });
+  }
+
+  async produceUnreadNotificationDigest(payload: UnreadNotificationDigest) {
+    await this.produceMessage({
+      type: EmailPayloadConstant.UNREAD_NOTIFICATION_DIGEST,
       data: payload,
     });
   }

--- a/server/src/common/email/email.type.ts
+++ b/server/src/common/email/email.type.ts
@@ -63,6 +63,12 @@ export interface MarketingBroadcast {
   content: string;
 }
 
+export interface UnreadNotificationDigest {
+  email: string;
+  userName: string;
+  unreadCount: number;
+}
+
 export const EmailPayloadConstant = {
   USER_CERTIFICATION: 'userCertification',
   RSS_REMOVAL: 'rssRemoval',
@@ -77,6 +83,7 @@ export const EmailPayloadConstant = {
   QNA_ANSWERED: 'qnaAnswered',
   NOTICE_PUBLISHED: 'noticePublished',
   MARKETING_BROADCAST: 'marketingBroadcast',
+  UNREAD_NOTIFICATION_DIGEST: 'unreadNotificationDigest',
 } as const;
 
 export type EmailPayload =
@@ -116,4 +123,8 @@ export type EmailPayload =
   | {
       type: typeof EmailPayloadConstant.MARKETING_BROADCAST;
       data: MarketingBroadcast;
+    }
+  | {
+      type: typeof EmailPayloadConstant.UNREAD_NOTIFICATION_DIGEST;
+      data: UnreadNotificationDigest;
     };

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -23,4 +23,5 @@ export const REDIS_KEYS = {
   USER_INVALIDATED_PREFIX: 'user:invalidated',
   OAUTH_PENDING_KEY: 'oauth:pending',
   OAUTH_LINK_KEY: 'oauth:link',
+  NOTIFICATION_DIGEST_LOCK: 'notification:digest:lock',
 };

--- a/server/src/notification/constant/notification.constant.ts
+++ b/server/src/notification/constant/notification.constant.ts
@@ -1,7 +1,14 @@
 export const NOTIFICATION_RETENTION_DAYS = 30;
+export const NOTIFICATION_EMAIL_DIGEST_STALE_DAYS = 7;
 
 export function getNotificationCutoffDate(now: Date = new Date()): Date {
   const cutoff = new Date(now);
   cutoff.setDate(cutoff.getDate() - NOTIFICATION_RETENTION_DAYS);
+  return cutoff;
+}
+
+export function getDigestStaleCutoffDate(now: Date = new Date()): Date {
+  const cutoff = new Date(now);
+  cutoff.setDate(cutoff.getDate() - NOTIFICATION_EMAIL_DIGEST_STALE_DAYS);
   return cutoff;
 }

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -207,4 +207,23 @@ export class NotificationRepository extends Repository<Notification> {
   async deleteExpired() {
     return this.delete({ updatedAt: LessThan(getNotificationCutoffDate()) });
   }
+
+  async findStaleUnreadDigestTargets(staleCutoff: Date, retentionCutoff: Date) {
+    return this.dataSource
+      .createQueryBuilder()
+      .select('u.id', 'userId')
+      .addSelect('u.email', 'email')
+      .addSelect('u.user_name', 'userName')
+      .addSelect('COUNT(*)', 'unreadCount')
+      .from(Notification, 'n')
+      .innerJoin('user', 'u', 'u.id = n.recipient_user_id')
+      .where('n.is_read = 0')
+      .andWhere('n.updated_at <= :staleCutoff', { staleCutoff })
+      .andWhere('n.updated_at >= :retentionCutoff', { retentionCutoff })
+      .andWhere('u.inactivity_email_agreed = 1')
+      .groupBy('u.id')
+      .addGroupBy('u.email')
+      .addGroupBy('u.user_name')
+      .getRawMany<{ userId: number; email: string; userName: string; unreadCount: string }>();
+  }
 }

--- a/server/src/notification/scheduler/notification.scheduler.ts
+++ b/server/src/notification/scheduler/notification.scheduler.ts
@@ -1,14 +1,21 @@
 import { Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
+import { EmailProducer } from '@common/email/email.producer';
 import { WinstonLoggerService } from '@common/logger/logger.service';
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
 
 import { NotificationService } from '@notification/service/notification.service';
+
+const DIGEST_LOCK_TTL_SECONDS = 3600;
 
 @Injectable()
 export class NotificationScheduler {
   constructor(
     private readonly notificationService: NotificationService,
+    private readonly emailProducer: EmailProducer,
+    private readonly redisService: RedisService,
     private readonly logger: WinstonLoggerService,
   ) {}
 
@@ -20,6 +27,54 @@ export class NotificationScheduler {
     } catch (error) {
       this.logger.error(
         `[NotificationScheduler]: 만료 알림 삭제 중 오류 발생: ${error}`,
+      );
+    }
+  }
+
+  @Cron('0 16 * * 5')
+  async sendUnreadNotificationDigest() {
+    const lockKey = `${REDIS_KEYS.NOTIFICATION_DIGEST_LOCK}:${new Date().toISOString().slice(0, 10)}`;
+    const acquired = await this.redisService.set(
+      lockKey,
+      '1',
+      'NX',
+      'EX',
+      DIGEST_LOCK_TTL_SECONDS,
+    );
+    
+    if (!acquired) {
+      this.logger.log(
+        '[NotificationScheduler]: 다른 인스턴스가 이미 다이제스트를 발행 중 - 건너뜀.',
+      );
+      return;
+    }
+
+    try {
+      const targets =
+        await this.notificationService.getStaleUnreadDigestTargets();
+
+      const results = await Promise.allSettled(
+        targets.map((target) =>
+          this.emailProducer.produceUnreadNotificationDigest(target),
+        ),
+      );
+
+      const failures = results.filter(
+        (r): r is PromiseRejectedResult => r.status === 'rejected',
+      );
+      if (failures.length > 0) {
+        this.logger.error(
+          `[NotificationScheduler]: 미읽음 알림 다이제스트 발행 실패 사유: ${failures
+            .map((f) => f.reason)
+            .join(', ')}`,
+        );
+      }
+      this.logger.log(
+        `[NotificationScheduler]: 미읽음 알림 다이제스트 발행 완료 (대상 ${targets.length}명, 실패 ${failures.length}건).`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `[NotificationScheduler]: 미읽음 알림 다이제스트 발행 중 오류 발생: ${error}`,
       );
     }
   }

--- a/server/src/notification/service/notification.service.ts
+++ b/server/src/notification/service/notification.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 
+import {
+  getDigestStaleCutoffDate,
+  getNotificationCutoffDate,
+} from '@notification/constant/notification.constant';
 import { GetNotificationsResponseDto } from '@notification/dto/response/getNotifications.dto';
 import { GetUnreadCountResponseDto } from '@notification/dto/response/getUnreadCount.dto';
 import { NotificationRepository } from '@notification/repository/notification.repository';
@@ -86,5 +90,17 @@ export class NotificationService {
 
   async deleteExpired() {
     await this.notificationRepository.deleteExpired();
+  }
+
+  async getStaleUnreadDigestTargets() {
+    const rows = await this.notificationRepository.findStaleUnreadDigestTargets(
+      getDigestStaleCutoffDate(),
+      getNotificationCutoffDate(),
+    );
+    return rows.map((row) => ({
+      email: row.email,
+      userName: row.userName,
+      unreadCount: Number(row.unreadCount),
+    }));
   }
 }

--- a/server/test/notification/unit/notification.service.unit.spec.ts
+++ b/server/test/notification/unit/notification.service.unit.spec.ts
@@ -22,6 +22,7 @@ describe(`${NotificationService.name} Unit Test`, () => {
       | 'findByRecipient'
       | 'markRead'
       | 'deleteExpired'
+      | 'findStaleUnreadDigestTargets'
     >
   >;
 
@@ -41,6 +42,7 @@ describe(`${NotificationService.name} Unit Test`, () => {
       findByRecipient: jest.fn(),
       markRead: jest.fn(),
       deleteExpired: jest.fn(),
+      findStaleUnreadDigestTargets: jest.fn(),
     };
 
     notificationService = new NotificationService(
@@ -212,6 +214,26 @@ describe(`${NotificationService.name} Unit Test`, () => {
         notificationService.markAsRead(1, 2),
       ).resolves.toBeUndefined();
       expect(notificationRepository.markRead).toHaveBeenCalledWith(1, 2);
+    });
+  });
+
+  describe('getStaleUnreadDigestTargets', () => {
+    it('7일 이상 미읽음 & inactivity_email_agreed 유저 목록을 조회하고 unreadCount를 숫자로 변환한다.', async () => {
+      // given
+      notificationRepository.findStaleUnreadDigestTargets.mockResolvedValue([
+        { userId: 1, email: 'a@denamu.dev', userName: 'a', unreadCount: '3' },
+      ]);
+
+      // when
+      const result = await notificationService.getStaleUnreadDigestTargets();
+
+      // then
+      expect(
+        notificationRepository.findStaleUnreadDigestTargets,
+      ).toHaveBeenCalledWith(expect.any(Date), expect.any(Date));
+      expect(result).toEqual([
+        { email: 'a@denamu.dev', userName: 'a', unreadCount: 3 },
+      ]);
     });
   });
 });


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #781

### 미확인 알림 다이제스트 이메일

-   일주일 넘게 읽지 않은 알림이 있는 사용자에게 주간 다이제스트 이메일을 발송
-   대상: `updated_at`이 7일~30일(보존 기간) 사이인 미확인 알림 보유 사용자 중 `inactivity_email_agreed = 1`인 사용자
-   집계 쿼리는 group-by + COUNT가 필요해 TypeORM repository API로는 불가 → QueryBuilder 사용
-   매주 금요일 16시 크론으로 실행, Redis `SET NX EX` 락으로 무중단 배포 시 중복 실행 방지 (하루 단위 키 + 1시간 TTL)
-   RabbitMQ를 통해 email-worker로 발행, email-worker에서 실제 발송 처리

# 📋 작업 내용

-   `server`: `NotificationScheduler`에 `sendUnreadNotificationDigest` 크론 작업 추가
-   `server`: `NotificationRepository.findStaleUnreadDigestTargets` 집계 쿼리 추가
-   `server`: `EmailProducer`에 다이제스트 발행 메서드 추가
-   `email-worker`: 다이제스트 이메일 컨슘 및 발송 처리 추가
-   `email-worker`: 다이제스트 이메일 템플릿 추가, 미확인 개수 강조 스타일 적용
-   `email-worker`: `preview:email` 스크립트에 다이제스트 템플릿 미리보기 추가
-   서버/email-worker 단위 테스트 작성

# 📷 스크린 샷(선택 사항)

<img width="841" height="711" alt="image" src="https://github.com/user-attachments/assets/1fd7e3ae-0545-495c-8748-6aea7e541b38" />