### PR TITLE
✨ feat: RSS 전체 목록 조회 페이지 구현

### DIFF
--- a/client/src/__storybook__/fixtures.ts
+++ b/client/src/__storybook__/fixtures.ts
@@ -147,6 +147,7 @@ export const mockRssSearchResult: RssSearchResult = {
   blogPlatform: "velog",
   blogImage: "https://picsum.photos/seed/rsearch/80/80",
   feedCount: 24,
+  lastPublishedAt: "2025-01-15T00:00:00.000Z",
 };
 
 export const mockAdminRssList: AdminRssData[] = [

--- a/client/src/__tests__/components/common/search/SearchResults/RssSearchResultItem.test.tsx
+++ b/client/src/__tests__/components/common/search/SearchResults/RssSearchResultItem.test.tsx
@@ -22,6 +22,7 @@ describe("RssSearchResultItem", () => {
     blogPlatform: "velog",
     blogImage: null,
     feedCount: 3,
+    lastPublishedAt: null,
   };
 
   it("RSS 이름이 렌더링되어야 한다", () => {

--- a/client/src/__tests__/components/layout/navigation/DesktopNavigation.test.tsx
+++ b/client/src/__tests__/components/layout/navigation/DesktopNavigation.test.tsx
@@ -77,6 +77,14 @@ describe("DesktopNavigation", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/board");
   });
 
+  it("'블로그 목록' 클릭 시 /rss로 이동해야 한다", () => {
+    render(<DesktopNavigation toggleModal={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("블로그 목록"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/rss");
+  });
+
   it("'블로그 등록' 클릭 시 toggleModal('rss')를 호출해야 한다", () => {
     const toggleModal = vi.fn();
     render(<DesktopNavigation toggleModal={toggleModal} />);

--- a/client/src/__tests__/components/layout/sidebar/NavigationButtons.test.tsx
+++ b/client/src/__tests__/components/layout/sidebar/NavigationButtons.test.tsx
@@ -38,6 +38,14 @@ describe("NavigationButtons", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/board");
   });
 
+  it("'블로그 목록' 클릭 시 /rss로 이동해야 한다", () => {
+    render(<NavigationButtons onAction={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "블로그 목록" }));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/rss");
+  });
+
   it("tap이 main이면 '차트' 버튼이 보이고 클릭 시 chart로 전환 후 onAction을 호출해야 한다", () => {
     const onAction = vi.fn();
     render(<NavigationButtons onAction={onAction} />);

--- a/client/src/__tests__/hooks/queries/useAllRss.test.tsx
+++ b/client/src/__tests__/hooks/queries/useAllRss.test.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAllRss } from "@/hooks/queries/useAllRss";
+
+import { getAllRss } from "@/api/services/rss";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+
+vi.mock("@/api/services/rss", async () => {
+  const actual = await vi.importActual<object>("@/api/services/rss");
+  return { ...actual, getAllRss: vi.fn() };
+});
+
+const mocked = { getAllRss: vi.mocked(getAllRss) };
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+describe("useAllRss", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocked.getAllRss.mockResolvedValue({
+      message: "성공",
+      data: { totalCount: 0, result: [], totalPages: 0 },
+    });
+  });
+
+  it("page와 limit을 그대로 전달해 getAllRss를 호출한다", async () => {
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useAllRss(2, 20), { wrapper });
+
+    await waitFor(() => expect(mocked.getAllRss).toHaveBeenCalledWith(2, 20, undefined));
+  });
+
+  it("blogPlatform이 있으면 함께 전달한다", async () => {
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useAllRss(1, 20, "velog"), { wrapper });
+
+    await waitFor(() => expect(mocked.getAllRss).toHaveBeenCalledWith(1, 20, "velog"));
+  });
+});

--- a/client/src/__tests__/hooks/queries/useRssSearch.test.tsx
+++ b/client/src/__tests__/hooks/queries/useRssSearch.test.tsx
@@ -91,7 +91,7 @@ describe("useRssSearch", () => {
 
   it("API 응답을 data로 반환한다.", async () => {
     const response = makeResponse([
-      { id: 1, name: "seok3765.log", blogPlatform: "velog", blogImage: null, feedCount: 5 },
+      { id: 1, name: "seok3765.log", blogPlatform: "velog", blogImage: null, feedCount: 5, lastPublishedAt: null },
     ]);
     getRssSearch.mockResolvedValue(response);
 

--- a/client/src/__tests__/pages/RssListPage.test.tsx
+++ b/client/src/__tests__/pages/RssListPage.test.tsx
@@ -1,0 +1,193 @@
+import type { ReactNode } from "react";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { lucideProxy } from "@/__tests__/__mocks__/external/lucide-proxy.tsx";
+
+import RssListPage from "@/pages/RssListPage.tsx";
+
+import { formatDate } from "@/utils/date";
+
+import { RssSearchData, RssSearchResponse } from "@/types/search";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const mockNavigateToRss = vi.fn();
+
+let allRssState: { data: RssSearchResponse | undefined; isLoading: boolean; isError: boolean };
+
+const useAllRssMock = vi.fn<
+  (page: number, limit: number, blogPlatform?: string) => typeof allRssState
+>(() => allRssState);
+
+vi.mock("lucide-react", () => lucideProxy());
+
+vi.mock("react-router-dom", () => ({
+  Link: ({ children, to }: { children: ReactNode; to: string }) => <a href={to}>{children}</a>,
+}));
+
+vi.mock("react-helmet", () => ({
+  Helmet: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/layout/Layout", () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/hooks/common/useNavigateToRss", () => ({
+  useNavigateToRss: () => mockNavigateToRss,
+}));
+
+vi.mock("@/hooks/queries/useAllRss", () => ({
+  useAllRss: (page: number, limit: number, blogPlatform?: string) => useAllRssMock(page, limit, blogPlatform),
+}));
+
+vi.mock("@/components/ui/select", () => {
+  const pass = ({ children }: { children: ReactNode }) => <>{children}</>;
+  return {
+    Select: ({ children, onValueChange }: { children: ReactNode; onValueChange: (value: string) => void }) => (
+      <div
+        onClick={(event) => {
+          const value = (event.target as HTMLElement).getAttribute("data-value");
+          if (value) onValueChange(value);
+        }}
+      >
+        {children}
+      </div>
+    ),
+    SelectContent: pass,
+    SelectItem: ({ children, value }: { children: ReactNode; value: string }) => (
+      <div role="option" data-value={value}>
+        {children}
+      </div>
+    ),
+    SelectTrigger: ({ children }: { children: ReactNode }) => <div data-testid="platform-trigger">{children}</div>,
+    SelectValue: pass,
+  };
+});
+
+const makeData = (result: RssSearchData["result"], totalCount = result.length, totalPages = 1): RssSearchResponse => ({
+  message: "성공",
+  data: { result, totalCount, totalPages },
+});
+
+describe("RssListPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allRssState = { data: makeData([]), isLoading: false, isError: false };
+  });
+
+  it("로딩 중에는 로딩 문구를 보여준다", () => {
+    allRssState = { data: undefined, isLoading: true, isError: false };
+
+    render(<RssListPage />);
+
+    expect(screen.getByText("불러오는 중...")).toBeInTheDocument();
+  });
+
+  it("에러 시 에러 문구를 보여준다", () => {
+    allRssState = { data: undefined, isLoading: false, isError: true };
+
+    render(<RssListPage />);
+
+    expect(screen.getByText("RSS 목록을 불러오지 못했습니다.")).toBeInTheDocument();
+  });
+
+  it("목록이 비어있으면 안내 문구를 보여준다", () => {
+    render(<RssListPage />);
+
+    expect(screen.getByText("등록된 RSS가 없습니다.")).toBeInTheDocument();
+  });
+
+  it("RSS 목록과 총 개수를 렌더링한다", () => {
+    allRssState = {
+      data: makeData(
+        [{
+          id: 1,
+          name: "seok3765.log",
+          blogPlatform: "velog",
+          blogImage: null,
+          feedCount: 12,
+          lastPublishedAt: "2025-01-15T00:00:00.000Z",
+        }],
+        1,
+        1
+      ),
+      isLoading: false,
+      isError: false,
+    };
+
+    render(<RssListPage />);
+
+    expect(screen.getByText("seok3765.log")).toBeInTheDocument();
+    expect(screen.getByText("게시글 12개")).toBeInTheDocument();
+    expect(screen.getByText("등록된 블로그 총 1개")).toBeInTheDocument();
+    expect(
+      screen.getByText(`최근 게시글 ${formatDate("2025-01-15T00:00:00.000Z")}`)
+    ).toBeInTheDocument();
+  });
+
+  it("최근 게시글이 없으면 날짜 대신 '-'를 표시한다", () => {
+    allRssState = {
+      data: makeData(
+        [{ id: 1, name: "seok3765.log", blogPlatform: "velog", blogImage: null, feedCount: 0, lastPublishedAt: null }],
+        1,
+        1
+      ),
+      isLoading: false,
+      isError: false,
+    };
+
+    render(<RssListPage />);
+
+    expect(screen.getByText("최근 게시글 -")).toBeInTheDocument();
+  });
+
+  it("카드를 클릭하면 해당 RSS로 이동한다", () => {
+    allRssState = {
+      data: makeData([{ id: 7, name: "seok3765.log", blogPlatform: "velog", blogImage: null, feedCount: 3, lastPublishedAt: null }], 1, 1),
+      isLoading: false,
+      isError: false,
+    };
+
+    render(<RssListPage />);
+
+    fireEvent.click(screen.getByText("seok3765.log"));
+
+    expect(mockNavigateToRss).toHaveBeenCalledWith(7);
+  });
+
+  it("페이지가 2개 이상이면 페이지네이션을 보여주고 다음 클릭 시 page를 올린다", () => {
+    allRssState = {
+      data: makeData([{ id: 1, name: "a", blogPlatform: "velog", blogImage: null, feedCount: 1, lastPublishedAt: null }], 2, 2),
+      isLoading: false,
+      isError: false,
+    };
+
+    render(<RssListPage />);
+
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "이전" })).toBeDisabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "다음" }));
+
+    expect(useAllRssMock).toHaveBeenLastCalledWith(2, 21, undefined);
+  });
+
+  it("초기 상태에서는 트리거에 '전체 플랫폼'이 표시된다", () => {
+    render(<RssListPage />);
+
+    expect(screen.getByTestId("platform-trigger")).toHaveTextContent("전체 플랫폼");
+  });
+
+  it("플랫폼 필터 선택 시 해당 플랫폼으로 조회하고, 트리거 표시와 페이지를 갱신한다", () => {
+    render(<RssListPage />);
+
+    expect(useAllRssMock).toHaveBeenLastCalledWith(1, 21, undefined);
+
+    fireEvent.click(screen.getByRole("option", { name: /Velog/ }));
+
+    expect(useAllRssMock).toHaveBeenLastCalledWith(1, 21, "velog");
+    expect(screen.getByTestId("platform-trigger")).toHaveTextContent("Velog");
+    expect(screen.getByText("Velog 블로그 총 0개")).toBeInTheDocument();
+  });
+});

--- a/client/src/api/services/rss.ts
+++ b/client/src/api/services/rss.ts
@@ -12,9 +12,17 @@ import {
   RssInfo,
 } from "@/types/profile";
 import { RecentRss, RegisterRss, RegisterResponse } from "@/types/rss";
+import { RssSearchResponse } from "@/types/search";
 
 export const registerRss = async (data: RegisterRss): Promise<RegisterResponse> => {
   const response = await axiosInstance.post<RegisterResponse>(BLOG.RSS.REGISTRER_RSS, data);
+  return response.data;
+};
+
+export const getAllRss = async (page: number, limit: number, blogPlatform?: string): Promise<RssSearchResponse> => {
+  const response = await axiosInstance.get<RssSearchResponse>(BLOG.RSS.ALL, {
+    params: { page, limit, blogPlatform },
+  });
   return response.data;
 };
 
@@ -95,11 +103,7 @@ export const getOwnedRssFeeds = async (
   return response.data.data;
 };
 
-export const setFeedVisibility = async (
-  rssId: number,
-  feedId: number,
-  isPublic: boolean
-): Promise<ApiMessage> => {
+export const setFeedVisibility = async (rssId: number, feedId: number, isPublic: boolean): Promise<ApiMessage> => {
   const response = await axiosInstance.patch<ApiMessage>(BLOG.RSS.FEED_VISIBILITY(rssId, feedId), { isPublic });
   return response.data;
 };

--- a/client/src/components/layout/navigation/DesktopNavigation.tsx
+++ b/client/src/components/layout/navigation/DesktopNavigation.tsx
@@ -63,6 +63,15 @@ export default function DesktopNavigation({ toggleModal }: { toggleModal: (modal
               </NavigationMenuLink>
             </NavigationMenuItem>
             <NavigationMenuItem>
+              <NavigationMenuLink
+                className={`${navigationMenuTriggerStyle()} hover:text-primary hover:bg-primary/10`}
+                onClick={() => navigate("/rss")}
+                href="#"
+              >
+                블로그 목록
+              </NavigationMenuLink>
+            </NavigationMenuItem>
+            <NavigationMenuItem>
               <NoticeBell />
             </NavigationMenuItem>
             <NavigationMenuItem>

--- a/client/src/components/layout/sidebar/NavigationButtons.tsx
+++ b/client/src/components/layout/sidebar/NavigationButtons.tsx
@@ -20,6 +20,10 @@ export const NavigationButtons = ({ onAction }: NavigationButtonsProps) => {
     navigate("/board");
   };
 
+  const handleRssListClick = () => {
+    navigate("/rss");
+  };
+
   const handleTapChange = (newTap: "main" | "chart") => {
     setTap(newTap);
     onAction();
@@ -33,6 +37,10 @@ export const NavigationButtons = ({ onAction }: NavigationButtonsProps) => {
 
       <Button onClick={handleBoardClick} variant="outline">
         공지사항 · Q&A
+      </Button>
+
+      <Button onClick={handleRssListClick} variant="outline">
+        블로그 목록
       </Button>
 
       {tap === "main" ? (

--- a/client/src/constants/endpoints.ts
+++ b/client/src/constants/endpoints.ts
@@ -46,6 +46,7 @@ export const BLOG = {
   },
   RSS: {
     REGISTRER_RSS: "/api/rss",
+    ALL: "/api/rss",
     RECENT: "/api/rss/recent",
     INFO: (id: number) => `/api/rss/${id}`,
     FEEDS: (id: number) => `/api/rss/${id}/feeds`,

--- a/client/src/constants/rss.ts
+++ b/client/src/constants/rss.ts
@@ -45,6 +45,15 @@ export const PLATFORMS: Record<PlatformType, Platform> = {
   },
 };
 
+export const RSS_LIST_PLATFORM_FILTERS: { value: string; label: string }[] = [
+  { value: "tistory", label: "Tistory" },
+  { value: "velog", label: "Velog" },
+  { value: "medium", label: "Medium" },
+  { value: "github", label: "Github" },
+  { value: "naver", label: "Naver" },
+  { value: "etc", label: "기타" },
+];
+
 export const BLOG_ADDRESS_PLATFORM_TYPES = ["tistory", "velog", "medium", "github", "naver"] as const;
 export type BlogAddressPlatformType = (typeof BLOG_ADDRESS_PLATFORM_TYPES)[number];
 

--- a/client/src/hooks/queries/useAllRss.ts
+++ b/client/src/hooks/queries/useAllRss.ts
@@ -1,0 +1,9 @@
+import { getAllRss } from "@/api/services/rss";
+import { useQuery } from "@tanstack/react-query";
+
+export const useAllRss = (page: number, limit: number, blogPlatform?: string) => {
+  return useQuery({
+    queryKey: ["allRss", page, limit, blogPlatform],
+    queryFn: () => getAllRss(page, limit, blogPlatform),
+  });
+};

--- a/client/src/pages/RssListPage.stories.tsx
+++ b/client/src/pages/RssListPage.stories.tsx
@@ -1,0 +1,118 @@
+import RssListPage from "@/pages/RssListPage";
+
+import { BLOG } from "@/constants/endpoints";
+
+import { fail, mockApi, ok } from "@/__storybook__/mockApi";
+import { RssSearchData } from "@/types/search";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, userEvent, waitFor, within } from "storybook/test";
+
+const meta = {
+  title: "pages/RssListPage",
+  component: RssListPage,
+  parameters: {
+    router: { initialEntries: ["/rss"] },
+  },
+} satisfies Meta<typeof RssListPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const rssListData: RssSearchData = {
+  totalCount: 4,
+  totalPages: 1,
+  result: [
+    {
+      id: 1,
+      name: "seok3765.log",
+      blogPlatform: "velog",
+      blogImage: null,
+      feedCount: 12,
+      lastPublishedAt: "2025-01-15T00:00:00.000Z",
+    },
+    {
+      id: 2,
+      name: "데나무 팀 블로그",
+      blogPlatform: "tistory",
+      blogImage: null,
+      feedCount: 34,
+      lastPublishedAt: null,
+    },
+    {
+      id: 3,
+      name: "denamu-devlog",
+      blogPlatform: "github",
+      blogImage: null,
+      feedCount: 5,
+      lastPublishedAt: "2025-03-02T00:00:00.000Z",
+    },
+    {
+      id: 4,
+      name: "우리팀 기술 블로그",
+      blogPlatform: "medium",
+      blogImage: null,
+      feedCount: 21,
+      lastPublishedAt: "2025-02-20T00:00:00.000Z",
+    },
+  ],
+};
+
+export const WithData: Story = {
+  name: "RSS 목록 있음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.ALL).reply(...ok(rssListData));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("seok3765.log")).toBeInTheDocument();
+    await expect(canvas.getByText("데나무 팀 블로그")).toBeInTheDocument();
+    await expect(canvas.getByText("denamu-devlog")).toBeInTheDocument();
+    await expect(canvas.getByText("우리팀 기술 블로그")).toBeInTheDocument();
+  },
+};
+
+export const FilterFlow: Story = {
+  name: "플랫폼 필터링",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.ALL).replyOnce(...ok(rssListData));
+    mockApi.onGet(BLOG.RSS.ALL).reply(
+      ...ok({
+        totalCount: 1,
+        totalPages: 1,
+        result: [rssListData.result[0]],
+      })
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.ownerDocument.body);
+    await expect(await body.findByText("데나무 팀 블로그")).toBeInTheDocument();
+
+    await userEvent.click(await body.findByRole("combobox"));
+    await userEvent.click(await body.findByRole("option", { name: /Velog/ }));
+
+    await waitFor(() => expect(body.queryByText("데나무 팀 블로그")).not.toBeInTheDocument());
+    await expect(body.getByText("seok3765.log")).toBeInTheDocument();
+  },
+};
+
+export const Empty: Story = {
+  name: "등록된 RSS 없음",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.ALL).reply(...ok({ totalCount: 0, totalPages: 0, result: [] }));
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("등록된 RSS가 없습니다.")).toBeInTheDocument();
+  },
+};
+
+export const Error: Story = {
+  name: "오류",
+  beforeEach: () => {
+    mockApi.onGet(BLOG.RSS.ALL).reply(...fail());
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(await canvas.findByText("RSS 목록을 불러오지 못했습니다.")).toBeInTheDocument();
+  },
+};

--- a/client/src/pages/RssListPage.tsx
+++ b/client/src/pages/RssListPage.tsx
@@ -1,0 +1,148 @@
+import { useState } from "react";
+import { Helmet } from "react-helmet";
+
+import { CalendarClock, FileText } from "lucide-react";
+
+import { Footer } from "@/components/about/Footer";
+import Layout from "@/components/layout/Layout";
+import { BlogPlatformBadge } from "@/components/profile/rss/BlogPlatformBadge";
+import { PlatformIcon } from "@/components/profile/rss/PlatformIcon";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+
+import { useNavigateToRss } from "@/hooks/common/useNavigateToRss";
+import { useAllRss } from "@/hooks/queries/useAllRss";
+
+import { formatDate } from "@/utils/date";
+
+import { RSS_LIST_PLATFORM_FILTERS } from "@/constants/rss";
+
+const PAGE_SIZE = 21;
+const ALL_PLATFORMS = "all";
+const ALL_PLATFORMS_LABEL = "전체 플랫폼";
+
+export default function RssListPage() {
+  const [page, setPage] = useState(1);
+  const [platform, setPlatform] = useState(ALL_PLATFORMS);
+  const navigateToRss = useNavigateToRss();
+  const { data, isLoading, isError } = useAllRss(page, PAGE_SIZE, platform === ALL_PLATFORMS ? undefined : platform);
+
+  const rssList = data?.data.result ?? [];
+  const totalCount = data?.data.totalCount ?? 0;
+  const totalPages = data?.data.totalPages ?? 0;
+
+  const handlePlatformChange = (value: string) => {
+    setPlatform(value);
+    setPage(1);
+  };
+
+  const selectedPlatform = RSS_LIST_PLATFORM_FILTERS.find((p) => p.value === platform);
+
+  return (
+    <>
+      <Layout>
+        <Helmet>
+          <title>등록된 RSS - 데나무</title>
+        </Helmet>
+
+        <div className="max-w-5xl px-4 py-8 mx-auto md:px-8">
+          <div className="flex items-end justify-between gap-4 mb-6">
+            <div>
+              <h1 className="mb-1 text-2xl font-bold">등록된 RSS</h1>
+              <p className="text-sm text-gray-500">
+                {selectedPlatform ? `${selectedPlatform.label} 블로그` : "등록된 블로그"} 총 {totalCount}개
+              </p>
+            </div>
+
+            <Select value={platform} onValueChange={handlePlatformChange}>
+              <SelectTrigger className="w-36 shrink-0" aria-label="플랫폼 필터">
+                <SelectValue placeholder={ALL_PLATFORMS_LABEL}>
+                  {selectedPlatform ? (
+                    <span className="flex items-center gap-2">
+                      <PlatformIcon platform={selectedPlatform.value} className="w-4 h-4" />
+                      {selectedPlatform.label}
+                    </span>
+                  ) : (
+                    ALL_PLATFORMS_LABEL
+                  )}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL_PLATFORMS}>{ALL_PLATFORMS_LABEL}</SelectItem>
+                {RSS_LIST_PLATFORM_FILTERS.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    <span className="flex items-center gap-2">
+                      <PlatformIcon platform={value} className="w-4 h-4" />
+                      {label}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {isLoading && <p className="py-12 text-sm text-center text-gray-400">불러오는 중...</p>}
+          {isError && <p className="py-12 text-sm text-center text-red-500">RSS 목록을 불러오지 못했습니다.</p>}
+          {!isLoading && !isError && rssList.length === 0 && (
+            <p className="py-12 text-sm text-center text-gray-400">등록된 RSS가 없습니다.</p>
+          )}
+
+          {!isLoading && !isError && rssList.length > 0 && (
+            <ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {rssList.map((rss) => (
+                <li key={rss.id}>
+                  <Card
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => navigateToRss(rss.id)}
+                    onKeyDown={(e) => e.key === "Enter" && navigateToRss(rss.id)}
+                    className="transition-colors cursor-pointer hover:bg-accent"
+                  >
+                    <CardContent className="flex items-center gap-3 p-4">
+                      <div className="overflow-hidden bg-white border rounded-full w-10 h-10 shrink-0">
+                        <PlatformIcon
+                          platform={rss.blogPlatform}
+                          image={rss.blogImage}
+                          name={rss.name}
+                          className="object-cover w-full h-full"
+                        />
+                      </div>
+                      <div className="flex flex-col flex-1 min-w-0 gap-0.5">
+                        <span className="font-medium truncate">{rss.name}</span>
+                        <span className="flex items-center gap-1 text-xs text-gray-500">
+                          <FileText className="w-3 h-3" />
+                          게시글 {rss.feedCount}개
+                        </span>
+                        <span className="flex items-center gap-1 text-xs text-gray-500">
+                          <CalendarClock className="w-3 h-3" />
+                          최근 게시글 {rss.lastPublishedAt ? formatDate(rss.lastPublishedAt) : "-"}
+                        </span>
+                      </div>
+                      <BlogPlatformBadge platform={rss.blogPlatform} className="shrink-0" />
+                    </CardContent>
+                  </Card>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-6">
+              <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)}>
+                이전
+              </Button>
+              <span className="text-sm text-gray-500">
+                {page} / {totalPages}
+              </span>
+              <Button variant="outline" size="sm" disabled={page >= totalPages} onClick={() => setPage((p) => p + 1)}>
+                다음
+              </Button>
+            </div>
+          )}
+        </div>
+      </Layout>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/routes/index.tsx
+++ b/client/src/routes/index.tsx
@@ -15,6 +15,7 @@ const PrivacyPolicy = lazy(() => import("@/pages/PrivacyPolicy"));
 const PostDetailPage = lazy(() => import("@/pages/PostDetailPage"));
 const Profile = lazy(() => import("@/pages/Profile"));
 const RssPage = lazy(() => import("@/pages/RssPage"));
+const RssListPage = lazy(() => import("@/pages/RssListPage"));
 const SignIn = lazy(() => import("@/pages/SignIn"));
 const SignUp = lazy(() => import("@/pages/SignUp"));
 const UserCertificate = lazy(() => import("@/pages/email-actions/UserCertificate"));
@@ -212,6 +213,14 @@ export const AppRouter = ({ location, state }: RouterProps) => {
           element={
             <Suspense fallback={<Loading />}>
               <Profile />
+            </Suspense>
+          }
+        />
+        <Route
+          path="/rss"
+          element={
+            <Suspense fallback={<Loading />}>
+              <RssListPage />
             </Suspense>
           }
         />

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -62,6 +62,7 @@ export interface RssSearchResult {
   blogPlatform: string;
   blogImage: string | null;
   feedCount: number;
+  lastPublishedAt: string | null;
 }
 
 export interface RssSearchData {

--- a/server/src/feed/repository/feed.repository.ts
+++ b/server/src/feed/repository/feed.repository.ts
@@ -143,6 +143,22 @@ export class FeedRepository extends Repository<Feed> {
     return rows.map((row) => Number(row.year));
   }
 
+  async getLatestPublicFeedDateByBlogIds(
+    blogIds: number[],
+  ): Promise<Map<number, Date>> {
+    if (!blogIds.length) return new Map();
+
+    const rows = await this.createQueryBuilder('feed')
+      .select('feed.blog_id', 'blogId')
+      .addSelect('MAX(feed.created_at)', 'latest')
+      .where('feed.blog_id IN (:...blogIds)', { blogIds })
+      .andWhere('feed.is_public = 1')
+      .groupBy('feed.blog_id')
+      .getRawMany<{ blogId: number; latest: Date }>();
+
+    return new Map(rows.map((row) => [Number(row.blogId), row.latest]));
+  }
+
   async countPublicFeedsByBlogIds(
     blogIds: number[],
   ): Promise<Map<number, number>> {

--- a/server/src/rss/api-docs/getAllRss.api-docs.ts
+++ b/server/src/rss/api-docs/getAllRss.api-docs.ts
@@ -6,7 +6,7 @@ import {
   ApiDataResponse,
 } from '@common/swagger/swagger.helper';
 
-import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
+import { RssListResponseDto } from '@rss/dto/response/rssList.dto';
 
 export function ApiGetAllRss() {
   return applyDecorators(
@@ -36,7 +36,7 @@ export function ApiGetAllRss() {
       description: '필터링할 RSS 블로그 플랫폼',
       example: 'velog',
     }),
-    ApiDataResponse(SearchRssResponseDto, false, '전체 RSS 목록 조회 성공'),
+    ApiDataResponse(RssListResponseDto, false, '전체 RSS 목록 조회 성공'),
     ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
   );
 }

--- a/server/src/rss/api-docs/getAllRss.api-docs.ts
+++ b/server/src/rss/api-docs/getAllRss.api-docs.ts
@@ -1,0 +1,42 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiQuery } from '@nestjs/swagger';
+
+import {
+  ApiBadRequestDoc,
+  ApiDataResponse,
+} from '@common/swagger/swagger.helper';
+
+import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
+
+export function ApiGetAllRss() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '전체 RSS 목록 조회 API',
+      description:
+        '승인된 RSS(rss_accept) 전체를 최근 공개 게시글 발행일 순으로 페이지네이션하여 조회합니다. 게시글이 없는 RSS는 마지막에 정렬됩니다. 결과는 id, 이름, 플랫폼, 프로필 이미지, 공개 게시글 개수, 최근 게시글 발행일을 포함합니다.',
+    }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      type: Number,
+      description: '페이지 번호',
+      example: 1,
+    }),
+    ApiQuery({
+      name: 'limit',
+      required: false,
+      type: Number,
+      description: '한 페이지에 보여줄 개수',
+      example: 20,
+    }),
+    ApiQuery({
+      name: 'blogPlatform',
+      required: false,
+      type: String,
+      description: '필터링할 RSS 블로그 플랫폼',
+      example: 'velog',
+    }),
+    ApiDataResponse(SearchRssResponseDto, false, '전체 RSS 목록 조회 성공'),
+    ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
+  );
+}

--- a/server/src/rss/api-docs/searchRss.api-docs.ts
+++ b/server/src/rss/api-docs/searchRss.api-docs.ts
@@ -6,7 +6,7 @@ import {
   ApiDataResponse,
 } from '@common/swagger/swagger.helper';
 
-import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
+import { RssListResponseDto } from '@rss/dto/response/rssList.dto';
 
 export function ApiSearchRss() {
   return applyDecorators(
@@ -36,7 +36,7 @@ export function ApiSearchRss() {
       description: '한 페이지에 보여줄 개수',
       example: 5,
     }),
-    ApiDataResponse(SearchRssResponseDto, false, 'RSS 검색 결과 조회 성공'),
+    ApiDataResponse(RssListResponseDto, false, 'RSS 검색 결과 조회 성공'),
     ApiBadRequestDoc('요청 데이터 검증에 실패했습니다.'),
   );
 }

--- a/server/src/rss/controller/rss.controller.ts
+++ b/server/src/rss/controller/rss.controller.ts
@@ -30,6 +30,7 @@ import { ApiCreateRssCertification } from '@rss/api-docs/createRssCertification.
 import { ApiDeleteCertificateRss } from '@rss/api-docs/deleteCertificateRss.api-docs';
 import { ApiDeleteRss } from '@rss/api-docs/deleteRss.api-docs';
 import { ApiDeleteRssCertification } from '@rss/api-docs/deleteRssCertification.api-docs';
+import { ApiGetAllRss } from '@rss/api-docs/getAllRss.api-docs';
 import { ApiGetOwnedRssFeeds } from '@rss/api-docs/getOwnedRssFeeds.api-docs';
 import { ApiGetRecentRss } from '@rss/api-docs/getRecentRss.api-docs';
 import { ApiGetRssActivities } from '@rss/api-docs/getRssActivities.api-docs';
@@ -45,6 +46,7 @@ import { CreateRssCertificationRequestDto } from '@rss/dto/request/createRssCert
 import { DeleteCertificateRssRequestDto } from '@rss/dto/request/deleteCertificateRss.dto';
 import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
 import { DeleteRssCertificationParamRequestDto } from '@rss/dto/request/deleteRssCertificationParam.dto';
+import { GetAllRssRequestDto } from '@rss/dto/request/getAllRss.dto';
 import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dto';
 import { GetOwnedRssFeedsParamRequestDto } from '@rss/dto/request/getOwnedRssFeedsParam.dto';
 import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
@@ -278,6 +280,20 @@ export class RssController {
     return ApiResponse.responseWithData(
       'RSS 게시글 목록 조회를 처리했습니다.',
       await this.rssService.getRssFeeds(paramDto.rssId, queryDto),
+    );
+  }
+
+  @ApiGetAllRss()
+  @UseGuards(OptionalJwtGuard)
+  @Get()
+  @HttpCode(HttpStatus.OK)
+  async getAllRss(
+    @CurrentUser() viewer: Payload | null,
+    @Query() getAllRssQueryDto: GetAllRssRequestDto,
+  ) {
+    return ApiResponse.responseWithData(
+      '전체 RSS 목록 조회를 처리했습니다.',
+      await this.rssService.getAllRss(getAllRssQueryDto, viewer?.id),
     );
   }
 

--- a/server/src/rss/dto/request/getAllRss.dto.ts
+++ b/server/src/rss/dto/request/getAllRss.dto.ts
@@ -1,0 +1,51 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+
+import { BLOG_PLATFORMS } from '@rss/util/blogUrlToRss';
+
+export class GetAllRssRequestDto {
+  @ApiPropertyOptional({
+    example: 1,
+    description: '페이지 번호 입력',
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({
+    message: '페이지 번호는 정수입니다.',
+  })
+  @Min(1, { message: '페이지 번호는 1 이상이어야 합니다.' })
+  @Type(() => Number)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    example: 20,
+    description: '받아올 RSS 최대 개수',
+    required: false,
+  })
+  @IsOptional()
+  @IsInt({
+    message: '한 페이지에 보여줄 개수는 정수입니다.',
+  })
+  @Min(1, { message: '개수 제한은 1 이상이어야 합니다.' })
+  @Max(100, { message: '개수 제한은 100 이하여야 합니다.' })
+  @Type(() => Number)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({
+    example: 'velog',
+    description: '필터링할 RSS 블로그 플랫폼',
+    enum: BLOG_PLATFORMS,
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(BLOG_PLATFORMS, {
+    message: `blogPlatform은 ${BLOG_PLATFORMS.join(', ')} 중 하나여야 합니다.`,
+  })
+  blogPlatform?: string;
+
+  constructor(partial: Partial<GetAllRssRequestDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/server/src/rss/dto/response/rssList.dto.ts
+++ b/server/src/rss/dto/response/rssList.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 
 import { RssAccept } from '@rss/entity/rss.entity';
 
-export class SearchRssResult {
+export class RssListItemDto {
   @ApiProperty({ example: 1, description: 'RSS(rss_accept) ID' })
   id: number;
 
@@ -29,7 +29,7 @@ export class SearchRssResult {
   })
   lastPublishedAt: Date | null;
 
-  private constructor(partial: Partial<SearchRssResult>) {
+  private constructor(partial: Partial<RssListItemDto>) {
     Object.assign(this, partial);
   }
 
@@ -38,7 +38,7 @@ export class SearchRssResult {
     feedCount: number,
     lastPublishedAt: Date | null = null,
   ) {
-    return new SearchRssResult({
+    return new RssListItemDto({
       id: rss.id,
       name: rss.name,
       blogPlatform: rss.blogPlatform,
@@ -63,15 +63,15 @@ export class SearchRssResult {
   }
 }
 
-export class SearchRssResponseDto {
+export class RssListResponseDto {
   @ApiProperty({
     example: 1,
     description: '전체 RSS 개수',
   })
   totalCount: number;
 
-  @ApiProperty({ type: [SearchRssResult], description: 'RSS 목록' })
-  result: SearchRssResult[];
+  @ApiProperty({ type: [RssListItemDto], description: 'RSS 목록' })
+  result: RssListItemDto[];
 
   @ApiProperty({
     example: 10,
@@ -85,17 +85,17 @@ export class SearchRssResponseDto {
   })
   limit: number;
 
-  constructor(partial: Partial<SearchRssResponseDto>) {
+  constructor(partial: Partial<RssListResponseDto>) {
     Object.assign(this, partial);
   }
 
   static toResponseDto(
     totalCount: number,
-    rssList: SearchRssResult[],
+    rssList: RssListItemDto[],
     totalPages: number,
     limit: number,
   ) {
-    return new SearchRssResponseDto({
+    return new RssListResponseDto({
       totalCount,
       result: rssList,
       totalPages,

--- a/server/src/rss/dto/response/searchRss.dto.ts
+++ b/server/src/rss/dto/response/searchRss.dto.ts
@@ -22,26 +22,43 @@ export class SearchRssResult {
   @ApiProperty({ example: 12, description: '공개 게시글 개수' })
   feedCount: number;
 
+  @ApiProperty({
+    example: '2025-01-15T00:00:00.000Z',
+    description: '최근 공개 게시글 발행일',
+    nullable: true,
+  })
+  lastPublishedAt: Date | null;
+
   private constructor(partial: Partial<SearchRssResult>) {
     Object.assign(this, partial);
   }
 
-  static toResultDto(rss: RssAccept, feedCount: number) {
+  static toResultDto(
+    rss: RssAccept,
+    feedCount: number,
+    lastPublishedAt: Date | null = null,
+  ) {
     return new SearchRssResult({
       id: rss.id,
       name: rss.name,
       blogPlatform: rss.blogPlatform,
       blogImage: rss.blogImage ?? null,
       feedCount,
+      lastPublishedAt,
     });
   }
 
   static toResultDtoArray(
     rssList: RssAccept[],
     feedCountMap: Map<number, number>,
+    lastPublishedAtMap: Map<number, Date> = new Map(),
   ) {
     return rssList.map((rss) =>
-      this.toResultDto(rss, feedCountMap.get(rss.id) ?? 0),
+      this.toResultDto(
+        rss,
+        feedCountMap.get(rss.id) ?? 0,
+        lastPublishedAtMap.get(rss.id) ?? null,
+      ),
     );
   }
 }
@@ -53,7 +70,7 @@ export class SearchRssResponseDto {
   })
   totalCount: number;
 
-  @ApiProperty({ type: [SearchRssResult], description: '검색 결과 RSS' })
+  @ApiProperty({ type: [SearchRssResult], description: 'RSS 목록' })
   result: SearchRssResult[];
 
   @ApiProperty({

--- a/server/src/rss/repository/rss.repository.ts
+++ b/server/src/rss/repository/rss.repository.ts
@@ -62,13 +62,43 @@ export class RssAcceptRepository extends Repository<RssAccept> {
     return query.getManyAndCount();
   }
 
-  findRecentlyPublished(limit: number, blockerId?: number) {
-    const query = this.createQueryBuilder('rss')
-      .innerJoin(
-        'feed',
-        'feed',
-        'feed.blog_id = rss.id AND feed.is_public = 1',
+  findAllRssList(
+    limit: number,
+    offset: number,
+    blockerId?: number,
+    blogPlatform?: string,
+  ) {
+    const query = this.createQueryBuilder('rss_accept')
+      .orderBy(
+        '(SELECT MAX(feed.created_at) FROM feed WHERE feed.blog_id = rss_accept.id AND feed.is_public = 1)',
+        'DESC',
+      )
+      .addOrderBy('rss_accept.id', 'DESC')
+      .skip(offset)
+      .take(limit);
+
+    if (blockerId) {
+      query.andWhere(
+        'rss_accept.id NOT IN (SELECT rss_block.blocked_rss_id FROM rss_blocks rss_block WHERE rss_block.blocker_id = :blockerId)',
+        { blockerId },
       );
+    }
+
+    if (blogPlatform) {
+      query.andWhere('rss_accept.blogPlatform = :blogPlatform', {
+        blogPlatform,
+      });
+    }
+
+    return query.getManyAndCount();
+  }
+
+  findRecentlyPublished(limit: number, blockerId?: number) {
+    const query = this.createQueryBuilder('rss').innerJoin(
+      'feed',
+      'feed',
+      'feed.blog_id = rss.id AND feed.is_public = 1',
+    );
 
     if (blockerId) {
       query.where(
@@ -89,9 +119,7 @@ export class RssAcceptRepository extends Repository<RssAccept> {
             .subQuery()
             .select('latest_feed.id')
             .from('feed', 'latest_feed')
-            .where(
-              'latest_feed.blog_id = rss.id AND latest_feed.is_public = 1',
-            )
+            .where('latest_feed.blog_id = rss.id AND latest_feed.is_public = 1')
             .orderBy('latest_feed.created_at', 'DESC')
             .addOrderBy('latest_feed.id', 'DESC')
             .limit(1),

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -54,9 +54,9 @@ import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
 import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
 import { ReadRssRejectHistoryResponseDto } from '@rss/dto/response/readRssRejectHistory.dto';
 import {
-  SearchRssResponseDto,
-  SearchRssResult,
-} from '@rss/dto/response/searchRss.dto';
+  RssListItemDto,
+  RssListResponseDto,
+} from '@rss/dto/response/rssList.dto';
 import { Rss, RssAccept, RssReject } from '@rss/entity/rss.entity';
 import {
   RssAcceptRepository,
@@ -351,14 +351,14 @@ export class RssService {
       this.feedRepository.getLatestPublicFeedDateByBlogIds(blogIds),
     ]);
 
-    const rssList = SearchRssResult.toResultDtoArray(
+    const rssList = RssListItemDto.toResultDtoArray(
       rssAcceptList,
       feedCountMap,
       lastPublishedAtMap,
     );
     const totalPages = Math.ceil(totalCount / limit);
 
-    return SearchRssResponseDto.toResponseDto(
+    return RssListResponseDto.toResponseDto(
       totalCount,
       rssList,
       totalPages,
@@ -382,13 +382,10 @@ export class RssService {
       searchResult.map((rss) => rss.id),
     );
 
-    const rssList = SearchRssResult.toResultDtoArray(
-      searchResult,
-      feedCountMap,
-    );
+    const rssList = RssListItemDto.toResultDtoArray(searchResult, feedCountMap);
     const totalPages = Math.ceil(totalCount / limit);
 
-    return SearchRssResponseDto.toResponseDto(
+    return RssListResponseDto.toResponseDto(
       totalCount,
       rssList,
       totalPages,

--- a/server/src/rss/service/rss.service.ts
+++ b/server/src/rss/service/rss.service.ts
@@ -37,6 +37,7 @@ import { FeedRepository } from '@feed/repository/feed.repository';
 
 import { DeleteCertificateRssRequestDto } from '@rss/dto/request/deleteCertificateRss.dto';
 import { DeleteRssRequestDto } from '@rss/dto/request/deleteRss.dto';
+import { GetAllRssRequestDto } from '@rss/dto/request/getAllRss.dto';
 import { GetOwnedRssFeedsRequestDto } from '@rss/dto/request/getOwnedRssFeeds.dto';
 import { GetRssFeedsRequestDto } from '@rss/dto/request/getRssFeeds.dto';
 import { ManageRssRequestDto } from '@rss/dto/request/manageRss.dto';
@@ -329,6 +330,39 @@ export class RssService {
     );
     return recentRssList.map((row) =>
       GetRecentRssResponseDto.toResponseDto(row),
+    );
+  }
+
+  async getAllRss(getAllRssQueryDto: GetAllRssRequestDto, viewerId?: number) {
+    const { page, limit, blogPlatform } = getAllRssQueryDto;
+    const offset = (page - 1) * limit;
+
+    const [rssAcceptList, totalCount] =
+      await this.rssAcceptRepository.findAllRssList(
+        limit,
+        offset,
+        viewerId,
+        blogPlatform,
+      );
+
+    const blogIds = rssAcceptList.map((rss) => rss.id);
+    const [feedCountMap, lastPublishedAtMap] = await Promise.all([
+      this.feedRepository.countPublicFeedsByBlogIds(blogIds),
+      this.feedRepository.getLatestPublicFeedDateByBlogIds(blogIds),
+    ]);
+
+    const rssList = SearchRssResult.toResultDtoArray(
+      rssAcceptList,
+      feedCountMap,
+      lastPublishedAtMap,
+    );
+    const totalPages = Math.ceil(totalCount / limit);
+
+    return SearchRssResponseDto.toResponseDto(
+      totalCount,
+      rssList,
+      totalPages,
+      limit,
     );
   }
 

--- a/server/test/rss/dto/getAllRss.dto.spec.ts
+++ b/server/test/rss/dto/getAllRss.dto.spec.ts
@@ -1,0 +1,130 @@
+import { validate } from 'class-validator';
+
+import { GetAllRssRequestDto } from '@rss/dto/request/getAllRss.dto';
+
+describe(`${GetAllRssRequestDto.name} Test`, () => {
+  let dto: GetAllRssRequestDto;
+
+  beforeEach(() => {
+    dto = new GetAllRssRequestDto({
+      page: 1,
+      limit: 20,
+    });
+  });
+
+  it('page와 limit이 있을 경우 유효성 검사에 성공한다.', async () => {
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  it('page와 limit을 생략해도 유효성 검사에 성공한다.', async () => {
+    // given
+    dto = new GetAllRssRequestDto({});
+
+    // when
+    const errors = await validate(dto);
+
+    // then
+    expect(errors).toHaveLength(0);
+  });
+
+  describe('page', () => {
+    it('페이지 번호가 정수가 아닐 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 1.1;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('페이지 번호가 1 미만일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.page = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+  });
+
+  describe('limit', () => {
+    it('개수 제한이 정수가 아닐 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 1.1;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isInt');
+    });
+
+    it('개수 제한이 1 미만일 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 0;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('min');
+    });
+
+    it('개수 제한이 100을 초과할 경우 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.limit = 101;
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('max');
+    });
+  });
+
+  describe('blogPlatform', () => {
+    it('허용된 플랫폼 값이면 유효성 검사에 성공한다.', async () => {
+      // given
+      dto.blogPlatform = 'velog';
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(0);
+    });
+
+    it('생략해도 유효성 검사에 성공한다.', async () => {
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(0);
+    });
+
+    it('허용되지 않은 값이면 유효성 검사에 실패한다.', async () => {
+      // given
+      dto.blogPlatform = 'blogger';
+
+      // when
+      const errors = await validate(dto);
+
+      // then
+      expect(errors).toHaveLength(1);
+      expect(errors[0].constraints).toHaveProperty('isIn');
+    });
+  });
+});

--- a/server/test/rss/e2e/get-all.e2e-spec.ts
+++ b/server/test/rss/e2e/get-all.e2e-spec.ts
@@ -7,7 +7,7 @@ import { RssBlockRepository } from '@block/repository/rssBlock.repository';
 
 import { FeedRepository } from '@feed/repository/feed.repository';
 
-import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
+import { RssListResponseDto } from '@rss/dto/response/rssList.dto';
 import { RssAcceptRepository } from '@rss/repository/rss.repository';
 
 import { UserRepository } from '@user/repository/user.repository';
@@ -47,7 +47,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     const ids = data.result.map((rss) => rss.id);
     expect(ids.indexOf(newRss.id)).toBeLessThan(ids.indexOf(oldRss.id));
   });
@@ -74,7 +74,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     const ids = data.result.map((rss) => rss.id);
     expect(ids.indexOf(registeredSecond.id)).toBeLessThan(
       ids.indexOf(registeredFirst.id),
@@ -97,7 +97,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     const ids = data.result.map((rss) => rss.id);
     expect(ids.indexOf(withPost.id)).toBeLessThan(ids.indexOf(withoutPost.id));
   });
@@ -123,7 +123,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     const target = data.result.find((rss) => rss.id === rssAccept.id);
     expect(new Date(target.lastPublishedAt).toISOString()).toBe(
       latest.createdAt.toISOString(),
@@ -139,7 +139,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     const target = data.result.find((rss) => rss.id === rssAccept.id);
     expect(target.lastPublishedAt).toBeNull();
   });
@@ -155,7 +155,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     expect(data.result.length).toBe(2);
     expect(data.totalCount).toBe(5);
     expect(data.totalPages).toBe(3);
@@ -172,7 +172,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     expect(data.result.map((rss) => rss.id)).toEqual([velogRss.id]);
     expect(data.result[0].blogPlatform).toBe('velog');
   });
@@ -192,7 +192,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     const target = data.result.find((rss) => rss.id === rssAccept.id);
     expect(target.feedCount).toBe(1);
   });
@@ -219,7 +219,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     const ids = data.result.map((rss) => rss.id);
     expect(ids).not.toContain(blockedRss.id);
     expect(ids).toContain(normalRss.id);
@@ -243,7 +243,7 @@ describe(`GET ${URL} E2E Test`, () => {
 
     // then
     expect(response.status).toBe(HttpStatus.OK);
-    const { data }: { data: SearchRssResponseDto } = response.body;
+    const { data }: { data: RssListResponseDto } = response.body;
     expect(data.result.map((rss) => rss.id)).toContain(blockedRss.id);
   });
 

--- a/server/test/rss/e2e/get-all.e2e-spec.ts
+++ b/server/test/rss/e2e/get-all.e2e-spec.ts
@@ -1,0 +1,265 @@
+import { HttpStatus } from '@nestjs/common';
+
+import supertest from 'supertest';
+import TestAgent from 'supertest/lib/agent';
+
+import { RssBlockRepository } from '@block/repository/rssBlock.repository';
+
+import { FeedRepository } from '@feed/repository/feed.repository';
+
+import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
+import { RssAcceptRepository } from '@rss/repository/rss.repository';
+
+import { UserRepository } from '@user/repository/user.repository';
+
+import { FeedFixture } from '@test/config/common/fixture/feed.fixture';
+import { RssAcceptFixture } from '@test/config/common/fixture/rss-accept.fixture';
+import { UserFixture } from '@test/config/common/fixture/user.fixture';
+import { createAccessToken, testApp } from '@test/config/e2e/env/jest.setup';
+
+const URL = '/api/rss';
+
+describe(`GET ${URL} E2E Test`, () => {
+  let agent: TestAgent;
+  let rssAcceptRepository: RssAcceptRepository;
+  let feedRepository: FeedRepository;
+
+  beforeAll(() => {
+    agent = supertest(testApp.getHttpServer());
+    rssAcceptRepository = testApp.get(RssAcceptRepository);
+    feedRepository = testApp.get(FeedRepository);
+  });
+
+  const createRss = async (
+    overwrites: Partial<{ blogPlatform: string }> = {},
+  ) =>
+    rssAcceptRepository.save(
+      RssAcceptFixture.createRssAcceptFixture(overwrites),
+    );
+
+  it('[200] 게시글이 없는 RSS는 등록순(id 내림차순)으로 정렬된다.', async () => {
+    // given
+    const oldRss = await createRss();
+    const newRss = await createRss();
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    const ids = data.result.map((rss) => rss.id);
+    expect(ids.indexOf(newRss.id)).toBeLessThan(ids.indexOf(oldRss.id));
+  });
+
+  it('[200] 게시글이 있는 RSS는 등록순과 무관하게 최근 공개 게시글 발행일 순으로 정렬된다.', async () => {
+    // given
+    const registeredFirst = await createRss();
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(registeredFirst, {
+        isPublic: true,
+        createdAt: new Date('2025-01-01'),
+      }),
+    );
+    const registeredSecond = await createRss();
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(registeredSecond, {
+        isPublic: true,
+        createdAt: new Date('2025-06-01'),
+      }),
+    );
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    const ids = data.result.map((rss) => rss.id);
+    expect(ids.indexOf(registeredSecond.id)).toBeLessThan(
+      ids.indexOf(registeredFirst.id),
+    );
+  });
+
+  it('[200] 게시글이 없는 RSS는 게시글이 있는 RSS보다 뒤에 정렬된다.', async () => {
+    // given
+    const withoutPost = await createRss();
+    const withPost = await createRss();
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(withPost, {
+        isPublic: true,
+        createdAt: new Date('2020-01-01'),
+      }),
+    );
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    const ids = data.result.map((rss) => rss.id);
+    expect(ids.indexOf(withPost.id)).toBeLessThan(ids.indexOf(withoutPost.id));
+  });
+
+  it('[200] 최근 공개 게시글 발행일을 lastPublishedAt으로 함께 반환한다.', async () => {
+    // given
+    const rssAccept = await createRss();
+    const latest = await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, {
+        isPublic: true,
+        createdAt: new Date('2025-06-01'),
+      }),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, {
+        isPublic: true,
+        createdAt: new Date('2025-01-01'),
+      }),
+    );
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    const target = data.result.find((rss) => rss.id === rssAccept.id);
+    expect(new Date(target.lastPublishedAt).toISOString()).toBe(
+      latest.createdAt.toISOString(),
+    );
+  });
+
+  it('[200] 공개 게시글이 없는 RSS는 lastPublishedAt이 null이다.', async () => {
+    // given
+    const rssAccept = await createRss();
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    const target = data.result.find((rss) => rss.id === rssAccept.id);
+    expect(target.lastPublishedAt).toBeNull();
+  });
+
+  it('[200] page와 limit에 맞춰 페이지네이션된 결과와 totalPages를 반환한다.', async () => {
+    // given
+    for (let i = 0; i < 5; i++) {
+      await createRss();
+    }
+
+    // when
+    const response = await agent.get(URL).query({ page: 2, limit: 2 });
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    expect(data.result.length).toBe(2);
+    expect(data.totalCount).toBe(5);
+    expect(data.totalPages).toBe(3);
+    expect(data.limit).toBe(2);
+  });
+
+  it('[200] blogPlatform으로 필터링한 RSS만 반환한다.', async () => {
+    // given
+    const velogRss = await createRss({ blogPlatform: 'velog' });
+    await createRss({ blogPlatform: 'tistory' });
+
+    // when
+    const response = await agent.get(URL).query({ blogPlatform: 'velog' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    expect(data.result.map((rss) => rss.id)).toEqual([velogRss.id]);
+    expect(data.result[0].blogPlatform).toBe('velog');
+  });
+
+  it('[200] 공개 게시글 개수를 feedCount로 함께 반환한다.', async () => {
+    // given
+    const rssAccept = await createRss();
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: true }),
+    );
+    await feedRepository.save(
+      FeedFixture.createFeedFixture(rssAccept, { isPublic: false }),
+    );
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    const target = data.result.find((rss) => rss.id === rssAccept.id);
+    expect(target.feedCount).toBe(1);
+  });
+
+  it('[200] 로그인한 사용자가 차단한 RSS는 목록에서 제외된다.', async () => {
+    // given
+    const userRepository = testApp.get(UserRepository);
+    const rssBlockRepository = testApp.get(RssBlockRepository);
+    const blockedRss = await createRss();
+    const normalRss = await createRss();
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await rssBlockRepository.save({
+      blocker: { id: viewer.id },
+      blockedRss: { id: blockedRss.id },
+    });
+    const accessToken = createAccessToken(viewer);
+
+    // when
+    const response = await agent
+      .get(URL)
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    const ids = data.result.map((rss) => rss.id);
+    expect(ids).not.toContain(blockedRss.id);
+    expect(ids).toContain(normalRss.id);
+  });
+
+  it('[200] 비로그인 사용자에게는 차단 여부와 관계없이 모든 RSS가 제공된다.', async () => {
+    // given
+    const userRepository = testApp.get(UserRepository);
+    const rssBlockRepository = testApp.get(RssBlockRepository);
+    const blockedRss = await createRss();
+    const viewer = await userRepository.save(
+      await UserFixture.createUserCryptFixture(),
+    );
+    await rssBlockRepository.save({
+      blocker: { id: viewer.id },
+      blockedRss: { id: blockedRss.id },
+    });
+
+    // when
+    const response = await agent.get(URL);
+
+    // then
+    expect(response.status).toBe(HttpStatus.OK);
+    const { data }: { data: SearchRssResponseDto } = response.body;
+    expect(data.result.map((rss) => rss.id)).toContain(blockedRss.id);
+  });
+
+  it('[400] 허용되지 않은 blogPlatform 값이면 검증에 실패한다.', async () => {
+    // when
+    const response = await agent.get(URL).query({ blogPlatform: 'blogger' });
+
+    // then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+
+  it('[400] limit이 100을 초과하면 검증에 실패한다.', async () => {
+    // when
+    const response = await agent.get(URL).query({ limit: 101 });
+
+    // then
+    expect(response.status).toBe(HttpStatus.BAD_REQUEST);
+  });
+});

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -56,6 +56,7 @@ describe(`${RssService.name} Unit Test`, () => {
       | 'update'
       | 'findRecentlyPublished'
       | 'searchRssList'
+      | 'findAllRssList'
     >
   >;
   let rssRejectRepository: jest.Mocked<Pick<RssRejectRepository, 'find'>>;
@@ -66,6 +67,7 @@ describe(`${RssService.name} Unit Test`, () => {
       | 'setVisibilityForBlog'
       | 'countPublicFeedsByBlogIds'
       | 'getLatestPublicFeedDate'
+      | 'getLatestPublicFeedDateByBlogIds'
       | 'findPublishActivityByBlogAndYear'
       | 'findPublishYearsByBlogId'
     >
@@ -110,6 +112,7 @@ describe(`${RssService.name} Unit Test`, () => {
       update: jest.fn().mockResolvedValue({ affected: 1 }),
       findRecentlyPublished: jest.fn().mockResolvedValue([]),
       searchRssList: jest.fn().mockResolvedValue([[], 0]),
+      findAllRssList: jest.fn().mockResolvedValue([[], 0]),
     };
     rssRejectRepository = { find: jest.fn() };
     feedRepository = {
@@ -117,6 +120,7 @@ describe(`${RssService.name} Unit Test`, () => {
       setVisibilityForBlog: jest.fn().mockResolvedValue(1),
       countPublicFeedsByBlogIds: jest.fn().mockResolvedValue(new Map()),
       getLatestPublicFeedDate: jest.fn().mockResolvedValue(null),
+      getLatestPublicFeedDateByBlogIds: jest.fn().mockResolvedValue(new Map()),
       findPublishActivityByBlogAndYear: jest.fn().mockResolvedValue([]),
       findPublishYearsByBlogId: jest.fn().mockResolvedValue([]),
     };
@@ -934,6 +938,119 @@ describe(`${RssService.name} Unit Test`, () => {
     });
   });
 
+  describe('getAllRss', () => {
+    const makeRssAccept = (id: number, name: string) =>
+      ({
+        id,
+        name,
+        blogPlatform: 'velog',
+        blogImage: null,
+      }) as any;
+
+    it('page와 limit으로 offset을 계산해 저장소에 전달하고 응답 DTO로 변환한다.', async () => {
+      // given
+      const rssList = [makeRssAccept(1, 'seok3765.log')];
+      const lastPublishedAt = new Date('2025-01-15T00:00:00.000Z');
+      rssAcceptRepository.findAllRssList.mockResolvedValue([rssList, 1]);
+      feedRepository.countPublicFeedsByBlogIds.mockResolvedValue(
+        new Map([[1, 12]]),
+      );
+      feedRepository.getLatestPublicFeedDateByBlogIds.mockResolvedValue(
+        new Map([[1, lastPublishedAt]]),
+      );
+
+      // when
+      const result = await rssService.getAllRss({ page: 3, limit: 5 });
+
+      // then
+      expect(rssAcceptRepository.findAllRssList).toHaveBeenCalledWith(
+        5,
+        10,
+        undefined,
+        undefined,
+      );
+      expect(feedRepository.countPublicFeedsByBlogIds).toHaveBeenCalledWith([
+        1,
+      ]);
+      expect(
+        feedRepository.getLatestPublicFeedDateByBlogIds,
+      ).toHaveBeenCalledWith([1]);
+      expect(result).toEqual(
+        SearchRssResponseDto.toResponseDto(
+          1,
+          [
+            {
+              id: 1,
+              name: 'seok3765.log',
+              blogPlatform: 'velog',
+              blogImage: null,
+              feedCount: 12,
+              lastPublishedAt,
+            },
+          ],
+          1,
+          5,
+        ),
+      );
+    });
+
+    it('viewerId가 있으면 차단 필터링을 위해 저장소에 함께 전달한다.', async () => {
+      // given
+      rssAcceptRepository.findAllRssList.mockResolvedValue([[], 0]);
+
+      // when
+      await rssService.getAllRss({ page: 1, limit: 5 }, 10);
+
+      // then
+      expect(rssAcceptRepository.findAllRssList).toHaveBeenCalledWith(
+        5,
+        0,
+        10,
+        undefined,
+      );
+    });
+
+    it('blogPlatform이 있으면 저장소에 함께 전달한다.', async () => {
+      // given
+      rssAcceptRepository.findAllRssList.mockResolvedValue([[], 0]);
+
+      // when
+      await rssService.getAllRss({ page: 1, limit: 5, blogPlatform: 'velog' });
+
+      // then
+      expect(rssAcceptRepository.findAllRssList).toHaveBeenCalledWith(
+        5,
+        0,
+        undefined,
+        'velog',
+      );
+    });
+
+    it('전체 개수를 limit으로 나눠 totalPages를 올림 계산한다.', async () => {
+      // given
+      rssAcceptRepository.findAllRssList.mockResolvedValue([[], 12]);
+
+      // when
+      const result = await rssService.getAllRss({ page: 1, limit: 5 });
+
+      // then
+      expect(result.totalPages).toBe(3);
+    });
+
+    it('등록된 RSS가 없으면 빈 배열을 반환한다.', async () => {
+      // given
+      rssAcceptRepository.findAllRssList.mockResolvedValue([[], 0]);
+
+      // when
+      const result = await rssService.getAllRss({ page: 1, limit: 5 });
+
+      // then
+      expect(result.result).toEqual([]);
+      expect(result.totalCount).toBe(0);
+      expect(result.totalPages).toBe(0);
+    });
+  });
+
   describe('searchRss', () => {
     const makeRssAccept = (id: number, name: string) =>
       ({
@@ -978,6 +1095,7 @@ describe(`${RssService.name} Unit Test`, () => {
               blogPlatform: 'velog',
               blogImage: null,
               feedCount: 12,
+              lastPublishedAt: null,
             },
           ],
           1,

--- a/server/test/rss/unit/rss.service.unit.spec.ts
+++ b/server/test/rss/unit/rss.service.unit.spec.ts
@@ -29,7 +29,7 @@ import { RegisterRssRequestDto } from '@rss/dto/request/registerRss.dto';
 import { ReadRssResponseDto } from '@rss/dto/response/readRss.dto';
 import { ReadRssAcceptHistoryResponseDto } from '@rss/dto/response/readRssAcceptHistory.dto';
 import { ReadRssRejectHistoryResponseDto } from '@rss/dto/response/readRssRejectHistory.dto';
-import { SearchRssResponseDto } from '@rss/dto/response/searchRss.dto';
+import { RssListResponseDto } from '@rss/dto/response/rssList.dto';
 import {
   RssAcceptRepository,
   RssRejectRepository,
@@ -976,7 +976,7 @@ describe(`${RssService.name} Unit Test`, () => {
         feedRepository.getLatestPublicFeedDateByBlogIds,
       ).toHaveBeenCalledWith([1]);
       expect(result).toEqual(
-        SearchRssResponseDto.toResponseDto(
+        RssListResponseDto.toResponseDto(
           1,
           [
             {
@@ -1086,7 +1086,7 @@ describe(`${RssService.name} Unit Test`, () => {
         1,
       ]);
       expect(result).toEqual(
-        SearchRssResponseDto.toResponseDto(
+        RssListResponseDto.toResponseDto(
           1,
           [
             {


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #949 

### 전체 RSS 목록 조회 API (서버)

-   `GET /rss`에 페이지네이션, `blogPlatform` 필터, 차단 RSS 제외 로직 추가. 응답 DTO를 기존 `/rss/search`와 공유하도록 설계해서, 이름이 검색 전용을 뜻하던 `SearchRssResult`/`SearchRssResponseDto`를 두 API 모두에 맞게 `RssListItemDto`/`RssListResponseDto`로 정리함.
-   정렬 기준은 최근 공개 게시글 발행일(상관 서브쿼리) DESC, 동률/게시글 없는 RSS는 id DESC로 tie-break. 게시글 없는 RSS는 MySQL의 NULL 정렬 특성상 자동으로 목록 뒤에 위치.
-   `limit`에 `@Max(100)` 추가 — WHERE 필터가 없는 전체 조회 특성상 무제한 limit이 위험하다고 판단.

### 클라이언트 RSS 목록 페이지 및 진입점

-   `/rss` 라우트에 페이지네이션 · 플랫폼 필터 드롭다운(등록 모달의 `PlatformSelector`와 동일한 아이콘 패턴 재사용) · 최근 게시글 날짜가 있는 3열 카드 그리드 페이지 구현.
-   데스크톱 네비게이션 · 모바일 사이드바 양쪽에 "블로그 목록" 진입 링크 추가.

# 📋 작업 내용

-   서버: `GET /rss` 엔드포인트(request DTO, repository, service, controller, swagger 문서) 및 unit · dto · e2e 테스트 추가
-   서버: 공유 응답 DTO 이름 정리(`SearchRssResult` → `RssListItemDto`, `SearchRssResponseDto` → `RssListResponseDto`)
-   클라이언트: `RssListPage`, `useAllRss` 훅, storybook 스토리, 컴포넌트/훅 테스트 추가
-   클라이언트: 데스크톱/모바일 네비게이션에 RSS 목록 진입 링크 추가

# 📷 스크린 샷(선택 사항)

-   미첨부