### PR TITLE
✨ feat: 구독한 RSS 새 글 알림(NEW_POST) 기능 추가

### DIFF
--- a/client/src/__tests__/components/common/NotificationBell.test.tsx
+++ b/client/src/__tests__/components/common/NotificationBell.test.tsx
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
 import { NotificationBell } from "@/components/common/NotificationBell.tsx";
 import { NotificationItem } from "@/api/services/notifications";
-
 import { fireEvent, render, screen } from "@testing-library/react";
 
 const mockNavigate = vi.fn();
@@ -242,5 +241,44 @@ describe("NotificationBell", () => {
 
     expect(markRead).toHaveBeenCalledWith(6);
     expect(mockNavigate).toHaveBeenCalledWith("/rss/7");
+  });
+
+  it("새 글 알림 메시지를 구독한 RSS 이름과 게시글 제목으로 표시한다", () => {
+    listState = {
+      data: [
+        makeItem({
+          type: "NEW_POST",
+          actor: { userName: null, profileImage: null },
+          rss: { id: 7, name: "테스트 블로그" },
+        }),
+      ],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    const item = screen.getByTestId("notification-item");
+    expect(item).toHaveTextContent("구독한 테스트 블로그에 테스트 게시글 새로운 게시글이 생겼습니다.");
+  });
+
+  it("새 글 알림을 클릭하면 해당 게시글로 이동한다", () => {
+    listState = {
+      data: [
+        makeItem({
+          id: 8,
+          type: "NEW_POST",
+          actor: { userName: null, profileImage: null },
+          rss: { id: 7, name: "테스트 블로그" },
+        }),
+      ],
+      isLoading: false,
+    };
+    render(<NotificationBell />);
+
+    fireEvent.click(screen.getByTestId("notification-item"));
+
+    expect(markRead).toHaveBeenCalledWith(8);
+    expect(mockNavigate).toHaveBeenCalledWith("/10", {
+      state: { backgroundLocation: { pathname: "/" }, highlightCommentId: null },
+    });
   });
 });

--- a/client/src/api/services/notifications.ts
+++ b/client/src/api/services/notifications.ts
@@ -3,7 +3,7 @@ import { NOTIFICATION } from "@/constants/endpoints";
 import { axiosInstance } from "@/api/instance";
 import { ApiData } from "@/types/api";
 
-export type NotificationType = "LIKE" | "COMMENT" | "REPLY" | "SUBSCRIBE";
+export type NotificationType = "LIKE" | "COMMENT" | "REPLY" | "SUBSCRIBE" | "NEW_POST";
 
 export type NotificationItem = {
   id: number;

--- a/client/src/components/common/NotificationBell.tsx
+++ b/client/src/components/common/NotificationBell.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ReactNode, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { Bell } from "lucide-react";
@@ -19,35 +19,41 @@ import { NotificationItem } from "@/api/services/notifications";
 import { cn } from "@/lib/utils";
 import { useAuthStore } from "@/store/useAuthStore";
 
-const NOTIFICATION_MESSAGE_CONFIG: Record<
-  NotificationItem["type"],
-  { target: (item: NotificationItem) => string | null | undefined; connector: string; action: [string, string] }
-> = {
-  LIKE: { target: (item) => item.feed?.title, connector: "에", action: ["좋아요", "를 표시했습니다"] },
-  COMMENT: { target: (item) => item.feed?.title, connector: "에", action: ["댓글", "을 남겼습니다"] },
-  REPLY: { target: (item) => item.feed?.title, connector: "에", action: ["답글", "을 남겼습니다"] },
-  SUBSCRIBE: { target: (item) => item.rss?.name, connector: "을(를)", action: ["구독", "했습니다"] },
-};
-
-const buildMessage = (item: NotificationItem) => {
+const actorMessage = (
+  item: NotificationItem,
+  target: string | null | undefined,
+  connector: string,
+  action: [string, string],
+): ReactNode => {
   const actorSuffix = item.otherCount > 0 ? `님 외 ${item.otherCount}명이 ` : "님이 ";
-  const {
-    target,
-    connector,
-    action: [actionBold, actionRest],
-  } = NOTIFICATION_MESSAGE_CONFIG[item.type];
+  const [actionBold, actionRest] = action;
 
   return (
     <>
       <span className="font-semibold">{item.actor.userName ?? "알 수 없는 사용자"}</span>
       {actorSuffix}
-      <span className="font-semibold">{target(item)}</span>
+      <span className="font-semibold">{target}</span>
       {connector}{" "}
       <span className="font-semibold">{actionBold}</span>
       {actionRest}.
     </>
   );
 };
+
+const NOTIFICATION_MESSAGE_CONFIG: Record<NotificationItem["type"], (item: NotificationItem) => ReactNode> = {
+  LIKE: (item) => actorMessage(item, item.feed?.title, "에", ["좋아요", "를 표시했습니다"]),
+  COMMENT: (item) => actorMessage(item, item.feed?.title, "에", ["댓글", "을 남겼습니다"]),
+  REPLY: (item) => actorMessage(item, item.feed?.title, "에", ["답글", "을 남겼습니다"]),
+  SUBSCRIBE: (item) => actorMessage(item, item.rss?.name, "을(를)", ["구독", "했습니다"]),
+  NEW_POST: (item) => (
+    <>
+      구독한 <span className="font-semibold">{item.rss?.name}</span>에{" "}
+      <span className="font-semibold">{item.feed?.title}</span> 새로운 게시글이 생겼습니다.
+    </>
+  ),
+};
+
+const buildMessage = (item: NotificationItem): ReactNode => NOTIFICATION_MESSAGE_CONFIG[item.type](item);
 
 export const NotificationBell = () => {
   const [open, setOpen] = useState(false);

--- a/docker-compose/rabbitMQ/definitions.json
+++ b/docker-compose/rabbitMQ/definitions.json
@@ -78,6 +78,15 @@
       }
     },
     {
+      "name": "crawling.newPost.queue",
+      "vhost": "/",
+      "durable": true,
+      "arguments": {
+        "x-dead-letter-exchange": "DeadLetterExchange",
+        "x-dead-letter-routing-key": "crawling.newPost.deadLetter"
+      }
+    },
+    {
       "name": "email.deadLetter.queue",
       "vhost": "/",
       "durable": true,
@@ -93,6 +102,14 @@
     },
     {
       "name": "crawling.aiRetry.deadLetter.queue",
+      "vhost": "/",
+      "durable": true,
+      "arguments": {
+        "x-message-ttl": 604800000
+      }
+    },
+    {
+      "name": "crawling.newPost.deadLetter.queue",
       "vhost": "/",
       "durable": true,
       "arguments": {
@@ -126,6 +143,14 @@
       "arguments": {}
     },
     {
+      "source": "CrawlingExchange",
+      "vhost": "/",
+      "destination": "crawling.newPost.queue",
+      "destination_type": "queue",
+      "routing_key": "crawling.newPost",
+      "arguments": {}
+    },
+    {
       "source": "DeadLetterExchange",
       "vhost": "/",
       "destination": "email.deadLetter.queue",
@@ -147,6 +172,14 @@
       "destination": "crawling.aiRetry.deadLetter.queue",
       "destination_type": "queue",
       "routing_key": "crawling.aiRetry.deadLetter",
+      "arguments": {}
+    },
+    {
+      "source": "DeadLetterExchange",
+      "vhost": "/",
+      "destination": "crawling.newPost.deadLetter.queue",
+      "destination_type": "queue",
+      "routing_key": "crawling.newPost.deadLetter",
       "arguments": {}
     }
   ]

--- a/feed-crawler/src/feed-crawler.ts
+++ b/feed-crawler/src/feed-crawler.ts
@@ -7,6 +7,9 @@ import { FeedDetail, FeedFetchResult, RssObj } from '@common/feed/feed.type';
 import logger from '@common/logger/logger';
 import { FeedParserManager } from '@common/parser/feed-parser-manager';
 
+import { RMQ_EXCHANGES, RMQ_ROUTING_KEYS } from '@rabbitmq/rabbitmq.constant';
+import { RabbitMQService } from '@rabbitmq/rabbitmq.service';
+
 import { FeedRepository } from '@repository/feed.repository';
 import { RssRepository } from '@repository/rss.repository';
 
@@ -19,7 +22,30 @@ export class FeedCrawler {
     private readonly feedRepository: FeedRepository,
     @inject(FeedParserManager)
     private readonly feedParserManager: FeedParserManager,
+    @inject(RabbitMQService)
+    private readonly rabbitMQService: RabbitMQService,
   ) {}
+
+  private async publishNewPostEvent(insertedData: FeedDetail[]): Promise<void> {
+    if (!insertedData.length) return;
+
+    const message = insertedData.map((feed) => ({
+      feedId: feed.id,
+      rssAcceptId: feed.blog.id,
+    }));
+
+    try {
+      await this.rabbitMQService.sendMessage(
+        RMQ_EXCHANGES.CRAWLING,
+        RMQ_ROUTING_KEYS.CRAWLING_NEW_POST,
+        JSON.stringify(message),
+      );
+    } catch (error) {
+      logger.error(
+        `[FeedCrawler] 새 글 알림 이벤트 발행 실패: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
 
   async start(startTime: Date) {
     logger.info('==========작업 시작==========');
@@ -45,6 +71,7 @@ export class FeedCrawler {
       await this.feedRepository.insertFeeds(newFeeds);
     await this.feedRepository.saveAiQueue(insertedData);
     await this.feedRepository.setRecentFeedList(insertedData);
+    await this.publishNewPostEvent(insertedData);
 
     const executionTime = Date.now() - startTime.getTime();
 

--- a/feed-crawler/src/rabbitmq/rabbitmq.constant.ts
+++ b/feed-crawler/src/rabbitmq/rabbitmq.constant.ts
@@ -8,6 +8,8 @@ export const RMQ_QUEUES = {
   CRAWLING_FULL_DEAD_LETTER: 'crawling.full.deadLetter.queue',
   CRAWLING_AI_RETRY: 'crawling.aiRetry.queue',
   CRAWLING_AI_RETRY_DEAD_LETTER: 'crawling.aiRetry.deadLetter.queue',
+  CRAWLING_NEW_POST: 'crawling.newPost.queue',
+  CRAWLING_NEW_POST_DEAD_LETTER: 'crawling.newPost.deadLetter.queue',
 } as const;
 
 export const RMQ_ROUTING_KEYS = {
@@ -15,4 +17,6 @@ export const RMQ_ROUTING_KEYS = {
   CRAWLING_FULL_DEAD_LETTER: 'crawling.full.deadLetter',
   CRAWLING_AI_RETRY: 'crawling.aiRetry',
   CRAWLING_AI_RETRY_DEAD_LETTER: 'crawling.aiRetry.deadLetter',
+  CRAWLING_NEW_POST: 'crawling.newPost',
+  CRAWLING_NEW_POST_DEAD_LETTER: 'crawling.newPost.deadLetter',
 } as const;

--- a/feed-crawler/test/e2e/feed-crawling.e2e-spec.ts
+++ b/feed-crawler/test/e2e/feed-crawling.e2e-spec.ts
@@ -13,6 +13,7 @@ describe('feed crawling e2e-test', () => {
       testContext.rssRepository,
       testContext.feedRepository,
       testContext.feedParserManager,
+      { sendMessage: jest.fn() } as any,
     );
   });
 

--- a/feed-crawler/test/unit/feed-crawler.spec.ts
+++ b/feed-crawler/test/unit/feed-crawler.spec.ts
@@ -6,6 +6,9 @@ import { PermanentError, RetryableError } from '@common/errors';
 import { FeedDetail, RssObj } from '@common/feed/feed.type';
 import { FeedParserManager } from '@common/parser/feed-parser-manager';
 
+import { RMQ_EXCHANGES, RMQ_ROUTING_KEYS } from '@rabbitmq/rabbitmq.constant';
+import { RabbitMQService } from '@rabbitmq/rabbitmq.service';
+
 import { FeedRepository } from '@repository/feed.repository';
 import { RssRepository } from '@repository/rss.repository';
 
@@ -16,6 +19,7 @@ describe('FeedCrawler', () => {
   let mockFeedRepository: jest.Mocked<FeedRepository>;
   let mockRssRepository: jest.Mocked<RssRepository>;
   let mockFeedParserManager: jest.Mocked<FeedParserManager>;
+  let mockRabbitMQService: jest.Mocked<RabbitMQService>;
   let deleteRecentFeedMock: jest.Mock;
   let insertFeedsMock: jest.Mock;
   let saveAiQueueMock: jest.Mock;
@@ -26,6 +30,7 @@ describe('FeedCrawler', () => {
   let updateImageMock: jest.Mock;
   let fetchAndParseMock: jest.Mock;
   let fetchAndParseAllMock: jest.Mock;
+  let sendMessageMock: jest.Mock;
 
   const mockRssObjects: RssObj[] = [
     {
@@ -92,6 +97,7 @@ describe('FeedCrawler', () => {
     updateImageMock = jest.fn();
     fetchAndParseMock = jest.fn();
     fetchAndParseAllMock = jest.fn();
+    sendMessageMock = jest.fn();
 
     mockFeedRepository = {
       deleteRecentFeed: deleteRecentFeedMock,
@@ -114,10 +120,15 @@ describe('FeedCrawler', () => {
       fetchAndParseAll: fetchAndParseAllMock,
     } as any;
 
+    mockRabbitMQService = {
+      sendMessage: sendMessageMock,
+    } as any;
+
     feedCrawler = new FeedCrawler(
       mockRssRepository,
       mockFeedRepository,
       mockFeedParserManager,
+      mockRabbitMQService,
     );
   });
 
@@ -127,8 +138,14 @@ describe('FeedCrawler', () => {
       const startTime = new Date('2024-01-01T12:00:00Z');
       selectAllRssMock.mockResolvedValue(mockRssObjects);
       fetchAndParseMock
-        .mockResolvedValueOnce({ feeds: [mockFeedDetails[0]], channelImage: undefined })
-        .mockResolvedValueOnce({ feeds: [mockFeedDetails[1]], channelImage: undefined });
+        .mockResolvedValueOnce({
+          feeds: [mockFeedDetails[0]],
+          channelImage: undefined,
+        })
+        .mockResolvedValueOnce({
+          feeds: [mockFeedDetails[1]],
+          channelImage: undefined,
+        });
       insertFeedsMock.mockResolvedValue(mockFeedDetails);
 
       // When
@@ -151,6 +168,16 @@ describe('FeedCrawler', () => {
       expect(insertFeedsMock).toHaveBeenCalledWith(mockFeedDetails);
       expect(saveAiQueueMock).toHaveBeenCalledWith(mockFeedDetails);
       expect(setRecentFeedListMock).toHaveBeenCalledWith(mockFeedDetails);
+      expect(sendMessageMock).toHaveBeenCalledWith(
+        RMQ_EXCHANGES.CRAWLING,
+        RMQ_ROUTING_KEYS.CRAWLING_NEW_POST,
+        JSON.stringify(
+          mockFeedDetails.map((feed) => ({
+            feedId: feed.id,
+            rssAcceptId: feed.blog.id,
+          })),
+        ),
+      );
     });
 
     it('등록된 RSS가 없을 때 조기 종료해야 한다', async () => {
@@ -172,7 +199,10 @@ describe('FeedCrawler', () => {
       // Given
       const startTime = new Date('2024-01-01T12:00:00Z');
       selectAllRssMock.mockResolvedValue(mockRssObjects);
-      fetchAndParseMock.mockResolvedValue({ feeds: [], channelImage: undefined });
+      fetchAndParseMock.mockResolvedValue({
+        feeds: [],
+        channelImage: undefined,
+      });
 
       // When
       await feedCrawler.start(startTime);
@@ -219,13 +249,18 @@ describe('FeedCrawler', () => {
       expect(insertFeedsMock).toHaveBeenCalledWith(expectedFeeds);
       expect(saveAiQueueMock).toHaveBeenCalledWith(expectedFeeds);
       expect(result).toEqual(expectedFeeds);
+      // 전체 크롤링(관리자 승인 시 백카탈로그)은 신규 글 알림을 발행하지 않아야 한다.
+      expect(sendMessageMock).not.toHaveBeenCalled();
     });
 
     it('가져올 피드가 없을 때 빈 배열을 반환해야 한다', async () => {
       // Given
       const rssObj = mockRssObjects[0];
       selectRssByIdMock.mockResolvedValue(rssObj);
-      fetchAndParseAllMock.mockResolvedValue({ feeds: [], channelImage: undefined });
+      fetchAndParseAllMock.mockResolvedValue({
+        feeds: [],
+        channelImage: undefined,
+      });
 
       // When
       const result = await feedCrawler.startFullCrawl(rssObj.id);
@@ -357,7 +392,9 @@ describe('FeedCrawler', () => {
         selectRssByIdMock.mockResolvedValue(mockRssObjects[0]);
         // 다른 link만 반환하여 매칭 실패 유도
         fetchAndParseAllMock.mockResolvedValue({
-          feeds: [{ ...mockFeedDetails[0], link: 'https://other.com/different' }],
+          feeds: [
+            { ...mockFeedDetails[0], link: 'https://other.com/different' },
+          ],
           channelImage: undefined,
         });
       });

--- a/server/src/common/rabbitmq/rabbitmq.constant.ts
+++ b/server/src/common/rabbitmq/rabbitmq.constant.ts
@@ -11,6 +11,8 @@ export const RMQ_QUEUES = {
   EMAIL_DEAD_LETTER: 'email.deadLetter.queue',
   CRAWLING_FULL_DEAD_LETTER: 'crawling.full.deadLetter.queue',
   CRAWLING_AI_RETRY_DEAD_LETTER: 'crawling.aiRetry.deadLetter.queue',
+  CRAWLING_NEW_POST: 'crawling.newPost.queue',
+  CRAWLING_NEW_POST_DEAD_LETTER: 'crawling.newPost.deadLetter.queue',
 };
 
 export const RMQ_ROUTING_KEYS = {
@@ -20,6 +22,8 @@ export const RMQ_ROUTING_KEYS = {
   EMAIL_DEAD_LETTER: 'email.deadLetter',
   CRAWLING_FULL_DEAD_LETTER: 'crawling.full.deadLetter',
   CRAWLING_AI_RETRY_DEAD_LETTER: 'crawling.aiRetry.deadLetter',
+  CRAWLING_NEW_POST: 'crawling.newPost',
+  CRAWLING_NEW_POST_DEAD_LETTER: 'crawling.newPost.deadLetter',
 };
 
 export const RMQ_EXCHANGE_TYPE = {

--- a/server/src/notification/consumer/newPost.consumer.ts
+++ b/server/src/notification/consumer/newPost.consumer.ts
@@ -1,0 +1,33 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+
+import { WinstonLoggerService } from '@common/logger/logger.service';
+import { RMQ_QUEUES } from '@common/rabbitmq/rabbitmq.constant';
+import { RabbitMQService } from '@common/rabbitmq/rabbitmq.service';
+
+import { NotificationService } from '@notification/service/notification.service';
+
+type NewPostMessage = { feedId: number; rssAcceptId: number }[];
+
+@Injectable()
+export class NewPostConsumer implements OnModuleInit {
+  constructor(
+    private readonly rabbitMQService: RabbitMQService,
+    private readonly notificationService: NotificationService,
+    private readonly logger: WinstonLoggerService,
+  ) {}
+
+  async onModuleInit() {
+    await this.rabbitMQService.consumeMessage<NewPostMessage>(
+      RMQ_QUEUES.CRAWLING_NEW_POST,
+      async (items) => {
+        for (const { feedId, rssAcceptId } of items) {
+          await this.notificationService.upsertNewPostNotifications(
+            rssAcceptId,
+            feedId,
+          );
+        }
+      },
+    );
+    this.logger.log('[NewPostConsumer]: crawling.newPost.queue 리스닝 시작');
+  }
+}

--- a/server/src/notification/dto/response/getNotifications.dto.ts
+++ b/server/src/notification/dto/response/getNotifications.dto.ts
@@ -57,7 +57,7 @@ export class NotificationItemResult {
 
   @ApiProperty({
     example: { id: 1, name: 'seok3765.log' },
-    description: '알림 대상 RSS 정보(SUBSCRIBE 알림에만 존재)',
+    description: '알림 대상 RSS 정보(SUBSCRIBE/NEW_POST 알림에만 존재)',
     nullable: true,
   })
   rss: {

--- a/server/src/notification/entity/notification.entity.ts
+++ b/server/src/notification/entity/notification.entity.ts
@@ -22,6 +22,7 @@ export enum NotificationType {
   COMMENT = 'COMMENT',
   REPLY = 'REPLY',
   SUBSCRIBE = 'SUBSCRIBE',
+  NEW_POST = 'NEW_POST',
 }
 
 @Entity({ name: 'notification' })

--- a/server/src/notification/module/notification.module.ts
+++ b/server/src/notification/module/notification.module.ts
@@ -4,6 +4,7 @@ import { JwtAuthModule } from '@common/auth/jwt.module';
 
 import { FeedModule } from '@feed/module/feed.module';
 
+import { NewPostConsumer } from '@notification/consumer/newPost.consumer';
 import { NotificationController } from '@notification/controller/notification.controller';
 import { CommentListener } from '@notification/listener/comment.listener';
 import { LikeListener } from '@notification/listener/like.listener';
@@ -25,6 +26,7 @@ import { SubscriptionRepository } from '@subscribe/repository/subscription.repos
     SubscriptionListener,
     SubscriptionRepository,
     NotificationScheduler,
+    NewPostConsumer,
   ],
   exports: [],
 })

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -1,15 +1,17 @@
 import { Injectable } from '@nestjs/common';
 
+import { activeSuspensionExclusion } from '@suspension/constant/activeSuspension.constant';
 import { DataSource, LessThan, MoreThanOrEqual, Repository } from 'typeorm';
 
 import { Feed } from '@feed/entity/feed.entity';
 
-import { Notification, NotificationType } from '@notification/entity/notification.entity';
 import { getNotificationCutoffDate } from '@notification/constant/notification.constant';
+import {
+  Notification,
+  NotificationType,
+} from '@notification/entity/notification.entity';
 
 import { RssAccept } from '@rss/entity/rss.entity';
-
-import { activeSuspensionExclusion } from '@suspension/constant/activeSuspension.constant';
 
 import { User } from '@user/entity/user.entity';
 
@@ -29,7 +31,10 @@ export class NotificationRepository extends Repository<Notification> {
         feed: { id: feedId } as Feed,
         isRead: false,
       })
-      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'feed_id'])
+      .orUpdate(
+        ['is_read', 'updated_at'],
+        ['recipient_user_id', 'type', 'feed_id'],
+      )
       .execute();
   }
 
@@ -47,7 +52,10 @@ export class NotificationRepository extends Repository<Notification> {
         feed: { id: feedId } as Feed,
         isRead: false,
       })
-      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'feed_id'])
+      .orUpdate(
+        ['is_read', 'updated_at'],
+        ['recipient_user_id', 'type', 'feed_id'],
+      )
       .execute();
   }
 
@@ -78,7 +86,10 @@ export class NotificationRepository extends Repository<Notification> {
         feed: { id: feedId } as Feed,
         isRead: false,
       })
-      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'feed_id'])
+      .orUpdate(
+        ['is_read', 'updated_at'],
+        ['recipient_user_id', 'type', 'feed_id'],
+      )
       .execute();
   }
 
@@ -115,12 +126,30 @@ export class NotificationRepository extends Repository<Notification> {
         rssAccept: { id: rssAcceptId } as RssAccept,
         isRead: false,
       })
-      .orUpdate(['is_read', 'updated_at'], ['recipient_user_id', 'type', 'rss_accept_id'])
+      .orUpdate(
+        ['is_read', 'updated_at'],
+        ['recipient_user_id', 'type', 'rss_accept_id'],
+      )
       .execute();
   }
 
   async deleteSubscribeNotification(rssAcceptId: number) {
-    await this.delete({ type: NotificationType.SUBSCRIBE, rssAccept: { id: rssAcceptId } });
+    await this.delete({
+      type: NotificationType.SUBSCRIBE,
+      rssAccept: { id: rssAcceptId },
+    });
+  }
+
+  async upsertNewPost(feedId: number, subscriberIds: number[]) {
+    await this.upsert(
+      subscriberIds.map((userId) => ({
+        recipient: { id: userId } as User,
+        type: NotificationType.NEW_POST,
+        feed: { id: feedId } as Feed,
+        updatedAt: new Date(),
+      })),
+      ['recipient', 'type', 'feed'],
+    );
   }
 
   async findByRecipient(recipientId: number, limit: number) {
@@ -129,6 +158,7 @@ export class NotificationRepository extends Repository<Notification> {
     return this.createQueryBuilder('n')
       .leftJoin('n.feed', 'feed')
       .leftJoin('n.rssAccept', 'rss')
+      .leftJoin('feed.blog', 'feedBlog')
       .leftJoin(
         'likes',
         'latest_like',
@@ -150,9 +180,17 @@ export class NotificationRepository extends Repository<Notification> {
         `latest_subscription.id = (SELECT s2.id FROM subscription s2 WHERE s2.rss_accept_id = n.rss_accept_id AND ${notSuspended('s2.user_id')} ORDER BY s2.id DESC LIMIT 1)`,
       )
       .leftJoin('user', 'like_actor', 'like_actor.id = latest_like.user_id')
-      .leftJoin('user', 'comment_actor', 'comment_actor.id = latest_comment.user_id')
+      .leftJoin(
+        'user',
+        'comment_actor',
+        'comment_actor.id = latest_comment.user_id',
+      )
       .leftJoin('user', 'reply_actor', 'reply_actor.id = latest_reply.user_id')
-      .leftJoin('user', 'subscribe_actor', 'subscribe_actor.id = latest_subscription.user_id')
+      .leftJoin(
+        'user',
+        'subscribe_actor',
+        'subscribe_actor.id = latest_subscription.user_id',
+      )
       .select('n.id', 'id')
       .addSelect('n.type', 'type')
       .addSelect('n.is_read', 'isRead')
@@ -160,8 +198,14 @@ export class NotificationRepository extends Repository<Notification> {
       .addSelect('feed.id', 'feedId')
       .addSelect('feed.title', 'feedTitle')
       .addSelect('feed.path', 'feedPath')
-      .addSelect('rss.id', 'rssId')
-      .addSelect('rss.name', 'rssName')
+      .addSelect(
+        "CASE WHEN n.type = 'NEW_POST' THEN feedBlog.id ELSE rss.id END",
+        'rssId',
+      )
+      .addSelect(
+        "CASE WHEN n.type = 'NEW_POST' THEN feedBlog.name ELSE rss.name END",
+        'rssName',
+      )
       .addSelect(
         'COALESCE(like_actor.user_name, comment_actor.user_name, reply_actor.user_name, subscribe_actor.user_name)',
         'actorUserName',
@@ -170,7 +214,10 @@ export class NotificationRepository extends Repository<Notification> {
         'COALESCE(like_actor.profile_image, comment_actor.profile_image, reply_actor.profile_image, subscribe_actor.profile_image)',
         'actorProfileImage',
       )
-      .addSelect('COALESCE(latest_comment.comment, latest_reply.comment)', 'commentContent')
+      .addSelect(
+        'COALESCE(latest_comment.comment, latest_reply.comment)',
+        'commentContent',
+      )
       .addSelect('COALESCE(latest_comment.id, latest_reply.id)', 'commentId')
       .addSelect(
         `CASE n.type
@@ -183,7 +230,9 @@ export class NotificationRepository extends Repository<Notification> {
         'otherActorsCount',
       )
       .where('n.recipient_user_id = :recipientId', { recipientId })
-      .andWhere('n.updated_at >= :cutoff', { cutoff: getNotificationCutoffDate() })
+      .andWhere('n.updated_at >= :cutoff', {
+        cutoff: getNotificationCutoffDate(),
+      })
       .having('actorUserName IS NOT NULL')
       .setParameter('now', new Date())
       .orderBy('n.updated_at', 'DESC')
@@ -230,6 +279,11 @@ export class NotificationRepository extends Repository<Notification> {
       .groupBy('u.id')
       .addGroupBy('u.email')
       .addGroupBy('u.user_name')
-      .getRawMany<{ userId: number; email: string; userName: string; unreadCount: string }>();
+      .getRawMany<{
+        userId: number;
+        email: string;
+        userName: string;
+        unreadCount: string;
+      }>();
   }
 }

--- a/server/src/notification/repository/notification.repository.ts
+++ b/server/src/notification/repository/notification.repository.ts
@@ -233,7 +233,7 @@ export class NotificationRepository extends Repository<Notification> {
       .andWhere('n.updated_at >= :cutoff', {
         cutoff: getNotificationCutoffDate(),
       })
-      .having('actorUserName IS NOT NULL')
+      .having("n.type = 'NEW_POST' OR actorUserName IS NOT NULL")
       .setParameter('now', new Date())
       .orderBy('n.updated_at', 'DESC')
       .limit(limit)

--- a/server/src/notification/service/notification.service.ts
+++ b/server/src/notification/service/notification.service.ts
@@ -8,10 +8,13 @@ import { GetNotificationsResponseDto } from '@notification/dto/response/getNotif
 import { GetUnreadCountResponseDto } from '@notification/dto/response/getUnreadCount.dto';
 import { NotificationRepository } from '@notification/repository/notification.repository';
 
+import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
+
 @Injectable()
 export class NotificationService {
   constructor(
     private readonly notificationRepository: NotificationRepository,
+    private readonly subscriptionRepository: SubscriptionRepository,
   ) {}
 
   async upsertLikeNotification(recipientId: number, feedId: number) {
@@ -55,6 +58,14 @@ export class NotificationService {
 
   async upsertSubscribeNotification(recipientId: number, rssAcceptId: number) {
     await this.notificationRepository.upsertSubscribe(recipientId, rssAcceptId);
+  }
+
+  async upsertNewPostNotifications(rssAcceptId: number, feedId: number) {
+    const subscriberIds =
+      await this.subscriptionRepository.getSubscriberIdsByBlog(rssAcceptId);
+    if (!subscriberIds.length) return;
+
+    await this.notificationRepository.upsertNewPost(feedId, subscriberIds);
   }
 
   async removeSubscribeNotificationIfEmpty(

--- a/server/src/subscribe/repository/subscription.repository.ts
+++ b/server/src/subscribe/repository/subscription.repository.ts
@@ -24,6 +24,16 @@ export class SubscriptionRepository extends Repository<Subscription> {
     return this.countBy({ rssAccept: { id: blogId } });
   }
 
+  async getSubscriberIdsByBlog(blogId: number): Promise<number[]> {
+    const rows = await this.find({
+      where: { rssAccept: { id: blogId } },
+      relations: { user: true },
+      select: { id: true, user: { id: true } },
+    });
+
+    return rows.map((row) => row.user.id);
+  }
+
   async countByBlogIds(blogIds: number[]): Promise<Map<number, number>> {
     if (!blogIds.length) return new Map();
 
@@ -49,7 +59,10 @@ export class SubscriptionRepository extends Repository<Subscription> {
         ...(lastId && { id: LessThan(lastId) }),
       },
       relations: { user: true },
-      select: { id: true, user: { id: true, userName: true, profileImage: true } },
+      select: {
+        id: true,
+        user: { id: true, userName: true, profileImage: true },
+      },
       order: { id: 'DESC' },
       take: limit + 1,
     });

--- a/server/test/config/e2e/global/rabbitMQ-definitions.json
+++ b/server/test/config/e2e/global/rabbitMQ-definitions.json
@@ -92,6 +92,15 @@
       }
     },
     {
+      "name": "crawling.newPost.queue",
+      "vhost": "/",
+      "durable": true,
+      "arguments": {
+        "x-dead-letter-exchange": "DeadLetterExchange",
+        "x-dead-letter-routing-key": "crawling.newPost.deadLetter"
+      }
+    },
+    {
       "name": "email.deadLetter.queue",
       "vhost": "/",
       "durable": true,
@@ -107,6 +116,14 @@
     },
     {
       "name": "crawling.aiRetry.deadLetter.queue",
+      "vhost": "/",
+      "durable": true,
+      "arguments": {
+        "x-message-ttl": 604800000
+      }
+    },
+    {
+      "name": "crawling.newPost.deadLetter.queue",
       "vhost": "/",
       "durable": true,
       "arguments": {
@@ -140,6 +157,14 @@
       "arguments": {}
     },
     {
+      "source": "CrawlingExchange",
+      "vhost": "/",
+      "destination": "crawling.newPost.queue",
+      "destination_type": "queue",
+      "routing_key": "crawling.newPost",
+      "arguments": {}
+    },
+    {
       "source": "DeadLetterExchange",
       "vhost": "/",
       "destination": "email.deadLetter.queue",
@@ -161,6 +186,14 @@
       "destination": "crawling.aiRetry.deadLetter.queue",
       "destination_type": "queue",
       "routing_key": "crawling.aiRetry.deadLetter",
+      "arguments": {}
+    },
+    {
+      "source": "DeadLetterExchange",
+      "vhost": "/",
+      "destination": "crawling.newPost.deadLetter.queue",
+      "destination_type": "queue",
+      "routing_key": "crawling.newPost.deadLetter",
       "arguments": {}
     }
   ]

--- a/server/test/notification/e2e/notification.e2e-spec.ts
+++ b/server/test/notification/e2e/notification.e2e-spec.ts
@@ -1,7 +1,14 @@
 import { HttpStatus } from '@nestjs/common';
 
+import { UserSuspensionRepository } from '@suspension/repository/userSuspension.repository';
 import supertest from 'supertest';
 import TestAgent from 'supertest/lib/agent';
+
+import {
+  RMQ_EXCHANGES,
+  RMQ_ROUTING_KEYS,
+} from '@common/rabbitmq/rabbitmq.constant';
+import { RabbitMQService } from '@common/rabbitmq/rabbitmq.service';
 
 import { Feed } from '@feed/entity/feed.entity';
 import { FeedRepository } from '@feed/repository/feed.repository';
@@ -13,7 +20,8 @@ import { NotificationRepository } from '@notification/repository/notification.re
 import { RssAccept } from '@rss/entity/rss.entity';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
-import { UserSuspensionRepository } from '@suspension/repository/userSuspension.repository';
+import { Subscription } from '@subscribe/entity/subscription.entity';
+import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
 
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
@@ -48,6 +56,8 @@ describe(`${NOTIFICATION_URL} E2E Test`, () => {
   let feedRepository: FeedRepository;
   let notificationRepository: NotificationRepository;
   let userSuspensionRepository: UserSuspensionRepository;
+  let subscriptionRepository: SubscriptionRepository;
+  let rabbitMQService: RabbitMQService;
   let owner: User;
   let liker: User;
   let rssAccept: RssAccept;
@@ -62,11 +72,17 @@ describe(`${NOTIFICATION_URL} E2E Test`, () => {
     feedRepository = testApp.get(FeedRepository);
     notificationRepository = testApp.get(NotificationRepository);
     userSuspensionRepository = testApp.get(UserSuspensionRepository);
+    subscriptionRepository = testApp.get(SubscriptionRepository);
+    rabbitMQService = testApp.get(RabbitMQService);
   });
 
   beforeEach(async () => {
-    owner = await userRepository.save(await UserFixture.createUserCryptFixture());
-    liker = await userRepository.save(await UserFixture.createUserCryptFixture());
+    owner = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    liker = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
     rssAccept = await rssAcceptRepository.save(
       RssAcceptFixture.createRssAcceptFixture({ user: owner }),
     );
@@ -76,10 +92,14 @@ describe(`${NOTIFICATION_URL} E2E Test`, () => {
   });
 
   const likeFeed = (token: string) =>
-    agent.post(`/api/feeds/${feed.id}/likes`).set('Authorization', `Bearer ${token}`);
+    agent
+      .post(`/api/feeds/${feed.id}/likes`)
+      .set('Authorization', `Bearer ${token}`);
 
   const unlikeFeed = (token: string) =>
-    agent.delete(`/api/feeds/${feed.id}/likes`).set('Authorization', `Bearer ${token}`);
+    agent
+      .delete(`/api/feeds/${feed.id}/likes`)
+      .set('Authorization', `Bearer ${token}`);
 
   const getUnreadCount = async (token: string) => {
     const response = await agent
@@ -131,14 +151,20 @@ describe(`${NOTIFICATION_URL} E2E Test`, () => {
     const item = notifications.result[0];
     expect(item.type).toBe('LIKE');
     expect(item.isRead).toBe(false);
-    expect(item.feed).toStrictEqual({ id: feed.id, title: feed.title, path: feed.path });
+    expect(item.feed).toStrictEqual({
+      id: feed.id,
+      title: feed.title,
+      path: feed.path,
+    });
     expect(item.actor.userName).toBe(liker.userName);
     expect(item.otherCount).toBe(0);
   });
 
   it('[200] 여러 명이 좋아요를 누르면 최신 좋아요 사용자 외 나머지 인원 수가 otherCount로 표시된다.', async () => {
     // given
-    const secondLiker = await userRepository.save(await UserFixture.createUserCryptFixture());
+    const secondLiker = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
     const secondLikerToken = createAccessToken({ id: secondLiker.id });
 
     // Http when
@@ -181,7 +207,9 @@ describe(`${NOTIFICATION_URL} E2E Test`, () => {
 
   it('[200] 최신 좋아요 작성자가 정지 중이면 정지되지 않은 다음 작성자를 대신 노출한다.', async () => {
     // given
-    const secondLiker = await userRepository.save(await UserFixture.createUserCryptFixture());
+    const secondLiker = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
     const secondLikerToken = createAccessToken({ id: secondLiker.id });
 
     await likeFeed(likerToken).expect(HttpStatus.CREATED);
@@ -281,5 +309,98 @@ describe(`${NOTIFICATION_URL} E2E Test`, () => {
       (result) => result === null,
     );
     expect(remaining).toBeNull();
+  });
+
+  describe('crawling.newPost.queue 메시지 처리', () => {
+    let subscriber: User;
+    let subscriberToken: string;
+
+    beforeEach(async () => {
+      subscriber = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+      subscriberToken = createAccessToken({ id: subscriber.id });
+      await subscriptionRepository.save({
+        rssAccept,
+        user: subscriber,
+      } as Subscription);
+    });
+
+    const publishNewPost = (items: { feedId: number; rssAcceptId: number }[]) =>
+      rabbitMQService.sendMessage(
+        RMQ_EXCHANGES.CRAWLING,
+        RMQ_ROUTING_KEYS.CRAWLING_NEW_POST,
+        JSON.stringify(items),
+      );
+
+    it('[200] 구독한 블로그에 새 글이 올라오면 구독자에게 NEW_POST 알림이 생성된다.', async () => {
+      // when
+      await publishNewPost([{ feedId: feed.id, rssAcceptId: rssAccept.id }]);
+
+      // then
+      const count = await waitFor(
+        () => getUnreadCount(subscriberToken),
+        (result) => result.count > 0,
+      );
+      expect(count.count).toBe(1);
+
+      const notifications = await getNotifications(subscriberToken);
+      expect(notifications.result).toHaveLength(1);
+      const item = notifications.result[0];
+      expect(item.type).toBe('NEW_POST');
+      expect(item.isRead).toBe(false);
+      expect(item.feed).toStrictEqual({
+        id: feed.id,
+        title: feed.title,
+        path: feed.path,
+      });
+      expect(item.rss).toStrictEqual({
+        id: rssAccept.id,
+        name: rssAccept.name,
+      });
+    });
+
+    it('[200] 구독하지 않은 사용자에게는 알림이 생성되지 않는다.', async () => {
+      // given
+      const nonSubscriber = await userRepository.save(
+        await UserFixture.createUserCryptFixture(),
+      );
+      const nonSubscriberToken = createAccessToken({ id: nonSubscriber.id });
+
+      // when
+      await publishNewPost([{ feedId: feed.id, rssAcceptId: rssAccept.id }]);
+      await waitFor(
+        () => getUnreadCount(subscriberToken),
+        (result) => result.count > 0,
+      );
+
+      // then
+      const count = await getUnreadCount(nonSubscriberToken);
+      expect(count.count).toBe(0);
+    });
+
+    it('[200] 같은 블로그의 서로 다른 새 글은 각각 별도의 알림으로 생성된다.', async () => {
+      // given - rss_accept_id를 공유하는 두 번째 새 글
+      const secondFeed = await feedRepository.save(
+        FeedFixture.createFeedFixture(rssAccept, { title: 'second post' }),
+      );
+
+      // when
+      await publishNewPost([
+        { feedId: feed.id, rssAcceptId: rssAccept.id },
+        { feedId: secondFeed.id, rssAcceptId: rssAccept.id },
+      ]);
+
+      // then - 같은 (recipient, type, rss_accept_id)로 충돌해 하나로 뭉개지지 않고 글 단위로 각각 생성돼야 한다
+      const count = await waitFor(
+        () => getUnreadCount(subscriberToken),
+        (result) => result.count >= 2,
+      );
+      expect(count.count).toBe(2);
+
+      const notifications = await getNotifications(subscriberToken);
+      const feedIds = notifications.result.map((item) => item.feed?.id).sort();
+      expect(feedIds).toStrictEqual([feed.id, secondFeed.id].sort());
+    });
   });
 });

--- a/server/test/notification/unit/notification.service.unit.spec.ts
+++ b/server/test/notification/unit/notification.service.unit.spec.ts
@@ -3,6 +3,8 @@ import { NotFoundException } from '@nestjs/common';
 import { NotificationRepository } from '@notification/repository/notification.repository';
 import { NotificationService } from '@notification/service/notification.service';
 
+import { SubscriptionRepository } from '@subscribe/repository/subscription.repository';
+
 describe(`${NotificationService.name} Unit Test`, () => {
   let notificationService: NotificationService;
   let notificationRepository: jest.Mocked<
@@ -18,12 +20,16 @@ describe(`${NotificationService.name} Unit Test`, () => {
       | 'hasActiveOtherReply'
       | 'upsertSubscribe'
       | 'deleteSubscribeNotification'
+      | 'upsertNewPost'
       | 'countUnread'
       | 'findByRecipient'
       | 'markRead'
       | 'deleteExpired'
       | 'findStaleUnreadDigestTargets'
     >
+  >;
+  let subscriptionRepository: jest.Mocked<
+    Pick<SubscriptionRepository, 'getSubscriberIdsByBlog'>
   >;
 
   beforeEach(() => {
@@ -38,6 +44,7 @@ describe(`${NotificationService.name} Unit Test`, () => {
       hasActiveOtherReply: jest.fn(),
       upsertSubscribe: jest.fn(),
       deleteSubscribeNotification: jest.fn(),
+      upsertNewPost: jest.fn(),
       countUnread: jest.fn(),
       findByRecipient: jest.fn(),
       markRead: jest.fn(),
@@ -45,8 +52,13 @@ describe(`${NotificationService.name} Unit Test`, () => {
       findStaleUnreadDigestTargets: jest.fn(),
     };
 
+    subscriptionRepository = {
+      getSubscriberIdsByBlog: jest.fn(),
+    };
+
     notificationService = new NotificationService(
       notificationRepository as unknown as NotificationRepository,
+      subscriptionRepository as unknown as SubscriptionRepository,
     );
   });
 
@@ -172,7 +184,10 @@ describe(`${NotificationService.name} Unit Test`, () => {
       await notificationService.upsertSubscribeNotification(1, 10);
 
       // then
-      expect(notificationRepository.upsertSubscribe).toHaveBeenCalledWith(1, 10);
+      expect(notificationRepository.upsertSubscribe).toHaveBeenCalledWith(
+        1,
+        10,
+      );
     });
   });
 
@@ -182,7 +197,9 @@ describe(`${NotificationService.name} Unit Test`, () => {
       await notificationService.removeSubscribeNotificationIfEmpty(10, 1);
 
       // then
-      expect(notificationRepository.deleteSubscribeNotification).not.toHaveBeenCalled();
+      expect(
+        notificationRepository.deleteSubscribeNotification,
+      ).not.toHaveBeenCalled();
     });
 
     it('구독자가 0명이면 해당 RSS의 알림을 삭제한다.', async () => {
@@ -190,7 +207,39 @@ describe(`${NotificationService.name} Unit Test`, () => {
       await notificationService.removeSubscribeNotificationIfEmpty(10, 0);
 
       // then
-      expect(notificationRepository.deleteSubscribeNotification).toHaveBeenCalledWith(10);
+      expect(
+        notificationRepository.deleteSubscribeNotification,
+      ).toHaveBeenCalledWith(10);
+    });
+  });
+
+  describe('upsertNewPostNotifications', () => {
+    it('구독자가 있으면 feedId와 구독자 ID 목록으로 upsertNewPost를 호출한다.', async () => {
+      // given
+      subscriptionRepository.getSubscriberIdsByBlog.mockResolvedValue([2, 3]);
+
+      // when
+      await notificationService.upsertNewPostNotifications(1, 10);
+
+      // then
+      expect(
+        subscriptionRepository.getSubscriberIdsByBlog,
+      ).toHaveBeenCalledWith(1);
+      expect(notificationRepository.upsertNewPost).toHaveBeenCalledWith(
+        10,
+        [2, 3],
+      );
+    });
+
+    it('구독자가 없으면 upsertNewPost를 호출하지 않는다.', async () => {
+      // given
+      subscriptionRepository.getSubscriberIdsByBlog.mockResolvedValue([]);
+
+      // when
+      await notificationService.upsertNewPostNotifications(1, 10);
+
+      // then
+      expect(notificationRepository.upsertNewPost).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- close #781 

### RabbitMQ 이벤트 브릿지 설계

- feed-crawler는 크롤링한 새 글을 별도 프로세스에서 MySQL에 직접 INSERT하기 때문에, 서버가 LIKE/COMMENT/SUBSCRIBE 알림에 쓰던 로컬 EventEmitter 패턴이 걸리지 않는다. 프로세스 간 이벤트 브릿지가 필요해 이미 있는 `CrawlingExchange`(RabbitMQ)를 재사용해 `crawling.newPost` 큐를 추가했다.
- 발행 지점은 30분 주기 증분 크롤링(`FeedCrawler.start()`)에서만 두고, 관리자 승인 시 전체 크롤링(`startFullCrawl`)에는 붙이지 않았다. 승인 시점에 붙이면 신규 승인 블로그의 과거 게시글 전체가 한 번에 알림으로 나가버리기 때문이다.

### NEW_POST 알림 중복 방지 설계

- `Notification`에는 이미 `UQ(recipient, type, feed)`와 `UQ(recipient, type, rssAccept)` 두 개의 유니크 제약이 있다. `NEW_POST` 알림에 `rssAccept`를 채우면, 같은 블로그의 두 번째 새 글이 첫 번째 알림 행을 덮어써 오래된 글을 가리키게 되는 문제가 있어 `rssAccept`는 의도적으로 NULL로 둔다. 이 설계가 실제 제약조건 앞에서 맞게 동작하는지는 e2e 테스트로 검증했다.
- 알림 생성 로직은 TypeORM `Repository.upsert()`를 사용해 재전달(at-least-once)에도 멱등하게 처리되며, 구독자 조회(`SubscriptionRepository`)와 알림 upsert(`NotificationRepository`)의 책임을 분리했다.
- rebase 과정에서 develop에 먼저 머지된 정지(suspension) 기능과 충돌이 발견됐다. `findByRecipient`의 `HAVING actorUserName IS NOT NULL` 필터가 행위자가 없는 `NEW_POST` 알림까지 걸러내고 있어, `NEW_POST` 타입은 이 필터에서 제외하도록 수정했다.

# 📋 작업 내용

- feed-crawler: 증분 크롤링 완료 시 `{feedId, rssAcceptId}`를 `crawling.newPost` 큐로 발행
- server: `NotificationType.NEW_POST` 추가, RabbitMQ 컨슈머(`NewPostConsumer`) 신규 작성, 구독자 목록 기반 알림 upsert, 알림 목록 응답에 새 글의 RSS 이름 노출
- client: 알림 벨에 새 글 알림 메시지 표시 및 클릭 시 게시글 상세로 이동
- feed-crawler/server 유닛 테스트, server e2e 테스트(RabbitMQ 실컨테이너 기반) 추가

# 📷 스크린 샷(선택 사항)

없음