### PR TITLE
✨ feat: 검색 결과(유저/게시글/RSS) 정보 표시 개선

### DIFF
--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -123,7 +123,7 @@ export const mockChatItem: ChatType = {
 export const mockSearchResult: SearchResult = {
   id: 1,
   title: "Storybook으로 컴포넌트 문서화하기",
-  blog: { name: "데나무 블로그", platform: "tistory" },
+  blog: { name: "데나무 블로그", platform: "tistory", image: "https://picsum.photos/seed/blog/80/80" },
   path: "https://example.com/post/1",
   createdAt: "2026-06-20T09:00:00.000Z",
   thumbnail: "https://picsum.photos/seed/search/400/240",

--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -146,6 +146,7 @@ export const mockRssSearchResult: RssSearchResult = {
   name: "seok3765.log",
   blogPlatform: "velog",
   blogImage: "https://picsum.photos/seed/rsearch/80/80",
+  feedCount: 24,
 };
 
 export const mockAdminRssList: AdminRssData[] = [

--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -137,6 +137,8 @@ export const mockUserSearchResult: UserSearchResult = {
   id: 1,
   userName: "조민석",
   profileImage: "https://picsum.photos/seed/usearch/80/80",
+  introduction: "안녕하세요, 데나무 블로그 운영자입니다.",
+  blogCount: 2,
 };
 
 export const mockRssSearchResult: RssSearchResult = {

--- a/client/src/__tests__/__mocks__/external/lucide-react.tsx
+++ b/client/src/__tests__/__mocks__/external/lucide-react.tsx
@@ -15,4 +15,5 @@ export const mockLucideIcons = {
   ArrowLeft: () => <div data-testid="arrow-left-icon">Mock Arrow Left Icon</div>,
   Rss: () => <div data-testid="rss-icon">Mock Rss Icon</div>,
   Smile: () => <div data-testid="smile-icon">Mock Smile Icon</div>,
+  BadgeCheck: () => <div data-testid="badge-check-icon">Mock Badge Check Icon</div>,
 };

--- a/client/src/__tests__/components/admin/suspension/AdminSuspensionTab.test.tsx
+++ b/client/src/__tests__/components/admin/suspension/AdminSuspensionTab.test.tsx
@@ -48,6 +48,8 @@ const makeSearchUser = (overrides: Partial<UserSearchResult> = {}): UserSearchRe
   id: 10,
   userName: "검색된유저",
   profileImage: null,
+  introduction: null,
+  blogCount: 0,
   ...overrides,
 });
 

--- a/client/src/__tests__/components/common/search/SearchFilters/FilterButton.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchFilters/FilterButton.test.tsx
@@ -18,8 +18,8 @@ describe("FilterButton", () => {
     render(<FilterButton />);
 
     expect(screen.getByText("제목")).toBeInTheDocument();
-    expect(screen.getByText("블로거")).toBeInTheDocument();
-    expect(screen.getByText("블로거 + 제목")).toBeInTheDocument();
+    expect(screen.getByText("RSS 이름")).toBeInTheDocument();
+    expect(screen.getByText("RSS 이름 + 제목")).toBeInTheDocument();
   });
 
   it("현재 선택된 필터에 accent 스타일이 적용되어야 한다", () => {
@@ -41,7 +41,7 @@ describe("FilterButton", () => {
 
     render(<FilterButton />);
 
-    fireEvent.click(screen.getByText("블로거"));
+    fireEvent.click(screen.getByText("RSS 이름"));
 
     expect(mockSetFilter).toHaveBeenCalledWith("blogName");
     expect(mockSetPage).toHaveBeenCalledWith(1);

--- a/client/src/__tests__/components/common/search/SearchResults/RssSearchResultItem.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/RssSearchResultItem.test.tsx
@@ -21,6 +21,7 @@ describe("RssSearchResultItem", () => {
     name: "denamu.log",
     blogPlatform: "velog",
     blogImage: null,
+    feedCount: 3,
   };
 
   it("RSS 이름이 렌더링되어야 한다", () => {

--- a/client/src/__tests__/components/common/search/SearchResults/SearchResultItem.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/SearchResultItem.test.tsx
@@ -20,7 +20,7 @@ describe("SearchResultItem", () => {
     id: 1,
     createdAt: "2024-01-01",
     title: "테스트 제목입니다",
-    blog: { name: "테스트 블로그", platform: "etc" },
+    blog: { name: "테스트 블로그", platform: "etc", image: null },
     path: "/test-path",
     thumbnail: "",
     viewCount: 0,

--- a/client/src/__tests__/components/common/search/SearchResults/SearchResultList.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/SearchResultList.test.tsx
@@ -82,8 +82,8 @@ describe("SearchResultList", () => {
   it("검색 결과가 있을 때는 결과 목록과 페이지네이션을 표시해야 한다", () => {
     const cardFields = { thumbnail: "", viewCount: 0, tag: [], likes: 0, comments: 0 };
     const mockResults = [
-      { id: 1, title: "제목1", blog: { name: "블로그1", platform: "etc" }, path: "/1", createdAt: "2024-01-01", ...cardFields },
-      { id: 2, title: "제목2", blog: { name: "블로그2", platform: "etc" }, path: "/2", createdAt: "2024-01-01", ...cardFields },
+      { id: 1, title: "제목1", blog: { name: "블로그1", platform: "etc", image: null }, path: "/1", createdAt: "2024-01-01", ...cardFields },
+      { id: 2, title: "제목2", blog: { name: "블로그2", platform: "etc", image: null }, path: "/2", createdAt: "2024-01-01", ...cardFields },
     ];
 
     vi.mocked(useSearchStore).mockReturnValue({

--- a/client/src/__tests__/components/common/search/SearchResults/UserSearchResultItem.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/UserSearchResultItem.test.tsx
@@ -20,12 +20,33 @@ describe("UserSearchResultItem", () => {
     id: 7,
     userName: "김개발",
     profileImage: null,
+    introduction: "안녕하세요, 백엔드 개발자입니다.",
+    blogCount: 1,
   };
 
   it("유저 닉네임이 렌더링되어야 한다", () => {
     render(<UserSearchResultItem {...mockUser} onSelect={vi.fn()} />);
 
     expect(screen.getByText(mockUser.userName)).toBeInTheDocument();
+  });
+
+  it("자기소개가 렌더링되어야 한다", () => {
+    render(<UserSearchResultItem {...mockUser} onSelect={vi.fn()} />);
+
+    expect(screen.getByText(mockUser.introduction as string)).toBeInTheDocument();
+  });
+
+  it("소유 RSS 개수와 체크 아이콘이 렌더링되어야 한다", () => {
+    render(<UserSearchResultItem {...mockUser} onSelect={vi.fn()} />);
+
+    expect(screen.getByText(`인증된 RSS ${mockUser.blogCount}개`)).toBeInTheDocument();
+    expect(screen.getByTestId("badge-check-icon")).toBeInTheDocument();
+  });
+
+  it("RSS가 없으면 체크 아이콘이 렌더링되지 않아야 한다", () => {
+    render(<UserSearchResultItem {...mockUser} blogCount={0} onSelect={vi.fn()} />);
+
+    expect(screen.queryByTestId("badge-check-icon")).not.toBeInTheDocument();
   });
 
   it("클릭하면 해당 유저 id로 onSelect가 호출되어야 한다", () => {

--- a/client/src/__tests__/components/profile/rss/PlatformIcon.test.tsx
+++ b/client/src/__tests__/components/profile/rss/PlatformIcon.test.tsx
@@ -37,4 +37,11 @@ describe("PlatformIcon", () => {
 
     expect(img).toHaveAttribute("src", expect.stringContaining("naver-icon.svg"));
   });
+
+  it("알 수 없는 플랫폼이고 name이 주어지면 이니셜을 렌더링해야 한다", () => {
+    render(<PlatformIcon platform="etc" name="데나무 블로그" />);
+
+    expect(screen.getByText("데나")).toBeInTheDocument();
+    expect(screen.queryByTestId("lucide-Rss")).not.toBeInTheDocument();
+  });
 });

--- a/client/src/__tests__/hooks/queries/useRssSearch.test.tsx
+++ b/client/src/__tests__/hooks/queries/useRssSearch.test.tsx
@@ -90,7 +90,9 @@ describe("useRssSearch", () => {
   });
 
   it("API 응답을 data로 반환한다.", async () => {
-    const response = makeResponse([{ id: 1, name: "seok3765.log", blogPlatform: "velog", blogImage: null }]);
+    const response = makeResponse([
+      { id: 1, name: "seok3765.log", blogPlatform: "velog", blogImage: null, feedCount: 5 },
+    ]);
     getRssSearch.mockResolvedValue(response);
 
     const wrapper = createWrapper();

--- a/client/src/api/searchMockApi.ts
+++ b/client/src/api/searchMockApi.ts
@@ -80,7 +80,7 @@ const baseMockData = [
 
 const mockData: SearchResult[] = baseMockData.map(({ blogName, ...item }) => ({
   ...item,
-  blog: { name: blogName, platform: "etc" },
+  blog: { name: blogName, platform: "etc", image: null },
   thumbnail: "",
   viewCount: 0,
   tag: [],

--- a/client/src/components/admin/rss/RssRequestCard.tsx
+++ b/client/src/components/admin/rss/RssRequestCard.tsx
@@ -20,6 +20,7 @@ export const RssRequestCard = ({ request, onApprove, onReject }: RssRequestCardP
           <PlatformIcon
             platform={request.blogPlatform ?? "etc"}
             image={request.blogImage}
+            name={request.name}
             className="flex-shrink-0 w-10 h-10"
           />
           <div className="min-w-0 space-y-2">

--- a/client/src/components/admin/rss/RssResponseCard.tsx
+++ b/client/src/components/admin/rss/RssResponseCard.tsx
@@ -14,6 +14,7 @@ export const RssResponseCard = ({ request }: RssResponseCardProps) => {
         <PlatformIcon
           platform={request.blogPlatform ?? "etc"}
           image={request.blogImage}
+          name={request.name}
           className="flex-shrink-0 w-10 h-10"
         />
         <div className="min-w-0 space-y-2">

--- a/client/src/components/common/BlockConfirmDialog.tsx
+++ b/client/src/components/common/BlockConfirmDialog.tsx
@@ -111,7 +111,7 @@ export function BlockConfirmDialog({
                   className="flex items-center justify-between gap-3 p-3 border border-gray-100 rounded-lg"
                 >
                   <div className="flex items-center min-w-0 gap-3">
-                    <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="flex-shrink-0 w-9 h-9" />
+                    <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="flex-shrink-0 w-9 h-9" />
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <p className="text-sm font-medium truncate">{rss.name}</p>

--- a/client/src/components/profile/BlockManagementTab.tsx
+++ b/client/src/components/profile/BlockManagementTab.tsx
@@ -107,6 +107,7 @@ export const BlockManagementTab = () => {
                       <PlatformIcon
                         platform={rss.blogPlatform}
                         image={rss.blogImage}
+                        name={rss.name}
                         className="flex-shrink-0 w-10 h-10"
                       />
                       <p className="font-medium truncate">{rss.name}</p>

--- a/client/src/components/profile/SubscriptionManagementTab.tsx
+++ b/client/src/components/profile/SubscriptionManagementTab.tsx
@@ -48,7 +48,7 @@ export const SubscriptionManagementTab = ({ userId, isOwner, onBack }: Subscript
                 className="flex items-center justify-between gap-3 p-4 border border-gray-100 rounded-lg"
               >
                 <div className="flex items-center min-w-0 gap-3">
-                  <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="flex-shrink-0 w-10 h-10" />
+                  <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="flex-shrink-0 w-10 h-10" />
                   <div className="min-w-0">
                     <div className="flex items-center gap-2">
                       <p className="font-medium truncate">{rss.name}</p>

--- a/client/src/components/profile/rss/CertifiedRssCard.tsx
+++ b/client/src/components/profile/rss/CertifiedRssCard.tsx
@@ -24,7 +24,7 @@ export const CertifiedRssCard = ({ userId, rss, isOwner }: CertifiedRssCardProps
     >
       <div className="flex items-center justify-between gap-3 p-4">
         <div className="flex items-center min-w-0 gap-3">
-          <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="flex-shrink-0 w-10 h-10" />
+          <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="flex-shrink-0 w-10 h-10" />
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <Link to={`/rss/${rss.id}`} className="font-medium truncate hover:underline">

--- a/client/src/components/profile/rss/OwnedRssCard.tsx
+++ b/client/src/components/profile/rss/OwnedRssCard.tsx
@@ -52,7 +52,7 @@ export const OwnedRssCard = ({ rss, onEdit, onDelete }: OwnedRssCardProps) => {
     <li className="border border-gray-100 rounded-lg">
       <div className="flex items-center justify-between p-4">
         <div className="flex items-center min-w-0 space-x-3">
-          <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="flex-shrink-0 w-10 h-10" />
+          <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="flex-shrink-0 w-10 h-10" />
           <div className="min-w-0">
             <div className="flex items-center gap-2">
               <p className="font-medium truncate">{rss.name}</p>

--- a/client/src/components/profile/rss/PlatformIcon.tsx
+++ b/client/src/components/profile/rss/PlatformIcon.tsx
@@ -5,11 +5,12 @@ const KNOWN_PLATFORMS = ["tistory", "velog", "medium", "naver", "github"];
 interface PlatformIconProps {
   platform: string;
   image?: string | null;
+  name?: string;
   className?: string;
   alt?: string;
 }
 
-export const PlatformIcon = ({ platform, image, className = "w-5 h-5", alt }: PlatformIconProps) => {
+export const PlatformIcon = ({ platform, image, name, className = "w-5 h-5", alt }: PlatformIconProps) => {
   const altText = alt ?? platform;
   const key = platform.toLowerCase().replace(" ", "_");
   const fallbackSrc = `https://denamu.dev/files/${key}-icon.svg`;
@@ -30,6 +31,18 @@ export const PlatformIcon = ({ platform, image, className = "w-5 h-5", alt }: Pl
 
   if (KNOWN_PLATFORMS.includes(key)) {
     return <img src={fallbackSrc} alt={altText} className={className} />;
+  }
+
+  if (name) {
+    return (
+      <div
+        role="img"
+        aria-label={altText}
+        className={`${className} rounded-full bg-muted flex items-center justify-center font-medium text-muted-foreground`}
+      >
+        {name.substring(0, 2).toUpperCase()}
+      </div>
+    );
   }
 
   return <Rss className={`${className} text-blue-500`} />;

--- a/client/src/components/profile/rss/RssClaimModal.tsx
+++ b/client/src/components/profile/rss/RssClaimModal.tsx
@@ -143,7 +143,7 @@ export const RssClaimModal = ({ open, onClose, userId }: RssClaimModalProps) => 
               </DialogDescription>
             </DialogHeader>
             <div className="flex items-center gap-3 p-4 border rounded-lg border-gray-100">
-              <PlatformIcon platform={preview.blogPlatform} className="flex-shrink-0 w-12 h-12" />
+              <PlatformIcon platform={preview.blogPlatform} name={preview.name} className="flex-shrink-0 w-12 h-12" />
               <div className="min-w-0">
                 <p className="font-semibold truncate">{preview.name}</p>
                 <p className="text-sm text-gray-500 truncate">{preview.userName}</p>

--- a/client/src/components/profile/rss/SubscribedRssCard.tsx
+++ b/client/src/components/profile/rss/SubscribedRssCard.tsx
@@ -28,7 +28,7 @@ export const SubscribedRssCard = ({ rss }: SubscribedRssCardProps) => {
   return (
     <li className="flex items-center justify-between p-4 border border-gray-100 rounded-lg">
       <div className="flex items-center min-w-0 space-x-3">
-        <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="flex-shrink-0 w-10 h-10" />
+        <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="flex-shrink-0 w-10 h-10" />
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <p className="font-medium truncate">{rss.name}</p>

--- a/client/src/components/search/SearchFilters/FilterButton.tsx
+++ b/client/src/components/search/SearchFilters/FilterButton.tsx
@@ -16,8 +16,8 @@ export default function FilterButton() {
 
   const filterOptions: FilterOption[] = [
     { label: "제목", filter: "title", icon: <FileText size={16} /> },
-    { label: "블로거", filter: "blogName", icon: <User size={16} /> },
-    { label: "블로거 + 제목", filter: "all", icon: <PanelBottom size={16} /> },
+    { label: "RSS 이름", filter: "blogName", icon: <User size={16} /> },
+    { label: "RSS 이름 + 제목", filter: "all", icon: <PanelBottom size={16} /> },
   ];
 
   const getItemClassName = (isActive: boolean) =>

--- a/client/src/components/search/SearchResults/RssSearchResultItem.tsx
+++ b/client/src/components/search/SearchResults/RssSearchResultItem.tsx
@@ -28,7 +28,7 @@ export default function RssSearchResultItem({
         className="flex items-center gap-3 w-full px-2 py-1.5 text-left cursor-pointer"
       >
         <div className="overflow-hidden bg-white border rounded-full w-9 h-9 shrink-0">
-          <PlatformIcon platform={blogPlatform} image={blogImage} className="object-cover w-full h-full" />
+          <PlatformIcon platform={blogPlatform} image={blogImage} name={name} className="object-cover w-full h-full" />
         </div>
         <div className="flex flex-col min-w-0 gap-0.5 flex-1">
           <p className="text-sm">

--- a/client/src/components/search/SearchResults/RssSearchResultItem.tsx
+++ b/client/src/components/search/SearchResults/RssSearchResultItem.tsx
@@ -1,5 +1,6 @@
 import SearchHighlight from "@/components/search/SearchHigilight";
 import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
+import { Badge } from "@/components/ui/badge";
 import { CommandItem } from "@/components/ui/command";
 
 import { useSearchStore } from "@/store/useSearchStore";
@@ -9,7 +10,14 @@ interface RssSearchResultItemProps extends RssSearchResult {
   onSelect: (rssId: number) => void;
 }
 
-export default function RssSearchResultItem({ id, name, blogPlatform, blogImage, onSelect }: RssSearchResultItemProps) {
+export default function RssSearchResultItem({
+  id,
+  name,
+  blogPlatform,
+  blogImage,
+  feedCount,
+  onSelect,
+}: RssSearchResultItemProps) {
   const { searchParam } = useSearchStore();
 
   return (
@@ -22,9 +30,15 @@ export default function RssSearchResultItem({ id, name, blogPlatform, blogImage,
         <div className="overflow-hidden bg-white border rounded-full w-9 h-9 shrink-0">
           <PlatformIcon platform={blogPlatform} image={blogImage} className="object-cover w-full h-full" />
         </div>
-        <p className="text-sm">
-          <SearchHighlight text={name} highlight={searchParam} />
-        </p>
+        <div className="flex flex-col min-w-0 gap-0.5 flex-1">
+          <p className="text-sm">
+            <SearchHighlight text={name} highlight={searchParam} />
+          </p>
+          <span className="text-xs text-muted-foreground">게시글 {feedCount}개</span>
+        </div>
+        <Badge variant="secondary" className="text-[10px] px-1.5 py-0 leading-4 shrink-0">
+          {blogPlatform}
+        </Badge>
       </button>
     </CommandItem>
   );

--- a/client/src/components/search/SearchResults/SearchResultItem.tsx
+++ b/client/src/components/search/SearchResults/SearchResultItem.tsx
@@ -1,21 +1,38 @@
+import { Image as ImageIcon } from "lucide-react";
+
 import SearchHighlight from "@/components/search/SearchHigilight";
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
 import { CommandItem } from "@/components/ui/command";
 
 import { useSearchStore } from "@/store/useSearchStore";
 import { SearchResult } from "@/types/search";
+import { formatDate } from "@/utils/date";
 
-export default function SearchResultItem({ id, title, blog }: SearchResult) {
+export default function SearchResultItem({ id, title, blog, thumbnail, createdAt }: SearchResult) {
   const { searchParam } = useSearchStore();
   return (
-    <CommandItem className="flex flex-col items-start">
-      <a href={`${id}`} className="hover:underline">
-        <p className=" text-sm text-500">
-          <SearchHighlight text={title} highlight={searchParam} />
-        </p>
+    <CommandItem className="p-0">
+      <a href={`${id}`} className="flex items-center gap-3 w-full px-2 py-1.5 hover:underline">
+        <div className="w-12 h-12 rounded overflow-hidden bg-muted flex items-center justify-center shrink-0">
+          {thumbnail ? (
+            <img src={thumbnail} alt={title} className="w-full h-full object-cover" loading="lazy" />
+          ) : (
+            <ImageIcon className="w-5 h-5 text-muted-foreground" />
+          )}
+        </div>
+        <div className="flex flex-col min-w-0">
+          <p className=" text-sm text-500 truncate">
+            <SearchHighlight text={title} highlight={searchParam} />
+          </p>
+          <div className="flex items-center gap-1.5">
+            <PlatformIcon platform={blog.platform} image={blog.image} className="w-4 h-4 shrink-0" />
+            <p className="text-sm text-gray-500 truncate">
+              <SearchHighlight text={blog.name} highlight={searchParam} />
+            </p>
+            <span className="text-xs text-gray-400 shrink-0">{formatDate(createdAt)}</span>
+          </div>
+        </div>
       </a>
-      <p className="text-sm text-gray-500">
-        <SearchHighlight text={blog.name} highlight={searchParam} />
-      </p>
     </CommandItem>
   );
 }

--- a/client/src/components/search/SearchResults/SearchResultItem.tsx
+++ b/client/src/components/search/SearchResults/SearchResultItem.tsx
@@ -25,7 +25,7 @@ export default function SearchResultItem({ id, title, blog, thumbnail, createdAt
             <SearchHighlight text={title} highlight={searchParam} />
           </p>
           <div className="flex items-center gap-1.5">
-            <PlatformIcon platform={blog.platform} image={blog.image} className="w-4 h-4 shrink-0" />
+            <PlatformIcon platform={blog.platform} image={blog.image} name={blog.name} className="w-4 h-4 shrink-0" />
             <p className="text-sm text-gray-500 truncate">
               <SearchHighlight text={blog.name} highlight={searchParam} />
             </p>

--- a/client/src/components/search/SearchResults/UserSearchResultItem.tsx
+++ b/client/src/components/search/SearchResults/UserSearchResultItem.tsx
@@ -1,3 +1,5 @@
+import { BadgeCheck } from "lucide-react";
+
 import SearchHighlight from "@/components/search/SearchHigilight";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { CommandItem } from "@/components/ui/command";
@@ -9,7 +11,14 @@ interface UserSearchResultItemProps extends UserSearchResult {
   onSelect: (userId: number) => void;
 }
 
-export default function UserSearchResultItem({ id, userName, profileImage, onSelect }: UserSearchResultItemProps) {
+export default function UserSearchResultItem({
+  id,
+  userName,
+  profileImage,
+  introduction,
+  blogCount,
+  onSelect,
+}: UserSearchResultItemProps) {
   const { searchParam } = useSearchStore();
   const initials = userName ? userName.substring(0, 2).toUpperCase() : "사용자";
 
@@ -20,13 +29,22 @@ export default function UserSearchResultItem({ id, userName, profileImage, onSel
         onClick={() => onSelect(id)}
         className="flex items-center gap-3 w-full px-2 py-1.5 text-left cursor-pointer"
       >
-        <Avatar className="h-9 w-9">
+        <Avatar className="h-9 w-9 shrink-0">
           {profileImage && <AvatarImage src={profileImage} alt={userName} />}
           <AvatarFallback>{initials}</AvatarFallback>
         </Avatar>
-        <p className="text-sm">
-          <SearchHighlight text={userName} highlight={searchParam} />
-        </p>
+        <div className="flex flex-col min-w-0">
+          <div className="text-sm flex items-center gap-1">
+            <SearchHighlight text={userName} highlight={searchParam} />
+            {blogCount > 0 && (
+              <span className="flex items-center gap-0.5 text-xs text-muted-foreground">
+                <BadgeCheck className="h-3.5 w-3.5" />
+                인증된 RSS {blogCount}개
+              </span>
+            )}
+          </div>
+          {introduction && <p className="text-xs text-muted-foreground truncate">{introduction}</p>}
+        </div>
       </button>
     </CommandItem>
   );

--- a/client/src/components/sections/RecentRssSection.tsx
+++ b/client/src/components/sections/RecentRssSection.tsx
@@ -37,7 +37,7 @@ function RssStoryItem({ rss }: { rss: RecentRss }) {
         >
           <div className={`rounded-full p-[2px] ${isStory ? "bg-white" : ""}`}>
             <div className="overflow-hidden bg-white border rounded-full w-14 h-14">
-              <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="object-cover w-full h-full" />
+              <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="object-cover w-full h-full" />
             </div>
           </div>
         </div>

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -153,7 +153,7 @@ const RssHeader = ({
     <CardContent className="p-6">
       <div className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 gap-4">
-          <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} className="flex-shrink-0 w-14 h-14" />
+          <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="flex-shrink-0 w-14 h-14" />
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
               <h1 className="text-2xl font-bold truncate">{rss.name}</h1>

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -61,6 +61,7 @@ export interface RssSearchResult {
   name: string;
   blogPlatform: string;
   blogImage: string | null;
+  feedCount: number;
 }
 
 export interface RssSearchData {

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -6,6 +6,7 @@ export interface SearchResult {
   blog: {
     name: string;
     platform: string;
+    image: string | null;
   };
   path: string;
   createdAt: string;

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -37,6 +37,8 @@ export interface UserSearchResult {
   id: number;
   userName: string;
   profileImage: string | null;
+  introduction: string | null;
+  blogCount: number;
 }
 
 export interface UserSearchData {

--- a/server/src/rss/api-docs/searchRss.api-docs.ts
+++ b/server/src/rss/api-docs/searchRss.api-docs.ts
@@ -13,7 +13,7 @@ export function ApiSearchRss() {
     ApiOperation({
       summary: 'RSS 블로그 이름 검색 API',
       description:
-        '승인된 RSS(rss_accept) 중 블로그 이름으로 검색합니다. 결과는 id, 이름, 플랫폼, 프로필 이미지를 포함합니다.',
+        '승인된 RSS(rss_accept) 중 블로그 이름으로 검색합니다. 결과는 id, 이름, 플랫폼, 프로필 이미지, 공개 게시글 개수를 포함합니다.',
     }),
     ApiQuery({
       name: 'find',

--- a/server/src/rss/dto/response/searchRss.dto.ts
+++ b/server/src/rss/dto/response/searchRss.dto.ts
@@ -19,21 +19,30 @@ export class SearchRssResult {
   })
   blogImage: string | null;
 
+  @ApiProperty({ example: 12, description: '공개 게시글 개수' })
+  feedCount: number;
+
   private constructor(partial: Partial<SearchRssResult>) {
     Object.assign(this, partial);
   }
 
-  static toResultDto(rss: RssAccept) {
+  static toResultDto(rss: RssAccept, feedCount: number) {
     return new SearchRssResult({
       id: rss.id,
       name: rss.name,
       blogPlatform: rss.blogPlatform,
       blogImage: rss.blogImage ?? null,
+      feedCount,
     });
   }
 
-  static toResultDtoArray(rssList: RssAccept[]) {
-    return rssList.map((rss) => this.toResultDto(rss));
+  static toResultDtoArray(
+    rssList: RssAccept[],
+    feedCountMap: Map<number, number>,
+  ) {
+    return rssList.map((rss) =>
+      this.toResultDto(rss, feedCountMap.get(rss.id) ?? 0),
+    );
   }
 }
 

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -344,7 +344,14 @@ export class RssService {
         viewerId,
       );
 
-    const rssList = SearchRssResult.toResultDtoArray(searchResult);
+    const feedCountMap = await this.feedRepository.countPublicFeedsByBlogIds(
+      searchResult.map((rss) => rss.id),
+    );
+
+    const rssList = SearchRssResult.toResultDtoArray(
+      searchResult,
+      feedCountMap,
+    );
     const totalPages = Math.ceil(totalCount / limit);
 
     return SearchRssResponseDto.toResponseDto(

--- a/server/src/user/api-docs/searchUser.api-docs.ts
+++ b/server/src/user/api-docs/searchUser.api-docs.ts
@@ -13,7 +13,7 @@ export function ApiSearchUser() {
     ApiOperation({
       summary: '유저 닉네임 검색 API',
       description:
-        '닉네임 부분 일치(LIKE)로 유저를 검색합니다. 결과는 id, 닉네임, 프로필 이미지를 포함합니다.',
+        '닉네임 부분 일치(LIKE)로 유저를 검색합니다. 결과는 id, 닉네임, 프로필 이미지, 자기소개, 소유 RSS 블로그 개수를 포함합니다.',
     }),
     ApiQuery({
       name: 'find',

--- a/server/src/user/dto/response/searchUser.dto.ts
+++ b/server/src/user/dto/response/searchUser.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-import { User } from '@user/entity/user.entity';
+import { UserSearchRow } from '@user/repository/user.repository';
 
 export class SearchUserResult {
   @ApiProperty({ example: 1, description: '유저 ID' })
@@ -16,20 +16,32 @@ export class SearchUserResult {
   })
   profileImage: string | null;
 
+  @ApiProperty({
+    example: '안녕하세요, 프론트엔드 개발자입니다.',
+    description: '유저 자기소개 (미설정 시 null)',
+    nullable: true,
+  })
+  introduction: string | null;
+
+  @ApiProperty({ example: 3, description: '유저가 소유한 RSS 블로그 개수' })
+  blogCount: number;
+
   private constructor(partial: Partial<SearchUserResult>) {
     Object.assign(this, partial);
   }
 
-  static toResultDto(user: User) {
+  static toResultDto(row: UserSearchRow) {
     return new SearchUserResult({
-      id: user.id,
-      userName: user.userName,
-      profileImage: user.profileImage ?? null,
+      id: row.id,
+      userName: row.userName,
+      profileImage: row.profileImage ?? null,
+      introduction: row.introduction ?? null,
+      blogCount: row.blogCount,
     });
   }
 
-  static toResultDtoArray(users: User[]) {
-    return users.map((user) => this.toResultDto(user));
+  static toResultDtoArray(rows: UserSearchRow[]) {
+    return rows.map((row) => this.toResultDto(row));
   }
 }
 

--- a/server/src/user/repository/user.repository.ts
+++ b/server/src/user/repository/user.repository.ts
@@ -4,9 +4,19 @@ import { DataSource, Repository } from 'typeorm';
 
 import { UserBlock } from '@block/entity/userBlock.entity';
 
+import { RssAccept } from '@rss/entity/rss.entity';
+
 import { activeSuspensionExclusion } from '@suspension/constant/activeSuspension.constant';
 
 import { User } from '@user/entity/user.entity';
+
+export interface UserSearchRow {
+  id: number;
+  userName: string;
+  profileImage: string | null;
+  introduction: string | null;
+  blogCount: number;
+}
 
 @Injectable()
 export class UserRepository extends Repository<User> {
@@ -23,6 +33,19 @@ export class UserRepository extends Repository<User> {
     const escaped = find.replace(/[\\%_]/g, (char) => `\\${char}`);
 
     const query = this.createQueryBuilder('user')
+      .select('user.id', 'id')
+      .addSelect('user.userName', 'userName')
+      .addSelect('user.profileImage', 'profileImage')
+      .addSelect('user.introduction', 'introduction')
+      .addSelect(
+        (qb) =>
+          qb
+            .subQuery()
+            .select('COUNT(*)')
+            .from(RssAccept, 'rss_accept')
+            .where('rss_accept.user_id = user.id'),
+        'blogCount',
+      )
       .where('user.userName LIKE :pattern', { pattern: `%${escaped}%` })
       .andWhere(activeSuspensionExclusion('user.id'))
       .orderBy('user.userName = :find', 'DESC')
@@ -39,7 +62,23 @@ export class UserRepository extends Repository<User> {
       );
     }
 
-    return query.getManyAndCount();
+    const [rows, totalCount] = await Promise.all([
+      query.getRawMany<
+        Omit<UserSearchRow, 'id' | 'blogCount'> & {
+          id: number | string;
+          blogCount: string;
+        }
+      >(),
+      query.getCount(),
+    ]);
+
+    const users: UserSearchRow[] = rows.map((row) => ({
+      ...row,
+      id: Number(row.id),
+      blogCount: Number(row.blogCount ?? 0),
+    }));
+
+    return [users, totalCount] as const;
   }
 
   async isUserBlocked(blockerId: number, blockedId: number) {

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -947,6 +947,9 @@ describe(`${RssService.name} Unit Test`, () => {
       // given
       const rssList = [makeRssAccept(1, 'seok3765.log')];
       rssAcceptRepository.searchRssList.mockResolvedValue([rssList, 1]);
+      feedRepository.countPublicFeedsByBlogIds.mockResolvedValue(
+        new Map([[1, 12]]),
+      );
 
       // when
       const result = await rssService.searchRss({
@@ -962,6 +965,9 @@ describe(`${RssService.name} Unit Test`, () => {
         10,
         undefined,
       );
+      expect(feedRepository.countPublicFeedsByBlogIds).toHaveBeenCalledWith([
+        1,
+      ]);
       expect(result).toEqual(
         SearchRssResponseDto.toResponseDto(
           1,
@@ -971,6 +977,7 @@ describe(`${RssService.name} Unit Test`, () => {
               name: 'seok3765.log',
               blogPlatform: 'velog',
               blogImage: null,
+              feedCount: 12,
             },
           ],
           1,

--- a/server/test/user/e2e/search.e2e-spec.ts
+++ b/server/test/user/e2e/search.e2e-spec.ts
@@ -5,11 +5,14 @@ import TestAgent from 'supertest/lib/agent';
 
 import { UserBlockRepository } from '@block/repository/userBlock.repository';
 
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
 import { UserSuspensionRepository } from '@suspension/repository/userSuspension.repository';
 
 import { User } from '@user/entity/user.entity';
 import { UserRepository } from '@user/repository/user.repository';
 
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
 import { UserFixture } from '@test/config/common/fixture/user.fixture';
 import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
 
@@ -20,7 +23,13 @@ type SearchResponseBody = {
     totalCount: number;
     totalPages: number;
     limit: number;
-    result: { id: number; userName: string; profileImage: string | null }[];
+    result: {
+      id: number;
+      userName: string;
+      profileImage: string | null;
+      introduction: string | null;
+      blogCount: number;
+    }[];
   };
 };
 
@@ -29,12 +38,14 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
   let userRepository: UserRepository;
   let blockRepository: UserBlockRepository;
   let userSuspensionRepository: UserSuspensionRepository;
+  let rssAcceptRepository: RssAcceptRepository;
 
   beforeAll(() => {
     agent = supertest(testApp.getHttpServer());
     userRepository = testApp.get(UserRepository);
     blockRepository = testApp.get(UserBlockRepository);
     userSuspensionRepository = testApp.get(UserSuspensionRepository);
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
   });
 
   const saveUser = (userName: string, overwrites: Partial<User> = {}) =>
@@ -67,11 +78,12 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
     ]);
   });
 
-  it('[200] 검색 결과는 id, 닉네임, 프로필 이미지만 포함한다.', async () => {
+  it('[200] 검색 결과는 id, 닉네임, 프로필 이미지, 자기소개, 소유 RSS 개수를 포함한다.', async () => {
     // given
     const user = await saveUser('프로필유저', {
       profileImage:
         'https://denamu.dev/objects/PROFILE_IMAGE/20250816/uuid.png',
+      introduction: '안녕하세요, 프로필유저입니다.',
     });
 
     // when
@@ -85,11 +97,13 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
         id: user.id,
         userName: user.userName,
         profileImage: user.profileImage,
+        introduction: user.introduction,
+        blogCount: 0,
       },
     ]);
   });
 
-  it('[200] 프로필 이미지가 없으면 null로 반환한다.', async () => {
+  it('[200] 프로필 이미지·자기소개가 없으면 null로 반환한다.', async () => {
     // given
     const user = await saveUser('이미지없음', { profileImage: null });
 
@@ -103,7 +117,33 @@ describe(`GET ${URL}?find={} E2E Test`, () => {
       id: user.id,
       userName: user.userName,
       profileImage: null,
+      introduction: null,
+      blogCount: 0,
     });
+  });
+
+  it('[200] 유저가 소유한 RSS 개수를 함께 반환한다.', async () => {
+    // given
+    const user = await saveUser('블로그유저');
+    await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+    await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: user.id }),
+    );
+    // 다른 유저 소유 RSS는 개수에 포함되면 안 된다.
+    const other = await saveUser('다른블로그유저');
+    await rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture({ userId: other.id }),
+    );
+
+    // when
+    const response = await agent.get(URL).query({ find: '블로그유저' });
+
+    // then
+    const { data } = response.body as SearchResponseBody;
+    expect(response.status).toBe(HttpStatus.OK);
+    expect(data.result[0].blogCount).toBe(2);
   });
 
   it('[200] LIKE 와일드카드(%)가 포함된 검색어는 리터럴로 처리한다.', async () => {

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -123,7 +123,10 @@ describe(`${UserService.name} Unit Test`, () => {
     jwtService = { sign: jest.fn().mockReturnValue('signed-token') };
     configService = { get: jest.fn().mockReturnValue('14d') };
     fileService = { deleteByPath: jest.fn() };
-    rssAcceptRepository = { find: jest.fn(), update: jest.fn() };
+    rssAcceptRepository = {
+      find: jest.fn().mockResolvedValue([]),
+      update: jest.fn(),
+    };
     feedRepository = {
       countPublicFeedsByBlogIds: jest.fn().mockResolvedValue(new Map()),
     };
@@ -168,12 +171,13 @@ describe(`${UserService.name} Unit Test`, () => {
   });
 
   describe('searchUserList', () => {
-    it('닉네임 검색 결과를 id·닉네임·프로필 이미지로 매핑하고 페이지 정보를 계산한다.', async () => {
+    it('닉네임 검색 결과를 id·닉네임·프로필 이미지·자기소개·소유 RSS 개수로 매핑하고 페이지 정보를 계산한다.', async () => {
       // given
       const users = [
         UserFixture.createUserFixture({
           userName: '김개발',
           profileImage: 'https://denamu.dev/profile.png',
+          introduction: '안녕하세요',
         }),
         UserFixture.createUserFixture({
           userName: '김철수',
@@ -182,7 +186,25 @@ describe(`${UserService.name} Unit Test`, () => {
       ] as User[];
       users[0].id = 1;
       users[1].id = 2;
-      userRepository.searchUserList.mockResolvedValue([users, 2]);
+      userRepository.searchUserList.mockResolvedValue([
+        [
+          {
+            id: users[0].id,
+            userName: users[0].userName,
+            profileImage: users[0].profileImage,
+            introduction: users[0].introduction,
+            blogCount: 3,
+          },
+          {
+            id: users[1].id,
+            userName: users[1].userName,
+            profileImage: users[1].profileImage,
+            introduction: users[1].introduction,
+            blogCount: 0,
+          },
+        ],
+        2,
+      ]);
 
       // when
       const result = await userService.searchUserList(
@@ -197,8 +219,16 @@ describe(`${UserService.name} Unit Test`, () => {
             id: 1,
             userName: '김개발',
             profileImage: 'https://denamu.dev/profile.png',
+            introduction: '안녕하세요',
+            blogCount: 3,
           },
-          { id: 2, userName: '김철수', profileImage: null },
+          {
+            id: 2,
+            userName: '김철수',
+            profileImage: null,
+            introduction: null,
+            blogCount: 0,
+          },
         ],
         totalPages: 1,
         limit: 5,


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연결된 이슈 없음

### 검색 결과 정보 부족

- 통합검색(유저/게시글/RSS 탭) 결과 항목이 텍스트 위주라 어떤 유저·게시글·RSS인지 한눈에 파악하기 어려웠음
- 각 탭별로 결과를 클릭해 진입하기 전에 필요한 최소 정보(프로필, 썸네일, 게시글 수, 작성일 등)를 미리 보여주도록 개선

### 게시글 검색 UX

- 게시글 검색 결과에서 제목 텍스트만 클릭 가능해 호버 영역과 실제 클릭 가능 영역이 달랐던 문제를 수정
- "블로거" 검색 필터가 실제로는 RSS 채널명을 검색하고 있어 라벨을 "RSS 이름"으로 명확히 변경

# 📋 작업 내용

- 유저 검색 결과에 인증된 RSS 뱃지, 소유 RSS 개수 및 introduction 표시
- 게시글 검색 결과에 썸네일, 블로그 프로필 이미지, 작성일 표시 및 카드 전체 영역 클릭 지원
- RSS 검색 결과에 플랫폼 뱃지와 공개 게시글 개수 표시 (백엔드: `feedRepository.countPublicFeedsByBlogIds` 재사용해 `feedCount` 응답 필드 추가)
- 게시글 검색 필터 라벨 "블로거" → "RSS 이름"으로 변경

# 📷 스크린 샷(선택 사항)

<img width="497" height="219" alt="image" src="https://github.com/user-attachments/assets/1535fc14-5686-462d-98dd-488679d7255b" />
