### PR TITLE
✨ feat: 좋아요/댓글 등록·삭제 시 최신 피드 Redis 캐시 HINCRBY 동기화

### DIFF
--- a/server/src/comment/event/comment-deleted.event.ts
+++ b/server/src/comment/event/comment-deleted.event.ts
@@ -2,5 +2,6 @@ export class CommentDeletedEvent {
   constructor(
     public readonly feedId: number,
     public readonly parentAuthorId: number | null,
+    public readonly commentCountDelta: number,
   ) {}
 }

--- a/server/src/comment/service/comment.service.ts
+++ b/server/src/comment/service/comment.service.ts
@@ -184,6 +184,8 @@ export class CommentService {
           })
         : 0;
 
+    let commentCountDelta = 0;
+
     await this.dataSource.transaction(async (manager) => {
       if (replyCount > 0) {
         comment.isDeleted = true;
@@ -194,6 +196,7 @@ export class CommentService {
       const feed = comment.feed;
       await manager.remove(comment);
       feed.commentCount--;
+      commentCountDelta--;
 
       if (comment.parent?.isDeleted) {
         const remainingReplyCount = await manager.count(Comment, {
@@ -203,6 +206,7 @@ export class CommentService {
         if (remainingReplyCount === 0) {
           await manager.remove(comment.parent);
           feed.commentCount--;
+          commentCountDelta--;
         }
       }
 
@@ -211,7 +215,11 @@ export class CommentService {
 
     this.eventEmitter.emit(
       'comment.deleted',
-      new CommentDeletedEvent(comment.feed.id, parentAuthorId),
+      new CommentDeletedEvent(
+        comment.feed.id,
+        parentAuthorId,
+        commentCountDelta,
+      ),
     );
   }
 
@@ -231,7 +239,11 @@ export class CommentService {
 
     this.eventEmitter.emit(
       'comment.deleted',
-      new CommentDeletedEvent(comment.feed.id, comment.parent?.user.id ?? null),
+      new CommentDeletedEvent(
+        comment.feed.id,
+        comment.parent?.user.id ?? null,
+        0,
+      ),
     );
   }
 

--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -4,6 +4,7 @@ export const REDIS_KEYS = {
   FEED_ORIGIN_TREND_KEY: 'feed:origin_trend',
   FEED_RECENT_ALL_KEY: 'feed:recent:*',
   FEED_RECENT_KEY: 'feed:recent',
+  FEED_RECENT_ITEM_KEY: (feedId: number | string) => `feed:recent:${feedId}`,
   FEED_AI_QUEUE: `feed:ai:queue`,
   FEED_AI_RETRY_LOCK: `feed:ai-retry:lock`,
   USER_AUTH_KEY: 'signup',

--- a/server/src/common/redis/redis.service.ts
+++ b/server/src/common/redis/redis.service.ts
@@ -165,4 +165,18 @@ export class RedisService {
   ): Promise<any> {
     return this.redisClient.eval(script, keys.length, ...keys, ...args);
   }
+
+  async hincrbyIfExists(
+    key: string,
+    field: string,
+    increment: number,
+  ): Promise<number | null> {
+    const script = `
+      if redis.call('EXISTS', KEYS[1]) == 1 then
+        return redis.call('HINCRBY', KEYS[1], ARGV[1], ARGV[2])
+      end
+      return nil
+    `;
+    return this.eval(script, [key], [field, String(increment)]);
+  }
 }

--- a/server/src/feed/listener/feedRecent.listener.ts
+++ b/server/src/feed/listener/feedRecent.listener.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+
+import { CommentCreatedEvent } from '@comment/event/comment-created.event';
+import { CommentDeletedEvent } from '@comment/event/comment-deleted.event';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { LikeCreatedEvent } from '@like/event/like-created.event';
+import { LikeDeletedEvent } from '@like/event/like-deleted.event';
+
+@Injectable()
+export class FeedRecentListener {
+  constructor(private readonly redisService: RedisService) {}
+
+  @OnEvent('like.created')
+  async handleLikeCreated({ feedId }: LikeCreatedEvent) {
+    await this.redisService.hincrbyIfExists(
+      REDIS_KEYS.FEED_RECENT_ITEM_KEY(feedId),
+      'likes',
+      1,
+    );
+  }
+
+  @OnEvent('like.deleted')
+  async handleLikeDeleted({ feedId }: LikeDeletedEvent) {
+    await this.redisService.hincrbyIfExists(
+      REDIS_KEYS.FEED_RECENT_ITEM_KEY(feedId),
+      'likes',
+      -1,
+    );
+  }
+
+  @OnEvent('comment.created')
+  async handleCommentCreated({ feedId }: CommentCreatedEvent) {
+    await this.redisService.hincrbyIfExists(
+      REDIS_KEYS.FEED_RECENT_ITEM_KEY(feedId),
+      'comments',
+      1,
+    );
+  }
+
+  @OnEvent('comment.deleted')
+  async handleCommentDeleted({
+    feedId,
+    commentCountDelta,
+  }: CommentDeletedEvent) {
+    if (commentCountDelta === 0) return;
+
+    await this.redisService.hincrbyIfExists(
+      REDIS_KEYS.FEED_RECENT_ITEM_KEY(feedId),
+      'comments',
+      commentCountDelta,
+    );
+  }
+}

--- a/server/src/feed/module/feed.module.ts
+++ b/server/src/feed/module/feed.module.ts
@@ -2,13 +2,14 @@ import { Module } from '@nestjs/common';
 
 import { ActivityModule } from '@activity/module/activity.module';
 
-import { JwtAuthModule } from '@common/auth/jwt.module';
-
 import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { JwtAuthModule } from '@common/auth/jwt.module';
 
 import { AdminFeedController } from '@feed/controller/adminFeed.controller';
 import { FeedController } from '@feed/controller/feed.controller';
 import { FeedViewedListener } from '@feed/listener/feed-viewed.listener';
+import { FeedRecentListener } from '@feed/listener/feedRecent.listener';
 import {
   FeedRepository,
   FeedViewRepository,
@@ -29,6 +30,7 @@ import { UserModule } from '@user/module/user.module';
     FeedViewRepository,
     FeedScheduler,
     FeedViewedListener,
+    FeedRecentListener,
     SubscriptionRepository,
     RssBlockRepository,
   ],

--- a/server/src/report/service/report.service.ts
+++ b/server/src/report/service/report.service.ts
@@ -197,6 +197,7 @@ export class ReportService {
 
       case ReportTargetType.COMMENT: {
         const comment = report.reportedComment;
+        let commentCountDelta = 0;
 
         return {
           targetUserId: comment.user.id,
@@ -222,6 +223,7 @@ export class ReportService {
                 'commentCount',
                 1,
               );
+              commentCountDelta = -1;
             }
           },
           afterCommit: () => {
@@ -230,6 +232,7 @@ export class ReportService {
               new CommentDeletedEvent(
                 comment.feed.id,
                 comment.parent?.user.id ?? null,
+                commentCountDelta,
               ),
             );
           },

--- a/server/test/comment/unit/comment.service.unit.spec.ts
+++ b/server/test/comment/unit/comment.service.unit.spec.ts
@@ -356,7 +356,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).toHaveBeenCalledWith(comment);
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10, null),
+        new CommentDeletedEvent(10, null, -1),
       );
     });
 
@@ -383,7 +383,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).not.toHaveBeenCalled();
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10, null),
+        new CommentDeletedEvent(10, null, 0),
       );
     });
 
@@ -408,7 +408,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).toHaveBeenCalledWith(comment);
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10, 42),
+        new CommentDeletedEvent(10, 42, -1),
       );
     });
 
@@ -438,7 +438,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).toHaveBeenCalledWith(parent);
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10, 42),
+        new CommentDeletedEvent(10, 42, -2),
       );
     });
 
@@ -480,7 +480,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(manager.remove).toHaveBeenCalledWith(comment);
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10, null),
+        new CommentDeletedEvent(10, null, -1),
       );
     });
   });
@@ -522,7 +522,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       expect(dataSource.transaction).not.toHaveBeenCalled();
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10, null),
+        new CommentDeletedEvent(10, null, 0),
       );
     });
 
@@ -543,7 +543,7 @@ describe(`${CommentService.name} Unit Test`, () => {
       // then
       expect(eventEmitter.emit).toHaveBeenCalledWith(
         'comment.deleted',
-        new CommentDeletedEvent(10, 42),
+        new CommentDeletedEvent(10, 42, 0),
       );
     });
   });

--- a/server/test/feed/e2e/recentCacheSync.e2e-spec.ts
+++ b/server/test/feed/e2e/recentCacheSync.e2e-spec.ts
@@ -1,0 +1,239 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { CommentRepository } from '@comment/repository/comment.repository';
+
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { Feed } from '@feed/entity/feed.entity';
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { Like } from '@like/entity/like.entity';
+import { LikeRepository } from '@like/repository/like.repository';
+
+import { RssAccept } from '@rss/entity/rss.entity';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { User } from '@user/entity/user.entity';
+import { UserRepository } from '@user/repository/user.repository';
+
+import { CommentFixture } from '@test/config/common/fixture/comment.fixture';
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken } from '@test/config/e2e/env/jest.setup';
+import { testApp } from '@test/config/e2e/env/jest.setup';
+
+describe(`좋아요/댓글 등록·삭제 시 feed:recent 캐시 동기화 E2E Test`, () => {
+  let agent: TestAgent;
+  let redisService: RedisService;
+  let commentRepository: CommentRepository;
+  let likeRepository: LikeRepository;
+  let userRepository: UserRepository;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+  let rssAccept: RssAccept;
+  let user: User;
+  let feed: Feed;
+  let accessToken: string;
+
+  const recentKey = () => REDIS_KEYS.FEED_RECENT_ITEM_KEY(feed.id);
+
+  const seedRecentCache = async (likes = 0, comments = 0) => {
+    await redisService.executePipeline((pipeline) => {
+      pipeline.hset(recentKey(), {
+        id: feed.id,
+        title: feed.title,
+        likes,
+        comments,
+      });
+    });
+  };
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    redisService = testApp.get(RedisService);
+    commentRepository = testApp.get(CommentRepository);
+    likeRepository = testApp.get(LikeRepository);
+    userRepository = testApp.get(UserRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  beforeEach(async () => {
+    rssAccept = await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(),
+    );
+    [user, feed] = await Promise.all([
+      userRepository.save(await UserFixture.createUserCryptFixture()),
+      feedRepository.save(FeedFixture.createFeedFixture(rssAccept)),
+    ]);
+    accessToken = createAccessToken(user);
+  });
+
+  describe('좋아요', () => {
+    it('[201] 좋아요 등록 시 캐시가 존재하면 likes 필드가 1 증가한다.', async () => {
+      // given
+      await seedRecentCache(0, 0);
+
+      // Http when
+      const response = await agent
+        .post(`/api/feeds/${feed.id}/likes`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.CREATED);
+
+      // Redis then
+      const cache = await redisService.redisClient.hgetall(recentKey());
+      expect(cache.likes).toBe('1');
+    });
+
+    it('[200] 좋아요 취소 시 캐시가 존재하면 likes 필드가 1 감소한다.', async () => {
+      // given
+      await seedRecentCache(1, 0);
+      await likeRepository.save({ user, feed } as Like);
+      await feedRepository.update(feed.id, { likeCount: 1 });
+
+      // Http when
+      const response = await agent
+        .delete(`/api/feeds/${feed.id}/likes`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.OK);
+
+      // Redis then
+      const cache = await redisService.redisClient.hgetall(recentKey());
+      expect(cache.likes).toBe('0');
+    });
+
+    it('[201] 최신 피드 캐시에 없는(순위 밀려난) 게시글에 좋아요를 등록해도 phantom 캐시가 생성되지 않는다.', async () => {
+      // given - 캐시를 미리 세팅하지 않음
+
+      // Http when
+      const response = await agent
+        .post(`/api/feeds/${feed.id}/likes`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.CREATED);
+
+      // Redis then
+      const exists = await redisService.redisClient.exists(recentKey());
+      expect(exists).toBe(0);
+    });
+  });
+
+  describe('댓글', () => {
+    it('[201] 댓글 등록 시 캐시가 존재하면 comments 필드가 1 증가한다.', async () => {
+      // given
+      await seedRecentCache(0, 0);
+
+      // Http when
+      const response = await agent
+        .post(`/api/feeds/${feed.id}/comments`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ comment: '동기화 테스트' });
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.CREATED);
+
+      // Redis then
+      const cache = await redisService.redisClient.hgetall(recentKey());
+      expect(cache.comments).toBe('1');
+    });
+
+    it('[200] 답글이 있는 최상위 댓글을 soft delete해도 comments 필드는 변하지 않는다.', async () => {
+      // given
+      await seedRecentCache(0, 2);
+      const root = await commentRepository.save(
+        CommentFixture.createCommentFixture(feed, user),
+      );
+      await commentRepository.save(
+        CommentFixture.createCommentFixture(feed, user, {
+          parentId: root.id,
+        }),
+      );
+
+      // Http when
+      const response = await agent
+        .delete(`/api/feeds/${feed.id}/comments/${root.id}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.OK);
+
+      // Redis then
+      const cache = await redisService.redisClient.hgetall(recentKey());
+      expect(cache.comments).toBe('2');
+    });
+
+    it('[200] 답글이 없는 댓글을 삭제하면 comments 필드가 1 감소한다.', async () => {
+      // given
+      await seedRecentCache(0, 1);
+      const comment = await commentRepository.save(
+        CommentFixture.createCommentFixture(feed, user),
+      );
+
+      // Http when
+      const response = await agent
+        .delete(`/api/feeds/${feed.id}/comments/${comment.id}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.OK);
+
+      // Redis then
+      const cache = await redisService.redisClient.hgetall(recentKey());
+      expect(cache.comments).toBe('0');
+    });
+
+    it('[200] soft delete된 부모의 마지막 답글을 삭제하면 comments 필드가 2 감소한다.', async () => {
+      // given
+      await seedRecentCache(0, 2);
+      const root = await commentRepository.save(
+        CommentFixture.createCommentFixture(feed, user),
+      );
+      const reply = await commentRepository.save(
+        CommentFixture.createCommentFixture(feed, user, {
+          parentId: root.id,
+        }),
+      );
+      root.isDeleted = true;
+      await commentRepository.save(root);
+
+      // Http when
+      const response = await agent
+        .delete(`/api/feeds/${feed.id}/comments/${reply.id}`)
+        .set('Authorization', `Bearer ${accessToken}`);
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.OK);
+
+      // Redis then
+      const cache = await redisService.redisClient.hgetall(recentKey());
+      expect(cache.comments).toBe('0');
+    });
+
+    it('[201] 최신 피드 캐시에 없는 게시글에 댓글을 등록해도 phantom 캐시가 생성되지 않는다.', async () => {
+      // given - 캐시를 미리 세팅하지 않음
+
+      // Http when
+      const response = await agent
+        .post(`/api/feeds/${feed.id}/comments`)
+        .set('Authorization', `Bearer ${accessToken}`)
+        .send({ comment: 'phantom 방지 테스트' });
+
+      // Http then
+      expect(response.status).toBe(HttpStatus.CREATED);
+
+      // Redis then
+      const exists = await redisService.redisClient.exists(recentKey());
+      expect(exists).toBe(0);
+    });
+  });
+});

--- a/server/test/notification/unit/comment.listener.unit.spec.ts
+++ b/server/test/notification/unit/comment.listener.unit.spec.ts
@@ -223,7 +223,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when
       await commentListener.handleCommentDeleted(
-        new CommentDeletedEvent(10, null),
+        new CommentDeletedEvent(10, null, -1),
       );
 
       // then
@@ -242,7 +242,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when
       await commentListener.handleCommentDeleted(
-        new CommentDeletedEvent(10, null),
+        new CommentDeletedEvent(10, null, -1),
       );
 
       // then
@@ -259,7 +259,9 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        commentListener.handleCommentDeleted(new CommentDeletedEvent(10, null)),
+        commentListener.handleCommentDeleted(
+          new CommentDeletedEvent(10, null, -1),
+        ),
       ).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
     });
@@ -274,7 +276,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when
       await commentListener.handleCommentDeleted(
-        new CommentDeletedEvent(10, null),
+        new CommentDeletedEvent(10, null, -1),
       );
 
       // then
@@ -293,7 +295,7 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when
       await commentListener.handleCommentDeleted(
-        new CommentDeletedEvent(10, 5),
+        new CommentDeletedEvent(10, 5, -1),
       );
 
       // then
@@ -315,7 +317,9 @@ describe(`${CommentListener.name} Unit Test`, () => {
 
       // when & then
       await expect(
-        commentListener.handleCommentDeleted(new CommentDeletedEvent(10, 5)),
+        commentListener.handleCommentDeleted(
+          new CommentDeletedEvent(10, 5, -1),
+        ),
       ).resolves.toBeUndefined();
       expect(logger.error).toHaveBeenCalled();
     });


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #937

### 배경

`GET /api/feeds/recent`는 Redis hash(`feed:recent:{feedId}`)를 조회해서 응답하는데, 좋아요/댓글 등록·삭제 시 MySQL의 `feed.likeCount`/`feed.commentCount`만 갱신되고 이 캐시는 갱신되지 않아 최신 피드 목록의 좋아요/댓글 수가 실제 값과 어긋나는 문제가 있었습니다.

### 고민했던 점

- **phantom hash 방지**: `HINCRBY`는 대상 키가 없으면 필드 일부만 채워진 hash를 자동 생성합니다. `feed:recent:*`는 TTL 없이 크롤러가 주기적으로 통째로 지웠다가 다시 쓰는 구조라, recent 목록에서 밀려난 게시글에 뒤늦게 좋아요/댓글이 들어오면 title/thumbnail 등이 없는 불완전한 hash가 생겨 `readRecentFeedList` 파싱이 깨질 수 있습니다. 그래서 `EXISTS` 확인 후에만 `HINCRBY`를 실행하는 Lua 스크립트(`hincrbyIfExists`)로 원자적으로 처리했습니다.
- **댓글 삭제의 실제 증감폭**: `CommentService.delete()`는 분기에 따라 `commentCount`가 0(대댓글 있어 soft delete) / -1(단순 hard delete) / -2(soft delete된 부모가 마지막 답글 삭제로 함께 제거)로 달라집니다. 이벤트는 매번 발생하므로 델타를 직접 계산해 `CommentDeletedEvent`에 실어 보내도록 수정했습니다(신고 처리 삭제 경로인 `report.service.ts`도 동일하게 반영).
- 알림(Notification) 로직과는 관심사를 분리해 `feed/listener/feedRecent.listener.ts`를 새로 두고, 기존 `feed-viewed.listener.ts`와 동일한 이벤트 리스너 패턴을 따랐습니다.

# 📋 작업 내용

- `RedisService.hincrbyIfExists()` 추가 (EXISTS 체크 후 HINCRBY, Lua eval로 원자성 보장)
- `REDIS_KEYS.FEED_RECENT_ITEM_KEY(feedId)` 헬퍼 추가
- `FeedRecentListener` 신규: `like.created`/`like.deleted`/`comment.created`/`comment.deleted` 이벤트 구독해 `feed:recent:{feedId}` hash의 `likes`/`comments` 필드 동기화
- `CommentDeletedEvent`에 `commentCountDelta` 필드 추가, `comment.service.ts`/`report.service.ts`에서 실제 증감폭 계산해 전달
- e2e 테스트(`recentCacheSync.e2e-spec.ts`) 8케이스 추가: 좋아요/댓글 증감 동기화, soft delete 시 불변, cascade 삭제 시 -2, 캐시 없는 게시글에 phantom hash 미생성 검증