### PR TITLE
🐛 fix: RabbitMQ/Prometheus/Redis 설정 변경 시 infra 배포 자동 트리거 누락 수정

### DIFF
--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -6,6 +6,7 @@ on:
     paths:
       [
         'docker-compose/docker-compose.prod.infra.yml',
+        'docker-compose/rabbitMQ/**',
         '.github/workflows/deploy_infra.yml',
       ]
   workflow_dispatch:

--- a/.github/workflows/deploy_infra.yml
+++ b/.github/workflows/deploy_infra.yml
@@ -7,6 +7,8 @@ on:
       [
         'docker-compose/docker-compose.prod.infra.yml',
         'docker-compose/rabbitMQ/**',
+        'docker-compose/prometheus/**',
+        'docker-compose/redis/**',
         '.github/workflows/deploy_infra.yml',
       ]
   workflow_dispatch:

--- a/.github/workflows/deploy_server.yml
+++ b/.github/workflows/deploy_server.yml
@@ -3,7 +3,12 @@ name: BE Deployment
 on:
   push:
     branches: [main]
-    paths: ['server/**', 'docker-compose/docker-compose.prod.yml']
+    paths:
+      [
+        'server/**',
+        'docker-compose/docker-compose.prod.yml',
+        'docker-compose/scripts/**',
+      ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   해당 없음 — release PR(#942) 작업 중 직접 발견한 CI 트리거 버그

### RabbitMQ/Prometheus/Redis 설정 변경 시 infra 배포 미트리거

-   `deploy_infra.yml`의 push trigger `paths`가 `docker-compose.prod.infra.yml`만 감시하고 있어, `docker-compose/rabbitMQ/`, `prometheus/`, `redis/` 하위 설정(definitions.json, prometheus.yml, redis-init.sh 등)만 바뀐 push는 워크플로우가 자동 트리거되지 않았음.
-   이번 release에서 definitions.json에 신규 큐(`crawling.aiRetry`, `crawling.newPost`)가 추가됐는데, main 머지만으로는 infra가 재배포되지 않아 신규 큐가 prod 브로커에 반영되지 않는 문제를 발견함. 수동 workflow_dispatch로 우회는 가능하나 근본적으로는 trigger paths 누락.
-   `import-definitions.sh`(rabbitmqctl 폴링 후 수동 import) 대신 RabbitMQ core 기능인 `load_definitions`(rabbitmq.conf)로 전환하는 것도 검토했으나, 로컬 검증 중 부팅 실패를 확인해 폐기함. `load_definitions`가 설정되면 RabbitMQ가 boot 단계에서 기본 vhost(`/`)·기본 유저 자동 생성(seeding)을 스킵하는데, 우리 definitions.json은 exchange/queue/binding만 정의하고 `vhosts`/`users` 섹션이 없어 vhost `/`가 아예 안 만들어진 상태로 import가 시도되어 `Please create virtual host "/" prior to importing definitions.` 에러로 부팅이 실패했음. 고치려면 definitions.json에 비밀번호를 하드코딩해야 해서(시크릿 핸들링 원칙 위반) 폐기하고 기존 방식을 유지, trigger paths만 보강함.
-   `docker-compose/scripts/blue-green-deploy.sh`는 `deploy_server.yml`(app 배포) 전용이라 `deploy_infra.yml`에는 포함하지 않음 — infra 스택과 무관해 넣으면 서버 배포 스크립트 변경 시 mysql/redis/rabbitmq까지 엉뚱하게 전체 재시작되는 부작용만 생김.

### blue-green-deploy.sh 변경 시 서버 배포도 미트리거

-   같은 종류 문제가 `deploy_server.yml`에도 있어서 확인 후 함께 수정함 — `paths`에 `server/**`, `docker-compose.prod.yml`만 있고 `docker-compose/scripts/**`가 빠져 있었음.

# 📋 작업 내용

-   `deploy_infra.yml` paths에 `docker-compose/rabbitMQ/**`, `docker-compose/prometheus/**`, `docker-compose/redis/**` 추가
-   `deploy_server.yml` paths에 `docker-compose/scripts/**` 추가

# 📷 스크린 샷(선택 사항)

해당 없음 — CI workflow 설정 변경