### PR TITLE
🐛 fix: 최신 피드 캐시 태그·요약 동기화 버그 수정 및 feed-crawler 타입 정리

### DIFF
--- a/feed-crawler/src/common/feed/feed.type.ts
+++ b/feed-crawler/src/common/feed/feed.type.ts
@@ -8,17 +8,12 @@ export interface RssObj {
 
 export interface FeedFetchResult {
   feeds: FeedDetail[];
-  channelImage: string | null | undefined;
+  rssObj: RssObj;
 }
 
 export interface FeedDetail {
   id: number;
-  blog: {
-    id: number;
-    name: string;
-    platform: string;
-    image: string | null;
-  };
+  blogId: number;
   pubDate: string;
   title: string;
   link: string;

--- a/feed-crawler/src/common/parser/base-feed-parser.ts
+++ b/feed-crawler/src/common/parser/base-feed-parser.ts
@@ -95,12 +95,7 @@ export abstract class BaseFeedParser {
 
         return {
           id: null,
-          blog: {
-            id: rssObj.id,
-            name: rssObj.blogName,
-            platform: rssObj.blogPlatform,
-            image: rssObj.blogImage,
-          },
+          blogId: rssObj.id,
           pubDate: formattedDate,
           title: feed.title,
           link: decodeURIComponent(feed.link),

--- a/feed-crawler/src/common/parser/feed-parser-manager.ts
+++ b/feed-crawler/src/common/parser/feed-parser-manager.ts
@@ -44,11 +44,14 @@ export class FeedParserManager {
 
       const feeds = await parser.parseFeed(rssObj, xmlData, startTime);
       this.metrics.success.inc({ type: 'scheduled' });
-      return { feeds, channelImage: parser.extractChannelImage(xmlData) };
+      return {
+        feeds,
+        rssObj: this.applyChannelImage(rssObj, parser.extractChannelImage(xmlData)),
+      };
     } catch (error) {
       this.metrics.failure.inc({ type: 'scheduled' });
       logger.error(`[${rssObj.rssUrl}] 피드 파싱 중 오류 발생: ${error}`);
-      return { feeds: [], channelImage: undefined };
+      return { feeds: [], rssObj };
     }
   }
 
@@ -75,12 +78,24 @@ export class FeedParserManager {
 
       const feeds = await parser.parseAllFeeds(rssObj, xmlData);
       this.metrics.success.inc({ type: 'full' });
-      return { feeds, channelImage: parser.extractChannelImage(xmlData) };
+      return {
+        feeds,
+        rssObj: this.applyChannelImage(rssObj, parser.extractChannelImage(xmlData)),
+      };
     } catch (error) {
       this.metrics.failure.inc({ type: 'full' });
       logger.error(`[${rssObj.rssUrl}] 전체 피드 파싱 중 오류 발생: ${error}`);
-      return { feeds: [], channelImage: undefined };
+      return { feeds: [], rssObj };
     }
+  }
+
+  private applyChannelImage(
+    rssObj: RssObj,
+    channelImage: string | null,
+  ): RssObj {
+    return channelImage !== rssObj.blogImage
+      ? { ...rssObj, blogImage: channelImage }
+      : rssObj;
   }
 
   private findSuitableParser(xmlData: string): BaseFeedParser | null {

--- a/feed-crawler/src/common/redis/redis-access.ts
+++ b/feed-crawler/src/common/redis/redis-access.ts
@@ -85,7 +85,7 @@ export class RedisConnection implements Lifecycle {
   }
 
   async hset(key: string, ...fieldValues: (string | Buffer | number)[]) {
-    await this.execute('hset', () => this.redis.hset(key, fieldValues));
+    await this.execute('hset', () => this.redis.hset(key, ...fieldValues));
   }
 
   async llen(key: string): Promise<number> {

--- a/feed-crawler/src/common/redis/redis-access.ts
+++ b/feed-crawler/src/common/redis/redis-access.ts
@@ -84,6 +84,11 @@ export class RedisConnection implements Lifecycle {
     return this.execute('smembers', () => this.redis.smembers(key));
   }
 
+  async exists(key: string) {
+    const result = await this.execute('exists', () => this.redis.exists(key));
+    return result === 1;
+  }
+
   async hset(key: string, ...fieldValues: (string | Buffer | number)[]) {
     await this.execute('hset', () => this.redis.hset(key, ...fieldValues));
   }

--- a/feed-crawler/src/common/redis/redis.type.ts
+++ b/feed-crawler/src/common/redis/redis.type.ts
@@ -8,7 +8,7 @@ export interface FeedRecentRedisRecord {
   thumbnail: string;
   path: string;
   title: string;
-  tag: string[];
+  tagList: string[];
   likes: number;
   comments: number;
 }

--- a/feed-crawler/src/event_worker/workers/claude-event-worker.ts
+++ b/feed-crawler/src/event_worker/workers/claude-event-worker.ts
@@ -14,8 +14,8 @@ import { redisConstant } from '@common/redis/redis.constant';
 import { AbstractQueueWorker } from '@event_worker/abstract-queue-worker';
 
 import { FeedRepository } from '@repository/feed.repository';
-import { TagRepository } from '@repository/tag.repository';
 import { TagMapRepository } from '@repository/tag-map.repository';
+import { TagRepository } from '@repository/tag.repository';
 
 @injectable()
 export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
@@ -171,11 +171,16 @@ export class ClaudeEventWorker extends AbstractQueueWorker<FeedAIQueueItem> {
     await this.tagMapRepository.insertTags(feed.id, feed.tagList);
     this.redisMetrics.total.inc({ operation: 'save_ai_result' });
     try {
-      await this.redisConnection.hset(
-        `feed:recent:${feed.id}`,
-        'tag',
-        feed.tagList.join(','),
-      );
+      const cacheKey = `feed:recent:${feed.id}`;
+      if (await this.redisConnection.exists(cacheKey)) {
+        await this.redisConnection.hset(
+          cacheKey,
+          'tagList',
+          feed.tagList.join(','),
+          'summary',
+          feed.summary,
+        );
+      }
       this.redisMetrics.success.inc({ operation: 'save_ai_result' });
     } catch (error) {
       this.redisMetrics.failure.inc({ operation: 'save_ai_result' });

--- a/feed-crawler/src/feed-crawler.ts
+++ b/feed-crawler/src/feed-crawler.ts
@@ -94,8 +94,12 @@ export class FeedCrawler {
       throw new PermanentError(`RSS를 찾을 수 없습니다: blogId=${feed.blogId}`);
     }
 
-    const { feeds: allFeeds } =
+    const { feeds: allFeeds, channelImage } =
       await this.feedParserManager.fetchAndParseAll(rssObj);
+    await this.syncChannelImages(
+      [rssObj],
+      [{ rssId: rssObj.id, channelImage }],
+    );
     const matched = allFeeds.find((parsed) => parsed.link === feed.path);
     if (!matched) {
       throw await this.buildMissingFeedError(feedId, feed.path);

--- a/feed-crawler/src/feed-crawler.ts
+++ b/feed-crawler/src/feed-crawler.ts
@@ -33,7 +33,7 @@ export class FeedCrawler {
     }
 
     const crawlResults = await this.feedGroupByRss(rssObjects, startTime);
-    await this.syncChannelImages(rssObjects, crawlResults);
+    await this.syncChannelImages(crawlResults);
     const newFeeds = crawlResults.flatMap((result) => result.feeds);
 
     if (!newFeeds.length) {
@@ -44,7 +44,10 @@ export class FeedCrawler {
     const insertedData: FeedDetail[] =
       await this.feedRepository.insertFeeds(newFeeds);
     await this.feedRepository.saveAiQueue(insertedData);
-    await this.feedRepository.setRecentFeedList(insertedData);
+    const rssObjectsById = new Map(
+      crawlResults.map((result) => [result.rssObj.id, result.rssObj]),
+    );
+    await this.feedRepository.setRecentFeedList(insertedData, rssObjectsById);
 
     const executionTime = Date.now() - startTime.getTime();
 
@@ -61,12 +64,11 @@ export class FeedCrawler {
 
     logger.info(`전체 피드 크롤링 시작: ${rssObj.blogName}(${rssObj.rssUrl})`);
 
-    const { feeds: newFeeds, channelImage } =
+    const { feeds: newFeeds, rssObj: updatedRssObj } =
       await this.feedParserManager.fetchAndParseAll(rssObj);
-    await this.syncChannelImages(
-      [rssObj],
-      [{ rssId: rssObj.id, channelImage }],
-    );
+    await this.syncChannelImages([
+      { rssObj: updatedRssObj, originalRssObj: rssObj },
+    ]);
 
     if (!newFeeds.length) {
       logger.info(`${rssObj.blogName}에서 가져올 피드가 없습니다.`);
@@ -94,12 +96,11 @@ export class FeedCrawler {
       throw new PermanentError(`RSS를 찾을 수 없습니다: blogId=${feed.blogId}`);
     }
 
-    const { feeds: allFeeds, channelImage } =
+    const { feeds: allFeeds, rssObj: updatedRssObj } =
       await this.feedParserManager.fetchAndParseAll(rssObj);
-    await this.syncChannelImages(
-      [rssObj],
-      [{ rssId: rssObj.id, channelImage }],
-    );
+    await this.syncChannelImages([
+      { rssObj: updatedRssObj, originalRssObj: rssObj },
+    ]);
     const matched = allFeeds.find((parsed) => parsed.link === feed.path);
     if (!matched) {
       throw await this.buildMissingFeedError(feedId, feed.path);
@@ -147,7 +148,7 @@ export class FeedCrawler {
   private feedGroupByRss(
     rssObjects: RssObj[],
     startTime: Date,
-  ): Promise<(FeedFetchResult & { rssId: number })[]> {
+  ): Promise<(FeedFetchResult & { originalRssObj: RssObj })[]> {
     return Promise.all(
       rssObjects.map(async (rssObj: RssObj) => {
         logger.info(
@@ -157,26 +158,21 @@ export class FeedCrawler {
           rssObj,
           startTime,
         );
-        return { ...result, rssId: rssObj.id };
+        return { ...result, originalRssObj: rssObj };
       }),
     );
   }
 
   private async syncChannelImages(
-    rssObjects: RssObj[],
-    crawlResults: { rssId: number; channelImage: string | null | undefined }[],
+    pairs: { rssObj: RssObj; originalRssObj: RssObj }[],
   ) {
-    const rssById = new Map(rssObjects.map((rssObj) => [rssObj.id, rssObj]));
-
     await Promise.all(
-      crawlResults
-        .filter((result) => result.channelImage !== undefined)
+      pairs
         .filter(
-          (result) =>
-            result.channelImage !== rssById.get(result.rssId)?.blogImage,
+          (pair) => pair.rssObj.blogImage !== pair.originalRssObj.blogImage,
         )
-        .map((result) =>
-          this.rssRepository.updateImage(result.rssId, result.channelImage),
+        .map((pair) =>
+          this.rssRepository.updateImage(pair.rssObj.id, pair.rssObj.blogImage),
         ),
     );
   }

--- a/feed-crawler/src/feed-crawler.ts
+++ b/feed-crawler/src/feed-crawler.ts
@@ -3,7 +3,7 @@ import { inject, injectable } from 'tsyringe';
 import axios from 'axios';
 
 import { PermanentError, RetryableError } from '@common/errors';
-import { FeedDetail, FeedFetchResult, RssObj } from '@common/feed/feed.type';
+import { FeedDetail, RssObj } from '@common/feed/feed.type';
 import logger from '@common/logger/logger';
 import { FeedParserManager } from '@common/parser/feed-parser-manager';
 
@@ -32,8 +32,9 @@ export class FeedCrawler {
       return;
     }
 
-    const crawlResults = await this.feedGroupByRss(rssObjects, startTime);
-    await this.syncChannelImages(crawlResults);
+    const crawlResults = await Promise.all(
+      rssObjects.map((rssObj) => this.crawlRss(rssObj, startTime)),
+    );
     const newFeeds = crawlResults.flatMap((result) => result.feeds);
 
     if (!newFeeds.length) {
@@ -44,10 +45,10 @@ export class FeedCrawler {
     const insertedData: FeedDetail[] =
       await this.feedRepository.insertFeeds(newFeeds);
     await this.feedRepository.saveAiQueue(insertedData);
-    const rssObjectsById = new Map(
-      crawlResults.map((result) => [result.rssObj.id, result.rssObj]),
+    await this.feedRepository.setRecentFeedList(
+      insertedData,
+      crawlResults.map((result) => result.rssObj),
     );
-    await this.feedRepository.setRecentFeedList(insertedData, rssObjectsById);
 
     const executionTime = Date.now() - startTime.getTime();
 
@@ -64,11 +65,7 @@ export class FeedCrawler {
 
     logger.info(`전체 피드 크롤링 시작: ${rssObj.blogName}(${rssObj.rssUrl})`);
 
-    const { feeds: newFeeds, rssObj: updatedRssObj } =
-      await this.feedParserManager.fetchAndParseAll(rssObj);
-    await this.syncChannelImages([
-      { rssObj: updatedRssObj, originalRssObj: rssObj },
-    ]);
+    const { feeds: newFeeds } = await this.crawlRssAll(rssObj);
 
     if (!newFeeds.length) {
       logger.info(`${rssObj.blogName}에서 가져올 피드가 없습니다.`);
@@ -96,11 +93,7 @@ export class FeedCrawler {
       throw new PermanentError(`RSS를 찾을 수 없습니다: blogId=${feed.blogId}`);
     }
 
-    const { feeds: allFeeds, rssObj: updatedRssObj } =
-      await this.feedParserManager.fetchAndParseAll(rssObj);
-    await this.syncChannelImages([
-      { rssObj: updatedRssObj, originalRssObj: rssObj },
-    ]);
+    const { feeds: allFeeds } = await this.crawlRssAll(rssObj);
     const matched = allFeeds.find((parsed) => parsed.link === feed.path);
     if (!matched) {
       throw await this.buildMissingFeedError(feedId, feed.path);
@@ -145,35 +138,38 @@ export class FeedCrawler {
     }
   }
 
-  private feedGroupByRss(
-    rssObjects: RssObj[],
+  private async crawlRss(
+    rssObj: RssObj,
     startTime: Date,
-  ): Promise<(FeedFetchResult & { originalRssObj: RssObj })[]> {
-    return Promise.all(
-      rssObjects.map(async (rssObj: RssObj) => {
-        logger.info(
-          `${rssObj.blogName}(${rssObj.rssUrl}) 에서 데이터 조회하는 중...`,
-        );
-        const result = await this.feedParserManager.fetchAndParse(
-          rssObj,
-          startTime,
-        );
-        return { ...result, originalRssObj: rssObj };
-      }),
+  ) {
+    logger.info(
+      `${rssObj.blogName}(${rssObj.rssUrl}) 에서 데이터 조회하는 중...`,
     );
+    const result = await this.feedParserManager.fetchAndParse(
+      rssObj,
+      startTime,
+    );
+    await this.syncChannelImage(rssObj, result.rssObj);
+    return result;
   }
 
-  private async syncChannelImages(
-    pairs: { rssObj: RssObj; originalRssObj: RssObj }[],
-  ) {
-    await Promise.all(
-      pairs
-        .filter(
-          (pair) => pair.rssObj.blogImage !== pair.originalRssObj.blogImage,
-        )
-        .map((pair) =>
-          this.rssRepository.updateImage(pair.rssObj.id, pair.rssObj.blogImage),
-        ),
-    );
+  private async crawlRssAll(rssObj: RssObj) {
+    const result = await this.feedParserManager.fetchAndParseAll(rssObj);
+    await this.syncChannelImage(rssObj, result.rssObj);
+    return result;
+  }
+
+  private async syncChannelImage(rssObj: RssObj, updatedRssObj: RssObj) {
+    if (updatedRssObj.blogImage === rssObj.blogImage) {
+      return;
+    }
+    try {
+      await this.rssRepository.updateImage(
+        updatedRssObj.id,
+        updatedRssObj.blogImage,
+      );
+    } catch (error) {
+      logger.error(`[${rssObj.rssUrl}] 채널 이미지 갱신 실패: ${error}`);
+    }
   }
 }

--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -2,7 +2,7 @@ import { inject, injectable } from 'tsyringe';
 
 import { DatabaseConnection } from '@common/database/database-connection';
 import { DEPENDENCY_SYMBOLS } from '@common/dependency-symbols';
-import { FeedDetail } from '@common/feed/feed.type';
+import { FeedDetail, RssObj } from '@common/feed/feed.type';
 import logger from '@common/logger/logger';
 import { DbMetrics } from '@common/metrics/db-metrics';
 import { RedisMetrics } from '@common/metrics/redis-metrics';
@@ -61,7 +61,7 @@ export class FeedRepository {
             VALUES ?
         `;
       const values = candidates.map((feed) => [
-        feed.blog.id,
+        feed.blogId,
         feed.pubDate,
         feed.title,
         feed.link,
@@ -125,7 +125,7 @@ export class FeedRepository {
           const result = await this.dbConnection.executeQueryStrict(
             insertQuery,
             [
-              feed.blog.id,
+              feed.blogId,
               feed.pubDate,
               feed.title,
               feed.link,
@@ -178,18 +178,28 @@ export class FeedRepository {
     }
   }
 
-  async setRecentFeedList(feedLists: FeedDetail[]) {
+  async setRecentFeedList(
+    feedLists: FeedDetail[],
+    rssObjectsById: Map<number, RssObj>,
+  ) {
     this.redisMetrics.total.inc({ operation: 'cache_feeds' });
     try {
       await this.redisConnection.executePipeline((pipeline) => {
         for (const feed of feedLists) {
+          const rssObj = rssObjectsById.get(feed.blogId);
+          if (!rssObj) {
+            logger.warn(
+              `[Redis] 최근 게시글 캐시 스킵: rss 정보를 찾을 수 없습니다. feedId=${feed.id}, blogId=${feed.blogId}`,
+            );
+            continue;
+          }
           const record: FeedRecentRedisRecord = {
             id: feed.id,
-            blogPlatform: feed.blog.platform,
-            blogImage: feed.blog.image ?? '',
+            blogPlatform: rssObj.blogPlatform,
+            blogImage: rssObj.blogImage ?? '',
             createdAt: feed.pubDate,
             viewCount: 0,
-            blogName: feed.blog.name,
+            blogName: rssObj.blogName,
             thumbnail: feed.thumbnail,
             path: feed.link,
             title: feed.title,

--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -193,7 +193,7 @@ export class FeedRepository {
             thumbnail: feed.thumbnail,
             path: feed.link,
             title: feed.title,
-            tag: Array.isArray(feed.tag) ? feed.tag : [],
+            tagList: Array.isArray(feed.tag) ? feed.tag : [],
             likes: 0,
             comments: 0,
           };

--- a/feed-crawler/src/repository/feed.repository.ts
+++ b/feed-crawler/src/repository/feed.repository.ts
@@ -178,11 +178,11 @@ export class FeedRepository {
     }
   }
 
-  async setRecentFeedList(
-    feedLists: FeedDetail[],
-    rssObjectsById: Map<number, RssObj>,
-  ) {
+  async setRecentFeedList(feedLists: FeedDetail[], rssObjects: RssObj[]) {
     this.redisMetrics.total.inc({ operation: 'cache_feeds' });
+    const rssObjectsById = new Map(
+      rssObjects.map((rssObj) => [rssObj.id, rssObj]),
+    );
     try {
       await this.redisConnection.executePipeline((pipeline) => {
         for (const feed of feedLists) {

--- a/feed-crawler/test/e2e/ai-summary-requeue.e2e-spec.ts
+++ b/feed-crawler/test/e2e/ai-summary-requeue.e2e-spec.ts
@@ -42,12 +42,7 @@ describe('AI 요약 재요청 e2e-test', () => {
         feeds: [
           {
             id: null,
-            blog: {
-              id: rssId,
-              name: 'requeue blog',
-              platform: 'etc',
-              image: null,
-            },
+            blogId: rssId,
             title: 'requeue title',
             link: feedPath,
             pubDate: new Date().toISOString().slice(0, 19).replace('T', ' '),
@@ -57,7 +52,13 @@ describe('AI 요약 재요청 e2e-test', () => {
             deathCount: 0,
           },
         ],
-        channelImage: null,
+        rssObj: {
+          id: rssId,
+          blogName: 'requeue blog',
+          blogPlatform: 'etc',
+          rssUrl: 'https://requeue-test.com/rss',
+          blogImage: null,
+        },
       });
 
     // when

--- a/feed-crawler/test/e2e/claude-event-worker.e2e-spec.ts
+++ b/feed-crawler/test/e2e/claude-event-worker.e2e-spec.ts
@@ -5,7 +5,9 @@ import { ClaudeEventWorker } from '@event_worker/workers/claude-event-worker';
 
 describe('Claude AI e2e-test', () => {
   const testContext = setupTestContainer();
-  let claudeEventWorker: ClaudeEventWorker, feedData: ResultSetHeader;
+  let claudeEventWorker: ClaudeEventWorker,
+    feedData: ResultSetHeader,
+    rssData: ResultSetHeader;
   const feedRedisAiQueueData: any = {
     content: 'test',
     deathCount: 0,
@@ -14,7 +16,7 @@ describe('Claude AI e2e-test', () => {
   beforeAll(async () => {
     claudeEventWorker = testContext.claudeEventWorker;
 
-    const rssData = (await testContext.dbConnection.executeQuery(
+    rssData = (await testContext.dbConnection.executeQuery(
       `INSERT INTO rss_accept (name, user_name, email, rss_url, platform) VALUES (?, ?, ?, ?, ?)`,
       ['test', 'test_name', 'test@test.com', 'https://test.com/rss', 'etc'],
     )) as any as ResultSetHeader;
@@ -165,5 +167,71 @@ describe('Claude AI e2e-test', () => {
       'test2',
       'test3',
     ]);
+  });
+
+  it('최근 게시글 캐시가 존재하면 tagList와 summary를 갱신한다.', async () => {
+    // given
+    await testContext.redisConnection.hset(
+      `feed:recent:${feedData.insertId}`,
+      'title',
+      'test',
+      'summary',
+      'AI 요약 처리 중...',
+    );
+
+    jest
+      .spyOn(claudeEventWorker as any, 'loadFeeds')
+      .mockResolvedValue([feedRedisAiQueueData]);
+
+    jest.spyOn(claudeEventWorker as any, 'requestAI').mockResolvedValue({
+      ...feedRedisAiQueueData,
+      id: feedData.insertId,
+      summary: 'cache summary',
+      tagList: ['test1'],
+    });
+
+    // when
+    await claudeEventWorker.start();
+
+    // then
+    const cached = (await testContext.redisConnection.executePipeline(
+      (pipeline) => {
+        pipeline.hgetall(`feed:recent:${feedData.insertId}`);
+      },
+    )) as [error: Error, result: Record<string, string>][];
+
+    expect(cached[0][1]).toMatchObject({
+      title: 'test',
+      summary: 'cache summary',
+      tagList: 'test1',
+    });
+  });
+
+  it('최근 게시글 캐시가 없으면 캐시를 새로 만들지 않는다.', async () => {
+    // given
+    const uncachedFeedData = (await testContext.dbConnection.executeQuery(
+      `INSERT INTO feed (created_at, title, path, thumbnail, blog_id) VALUES (?, ?, ?, ?, ?)`,
+      [new Date(), 'uncached', 'uncached-path', 'test', rssData.insertId],
+    )) as any as ResultSetHeader;
+
+    jest
+      .spyOn(claudeEventWorker as any, 'loadFeeds')
+      .mockResolvedValue([feedRedisAiQueueData]);
+
+    jest.spyOn(claudeEventWorker as any, 'requestAI').mockResolvedValue({
+      ...feedRedisAiQueueData,
+      id: uncachedFeedData.insertId,
+      summary: 'no cache summary',
+      tagList: ['test1'],
+    });
+
+    // when
+    await claudeEventWorker.start();
+
+    // then
+    const exists = await testContext.redisConnection.exists(
+      `feed:recent:${uncachedFeedData.insertId}`,
+    );
+    expect(exists).toBe(false);
   });
 });

--- a/feed-crawler/test/e2e/feed-crawling.e2e-spec.ts
+++ b/feed-crawler/test/e2e/feed-crawling.e2e-spec.ts
@@ -50,12 +50,7 @@ describe('feed crawling e2e-test', () => {
         feeds: [
           {
             id: null,
-            blog: {
-              id: 1,
-              name: 'test blog',
-              platform: 'etc',
-              image: null,
-            },
+            blogId: 1,
             title: 'Mock Title',
             link: 'https://example.com/mock',
             pubDate: new Date().toISOString().slice(0, 19).replace('T', ' '),
@@ -65,7 +60,13 @@ describe('feed crawling e2e-test', () => {
             deathCount: 0,
           },
         ],
-        channelImage: null,
+        rssObj: {
+          id: 1,
+          blogName: 'test blog',
+          blogPlatform: 'etc',
+          rssUrl: 'https://test.com/rss',
+          blogImage: null,
+        },
       });
 
     await testContext.dbConnection.executeQuery(

--- a/feed-crawler/test/unit/claude-event-worker.spec.ts
+++ b/feed-crawler/test/unit/claude-event-worker.spec.ts
@@ -25,6 +25,7 @@ describe('ClaudeEventWorker', () => {
   let updateNullSummaryMock: jest.Mock;
   let executePipelineMock: jest.Mock;
   let hsetMock: jest.Mock;
+  let existsMock: jest.Mock;
   let rpushMock: jest.Mock;
   let messagesCreateMock: jest.Mock;
 
@@ -55,6 +56,7 @@ describe('ClaudeEventWorker', () => {
     updateNullSummaryMock = jest.fn();
     executePipelineMock = jest.fn();
     hsetMock = jest.fn();
+    existsMock = jest.fn().mockResolvedValue(true);
     rpushMock = jest.fn();
     messagesCreateMock = jest.fn();
 
@@ -74,6 +76,7 @@ describe('ClaudeEventWorker', () => {
     mockRedisConnection = {
       executePipeline: executePipelineMock,
       hset: hsetMock,
+      exists: existsMock,
       rpush: rpushMock,
       llen: jest.fn().mockResolvedValue(0),
     } as any;
@@ -305,9 +308,31 @@ describe('ClaudeEventWorker', () => {
       );
       expect(hsetMock).toHaveBeenCalledWith(
         `feed:recent:${feedWithAIResult.id}`,
-        'tag',
+        'tagList',
         feedWithAIResult.tagList.join(','),
+        'summary',
+        feedWithAIResult.summary,
       );
+      expect(updateSummaryMock).toHaveBeenCalledWith(
+        feedWithAIResult.id,
+        feedWithAIResult.summary,
+      );
+    });
+
+    it('캐시에 없는 게시글이면 hset을 호출하지 않아야 한다', async () => {
+      // Given
+      existsMock.mockResolvedValue(false);
+      const feedWithAIResult = {
+        ...mockFeedAIQueueItem,
+        summary: mockClaudeResponse.summary,
+        tagList: Object.keys(mockClaudeResponse.tags),
+      };
+
+      // When
+      await claudeEventWorker['saveAIResult'](feedWithAIResult);
+
+      // Then
+      expect(hsetMock).not.toHaveBeenCalled();
       expect(updateSummaryMock).toHaveBeenCalledWith(
         feedWithAIResult.id,
         feedWithAIResult.summary,

--- a/feed-crawler/test/unit/feed-crawler.spec.ts
+++ b/feed-crawler/test/unit/feed-crawler.spec.ts
@@ -47,12 +47,7 @@ describe('FeedCrawler', () => {
   const mockFeedDetails: FeedDetail[] = [
     {
       id: 1,
-      blog: {
-        id: 1,
-        name: '테스트 블로그 1',
-        platform: 'tistory',
-        image: null,
-      },
+      blogId: 1,
       pubDate: '2024-01-01 12:00:00',
       title: '테스트 피드 1',
       link: 'https://test1.tistory.com/1',
@@ -63,12 +58,7 @@ describe('FeedCrawler', () => {
     },
     {
       id: 2,
-      blog: {
-        id: 2,
-        name: '테스트 블로그 2',
-        platform: 'velog',
-        image: null,
-      },
+      blogId: 2,
       pubDate: '2024-01-01 12:30:00',
       title: '테스트 피드 2',
       link: 'https://velog.io/@test2/2',
@@ -127,8 +117,8 @@ describe('FeedCrawler', () => {
       const startTime = new Date('2024-01-01T12:00:00Z');
       selectAllRssMock.mockResolvedValue(mockRssObjects);
       fetchAndParseMock
-        .mockResolvedValueOnce({ feeds: [mockFeedDetails[0]], channelImage: undefined })
-        .mockResolvedValueOnce({ feeds: [mockFeedDetails[1]], channelImage: undefined });
+        .mockResolvedValueOnce({ feeds: [mockFeedDetails[0]], rssObj: mockRssObjects[0] })
+        .mockResolvedValueOnce({ feeds: [mockFeedDetails[1]], rssObj: mockRssObjects[1] });
       insertFeedsMock.mockResolvedValue(mockFeedDetails);
 
       // When
@@ -150,7 +140,13 @@ describe('FeedCrawler', () => {
       );
       expect(insertFeedsMock).toHaveBeenCalledWith(mockFeedDetails);
       expect(saveAiQueueMock).toHaveBeenCalledWith(mockFeedDetails);
-      expect(setRecentFeedListMock).toHaveBeenCalledWith(mockFeedDetails);
+      expect(setRecentFeedListMock).toHaveBeenCalledWith(
+        mockFeedDetails,
+        new Map([
+          [mockRssObjects[0].id, mockRssObjects[0]],
+          [mockRssObjects[1].id, mockRssObjects[1]],
+        ]),
+      );
     });
 
     it('등록된 RSS가 없을 때 조기 종료해야 한다', async () => {
@@ -172,7 +168,7 @@ describe('FeedCrawler', () => {
       // Given
       const startTime = new Date('2024-01-01T12:00:00Z');
       selectAllRssMock.mockResolvedValue(mockRssObjects);
-      fetchAndParseMock.mockResolvedValue({ feeds: [], channelImage: undefined });
+      fetchAndParseMock.mockResolvedValue({ feeds: [], rssObj: mockRssObjects[0] });
 
       // When
       await feedCrawler.start(startTime);
@@ -207,7 +203,7 @@ describe('FeedCrawler', () => {
       selectRssByIdMock.mockResolvedValue(rssObj);
       fetchAndParseAllMock.mockResolvedValue({
         feeds: expectedFeeds,
-        channelImage: undefined,
+        rssObj,
       });
       insertFeedsMock.mockResolvedValue(expectedFeeds);
 
@@ -225,7 +221,7 @@ describe('FeedCrawler', () => {
       // Given
       const rssObj = mockRssObjects[0];
       selectRssByIdMock.mockResolvedValue(rssObj);
-      fetchAndParseAllMock.mockResolvedValue({ feeds: [], channelImage: undefined });
+      fetchAndParseAllMock.mockResolvedValue({ feeds: [], rssObj });
 
       // When
       const result = await feedCrawler.startFullCrawl(rssObj.id);
@@ -261,13 +257,13 @@ describe('FeedCrawler', () => {
         .mockImplementationOnce(async () => {
           await new Promise((resolve) => setTimeout(resolve, 50));
           callOrder.push(1);
-          return { feeds: [mockFeedDetails[0]], channelImage: undefined };
+          return { feeds: [mockFeedDetails[0]], rssObj: mockRssObjects[0] };
         })
         .mockImplementationOnce(() => {
           callOrder.push(2);
           return Promise.resolve({
             feeds: [mockFeedDetails[1]],
-            channelImage: undefined,
+            rssObj: mockRssObjects[1],
           });
         });
 
@@ -280,8 +276,16 @@ describe('FeedCrawler', () => {
       // Then
       expect(fetchAndParseMock).toHaveBeenCalledTimes(2);
       expect(result).toEqual([
-        { feeds: [mockFeedDetails[0]], channelImage: undefined, rssId: 1 },
-        { feeds: [mockFeedDetails[1]], channelImage: undefined, rssId: 2 },
+        {
+          feeds: [mockFeedDetails[0]],
+          rssObj: mockRssObjects[0],
+          originalRssObj: mockRssObjects[0],
+        },
+        {
+          feeds: [mockFeedDetails[1]],
+          rssObj: mockRssObjects[1],
+          originalRssObj: mockRssObjects[1],
+        },
       ]);
       // 병렬 실행이면 지연이 없는 두 번째가 먼저 완료됨
       expect(callOrder).toEqual([2, 1]);
@@ -314,7 +318,7 @@ describe('FeedCrawler', () => {
       selectRssByIdMock.mockResolvedValue(mockRssObjects[0]);
       fetchAndParseAllMock.mockResolvedValue({
         feeds: [{ ...mockFeedDetails[0], link: mockFeed.path }],
-        channelImage: undefined,
+        rssObj: mockRssObjects[0],
       });
 
       // When
@@ -358,7 +362,7 @@ describe('FeedCrawler', () => {
         // 다른 link만 반환하여 매칭 실패 유도
         fetchAndParseAllMock.mockResolvedValue({
           feeds: [{ ...mockFeedDetails[0], link: 'https://other.com/different' }],
-          channelImage: undefined,
+          rssObj: mockRssObjects[0],
         });
       });
 

--- a/feed-crawler/test/unit/feed-crawler.spec.ts
+++ b/feed-crawler/test/unit/feed-crawler.spec.ts
@@ -140,13 +140,10 @@ describe('FeedCrawler', () => {
       );
       expect(insertFeedsMock).toHaveBeenCalledWith(mockFeedDetails);
       expect(saveAiQueueMock).toHaveBeenCalledWith(mockFeedDetails);
-      expect(setRecentFeedListMock).toHaveBeenCalledWith(
-        mockFeedDetails,
-        new Map([
-          [mockRssObjects[0].id, mockRssObjects[0]],
-          [mockRssObjects[1].id, mockRssObjects[1]],
-        ]),
-      );
+      expect(setRecentFeedListMock).toHaveBeenCalledWith(mockFeedDetails, [
+        mockRssObjects[0],
+        mockRssObjects[1],
+      ]);
     });
 
     it('등록된 RSS가 없을 때 조기 종료해야 한다', async () => {
@@ -246,61 +243,63 @@ describe('FeedCrawler', () => {
     });
   });
 
-  describe('feedGroupByRss', () => {
-    it('모든 RSS 객체에 대해 병렬 처리해야 한다', async () => {
-      // Given
-      const startTime = new Date('2024-01-01T12:00:00Z');
-      const callOrder: number[] = [];
+  describe('crawlRss', () => {
+    const startTime = new Date('2024-01-01T12:00:00Z');
 
-      // 병렬 실행 검증: 첫 번째 호출에 지연을 주어 병렬 실행 시 순서가 뒤바뀌는지 확인
-      fetchAndParseMock
-        .mockImplementationOnce(async () => {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          callOrder.push(1);
-          return { feeds: [mockFeedDetails[0]], rssObj: mockRssObjects[0] };
-        })
-        .mockImplementationOnce(() => {
-          callOrder.push(2);
-          return Promise.resolve({
-            feeds: [mockFeedDetails[1]],
-            rssObj: mockRssObjects[1],
-          });
-        });
+    it('크롤링 결과를 그대로 반환해야 한다', async () => {
+      // Given
+      fetchAndParseMock.mockResolvedValue({
+        feeds: [mockFeedDetails[0]],
+        rssObj: mockRssObjects[0],
+      });
 
       // When
-      const result = await feedCrawler['feedGroupByRss'](
-        mockRssObjects,
+      const result = await feedCrawler['crawlRss'](
+        mockRssObjects[0],
         startTime,
       );
 
       // Then
-      expect(fetchAndParseMock).toHaveBeenCalledTimes(2);
-      expect(result).toEqual([
-        {
-          feeds: [mockFeedDetails[0]],
-          rssObj: mockRssObjects[0],
-          originalRssObj: mockRssObjects[0],
-        },
-        {
-          feeds: [mockFeedDetails[1]],
-          rssObj: mockRssObjects[1],
-          originalRssObj: mockRssObjects[1],
-        },
-      ]);
-      // 병렬 실행이면 지연이 없는 두 번째가 먼저 완료됨
-      expect(callOrder).toEqual([2, 1]);
+      expect(fetchAndParseMock).toHaveBeenCalledWith(
+        mockRssObjects[0],
+        startTime,
+      );
+      expect(result).toEqual({
+        feeds: [mockFeedDetails[0]],
+        rssObj: mockRssObjects[0],
+      });
     });
 
-    it('빈 RSS 배열에 대해 빈 결과를 반환해야 한다', async () => {
+    it('채널 이미지가 바뀌면 rss의 이미지를 갱신해야 한다', async () => {
       // Given
-      const startTime = new Date('2024-01-01T12:00:00Z');
+      const updatedRssObj = {
+        ...mockRssObjects[0],
+        blogImage: 'https://example.com/new-image.png',
+      };
+      fetchAndParseMock.mockResolvedValue({ feeds: [], rssObj: updatedRssObj });
 
       // When
-      const result = await feedCrawler['feedGroupByRss']([], startTime);
+      await feedCrawler['crawlRss'](mockRssObjects[0], startTime);
 
       // Then
-      expect(fetchAndParseMock).not.toHaveBeenCalled();
-      expect(result).toEqual([]);
+      expect(updateImageMock).toHaveBeenCalledWith(
+        updatedRssObj.id,
+        updatedRssObj.blogImage,
+      );
+    });
+
+    it('채널 이미지가 그대로면 이미지를 갱신하지 않아야 한다', async () => {
+      // Given
+      fetchAndParseMock.mockResolvedValue({
+        feeds: [],
+        rssObj: mockRssObjects[0],
+      });
+
+      // When
+      await feedCrawler['crawlRss'](mockRssObjects[0], startTime);
+
+      // Then
+      expect(updateImageMock).not.toHaveBeenCalled();
     });
   });
 

--- a/feed-crawler/test/unit/feed-parser-manager.spec.ts
+++ b/feed-crawler/test/unit/feed-parser-manager.spec.ts
@@ -37,12 +37,7 @@ describe('FeedParserManager', () => {
   const mockFeedDetails: FeedDetail[] = [
     {
       id: null,
-      blog: {
-        id: 1,
-        name: '테스트 블로그',
-        platform: 'tistory',
-        image: null,
-      },
+      blogId: 1,
       pubDate: '2024-01-01 12:00:00',
       title: '테스트 피드 1',
       link: 'https://test.tistory.com/1',
@@ -137,7 +132,7 @@ describe('FeedParserManager', () => {
         rssXmlData,
         startTime,
       );
-      expect(result).toEqual({ feeds: mockFeedDetails, channelImage: null });
+      expect(result).toEqual({ feeds: mockFeedDetails, rssObj: mockRssObj });
     });
 
     it('Atom 1.0 피드를 성공적으로 파싱해야 한다', async () => {
@@ -165,7 +160,7 @@ describe('FeedParserManager', () => {
         atomXmlData,
         startTime,
       );
-      expect(result).toEqual({ feeds: mockFeedDetails, channelImage: null });
+      expect(result).toEqual({ feeds: mockFeedDetails, rssObj: mockRssObj });
     });
 
     it('HTTP 요청이 실패할 때 빈 배열을 반환해야 한다', async () => {
@@ -181,7 +176,7 @@ describe('FeedParserManager', () => {
       );
 
       // Then
-      expect(result).toEqual({ feeds: [], channelImage: undefined });
+      expect(result).toEqual({ feeds: [], rssObj: mockRssObj });
     });
 
     it('지원하지 않는 피드 형식일 때 빈 배열을 반환해야 한다', async () => {
@@ -201,7 +196,7 @@ describe('FeedParserManager', () => {
       );
 
       // Then
-      expect(result).toEqual({ feeds: [], channelImage: undefined });
+      expect(result).toEqual({ feeds: [], rssObj: mockRssObj });
     });
 
     it('파서에서 에러가 발생할 때 빈 배열을 반환해야 한다', async () => {
@@ -221,7 +216,7 @@ describe('FeedParserManager', () => {
       );
 
       // Then
-      expect(result).toEqual({ feeds: [], channelImage: undefined });
+      expect(result).toEqual({ feeds: [], rssObj: mockRssObj });
     });
   });
 
@@ -245,7 +240,7 @@ describe('FeedParserManager', () => {
         mockRssObj,
         rssXmlData,
       );
-      expect(result).toEqual({ feeds: mockFeedDetails, channelImage: null });
+      expect(result).toEqual({ feeds: mockFeedDetails, rssObj: mockRssObj });
       expect(metricsTotalIncMock).toHaveBeenCalledWith({ type: 'full' });
       expect(metricsSuccessIncMock).toHaveBeenCalledWith({ type: 'full' });
     });
@@ -270,7 +265,7 @@ describe('FeedParserManager', () => {
         mockRssObj,
         atomXmlData,
       );
-      expect(result).toEqual({ feeds: mockFeedDetails, channelImage: null });
+      expect(result).toEqual({ feeds: mockFeedDetails, rssObj: mockRssObj });
     });
 
     it('HTTP 요청이 실패하면 빈 배열을 반환하고 에러를 로깅해야 한다', async () => {
@@ -281,7 +276,7 @@ describe('FeedParserManager', () => {
       const result = await feedParserManager.fetchAndParseAll(mockRssObj);
 
       // Then
-      expect(result).toEqual({ feeds: [], channelImage: undefined });
+      expect(result).toEqual({ feeds: [], rssObj: mockRssObj });
       expect(metricsFailureIncMock).toHaveBeenCalledWith({ type: 'full' });
       expect(errorSpy).toHaveBeenCalled();
     });
@@ -299,7 +294,7 @@ describe('FeedParserManager', () => {
       const result = await feedParserManager.fetchAndParseAll(mockRssObj);
 
       // Then
-      expect(result).toEqual({ feeds: [], channelImage: undefined });
+      expect(result).toEqual({ feeds: [], rssObj: mockRssObj });
       expect(metricsFailureIncMock).toHaveBeenCalledWith({ type: 'full' });
     });
 
@@ -317,7 +312,7 @@ describe('FeedParserManager', () => {
       const result = await feedParserManager.fetchAndParseAll(mockRssObj);
 
       // Then
-      expect(result).toEqual({ feeds: [], channelImage: undefined });
+      expect(result).toEqual({ feeds: [], rssObj: mockRssObj });
     });
   });
 
@@ -339,7 +334,7 @@ describe('FeedParserManager', () => {
       );
 
       // Then
-      expect(result).toEqual({ feeds: [], channelImage: undefined });
+      expect(result).toEqual({ feeds: [], rssObj: mockRssObj });
     });
 
     it('매우 큰 응답을 처리해야 한다', async () => {
@@ -362,7 +357,7 @@ describe('FeedParserManager', () => {
       );
 
       // Then
-      expect(result).toEqual({ feeds: mockFeedDetails, channelImage: null });
+      expect(result).toEqual({ feeds: mockFeedDetails, rssObj: mockRssObj });
       expect(rss20ParseFeedMock).toHaveBeenCalledWith(
         mockRssObj,
         largeXmlData,

--- a/feed-crawler/test/unit/feed.repository.spec.ts
+++ b/feed-crawler/test/unit/feed.repository.spec.ts
@@ -22,12 +22,7 @@ describe('FeedRepository', () => {
 
   const createFeed = (id: number): FeedDetail => ({
     id,
-    blog: {
-      id,
-      name: `테스트 블로그 ${id}`,
-      platform: 'tistory',
-      image: null,
-    },
+    blogId: id,
     pubDate: `2024-01-01 12:0${id}:00`,
     title: `테스트 피드 ${id}`,
     link: `https://test${id}.tistory.com/${id}`,
@@ -38,7 +33,7 @@ describe('FeedRepository', () => {
   });
 
   const toValueRow = (feed: FeedDetail) => [
-    feed.blog.id,
+    feed.blogId,
     feed.pubDate,
     feed.title,
     feed.link,

--- a/feed-crawler/test/unit/parser.spec.ts
+++ b/feed-crawler/test/unit/parser.spec.ts
@@ -113,11 +113,7 @@ describe('Parser 모듈 테스트', () => {
           );
 
           expect(result.feeds[0]).toMatchObject({
-            blog: {
-              id: MOCK_RSS_OBJ.id,
-              name: MOCK_RSS_OBJ.blogName,
-              platform: MOCK_RSS_OBJ.blogPlatform,
-            },
+            blogId: MOCK_RSS_OBJ.id,
             title: '첫 번째 글제목',
             link: expect.stringContaining('https://rssfeed.com/post1'),
             thumbnail: expect.any(String),
@@ -154,11 +150,7 @@ describe('Parser 모듈 테스트', () => {
           );
 
           expect(result.feeds[0]).toMatchObject({
-            blog: {
-              id: MOCK_RSS_OBJ.id,
-              name: MOCK_RSS_OBJ.blogName,
-              platform: MOCK_RSS_OBJ.blogPlatform,
-            },
+            blogId: MOCK_RSS_OBJ.id,
             title: 'Atom 첫 번째 글',
             link: expect.stringContaining('https://atomfeed.com/entry1'),
             thumbnail: expect.any(String),
@@ -326,9 +318,7 @@ describe('Parser 모듈 테스트', () => {
         // Then - parseFeed와 달리 시간 필터가 없으므로 모든 피드 반환
         expect(result).toHaveLength(2);
         expect(result[0]).toMatchObject({
-          blog: {
-            id: MOCK_RSS_OBJ.id,
-          },
+          blogId: MOCK_RSS_OBJ.id,
           title: '첫 번째 글제목',
           summary: expect.any(String),
           deathCount: 0,


### PR DESCRIPTION
# 🔨 테스크

### Issue

-  close #937

### AI 요약/태그 처리 결과가 최근 피드 캐시에 반영 안 되는 문제

-   AI 처리(`claude-event-worker`)가 DB `summary`만 갱신하고 `feed:recent:*` Redis 캐시는 갱신하지 않아서, AI 처리가 끝나도 캐시엔 "AI 요약 처리 중..." placeholder가 그대로 남아있었음
-   캐시 쓰기 필드명이 `tag`인데 서버 응답 DTO(`readFeedRecent.dto.ts`)는 `tagList`를 읽고 있어서, 애초에 태그가 클라이언트까지 전달된 적이 없었음
-   `RedisConnection.hset`이 필드-값 배열을 통째로 두 번째 인자로 넘기고 있어서(`redis.hset(key, array)`), `ioredis-mock` 기준으로는 배열 인덱스가 필드명으로 저장되는 것을 확인 (실제 ioredis는 내부적으로 flatten하기 때문에 프로덕션 영향은 없었지만, 명시적으로 spread하도록 고쳐 mock과 real 동작을 일치시킴)
-   AI 처리가 크롤 주기(30분)보다 늦게 끝나 최근 피드 캐시가 이미 삭제된 경우, `hset`이 불완전한(phantom) hash를 새로 만들지 않도록 `EXISTS` 가드 추가

### FeedDetail/FeedFetchResult 타입 정리

-   `FeedDetail.blog`(id/name/platform/image 중첩 객체)가 `RssObj`와 완전히 중복돼서 `blogId: number`로 단순화
-   `FeedFetchResult.channelImage`를 `rssObj`에 병합 — RSS 채널 이미지가 바뀌면 크롤링 결과 자체가 최신 `blogImage`를 들고 있도록 변경
-   `feedGroupByRss`/`syncChannelImages`(2-array, id 상관관계)를 `crawlRss`/`crawlRssAll`/`syncChannelImage`로 재구성 — fetch와 이미지 동기화를 한 호출로 묶어 3개 호출부(`start`, `startFullCrawl`, `requeueFeedForAiSummary`)의 중복 보일러플레이트 제거
-   이미지 동기화(`updateImage`) 실패가 `Promise.all`을 타고 전체 크롤 사이클을 죽이지 않도록 try/catch로 격리

# 📋 작업 내용

-   `feed-crawler`의 `FeedDetail`/`FeedFetchResult` 타입을 `blogId`/`rssObj` 기반으로 정리
-   `feedGroupByRss`/`syncChannelImages` → `crawlRss`/`crawlRssAll`/`syncChannelImage`로 재구성, 실패 격리 추가
-   `feed:recent:*` Redis 캐시 필드명 `tag` → `tagList` 통일
-   `RedisConnection.hset` 배열 인자 spread 수정
-   AI 요약/태그 처리 완료 시 `feed:recent:*` 캐시의 `tagList`/`summary` 갱신 (캐시 존재 시에만)
-   관련 유닛/e2e 테스트 추가·수정