### PR TITLE
🐛 fix: 게시글 ID로 바로 접근 시 랜딩 페이지 스킵

### DIFF
--- a/client/src/__tests__/hooks/useAppInitialization.test.tsx
+++ b/client/src/__tests__/hooks/useAppInitialization.test.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppInitialization } from "@/hooks/useAppInitialization";
+import { useVisitStore } from "@/store/useVisitStore";
+
+import { MemoryRouter } from "react-router-dom";
+import { renderHook } from "@testing-library/react";
+
+vi.mock("@/hooks/common/useMediaQuery", () => ({ useMediaQuery: () => false }));
+
+const createWrapper = (path: string) => {
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[path]}>{children}</MemoryRouter>
+  );
+  return wrapper;
+};
+
+describe("useAppInitialization", () => {
+  beforeEach(() => {
+    useVisitStore.setState({ hasVisited: false });
+  });
+
+  it("첫 방문이고 경로가 '/'이면 about 페이지로 리다이렉트한다", () => {
+    const { result } = renderHook(() => useAppInitialization(), { wrapper: createWrapper("/") });
+
+    expect(result.current.shouldRedirectToAbout).toBe(true);
+  });
+
+  it("첫 방문이어도 게시글 ID로 바로 접근하면 리다이렉트하지 않는다", () => {
+    const { result } = renderHook(() => useAppInitialization(), { wrapper: createWrapper("/123") });
+
+    expect(result.current.shouldRedirectToAbout).toBe(false);
+  });
+});

--- a/client/src/hooks/useAppInitialization.ts
+++ b/client/src/hooks/useAppInitialization.ts
@@ -39,7 +39,7 @@ export const useAppInitialization = () => {
     setIsMobile(isMobile);
   }, [isMobile, setIsMobile]);
 
-  const shouldRedirectToAbout = !hasVisited;
+  const shouldRedirectToAbout = !hasVisited && location.pathname === "/";
 
   return {
     state,


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연관된 open 이슈 없음

### 소주제1: 게시글 직접 접근 시 About 페이지로 튕기는 문제

- `useAppInitialization`의 `shouldRedirectToAbout`가 `!hasVisited`만으로 계산되어 있어서, 첫 방문자가 `/:id` 같은 게시글 상세 URL로 바로 들어와도 무조건 `/about` 랜딩 페이지로 리다이렉트되는 문제가 있었습니다.
- 공유된 게시글 링크로 유입되는 케이스(가장 흔한 첫 방문 경로 중 하나)가 About 페이지에 가로막히는 셈이라, 조건에 `location.pathname === "/"`를 추가해서 루트 경로로 들어왔을 때만 About으로 리다이렉트하도록 수정했습니다.

# 📋 작업 내용

- `client/src/hooks/useAppInitialization.ts`: `shouldRedirectToAbout` 조건에 `location.pathname === "/"` 추가
- `client/src/__tests__/hooks/useAppInitialization.test.tsx`: 회귀 방지용 테스트 추가 (루트 경로 첫 방문 → 리다이렉트 O, 게시글 ID 직접 접근 → 리다이렉트 X)

# 📷 스크린 샷(선택 사항)

해당 없음