### PR TITLE
🐛 fix: 로그인 스로틀 제한 및 초과 토스트 메시지 수정

### DIFF
--- a/server/src/common/filters/http.exception.filter.ts
+++ b/server/src/common/filters/http.exception.filter.ts
@@ -16,7 +16,11 @@ export class HttpExceptionsFilter implements ExceptionFilter {
     const response = host.switchToHttp().getResponse<Response>();
 
     const statusCode = exception.getStatus();
-    const res = exception.getResponse()['message'];
+    const exceptionResponse = exception.getResponse();
+    const res =
+      typeof exceptionResponse === 'string'
+        ? exceptionResponse
+        : exceptionResponse['message'];
     const message = Array.isArray(res) ? res[0] : res;
 
     const apiResponse = ApiResponse.responseWithNoContent(message);

--- a/server/src/common/throttler/login-throttler.module.ts
+++ b/server/src/common/throttler/login-throttler.module.ts
@@ -12,7 +12,7 @@ import { RedisService } from '@common/redis/redis.service';
       imports: [RedisModule],
       inject: [RedisService],
       useFactory: (redisService: RedisService) => ({
-        throttlers: [{ ttl: 60_000, limit: 5 }],
+        throttlers: [{ ttl: 60_000, limit: 10 }],
         storage: new ThrottlerStorageRedisService(redisService.redisClient),
         errorMessage: '로그인 시도가 너무 많습니다. 잠시 후 다시 시도해주세요.',
       }),

--- a/server/test/admin/e2e/login.e2e-spec.ts
+++ b/server/test/admin/e2e/login.e2e-spec.ts
@@ -170,7 +170,7 @@ describe(`POST ${URL} E2E Test`, () => {
     expect(newSession).toBe(admin.email);
   });
 
-  it('[429] 60초 내 5회 초과 로그인 시도 시 요청을 차단한다.', async () => {
+  it('[429] 60초 내 10회 초과 로그인 시도 시 요청을 차단한다.', async () => {
     // given
     const requestDto = new LoginAdminRequestDto({
       email: admin.email,
@@ -178,7 +178,7 @@ describe(`POST ${URL} E2E Test`, () => {
     });
 
     // Http when
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 10; i++) {
       await agent.post(URL).send(requestDto);
     }
     const response = await agent.post(URL).send(requestDto);

--- a/server/test/user/e2e/login.e2e-spec.ts
+++ b/server/test/user/e2e/login.e2e-spec.ts
@@ -101,7 +101,7 @@ describe(`POST ${URL} E2E Test`, () => {
     });
   });
 
-  it('[429] 60초 내 5회 초과 로그인 시도 시 요청을 차단한다.', async () => {
+  it('[429] 60초 내 10회 초과 로그인 시도 시 요청을 차단한다.', async () => {
     // given
     const requestDto = new LoginUserRequestDto({
       email: user.email,
@@ -109,7 +109,7 @@ describe(`POST ${URL} E2E Test`, () => {
     });
 
     // Http when
-    for (let i = 0; i < 5; i++) {
+    for (let i = 0; i < 10; i++) {
       await agent.post(URL).send(requestDto);
     }
     const response = await agent.post(URL).send(requestDto);


### PR DESCRIPTION
# 🔨 테스크

### 로그인 스로틀 제한 완화

-   로그인 시도 제한을 1분당 5회 → 10회로 완화

### 스로틀 초과 시 토스트 메시지 미노출 수정

-   스로틀에 걸려도 토스트에 지정한 안내 메시지 대신 일반 에러 메시지("로그인 중 오류가 발생했습니다.")만 노출되는 문제 발견
-   원인: `ThrottlerException`은 Nest 내장 예외들과 달리 `createBody`로 감싸지 않고 문자열을 그대로 `getResponse()`에 저장함. 공용 `HttpExceptionsFilter`는 `exception.getResponse()['message']`로만 접근했기 때문에, string에 `['message']`를 인덱싱해 `undefined`가 되어 클라이언트가 fallback 메시지를 사용하게 됨
-   `HttpExceptionsFilter`가 `getResponse()`의 string/object 두 형태를 모두 처리하도록 수정 (공유 필터 수정이라 동일 패턴의 다른 예외에도 함께 적용됨)

# 📋 작업 내용

-   `server/src/common/throttler/login-throttler.module.ts`: 로그인 스로틀 `limit: 5` → `10`
-   `server/src/common/filters/http.exception.filter.ts`: `exception.getResponse()`가 string인 경우도 처리하도록 수정

# 📷 스크린 샷(선택 사항)
<img width="727" height="641" alt="image" src="https://github.com/user-attachments/assets/f8d19606-c542-46f9-959c-9e3f43a5a76f" />
