### PR TITLE
🐛 fix: Footer sticky 구조 통합 및 공지사항 페이지 Footer 추가

### DIFF
--- a/client/src/__tests__/components/layout/Layout.test.tsx
+++ b/client/src/__tests__/components/layout/Layout.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@/components/layout/Header", () => ({
   default: () => <header data-testid="header" />,
 }));
 
+vi.mock("@/components/about/Footer", () => ({
+  Footer: () => <footer data-testid="footer" />,
+}));
+
 describe("Layout", () => {
   it("Header와 children을 main 영역에 렌더링해야 한다", () => {
     render(
@@ -19,5 +23,25 @@ describe("Layout", () => {
     expect(screen.getByTestId("header")).toBeInTheDocument();
     expect(screen.getByRole("main")).toBeInTheDocument();
     expect(screen.getByText("본문 콘텐츠")).toBeInTheDocument();
+  });
+
+  it("footer prop이 없으면 Footer를 렌더링하지 않는다", () => {
+    render(
+      <Layout>
+        <p>본문 콘텐츠</p>
+      </Layout>
+    );
+
+    expect(screen.queryByTestId("footer")).not.toBeInTheDocument();
+  });
+
+  it("footer prop이 true면 Footer를 렌더링한다", () => {
+    render(
+      <Layout footer>
+        <p>본문 콘텐츠</p>
+      </Layout>
+    );
+
+    expect(screen.getByTestId("footer")).toBeInTheDocument();
   });
 });

--- a/client/src/components/layout/Layout.tsx
+++ b/client/src/components/layout/Layout.tsx
@@ -1,16 +1,19 @@
+import { Footer } from "@/components/about/Footer";
 import Header from "@/components/layout/Header";
 
 interface LayoutProps {
   children: React.ReactNode;
+  footer?: boolean;
 }
 
-export default function Layout({ children }: LayoutProps) {
+export default function Layout({ children, footer = false }: LayoutProps) {
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <Header />
-      <main className="w-full">
+      <main className="w-full flex-1">
         <div className="mx-auto max-w-7xl px-0 md:px-8">{children}</div>
       </main>
-    </>
+      {footer && <Footer />}
+    </div>
   );
 }

--- a/client/src/pages/BoardDetailPage.tsx
+++ b/client/src/pages/BoardDetailPage.tsx
@@ -23,7 +23,7 @@ export default function BoardDetailPage() {
   const categoryLabel = board ? CATEGORY_LABELS[board.category] : "공지사항 · FAQ";
 
   return (
-    <Layout>
+    <Layout footer>
       <Helmet>
         <title>{board ? `${board.title} - ${categoryLabel}` : "공지사항 · FAQ"} - 데나무</title>
       </Helmet>

--- a/client/src/pages/BoardListPage.tsx
+++ b/client/src/pages/BoardListPage.tsx
@@ -138,7 +138,7 @@ export default function BoardListPage() {
   const isQnaFormMode = tab === "QNA" && qnaMode === "form";
 
   return (
-    <Layout>
+    <Layout footer>
       <Helmet>
         <title>공지사항 · FAQ · Q&A - 데나무</title>
       </Helmet>

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 
 import axios from "axios";
 
-import { Footer } from "@/components/about/Footer";
 import Layout from "@/components/layout/Layout";
 import { BlockManagementTab } from "@/components/profile/BlockManagementTab.tsx";
 import { BlockedProfileView } from "@/components/profile/BlockedProfileView.tsx";
@@ -65,42 +64,39 @@ export default function Profile() {
   };
 
   return (
-    <>
-      <Layout>
-        <div className="flex min-h-screen">
-          <ProfileSidebar activeTab={currentTab} onTabChange={handleTabChange} isOwner={isOwner} />
+    <Layout footer>
+      <div className="flex min-h-screen">
+        <ProfileSidebar activeTab={currentTab} onTabChange={handleTabChange} isOwner={isOwner} />
 
-          <div className="flex-1 min-w-0 px-4 py-8 md:px-8">
-            {currentTab === "mypage" &&
-              (isSuspended ? (
-                <SuspendedProfileView />
-              ) : isBlocked ? (
-                <BlockedProfileView userId={targetId as number} />
-              ) : isVisitor && isVisitorProfileLoading ? null : showSubscriptions ? (
-                <SubscriptionManagementTab
-                  userId={targetId as number}
-                  isOwner={isOwner}
-                  onBack={() => setShowSubscriptions(false)}
-                />
-              ) : (
-                <MyPage
-                  userId={targetId as number}
-                  name={isOwner ? (userInfo.userName ?? "") : ""}
-                  email={isOwner ? (userInfo.email ?? "") : ""}
-                  isOwner={isOwner}
-                  canBlock={isAuthenticated && isVisitor}
-                  onShowSubscriptions={() => setShowSubscriptions(true)}
-                />
-              ))}
-            {isOwner && currentTab === "rss" && <RssManagementTab userId={targetId as number} />}
-            {isOwner && currentTab === "blocks" && <BlockManagementTab />}
-            {isOwner && currentTab === "settings" && (
-              <ProfileEditTab userId={targetId as number} email={userInfo.email ?? ""} />
-            )}
-          </div>
+        <div className="flex-1 min-w-0 px-4 py-8 md:px-8">
+          {currentTab === "mypage" &&
+            (isSuspended ? (
+              <SuspendedProfileView />
+            ) : isBlocked ? (
+              <BlockedProfileView userId={targetId as number} />
+            ) : isVisitor && isVisitorProfileLoading ? null : showSubscriptions ? (
+              <SubscriptionManagementTab
+                userId={targetId as number}
+                isOwner={isOwner}
+                onBack={() => setShowSubscriptions(false)}
+              />
+            ) : (
+              <MyPage
+                userId={targetId as number}
+                name={isOwner ? (userInfo.userName ?? "") : ""}
+                email={isOwner ? (userInfo.email ?? "") : ""}
+                isOwner={isOwner}
+                canBlock={isAuthenticated && isVisitor}
+                onShowSubscriptions={() => setShowSubscriptions(true)}
+              />
+            ))}
+          {isOwner && currentTab === "rss" && <RssManagementTab userId={targetId as number} />}
+          {isOwner && currentTab === "blocks" && <BlockManagementTab />}
+          {isOwner && currentTab === "settings" && (
+            <ProfileEditTab userId={targetId as number} email={userInfo.email ?? ""} />
+          )}
         </div>
-      </Layout>
-      <Footer />
-    </>
+      </div>
+    </Layout>
   );
 }

--- a/client/src/pages/RssPage.tsx
+++ b/client/src/pages/RssPage.tsx
@@ -14,7 +14,6 @@ import {
   Users,
 } from "lucide-react";
 
-import { Footer } from "@/components/about/Footer";
 import { BlockConfirmDialog } from "@/components/common/BlockConfirmDialog";
 import { SubscribeButton } from "@/components/common/Card/detail/SubscribeButton.tsx";
 import { ReportDialog } from "@/components/common/ReportDialog";
@@ -153,7 +152,12 @@ const RssHeader = ({
     <CardContent className="p-6">
       <div className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 gap-4">
-          <PlatformIcon platform={rss.blogPlatform} image={rss.blogImage} name={rss.name} className="flex-shrink-0 w-14 h-14" />
+          <PlatformIcon
+            platform={rss.blogPlatform}
+            image={rss.blogImage}
+            name={rss.name}
+            className="flex-shrink-0 w-14 h-14"
+          />
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-2">
               <h1 className="text-2xl font-bold truncate">{rss.name}</h1>
@@ -309,12 +313,9 @@ export default function RssPage() {
 
   if (rss.isBlocked) {
     return (
-      <>
-        <Layout>
-          <BlockedRssView rssId={rss.id} />
-        </Layout>
-        <Footer />
-      </>
+      <Layout footer>
+        <BlockedRssView rssId={rss.id} />
+      </Layout>
     );
   }
 
@@ -369,100 +370,97 @@ export default function RssPage() {
   };
 
   return (
-    <>
-      <Layout>
-        <div className="max-w-4xl px-4 py-8 mx-auto md:px-8">
-          <RssHeader
-            rss={rss}
-            onEdit={() => setEditOpen(true)}
-            onBlock={isAuthenticated && !rss.isOwner ? () => setShowBlockConfirm(true) : undefined}
-            onReport={isAuthenticated && !rss.isOwner ? () => setShowReportDialog(true) : undefined}
-          />
-
-          {rss.owner && <OwnerProfileCard owner={rss.owner} />}
-
-          {rss.isOwner && (
-            <>
-              <OwnerFeedManager rssId={rss.id} />
-              <RssEditModal
-                target={editOpen ? rss : null}
-                userId={rss.owner?.id ?? 0}
-                onClose={() => setEditOpen(false)}
-                extraInvalidateKeys={[["rssInfo", rss.id]]}
-              />
-            </>
-          )}
-
-          <Card className="mb-8">
-            <CardContent className="p-6">
-              <ActivityGraph
-                dailyActivities={activity?.dailyActivities ?? []}
-                year={year}
-                years={years}
-                onYearChange={handleYearChange}
-                scale="posts"
-                selectedDate={selectedDate}
-                onDayClick={handleDayClick}
-              />
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardContent className="p-6">
-              <h3 className="mb-4 text-lg font-semibold">
-                포스트
-                {selectedDate && <span className="ml-2 text-sm font-normal text-gray-500">{selectedDate} 발행분</span>}
-              </h3>
-              {feedsLoading && <p className="text-sm text-gray-400">포스트를 불러오는 중...</p>}
-              {feedsError && <p className="text-sm text-red-500">포스트를 불러오지 못했습니다.</p>}
-              {!feedsLoading && !feedsError && feeds.length === 0 && (
-                <p className="text-sm text-gray-400">포스트가 없습니다.</p>
-              )}
-
-              <ul className="space-y-3">
-                {feeds.map((feed) => (
-                  <RssFeedCard
-                    key={feed.id}
-                    id={feed.id}
-                    title={feed.title}
-                    thumbnail={feed.thumbnail}
-                    createdAt={feed.createdAt}
-                    commentCount={feed.commentCount}
-                    likeCount={feed.likeCount}
-                  />
-                ))}
-              </ul>
-
-              {hasNextPage && (
-                <div className="mt-4 text-center">
-                  <Button variant="outline" size="sm" onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
-                    {isFetchingNextPage ? "불러오는 중..." : "더 보기"}
-                  </Button>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
-
-        <BlockConfirmDialog
-          open={showBlockConfirm}
-          onOpenChange={setShowBlockConfirm}
-          title={`${rss.name} RSS를 차단하시겠습니까?`}
-          description="게시글 및 RSS 프로필 페이지 조회가 제한됩니다."
-          owner={rss.owner ? { id: rss.owner.id, userName: rss.owner.userName } : undefined}
-          ownedRss={otherOwnedRss}
-          onConfirm={handleBlock}
+    <Layout footer>
+      <div className="max-w-4xl px-4 py-8 mx-auto md:px-8">
+        <RssHeader
+          rss={rss}
+          onEdit={() => setEditOpen(true)}
+          onBlock={isAuthenticated && !rss.isOwner ? () => setShowBlockConfirm(true) : undefined}
+          onReport={isAuthenticated && !rss.isOwner ? () => setShowReportDialog(true) : undefined}
         />
 
-        <ReportDialog
-          open={showReportDialog}
-          onOpenChange={setShowReportDialog}
-          title={`${rss.name} RSS 신고`}
-          isPending={isReportPending}
-          onSubmit={handleReport}
-        />
-      </Layout>
-      <Footer />
-    </>
+        {rss.owner && <OwnerProfileCard owner={rss.owner} />}
+
+        {rss.isOwner && (
+          <>
+            <OwnerFeedManager rssId={rss.id} />
+            <RssEditModal
+              target={editOpen ? rss : null}
+              userId={rss.owner?.id ?? 0}
+              onClose={() => setEditOpen(false)}
+              extraInvalidateKeys={[["rssInfo", rss.id]]}
+            />
+          </>
+        )}
+
+        <Card className="mb-8">
+          <CardContent className="p-6">
+            <ActivityGraph
+              dailyActivities={activity?.dailyActivities ?? []}
+              year={year}
+              years={years}
+              onYearChange={handleYearChange}
+              scale="posts"
+              selectedDate={selectedDate}
+              onDayClick={handleDayClick}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6">
+            <h3 className="mb-4 text-lg font-semibold">
+              포스트
+              {selectedDate && <span className="ml-2 text-sm font-normal text-gray-500">{selectedDate} 발행분</span>}
+            </h3>
+            {feedsLoading && <p className="text-sm text-gray-400">포스트를 불러오는 중...</p>}
+            {feedsError && <p className="text-sm text-red-500">포스트를 불러오지 못했습니다.</p>}
+            {!feedsLoading && !feedsError && feeds.length === 0 && (
+              <p className="text-sm text-gray-400">포스트가 없습니다.</p>
+            )}
+
+            <ul className="space-y-3">
+              {feeds.map((feed) => (
+                <RssFeedCard
+                  key={feed.id}
+                  id={feed.id}
+                  title={feed.title}
+                  thumbnail={feed.thumbnail}
+                  createdAt={feed.createdAt}
+                  commentCount={feed.commentCount}
+                  likeCount={feed.likeCount}
+                />
+              ))}
+            </ul>
+
+            {hasNextPage && (
+              <div className="mt-4 text-center">
+                <Button variant="outline" size="sm" onClick={() => fetchNextPage()} disabled={isFetchingNextPage}>
+                  {isFetchingNextPage ? "불러오는 중..." : "더 보기"}
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <BlockConfirmDialog
+        open={showBlockConfirm}
+        onOpenChange={setShowBlockConfirm}
+        title={`${rss.name} RSS를 차단하시겠습니까?`}
+        description="게시글 및 RSS 프로필 페이지 조회가 제한됩니다."
+        owner={rss.owner ? { id: rss.owner.id, userName: rss.owner.userName } : undefined}
+        ownedRss={otherOwnedRss}
+        onConfirm={handleBlock}
+      />
+
+      <ReportDialog
+        open={showReportDialog}
+        onOpenChange={setShowReportDialog}
+        title={`${rss.name} RSS 신고`}
+        isPending={isReportPending}
+        onSubmit={handleReport}
+      />
+    </Layout>
   );
 }


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #950

### Footer sticky 구조 통합

-   Footer가 각 페이지에서 `<Layout>` 밖 형제 요소(`<><Layout>...</Layout><Footer/></>`)로 개별 렌더링되던 구조라, 앱 전체에 sticky footer용 최소 높이 레이아웃이 없었음. 컨텐츠가 짧은 페이지(RSS 상세/목록 등)에서 Footer가 뷰포트 하단이 아니라 컨텐츠 바로 아래(화면 중간)에 뜨는 문제로 이어짐.
-   `Layout`에 `flex min-h-screen flex-col` 래퍼와 `footer`(기본값 false) prop을 추가해, Footer가 필요한 페이지는 `<Layout footer>`로만 선언하면 되도록 정리. Footer를 쓰던 3개 페이지(RssPage 2개 분기, Profile)를 이 구조로 전환.
-   Footer를 원래 쓰지 않던 페이지(공지사항, Q&A, 로그인/회원가입 등)는 기본값이 false라 동작 변화 없음.

### 공지사항 목록/상세 페이지 Footer 추가

-   기존에 Footer가 없던 공지사항 목록(`BoardListPage`)·상세(`BoardDetailPage`) 페이지에 `footer` prop을 켜서 다른 컨텐츠 페이지들과 통일함.

# 📋 작업 내용

-   `Layout`에 sticky footer 구조(`min-h-screen flex-col` + `footer` prop) 도입
-   `RssPage`, `Profile` 페이지를 신규 `Layout footer` 구조로 전환, 개별 `<Footer/>` 호출 제거
-   `BoardListPage`, `BoardDetailPage`에 Footer 노출
-   `Layout` 컴포넌트 테스트에 `footer` prop 케이스 추가

# 📷 스크린 샷(선택 사항)
<img width="1905" height="908" alt="image" src="https://github.com/user-attachments/assets/738fdc17-21d3-4de1-8f49-180093e936f9" />