### PR TITLE
♻️ refactor: 사용하지 않는 양방향 엔티티 관계 제거

### DIFF
--- a/server/src/activity/entity/activity.entity.ts
+++ b/server/src/activity/entity/activity.entity.ts
@@ -41,7 +41,7 @@ export class Activity extends BaseEntity {
   })
   viewCount: number;
 
-  @ManyToOne(() => User, (user) => user.activities)
+  @ManyToOne(() => User)
   @JoinColumn({ name: 'user_id', foreignKeyConstraintName: 'FK_activity_user_id' })
   user: User;
 }

--- a/server/src/feed/entity/feed.entity.ts
+++ b/server/src/feed/entity/feed.entity.ts
@@ -78,7 +78,7 @@ export class Feed extends BaseEntity {
   })
   isPublic: boolean;
 
-  @ManyToOne(() => RssAccept, (rssAccept) => rssAccept.feeds, {
+  @ManyToOne(() => RssAccept, {
     nullable: false,
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',
@@ -89,7 +89,7 @@ export class Feed extends BaseEntity {
   })
   blog: RssAccept;
 
-  @ManyToMany(() => Tag, (tag) => tag.feeds, { cascade: true })
+  @ManyToMany(() => Tag, { cascade: true })
   @JoinTable({
     name: 'tag_map',
     joinColumn: {

--- a/server/src/rss/entity/rss.entity.ts
+++ b/server/src/rss/entity/rss.entity.ts
@@ -5,12 +5,9 @@ import {
   Index,
   JoinColumn,
   ManyToOne,
-  OneToMany,
   PrimaryGeneratedColumn,
   Unique,
 } from 'typeorm';
-
-import { Feed } from '@feed/entity/feed.entity';
 
 import { User } from '@user/entity/user.entity';
 
@@ -95,9 +92,6 @@ export class RssReject extends RssInformation {
 @Unique('UQ_rss_accept_name', ['name'])
 @Unique('UQ_rss_accept_rss_url', ['rssUrl'])
 export class RssAccept extends RssInformation {
-  @OneToMany(() => Feed, (feed) => feed.blog)
-  feeds: Feed[];
-
   @Index('FT_rss_accept_name', { fulltext: true, parser: 'ngram' })
   @Column({ name: 'name', nullable: false })
   name: string;
@@ -137,7 +131,6 @@ export class RssAccept extends RssInformation {
     blog.blogUrl = rss.blogUrl;
     blog.blogPlatform = rss.blogPlatform;
     blog.blogImage = rss.blogImage;
-    blog.feeds = [];
 
     return blog;
   }

--- a/server/src/tag/entity/tag.entity.ts
+++ b/server/src/tag/entity/tag.entity.ts
@@ -1,14 +1,5 @@
-import {
-  Column,
-  Entity,
-  JoinColumn,
-  ManyToMany,
-  ManyToOne,
-  PrimaryGeneratedColumn,
-  Unique,
-} from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from 'typeorm';
 
-import { Feed } from '@feed/entity/feed.entity';
 import { Category } from '@tag/entity/category.entity';
 
 @Entity({ name: 'tag' })
@@ -29,7 +20,4 @@ export class Tag {
     foreignKeyConstraintName: 'FK_tag_category',
   })
   category: Category;
-
-  @ManyToMany(() => Feed, (feed) => feed.tags)
-  feeds: Feed[];
 }

--- a/server/src/user/entity/provider.entity.ts
+++ b/server/src/user/entity/provider.entity.ts
@@ -55,7 +55,7 @@ export class Provider extends BaseEntity {
   })
   updatedAt: Date;
 
-  @ManyToOne(() => User, (user) => user.providers, {
+  @ManyToOne(() => User, {
     nullable: false,
     onUpdate: 'CASCADE',
     onDelete: 'CASCADE',

--- a/server/src/user/entity/user.entity.ts
+++ b/server/src/user/entity/user.entity.ts
@@ -3,15 +3,10 @@ import {
   Column,
   CreateDateColumn,
   Entity,
-  OneToMany,
   PrimaryGeneratedColumn,
   Unique,
   UpdateDateColumn,
 } from 'typeorm';
-
-import { Activity } from '@activity/entity/activity.entity';
-
-import { Provider } from '@user/entity/provider.entity';
 
 @Entity({
   name: 'user',
@@ -131,10 +126,4 @@ export class User extends BaseEntity {
     default: 0,
   })
   profileImageChangeCount: number;
-
-  @OneToMany(() => Activity, (activity) => activity.user)
-  activities: Activity[];
-
-  @OneToMany(() => Provider, (provider) => provider.user)
-  providers: Provider[];
 }

--- a/server/test/user/unit/user.service.unit.spec.ts
+++ b/server/test/user/unit/user.service.unit.spec.ts
@@ -891,7 +891,7 @@ describe(`${UserService.name} Unit Test`, () => {
     it('사용자가 있으면 인증 코드를 저장하고 메일을 발송한다.', async () => {
       // given
       userRepository.findOne.mockResolvedValue(
-        UserFixture.createUserFixture({ id: 1, providers: [] }),
+        UserFixture.createUserFixture({ id: 1 }),
       );
 
       // when
@@ -913,7 +913,6 @@ describe(`${UserService.name} Unit Test`, () => {
         UserFixture.createUserFixture({
           id: 1,
           password: null,
-          providers: [{}] as any,
         }),
       );
 


### PR DESCRIPTION
# 🔨 테스크

### Issue

- 연결된 이슈 없음 (엔티티 관계 점검 중 발견한 구조적 개선 사항)

### 단방향 관계로 정리

- 작업 이유: TypeORM 엔티티는 단방향(`@ManyToOne`만 정의)이 베스트 프랙티스인데, 코드베이스 전수 점검 결과 역방향(`@OneToMany` / `@ManyToMany` inverse)이 걸려 있으면서 실제로는 어디서도 참조되지 않는 관계 4쌍을 발견해 정리함.
- 고민했던 점: 역방향 관계 6쌍 중 실사용 여부를 `relations:`, `leftJoinAndSelect`, 프로퍼티 접근 전체를 grep해서 확인 → 4쌍은 완전 미사용, 2쌍(`Category.tags`, `Qna.messages`)은 단일 지점에서 JOIN 조회에 쓰이고 있어 구분해서 처리함.

# 📋 작업 내용

**제거한 미사용 역방향 관계 4쌍** (단방향 `@ManyToOne`/`@ManyToMany`로 정리)

- `User.activities` ↔ `Activity.user`
- `User.providers` ↔ `Provider.user`
- `RssAccept.feeds` ↔ `Feed.blog`
- `Tag.feeds` ↔ `Feed.tags` (ManyToMany)

FK 컬럼/조인 테이블(`tag_map`) 구조는 그대로 유지해 스키마 변경은 없음 (`init.sql`/마이그레이션 대상 아님).

**장점**

- 미사용 인버스 프로퍼티가 사라져 엔티티만 봐도 실제 참조 관계를 바로 파악 가능 (죽은 코드 제거)
- 부모 엔티티가 자식 컬렉션 존재를 몰라도 되므로 양방향 결합 감소 → 스키마 변경 시 동기화해야 할 지점이 줄어듦
- 실수로 `relations: ['activities']`, `relations: ['providers']`, `relations: ['feeds']` 등을 걸어 컬렉션 전체를 의도치 않게 로드하는 사고를 원천 차단
- 엔티티 정의가 짧아져 가독성/유지보수성 향상

**그대로 둔 2쌍과 이유**

- `Category.tags` ↔ `Tag.category`, `Qna.messages` ↔ `QnaMessage.qna`는 각각 `category.repository.ts`, `qna.repository.ts`에서 `relations: {...}`로 부모+자식을 **단일 JOIN 쿼리**로 가져오는 유일한 사용처가 있음.
- 카테고리당 태그 수, 문의 스레드 길이 모두 자연히 유계라 무제한 로드·N+1 위험이 없어, 애초에 단방향 원칙이 막으려는 문제(안 쓰는데 걸린 역방향, 무분별한 지연 로딩)에 해당하지 않음.
- 단방향으로 바꾸면 JOIN 1회 → 자식 리포지토리 조회 1회 추가로 쿼리 왕복이 늘고 서비스 코드도 늘어나는데, 해결되는 문제는 없어 순수 리팩터링 비용만 발생 → 손대지 않는 게 이득.

# 📷 스크린 샷(선택 사항)

해당 없음 (엔티티 관계 정리, 동작 변화 없음)