### PR TITLE
🐛 fix: 블로그 프로필 이미지 로드 실패 시 플랫폼 아이콘 fallback 처리

### DIFF
--- a/client/src/__tests__/components/profile/rss/PlatformIcon.test.tsx
+++ b/client/src/__tests__/components/profile/rss/PlatformIcon.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon.tsx";
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("lucide-react", () => lucideProxy());
 
@@ -20,5 +20,21 @@ describe("PlatformIcon", () => {
 
     expect(screen.getByTestId("lucide-Rss")).toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("image가 주어지면 해당 이미지를 렌더링해야 한다", () => {
+    render(<PlatformIcon platform="naver" image="https://blog.naver.com/profile.png" />);
+
+    const img = screen.getByRole("img", { name: "naver" });
+    expect(img).toHaveAttribute("src", "https://blog.naver.com/profile.png");
+  });
+
+  it("image 로드에 실패하면 플랫폼 아이콘으로 대체해야 한다", () => {
+    render(<PlatformIcon platform="naver" image="https://blog.naver.com/profile.png" />);
+
+    const img = screen.getByRole("img", { name: "naver" });
+    fireEvent.error(img);
+
+    expect(img).toHaveAttribute("src", expect.stringContaining("naver-icon.svg"));
   });
 });

--- a/client/src/components/profile/rss/PlatformIcon.tsx
+++ b/client/src/components/profile/rss/PlatformIcon.tsx
@@ -11,15 +11,25 @@ interface PlatformIconProps {
 
 export const PlatformIcon = ({ platform, image, className = "w-5 h-5", alt }: PlatformIconProps) => {
   const altText = alt ?? platform;
+  const key = platform.toLowerCase().replace(" ", "_");
+  const fallbackSrc = `https://denamu.dev/files/${key}-icon.svg`;
 
   if (image) {
-    return <img src={image} alt={altText} className={`${className} rounded-full object-cover`} />;
+    return (
+      <img
+        src={image}
+        alt={altText}
+        className={`${className} rounded-full object-cover`}
+        onError={(e) => {
+          e.currentTarget.onerror = null;
+          e.currentTarget.src = fallbackSrc;
+        }}
+      />
+    );
   }
 
-  const key = platform.toLowerCase().replace(" ", "_");
-
   if (KNOWN_PLATFORMS.includes(key)) {
-    return <img src={`https://denamu.dev/files/${key}-icon.svg`} alt={altText} className={className} />;
+    return <img src={fallbackSrc} alt={altText} className={className} />;
   }
 
   return <Rss className={`${className} text-blue-500`} />;


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 관련 이슈 없음

### 아이콘 fallback 누락

- 게시글/프로필 카드에서 blogImage가 있으면 `PlatformIcon`이 해당 URL을 검증 없이 그대로 렌더링했음. 이미지 로드가 실패(`ERR_CONNECTION_REFUSED` 등)해도 대체 처리가 없어 깨진 이미지로 노출됨.
- `<img>`의 `onError`에서 플랫폼별 정적 아이콘(`https://denamu.dev/files/{platform}-icon.svg`)으로 교체하도록 수정. 무한 루프 방지를 위해 fallback 적용 전에 `onerror`를 초기화.

# 📋 작업 내용

- `client/src/components/profile/rss/PlatformIcon.tsx`: `image` prop 렌더링 시 `onError` 핸들러 추가, 실패 시 플랫폼 아이콘으로 교체

# 📷 스크린 샷(선택 사항)

-