### PR TITLE
🐛 fix: refresh token 만료 시 조용히 깨지는 로그인 세션 정리

### DIFF
--- a/client/src/__tests__/api/instance.test.ts
+++ b/client/src/__tests__/api/instance.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import MockAdapter from "axios-mock-adapter";
+
+import { axiosInstance } from "@/api/instance";
+import { useAuthStore } from "@/store/useAuthStore";
+import { USER } from "@/constants/endpoints";
+import { nav } from "@/utils/redirect";
+
+vi.mock("@/utils/redirect.ts", () => ({
+  nav: { redirect: vi.fn() },
+}));
+
+const AUTH_HINT_KEY = "denamu_auth_hint";
+const PROTECTED_URL = "/api/protected-test";
+
+const encode = (value: Record<string, unknown>) => Buffer.from(JSON.stringify(value)).toString("base64url");
+
+const makeJwt = (payload: Record<string, unknown>) =>
+  `${encode({ alg: "none", typ: "JWT" })}.${encode(payload)}.signature`;
+
+const setAuthenticatedState = () => {
+  useAuthStore.setState({
+    accessToken: "old-access-token",
+    role: "user",
+    userInfo: { id: 1, email: "tester@denamu.dev", userName: "tester" },
+    isAuthenticated: true,
+    isInitialized: true,
+  });
+  localStorage.setItem(AUTH_HINT_KEY, "1");
+};
+
+const setGuestState = () => {
+  useAuthStore.setState({
+    accessToken: null,
+    role: "guest",
+    userInfo: { id: null, email: null, userName: null },
+    isAuthenticated: false,
+    isInitialized: true,
+  });
+};
+
+let mock: MockAdapter;
+
+describe("axiosInstance 응답 인터셉터 - refresh token 만료 처리", () => {
+  beforeEach(() => {
+    mock = new MockAdapter(axiosInstance);
+    vi.mocked(nav.redirect).mockClear();
+    setGuestState();
+  });
+
+  afterEach(() => {
+    mock.restore();
+    localStorage.clear();
+  });
+
+  it("로그인 상태에서 AT가 만료되고 refresh마저 실패하면 세션을 완전히 초기화하고 /signin으로 유도한다", async () => {
+    setAuthenticatedState();
+    mock.onGet(PROTECTED_URL).reply(401);
+    mock.onPost(USER.REFRESH_TOKEN).reply(401);
+
+    await expect(axiosInstance.get(PROTECTED_URL)).rejects.toBeTruthy();
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(false);
+    expect(state.accessToken).toBeNull();
+    expect(state.role).toBe("guest");
+    expect(state.userInfo).toEqual({ id: null, email: null, userName: null });
+    expect(localStorage.getItem(AUTH_HINT_KEY)).toBeNull();
+    expect(nav.redirect).toHaveBeenCalledWith("/signin");
+  });
+
+  it("refresh가 성공하면 원래 요청을 새 토큰으로 재시도하고 로그인 상태를 유지한다", async () => {
+    setAuthenticatedState();
+    const newAccessToken = makeJwt({
+      id: 1,
+      email: "tester@denamu.dev",
+      userName: "tester",
+      role: "user",
+      iat: 1,
+      exp: 9999999999,
+    });
+    mock.onGet(PROTECTED_URL).replyOnce(401).onGet(PROTECTED_URL).reply(200, { data: "ok" });
+    mock.onPost(USER.REFRESH_TOKEN).reply(200, { message: "재발급 성공", data: { accessToken: newAccessToken } });
+
+    const response = await axiosInstance.get(PROTECTED_URL);
+
+    expect(response.data).toEqual({ data: "ok" });
+    expect(mock.history.get[1].headers?.Authorization).toBe(`Bearer ${newAccessToken}`);
+
+    const state = useAuthStore.getState();
+    expect(state.isAuthenticated).toBe(true);
+    expect(state.accessToken).toBe(newAccessToken);
+    expect(nav.redirect).not.toHaveBeenCalled();
+  });
+
+  it("비로그인(guest) 상태에서 401을 받으면 refresh 실패해도 /signin으로 리다이렉트하지 않는다", async () => {
+    mock.onGet(PROTECTED_URL).reply(401);
+    mock.onPost(USER.REFRESH_TOKEN).reply(401);
+
+    await expect(axiosInstance.get(PROTECTED_URL)).rejects.toBeTruthy();
+
+    expect(nav.redirect).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/api/instance.ts
+++ b/client/src/api/instance.ts
@@ -3,6 +3,19 @@ import axios, { AxiosError, AxiosHeaders, InternalAxiosRequestConfig } from "axi
 import { BASE_URL } from "@/constants/endpoints";
 import { useAuthStore } from "@/store/useAuthStore.ts";
 import { refreshAccessToken } from "@/api/services/user.ts";
+import { toast } from "@/hooks/common/useCustomToast";
+import { TOAST_MESSAGES } from "@/constants/messages";
+import { nav } from "@/utils/redirect";
+
+function handleSessionExpired() {
+  const wasAuthenticated = useAuthStore.getState().isAuthenticated;
+  useAuthStore.getState().forceLogout();
+
+  if (wasAuthenticated && window.location.pathname !== "/signin") {
+    toast(TOAST_MESSAGES.SESSION_EXPIRED);
+    nav.redirect("/signin");
+  }
+}
 
 export const api = axios.create({
   baseURL: "/api",
@@ -68,7 +81,7 @@ axiosInstance.interceptors.response.use((res) => res, async (error: AxiosError) 
 
     const newToken = await refreshPromise;
     if (!newToken) {
-      useAuthStore.getState().setAccessToken(null);
+      handleSessionExpired();
       return Promise.reject(error);
     }
 
@@ -76,7 +89,7 @@ axiosInstance.interceptors.response.use((res) => res, async (error: AxiosError) 
     originalRequest.headers.Authorization = `Bearer ${newToken}`;
     return axiosInstance.request(originalRequest);
   } catch (e) {
-    useAuthStore.getState().setAccessToken(null);
+    handleSessionExpired();
     return Promise.reject(e);
   }
 });

--- a/client/src/components/layout/sidebar/AuthSection.stories.tsx
+++ b/client/src/components/layout/sidebar/AuthSection.stories.tsx
@@ -1,7 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { fn } from "storybook/test";
+import { expect, fn, waitFor, within } from "storybook/test";
 
 import { AuthSection } from "@/components/layout/sidebar/AuthSection";
+import { axiosInstance } from "@/api/instance";
+import { useAuthStore } from "@/store/useAuthStore";
+import { USER } from "@/constants/endpoints";
+import { mockApi, mockRedirect, fail } from "@/__storybook__/mockApi";
+import { nav } from "@/utils/redirect";
 
 const meta = {
   title: "layout/sidebar/AuthSection",
@@ -13,3 +18,43 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+const PROTECTED_URL = "/api/storybook/session-check";
+
+const loginAsUser = () => {
+  useAuthStore.setState({
+    accessToken: "storybook-access-token",
+    role: "user",
+    userInfo: { id: 1, email: "tester@denamu.dev", userName: "데나무 테스터" },
+    isAuthenticated: true,
+    isInitialized: true,
+  });
+};
+
+export const SessionExpired: Story = {
+  name: "refresh token 만료 → 자동 로그아웃 + 재로그인 유도",
+  beforeEach: () => {
+    loginAsUser();
+    const restoreRedirect = mockRedirect();
+    mockApi.onGet(PROTECTED_URL).reply(...fail(401, "인증이 만료되었습니다."));
+    mockApi.onPost(USER.REFRESH_TOKEN).reply(...fail(401, "refresh token이 만료되었습니다."));
+
+    return () => {
+      restoreRedirect();
+      useAuthStore.getState().forceLogout();
+    };
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 시작 시점: 로그인 상태 (닉네임 노출)
+    await expect(canvas.getByText("데나무 테스터")).toBeInTheDocument();
+
+    // 만료된 refresh token 상태에서 보호된 API를 호출 → axiosInstance 인터셉터가 세션을 정리
+    await axiosInstance.get(PROTECTED_URL).catch(() => undefined);
+
+    // 자동으로 로그아웃 상태로 전환되어 로그인 버튼이 노출됨
+    await waitFor(() => expect(canvas.getByRole("button", { name: "로그인" })).toBeInTheDocument());
+    await expect(nav.redirect).toHaveBeenCalledWith("/signin");
+  },
+};

--- a/client/src/constants/messages.ts
+++ b/client/src/constants/messages.ts
@@ -9,4 +9,10 @@ export const TOAST_MESSAGES = {
     title: "복사 성공",
     description: "링크가 클립보드에 저장되었어요! ",
   },
+  SESSION_EXPIRED: {
+    title: "세션 만료",
+    description: "로그인이 만료되었어요. 다시 로그인해주세요.",
+    variant: "destructive",
+    duration: 3000,
+  },
 } as const;

--- a/client/src/store/useAuthStore.ts
+++ b/client/src/store/useAuthStore.ts
@@ -22,6 +22,7 @@ type AuthState = {
   setUserName: (userName: string) => void;
   setUserFromToken: (token: string) => void;
   logout: () => Promise<void>;
+  forceLogout: () => void;
   initialize: () => void;
 };
 
@@ -54,6 +55,19 @@ export const useAuthStore = create<AuthState>((set) => ({
         isInitialized: true,
       });
     }
+  },
+  forceLogout: () => {
+    localStorage.removeItem(AUTH_HINT_KEY);
+    set({
+      accessToken: null,
+      role: "guest",
+      userInfo: {
+        id: null,
+        email: null,
+        userName: null,
+      },
+      isAuthenticated: false,
+    });
   },
   logout: async () => {
     try {


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연결된 열린 이슈 없음 (사용자 리포트 기반 자체 발견 버그)

### 문제

- Access token(1h)이 만료된 채로 탭을 켜놓고 있다가 refresh token(7d)까지 만료되면, `axiosInstance` 응답 인터셉터가 `accessToken`만 `null`로 지우고 `isAuthenticated`/`role`/`userInfo`는 그대로 남겨뒀습니다.
- 그 결과 사이드바 등 UI는 여전히 로그인 상태로 렌더링되지만, 이후 모든 인증 API 호출은 토큰 없이 나가 401 → refresh 재시도 → 재실패를 조용히 반복하는 "유령 로그인" 상태가 됐습니다. 사용자에게는 아무 안내도 없이 기능만 계속 실패했습니다.

### 해결

- `useAuthStore`에 `forceLogout()` 액션을 추가해 `accessToken`, `isAuthenticated`, `role`, `userInfo`, `localStorage`의 `denamu_auth_hint`를 한 번에 초기화하도록 했습니다.
- `axiosInstance`의 refresh 최종 실패 경로(두 곳)에서 `forceLogout()`을 호출하고, 원래 로그인 상태였을 때만 세션 만료 토스트를 띄운 뒤 기존 `nav.redirect` 유틸로 `/signin`으로 이동시켜 재로그인을 유도합니다.
- 게스트 상태에서 발생하는 401(비보호 흐름)은 리다이렉트를 유발하지 않도록 `wasAuthenticated` 가드를 뒀습니다.

# 📋 작업 내용

- `client/src/store/useAuthStore.ts`: `forceLogout()` 액션 추가
- `client/src/api/instance.ts`: refresh 최종 실패 시 `forceLogout()` + 세션 만료 토스트 + `/signin` 리다이렉트
- `client/src/constants/messages.ts`: `SESSION_EXPIRED` 토스트 문구 추가
- `client/src/__tests__/api/instance.test.ts`: refresh 실패/성공/게스트 401 3가지 시나리오에 대한 인터셉터 단위 테스트 추가
- `client/src/components/layout/sidebar/AuthSection.stories.tsx`: 로그인 상태 → 세션 만료 API 호출 → 자동 로그아웃 UI 전환 → `/signin` 리다이렉트까지 실제 axiosInstance/스토어로 재현하는 Storybook interaction 스토리(`SessionExpired`) 추가

# 📷 스크린 샷(선택 사항)

- Storybook `layout/sidebar/AuthSection` → `refresh token 만료 → 자동 로그아웃 + 재로그인 유도` 스토리의 Interactions 패널에서 4단계 어설션 전부 PASS 확인 (로그인 상태 → 세션 만료 재현 → 로그아웃 UI 전환 → `/signin` 리다이렉트 호출)
<img width="424" height="112" alt="image" src="https://github.com/user-attachments/assets/8620a68f-405e-4162-9228-bec7cb451755" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)