### PR TITLE
⚡️ perf: AI 요약 프롬프트 캐싱 적용

### DIFF
--- a/feed-crawler/src/event_worker/workers/claude-event-worker.ts
+++ b/feed-crawler/src/event_worker/workers/claude-event-worker.ts
@@ -129,7 +129,13 @@ export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
     try {
       const params: Anthropic.MessageCreateParams = {
         max_tokens: 8192,
-        system: await this.getPromptContent(),
+        system: [
+          {
+            type: 'text',
+            text: await this.getPromptContent(),
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
         messages: [{ role: 'user', content: feed.content }],
         model: 'claude-haiku-4-5',
       };

--- a/feed-crawler/test/unit/claude-event-worker.spec.ts
+++ b/feed-crawler/test/unit/claude-event-worker.spec.ts
@@ -261,7 +261,13 @@ describe('ClaudeEventWorker', () => {
       // Then
       expect(messagesCreateMock).toHaveBeenCalledWith({
         max_tokens: 8192,
-        system: expect.any(String),
+        system: [
+          {
+            type: 'text',
+            text: expect.any(String),
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
         messages: [{ role: 'user', content: mockFeedAIQueueItem.content }],
         model: 'claude-haiku-4-5',
       });


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #918

### 캐싱 도입 배경

-   `ClaudeEventWorker`는 1분마다(`AI_RATE_LIMIT_COUNT`만큼) Claude Haiku 4.5에 태그/요약 요청을 보냅니다. `system` 프롬프트(태그 분류 지침 + 허용 태그 목록)는 태그 목록이 바뀌지 않는 한 매 요청 동일한 내용으로 재사용됩니다.
-   [Anthropic Prompt Caching](https://platform.claude.com/docs/ko/build-with-claude/prompt-caching)을 적용하면 동일 프리픽스로 반복 요청 시 캐시 read 요금(정가의 0.1배)으로 처리할 수 있습니다. `system` 필드에 `cache_control: { type: 'ephemeral' }`만 추가하면 활성화됩니다.

### 검토한 점

-   Haiku 4.5는 캐시 최소 토큰이 4096으로 다른 모델보다 높습니다. 현재 시스템 프롬프트(고정 지침 + 허용 태그 목록)는 문자 수 기준 추정 시 이 임계값에 못 미칠 가능성이 있어, 지금 당장은 캐시 히트가 발생하지 않을 수 있습니다.
-   다만 `cache_control` 필드 자체는 무해합니다 — 임계값 미만이면 캐시 없이 기존과 동일하게 동작하고(`cache_creation_input_tokens: 0`), 이후 허용 태그 목록이 늘어나 임계값을 넘으면 코드 변경 없이 자동으로 캐싱이 시작됩니다. 향후 태그가 늘어날 것을 감안해 선제적으로 인프라를 마련해두는 방향으로 판단했습니다.

# 📋 작업 내용

-   `ClaudeEventWorker.requestAI`에서 `system` 필드를 문자열에서 `[{ type: 'text', text, cache_control: { type: 'ephemeral' } }]` 배열 형태로 변경
-   관련 유닛 테스트(`claude-event-worker.spec.ts`)의 mock 호출 검증 값 갱신

# 📷 스크린 샷(선택 사항)

-   해당 없음 (백엔드 로직 변경)