### PR TITLE
♻️ refactor: Feed Crawler 게시글 삽입 Bulk 방식 전환

### DIFF
--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -23,48 +23,78 @@ export class FeedRepository {
   ) {}
 
   public async insertFeeds(resultData: FeedDetail[]) {
-    const query = `
-            INSERT INTO feed (blog_id, created_at, title, path, thumbnail, summary)
-            VALUES (?, ?, ?, ?, ?, ?)
-        `;
+    this.dbMetrics.total.inc({ operation: 'insert_feed' }, resultData.length);
 
-    const insertPromises = resultData.map(async (feed, index) => {
-      this.dbMetrics.total.inc({ operation: 'insert_feed' });
-      try {
-        const result = await this.dbConnection.executeQueryStrict(query, [
-          feed.blogId,
-          feed.pubDate,
-          feed.title,
-          feed.link,
-          feed.imageUrl,
-          feed.summary,
-        ]);
-        this.dbMetrics.success.inc({ operation: 'insert_feed' });
-        return { result, index, success: true };
-      } catch (error) {
-        const mysqlError = error as { code?: string };
-        if (mysqlError.code === 'ER_DUP_ENTRY') {
-          this.dbMetrics.duplicate.inc();
-          logger.info(`중복 피드 스킵: ${feed.title} (${feed.link})`);
-          return { result: null, index, success: false, duplicate: true };
-        }
-        this.dbMetrics.failure.inc({ operation: 'insert_feed' });
-        throw error;
+    const paths = resultData.map((feed) => feed.link);
+    let existing: { path: string }[];
+
+    try {
+      existing = await this.dbConnection.executeQueryStrict<{
+        path: string;
+      }>(`SELECT path FROM feed WHERE path IN (?)`, [paths]);
+    } catch (error) {
+      this.dbMetrics.failure.inc(
+        { operation: 'insert_feed' },
+        resultData.length,
+      );
+      throw error;
+    }
+
+    const existingPaths = new Set(existing.map((row) => row.path));
+    const seenPaths = new Set<string>();
+    const candidates = resultData.filter((feed) => {
+      if (existingPaths.has(feed.link) || seenPaths.has(feed.link)) {
+        return false;
       }
+      seenPaths.add(feed.link);
+      return true;
     });
 
-    const promiseResults = await Promise.all(insertPromises);
+    let insertedFeeds: FeedDetail[] = [];
+    if (candidates.length > 0) {
+      const insertQuery = `
+            INSERT IGNORE INTO feed (blog_id, created_at, title, path, thumbnail, summary)
+            VALUES ?
+        `;
+      const values = candidates.map((feed) => [
+        feed.blogId,
+        feed.pubDate,
+        feed.title,
+        feed.link,
+        feed.imageUrl,
+        feed.summary,
+      ]);
 
-    const insertedFeeds = promiseResults
-      .filter((result) => result.success)
-      .map((result) => ({
-        ...resultData[result.index],
-        id: (result.result as unknown as { insertId: number }).insertId,
-      }));
+      try {
+        await this.dbConnection.executeQueryStrict(insertQuery, [values]);
 
-    const duplicateCount = promiseResults.filter(
-      (result) => result.duplicate,
-    ).length;
+        const candidatePaths = candidates.map((feed) => feed.link);
+        const inserted = await this.dbConnection.executeQueryStrict<{
+          id: number;
+          path: string;
+        }>(`SELECT id, path FROM feed WHERE path IN (?)`, [candidatePaths]);
+        const idByPath = new Map(inserted.map((row) => [row.path, row.id]));
+
+        insertedFeeds = candidates
+          .filter((feed) => idByPath.has(feed.link))
+          .map((feed) => ({ ...feed, id: idByPath.get(feed.link) }));
+      } catch (error) {
+        logger.error(
+          `[MySQL] Bulk 방식으로 삽입 실패, 행 단위 재시도로 폴백합니다.
+          에러 메시지: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        insertedFeeds = await this.insertFeedsIndividually(candidates);
+      }
+    }
+
+    const duplicateCount = resultData.length - insertedFeeds.length;
+    this.dbMetrics.success.inc(
+      { operation: 'insert_feed' },
+      insertedFeeds.length,
+    );
+    if (duplicateCount > 0) {
+      this.dbMetrics.duplicate.inc(duplicateCount);
+    }
 
     logger.info(
       `[MySQL] ${
@@ -75,6 +105,47 @@ export class FeedRepository {
     );
 
     return insertedFeeds;
+  }
+
+  private async insertFeedsIndividually(
+    candidates: FeedDetail[],
+  ): Promise<FeedDetail[]> {
+    const insertQuery = `
+            INSERT INTO feed (blog_id, created_at, title, path, thumbnail, summary)
+            VALUES (?, ?, ?, ?, ?, ?)
+        `;
+
+    const results = await Promise.all(
+      candidates.map(async (feed) => {
+        try {
+          const result = await this.dbConnection.executeQueryStrict(
+            insertQuery,
+            [
+              feed.blogId,
+              feed.pubDate,
+              feed.title,
+              feed.link,
+              feed.imageUrl,
+              feed.summary,
+            ],
+          );
+          const insertId = (result as unknown as { insertId: number }).insertId;
+          return { ...feed, id: insertId };
+        } catch (error) {
+          const mysqlError = error as { code?: string };
+          if (mysqlError.code !== 'ER_DUP_ENTRY') {
+            this.dbMetrics.failure.inc({ operation: 'insert_feed' });
+            logger.error(
+              `[MySQL] 개별 삽입 재시도 실패: ${feed.title} (${feed.link})
+              에러 메시지: ${error instanceof Error ? error.message : String(error)}`,
+            );
+          }
+          return null;
+        }
+      }),
+    );
+
+    return results.filter((feed) => feed !== null);
   }
 
   async deleteRecentFeed() {

--- a/feed-crawler/test/unit/feed.repository.spec.ts
+++ b/feed-crawler/test/unit/feed.repository.spec.ts
@@ -1,0 +1,346 @@
+import 'reflect-metadata';
+
+import { DatabaseConnection } from '@common/database/database-connection';
+import { FeedDetail } from '@common/feed/feed.type';
+import { DbMetrics } from '@common/metrics/db-metrics';
+import { RedisMetrics } from '@common/metrics/redis-metrics';
+import { RedisConnection } from '@common/redis/redis-access';
+
+import { FeedRepository } from '@repository/feed.repository';
+
+describe('FeedRepository', () => {
+  let feedRepository: FeedRepository;
+  let mockDbConnection: jest.Mocked<DatabaseConnection>;
+  let mockDbMetrics: jest.Mocked<DbMetrics>;
+  let executeQueryStrictMock: jest.Mock<Promise<any>, [string, any[]]>;
+  let totalIncMock: jest.Mock;
+  let successIncMock: jest.Mock;
+  let failureIncMock: jest.Mock;
+  let duplicateIncMock: jest.Mock;
+
+  const INSERT_LABEL = { operation: 'insert_feed' };
+
+  const createFeed = (id: number): FeedDetail => ({
+    id,
+    blogId: id,
+    blogName: `테스트 블로그 ${id}`,
+    blogPlatform: 'tistory',
+    blogImage: null,
+    pubDate: `2024-01-01 12:0${id}:00`,
+    title: `테스트 피드 ${id}`,
+    link: `https://test${id}.tistory.com/${id}`,
+    imageUrl: `https://test${id}.tistory.com/image${id}.jpg`,
+    content: `테스트 내용 ${id}`,
+    summary: 'AI 요약 처리 중...',
+    deathCount: 0,
+  });
+
+  const toValueRow = (feed: FeedDetail) => [
+    feed.blogId,
+    feed.pubDate,
+    feed.title,
+    feed.link,
+    feed.imageUrl,
+    feed.summary,
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    executeQueryStrictMock = jest.fn();
+    totalIncMock = jest.fn();
+    successIncMock = jest.fn();
+    failureIncMock = jest.fn();
+    duplicateIncMock = jest.fn();
+
+    mockDbConnection = {
+      executeQuery: jest.fn(),
+      executeQueryStrict: executeQueryStrictMock,
+    };
+
+    mockDbMetrics = {
+      total: { inc: totalIncMock },
+      success: { inc: successIncMock },
+      failure: { inc: failureIncMock },
+      duplicate: { inc: duplicateIncMock },
+    } as any;
+
+    feedRepository = new FeedRepository(
+      mockDbConnection,
+      {} as RedisConnection,
+      mockDbMetrics,
+      {} as RedisMetrics,
+    );
+  });
+
+  describe('insertFeeds', () => {
+    it('모든 피드가 신규일 때 선조회 → INSERT → 재조회 순으로 실행하고 재조회한 id를 붙여 전부 반환해야 한다', async () => {
+      // GIVEN: 선조회 결과가 비어 있어 입력 전체가 삽입 후보가 된다
+      const feeds = [createFeed(1), createFeed(2)];
+      executeQueryStrictMock
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([
+          { id: 101, path: feeds[0].link },
+          { id: 102, path: feeds[1].link },
+        ]);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN: 선조회 1회 + 다중 행 INSERT 1회 + 재조회 1회여야 한다
+      expect(result).toEqual([
+        { ...feeds[0], id: 101 },
+        { ...feeds[1], id: 102 },
+      ]);
+      expect(executeQueryStrictMock).toHaveBeenCalledTimes(3);
+      expect(executeQueryStrictMock).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('SELECT path FROM feed'),
+        [[feeds[0].link, feeds[1].link]],
+      );
+      expect(executeQueryStrictMock).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('INSERT IGNORE INTO feed'),
+        [[toValueRow(feeds[0]), toValueRow(feeds[1])]],
+      );
+      expect(executeQueryStrictMock).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('SELECT id, path FROM feed'),
+        [[feeds[0].link, feeds[1].link]],
+      );
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(duplicateIncMock).not.toHaveBeenCalled();
+      expect(failureIncMock).not.toHaveBeenCalled();
+    });
+
+    it('이전 사이클에 이미 저장된 path는 INSERT 후보에서 제외하고 duplicate로 집계해야 한다', async () => {
+      // GIVEN: 2번 피드는 선조회에서 이미 존재하는 것으로 확인된다
+      const feeds = [createFeed(1), createFeed(2), createFeed(3)];
+      executeQueryStrictMock
+        .mockResolvedValueOnce([{ path: feeds[1].link }])
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([
+          { id: 103, path: feeds[2].link },
+          { id: 101, path: feeds[0].link },
+        ]);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN: 재조회 반환 순서가 아닌 원본 입력 순서를 유지해야 한다
+      expect(result).toEqual([
+        { ...feeds[0], id: 101 },
+        { ...feeds[2], id: 103 },
+      ]);
+
+      const insertValues = executeQueryStrictMock.mock.calls[1][1][0];
+      expect(insertValues).toHaveLength(2);
+      expect(insertValues).toEqual([toValueRow(feeds[0]), toValueRow(feeds[2])]);
+      // 기존 path는 INSERT에도 재조회에도 실려서는 안 된다
+      expect(executeQueryStrictMock).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('SELECT id, path FROM feed'),
+        [[feeds[0].link, feeds[2].link]],
+      );
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 3);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(duplicateIncMock).toHaveBeenCalledWith(1);
+      expect(failureIncMock).not.toHaveBeenCalled();
+    });
+
+    it('모든 피드가 이미 저장되어 있으면 INSERT와 재조회를 실행하지 않고 빈 배열을 반환해야 한다', async () => {
+      // GIVEN: 선조회가 입력 전체를 이미 존재하는 path로 반환한다
+      const feeds = [createFeed(1), createFeed(2)];
+      executeQueryStrictMock.mockResolvedValueOnce([
+        { path: feeds[0].link },
+        { path: feeds[1].link },
+      ]);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN
+      expect(result).toEqual([]);
+      expect(executeQueryStrictMock).toHaveBeenCalledTimes(1);
+      expect(executeQueryStrictMock).toHaveBeenCalledWith(
+        expect.stringContaining('SELECT path FROM feed'),
+        [[feeds[0].link, feeds[1].link]],
+      );
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 0);
+      expect(duplicateIncMock).toHaveBeenCalledWith(2);
+      expect(failureIncMock).not.toHaveBeenCalled();
+    });
+
+    it('INSERT IGNORE로 스킵되어 재조회에 잡히지 않은 후보는 결과에서 제외하고 duplicate로 집계해야 한다', async () => {
+      // GIVEN: 후보 3건 중 2번 피드가 재조회 결과에 없다
+      const feeds = [createFeed(1), createFeed(2), createFeed(3)];
+      executeQueryStrictMock
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([
+          { id: 101, path: feeds[0].link },
+          { id: 103, path: feeds[2].link },
+        ]);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN
+      expect(result).toEqual([
+        { ...feeds[0], id: 101 },
+        { ...feeds[2], id: 103 },
+      ]);
+      expect(executeQueryStrictMock.mock.calls[1][1][0]).toHaveLength(3);
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 3);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(duplicateIncMock).toHaveBeenCalledWith(1);
+      expect(failureIncMock).not.toHaveBeenCalled();
+    });
+
+    it('다중 행 INSERT가 실패하면 행 단위 재시도로 폴백해서 나머지를 살려야 한다', async () => {
+      // GIVEN: 다중 행 INSERT는 데드락 등으로 실패하지만, 개별 재시도는 둘 다 성공한다
+      const feeds = [createFeed(1), createFeed(2)];
+      const dbError = new Error('데드락 감지');
+      executeQueryStrictMock
+        .mockResolvedValueOnce([]) // 선조회
+        .mockRejectedValueOnce(dbError) // 다중 행 INSERT 실패
+        .mockResolvedValueOnce({ insertId: 201 }) // 개별 재시도: feeds[0]
+        .mockResolvedValueOnce({ insertId: 202 }); // 개별 재시도: feeds[1]
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN: 재조회 없이 개별 INSERT로 폴백해서 둘 다 결과에 포함되어야 한다
+      expect(result).toEqual([
+        { ...feeds[0], id: 201 },
+        { ...feeds[1], id: 202 },
+      ]);
+      expect(executeQueryStrictMock).toHaveBeenCalledTimes(4);
+      expect(executeQueryStrictMock).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('INSERT INTO feed'),
+        toValueRow(feeds[0]),
+      );
+      expect(executeQueryStrictMock).toHaveBeenNthCalledWith(
+        4,
+        expect.stringContaining('INSERT INTO feed'),
+        toValueRow(feeds[1]),
+      );
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(duplicateIncMock).not.toHaveBeenCalled();
+      expect(failureIncMock).not.toHaveBeenCalled();
+    });
+
+    it('폴백한 개별 INSERT 중 일부가 실패하면 그 행만 제외하고 failure를 증가시켜야 한다', async () => {
+      // GIVEN: feeds[1]의 개별 재시도가 FK 위반 등 진짜 에러로 실패한다
+      const feeds = [createFeed(1), createFeed(2)];
+      const bulkError = new Error('데드락 감지');
+      const rowError = new Error('FK 위반');
+      executeQueryStrictMock
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(bulkError)
+        .mockResolvedValueOnce({ insertId: 201 })
+        .mockRejectedValueOnce(rowError);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN
+      expect(result).toEqual([{ ...feeds[0], id: 201 }]);
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 1);
+      expect(duplicateIncMock).toHaveBeenCalledWith(1);
+      expect(failureIncMock).toHaveBeenCalledWith(INSERT_LABEL);
+    });
+
+    it('폴백한 개별 INSERT가 ER_DUP_ENTRY로 실패하면 failure 없이 duplicate로만 집계해야 한다', async () => {
+      // GIVEN: feeds[1]은 배치 내부 경합으로 이미 다른 곳에서 먼저 들어갔다
+      const feeds = [createFeed(1), createFeed(2)];
+      const bulkError = new Error('데드락 감지');
+      const dupError = Object.assign(new Error('중복'), {
+        code: 'ER_DUP_ENTRY',
+      });
+      executeQueryStrictMock
+        .mockResolvedValueOnce([])
+        .mockRejectedValueOnce(bulkError)
+        .mockResolvedValueOnce({ insertId: 201 })
+        .mockRejectedValueOnce(dupError);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN
+      expect(result).toEqual([{ ...feeds[0], id: 201 }]);
+      expect(duplicateIncMock).toHaveBeenCalledWith(1);
+      expect(failureIncMock).not.toHaveBeenCalled();
+    });
+
+    it('선조회가 실패하면 INSERT 없이 failure를 증가시킨 뒤 에러를 전파한다', async () => {
+      // GIVEN: 선조회도 INSERT와 동일하게 try/catch로 감싸여 failure 메트릭을 남긴다
+      const feeds = [createFeed(1), createFeed(2)];
+      const dbError = new Error('선조회 실패');
+      executeQueryStrictMock.mockRejectedValueOnce(dbError);
+
+      // WHEN & THEN
+      await expect(feedRepository.insertFeeds(feeds)).rejects.toThrow(dbError);
+      expect(executeQueryStrictMock).toHaveBeenCalledTimes(1);
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(failureIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(successIncMock).not.toHaveBeenCalled();
+      expect(duplicateIncMock).not.toHaveBeenCalled();
+    });
+
+    it('같은 사이클 내에 동일한 link가 중복으로 들어오면 하나만 삽입 후보로 남겨야 한다', async () => {
+      // GIVEN: feeds[1]과 feeds[2]가 같은 link를 가진다 (동일 게시글 중복 파싱)
+      const duplicateLink = createFeed(2).link;
+      const feeds = [
+        createFeed(1),
+        { ...createFeed(2), link: duplicateLink },
+        { ...createFeed(3), link: duplicateLink },
+      ];
+      executeQueryStrictMock
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce([
+          { id: 101, path: feeds[0].link },
+          { id: 102, path: feeds[1].link },
+        ]);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN: 중복 link 중 먼저 나온 feeds[1]만 후보로 살아남고, feeds[2]는 duplicate로 집계된다
+      const insertValues = executeQueryStrictMock.mock.calls[1][1][0];
+      expect(insertValues).toHaveLength(2);
+      expect(insertValues).toEqual([toValueRow(feeds[0]), toValueRow(feeds[1])]);
+      expect(result).toEqual([
+        { ...feeds[0], id: 101 },
+        { ...feeds[1], id: 102 },
+      ]);
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 3);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 2);
+      expect(duplicateIncMock).toHaveBeenCalledWith(1);
+    });
+
+    it('빈 배열이 입력되면 선조회만 실행하고 빈 배열을 반환해야 한다', async () => {
+      // GIVEN
+      const feeds: FeedDetail[] = [];
+      executeQueryStrictMock.mockResolvedValueOnce([]);
+
+      // WHEN
+      const result = await feedRepository.insertFeeds(feeds);
+
+      // THEN
+      expect(result).toEqual([]);
+      expect(executeQueryStrictMock).toHaveBeenCalledTimes(1);
+      expect(totalIncMock).toHaveBeenCalledWith(INSERT_LABEL, 0);
+      expect(successIncMock).toHaveBeenCalledWith(INSERT_LABEL, 0);
+      expect(duplicateIncMock).not.toHaveBeenCalled();
+      expect(failureIncMock).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #453 

### 소주제1: 커넥션 풀 압박 완화

- 기존엔 게시글 1건당 INSERT 쿼리 1개, 즉 신규 피드가 N건이면 커넥션 풀에서 N번 connection을 얻고 반납하는 구조였습니다. 크롤링 배치가 커질수록 커넥션 풀(50개) 경합이 심해지는 문제가 있었습니다.
- 다중 행 INSERT로 전환해 왕복 횟수를 최대 3회(선조회 SELECT → Bulk INSERT IGNORE → 재조회 SELECT)로 줄였습니다.

### 소주제2: 중복 처리 정합성

- 선조회로 이미 DB에 저장된 path를 후보에서 먼저 제외해서, 이전 크롤링 사이클이나 Full Crawl과 겹치는 게시글이 "신규"로 오인되어 AI 큐/캐시에 재적재되지 않도록 했습니다.
- 같은 배치 내부에 동일한 link가 중복으로 들어와도 하나만 삽입 후보로 남기도록 dedupe 처리했습니다 (기존 방식은 DB의 UNIQUE 제약이 자동으로 처리해주던 부분이라, Bulk로 바뀌면서 직접 처리가 필요했습니다).

### 소주제3: Bulk 실패 시 개별 삽입 폴백

- 데드락/FK 위반처럼 `INSERT IGNORE`로도 못 거르는 에러가 발생하면 다중 행 INSERT 문 전체가 실패해서, 그 사이클의 신규 피드 전체가 유실될 위험이 있었습니다.
- Bulk INSERT가 실패하면 후보를 행 단위로 재시도하는 폴백(`insertFeedsIndividually`)을 추가해서, 문제가 있는 행만 제외하고 나머지는 정상적으로 삽입되도록 했습니다.

# 📋 작업 내용

- `feed-crawler/src/repository/feed.repository.ts`
  - `insertFeeds`: 개별 INSERT × N 구조 → 선조회 + Bulk `INSERT IGNORE` + 재조회 구조로 변경
  - Bulk INSERT 실패 시 개별 INSERT로 폴백하는 `insertFeedsIndividually` 추가
- `feed-crawler/test/unit/feed.repository.spec.ts`: 단위 테스트 10건 추가 (신규 삽입/기존 중복 제외/배치 내부 중복/IGNORE 스킵/Bulk 실패 폴백 성공·부분 실패·ER_DUP_ENTRY/선조회 실패/빈 배열)

# 📊 성능 측정

로컬 Testcontainers(MySQL 8.0.39)에 대해 기존 방식(개별 INSERT × N)과 현재 `insertFeeds`(Bulk + 폴백)를 배치 크기별로 단발 비교한 결과입니다 (반복 측정한 평균이 아닌 참고용 수치입니다):

| 배치 크기 | 개별 INSERT (기존) | Bulk insertFeeds (현재) | 절감 |
|---|---|---|---|
| 20건 | 117.7ms | 20.1ms | 82.9% |
| 100건 | 100.4ms | 22.7ms | 77.4% |
| 300건 | 170.7ms | 97.3ms | 43.0% |

- 커넥션 왕복이 N회 → 최대 3회로 줄어든 효과가 실측으로도 확인됩니다.
- 배치가 커질수록 절감폭(%)이 줄어드는 경향이 있는데, 재조회 SELECT(`path IN (?)`)의 크기가 후보 수에 비례해서 커지기 때문입니다. 모든 구간에서 기존 방식보다 빠르지만, 배치가 커질수록 격차는 좁혀집니다.
- 측정에 쓴 스크립트는 1회성이라 이 PR에는 포함하지 않았습니다.

# 📷 스크린 샷(선택 사항)

해당 없음