### PR TITLE
🐛 fix: feed 조회수/유저 활동 중복 방지 Redis 키에 TTL 추가

### DIFF
--- a/server/src/common/redis/redis.constant.ts
+++ b/server/src/common/redis/redis.constant.ts
@@ -1,5 +1,4 @@
 export const REDIS_KEYS = {
-  FEED_ALL_IP_KEY: `feed:*:ip`,
   FEED_TREND_KEY: `feed:trend`,
   FEED_ORIGIN_TREND_KEY: 'feed:origin_trend',
   FEED_RECENT_INDEX_KEY: 'feed:recent:index',

--- a/server/src/common/util/kstDate.ts
+++ b/server/src/common/util/kstDate.ts
@@ -22,3 +22,7 @@ export function getKstMidnightInstant(
     getKstCalendarDate(base, dayOffset).getTime() - KST_OFFSET_MS,
   );
 }
+
+export function getSecondsUntilNextKstMidnight(base: Date = new Date()) {
+  return Math.ceil((getKstMidnightInstant(base, 1).getTime() - base.getTime()) / 1000);
+}

--- a/server/src/feed/listener/feed-viewed.listener.ts
+++ b/server/src/feed/listener/feed-viewed.listener.ts
@@ -4,6 +4,7 @@ import { OnEvent } from '@nestjs/event-emitter';
 import { ActivityService } from '@activity/service/activity.service';
 
 import { RedisService } from '@common/redis/redis.service';
+import { getSecondsUntilNextKstMidnight } from '@common/util/kstDate';
 
 import { FeedViewedEvent } from '@feed/event/feed-viewed.event';
 
@@ -19,14 +20,15 @@ export class FeedViewedListener {
 
   @OnEvent('feed.viewed')
   async handleFeedViewed({ feedId, userId }: FeedViewedEvent) {
-    const hasUserFlag = await this.redisService.sismember(
-      `feed:${feedId}:userId`,
-      userId,
-    );
+    const key = `feed:${feedId}:userId`;
+    const hasUserFlag = await this.redisService.sismember(key, userId);
 
     if (hasUserFlag) return;
 
-    await this.redisService.sadd(`feed:${feedId}:userId`, userId);
+    await this.redisService.executePipeline((pipeline) => {
+      pipeline.sadd(key, userId);
+      pipeline.expire(key, getSecondsUntilNextKstMidnight());
+    });
     await this.userService.updateUserActivity(userId);
     await this.activityService.upsertActivity(userId);
   }

--- a/server/src/feed/scheduler/feed.scheduler.ts
+++ b/server/src/feed/scheduler/feed.scheduler.ts
@@ -50,13 +50,4 @@ export class FeedScheduler {
       this.eventService.emit('ranking-update', trendFeeds);
     }
   }
-
-  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
-  async resetIpTable() {
-    const keys = await this.redisService.keys(REDIS_KEYS.FEED_ALL_IP_KEY);
-
-    if (keys.length > 0) {
-      await this.redisService.del(...keys);
-    }
-  }
 }

--- a/server/src/feed/service/feed.service.ts
+++ b/server/src/feed/service/feed.service.ts
@@ -18,6 +18,7 @@ import { RabbitMQService } from '@common/rabbitmq/rabbitmq.service';
 import { REDIS_KEYS } from '@common/redis/redis.constant';
 import { RedisService } from '@common/redis/redis.service';
 import { getIp } from '@common/util/getIp';
+import { getSecondsUntilNextKstMidnight } from '@common/util/kstDate';
 
 import {
   AI_RETRY_LOCK_TTL_SECONDS,
@@ -287,8 +288,13 @@ export class FeedService {
 
     createCookie(response, feedId);
 
+    const ipKey = `feed:${feedId}:ip`;
+
     await Promise.all([
-      this.redisService.sadd(`feed:${feedId}:ip`, ip),
+      this.redisService.executePipeline((pipeline) => {
+        pipeline.sadd(ipKey, ip);
+        pipeline.expire(ipKey, getSecondsUntilNextKstMidnight());
+      }),
       this.feedRepository.update(feedId, {
         viewCount: () => 'view_count + 1',
       }),

--- a/server/test/feed/unit/feed.scheduler.unit.spec.ts
+++ b/server/test/feed/unit/feed.scheduler.unit.spec.ts
@@ -1,0 +1,33 @@
+import { REDIS_KEYS } from '@common/redis/redis.constant';
+import { RedisService } from '@common/redis/redis.service';
+
+import { FeedScheduler } from '@feed/scheduler/feed.scheduler';
+
+describe(`${FeedScheduler.name} Unit Test`, () => {
+  let feedScheduler: FeedScheduler;
+  let redisService: jest.Mocked<Pick<RedisService, 'del' | 'keys'>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    redisService = {
+      del: jest.fn(),
+      keys: jest.fn(),
+    };
+
+    feedScheduler = new FeedScheduler(
+      redisService as unknown as RedisService,
+      {} as any,
+      {} as any,
+    );
+  });
+
+  describe('resetTrendTable', () => {
+    it('feed:trend 키를 삭제한다.', async () => {
+      // when
+      await feedScheduler.resetTrendTable();
+
+      // then
+      expect(redisService.del).toHaveBeenCalledWith(REDIS_KEYS.FEED_TREND_KEY);
+    });
+  });
+});

--- a/server/test/feed/unit/feed.service.unit.spec.ts
+++ b/server/test/feed/unit/feed.service.unit.spec.ts
@@ -58,7 +58,6 @@ describe(`${FeedService.name} Unit Test`, () => {
       | 'smembers'
       | 'lrange'
       | 'sismember'
-      | 'sadd'
       | 'zincrby'
       | 'hincrbyIfExists'
       | 'executePipeline'
@@ -89,7 +88,6 @@ describe(`${FeedService.name} Unit Test`, () => {
       smembers: jest.fn(),
       lrange: jest.fn(),
       sismember: jest.fn(),
-      sadd: jest.fn(),
       zincrby: jest.fn(),
       hincrbyIfExists: jest.fn(),
       executePipeline: jest.fn(),
@@ -542,12 +540,22 @@ describe(`${FeedService.name} Unit Test`, () => {
       feedRepository.findOneBy.mockResolvedValue({ id: 10 } as any);
       redisService.sismember.mockResolvedValue(0);
       const response = createResponse();
+      const saddMock = jest.fn();
+      const expireMock = jest.fn();
+      redisService.executePipeline.mockImplementation((cb: any) => {
+        cb({ sadd: saddMock, expire: expireMock });
+        return Promise.resolve([]);
+      });
 
       // when
       await feedService.updateFeedViewCount(dto, createRequest(), response);
 
       // then
-      expect(redisService.sadd).toHaveBeenCalledWith('feed:10:ip', '1.2.3.4');
+      expect(saddMock).toHaveBeenCalledWith('feed:10:ip', '1.2.3.4');
+      expect(expireMock).toHaveBeenCalledWith(
+        'feed:10:ip',
+        expect.any(Number),
+      );
       expect(feedRepository.update).toHaveBeenCalledWith(10, {
         viewCount: expect.any(Function),
       });


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #964

### 유저 활동/조회수 중복 방지 Redis 키가 지워지지 않는 문제

-   `feed:{feedId}:ip`, `feed:{feedId}:userId` 키에 TTL이 없어 계속 쌓이기만 하고, 자정마다 도는 `resetIpTable` 스케줄러는 `KEYS feed:*:ip` 패턴으로 IP 키만 지우고 있어 userId 키는 애초에 정리되지 않았음.
-   `KEYS` 명령은 Redis를 블로킹하는 데다 매일 전체 IP 키를 스캔하는 방식이라 키 개수가 늘어날수록 부담이 커지는 구조.
-   각 키를 만드는 시점에 "다음 KST 자정까지 남은 초"를 계산해 `EXPIRE`를 함께 걸어주는 방식으로 변경해서, 스케줄러 없이 키 자체가 자정에 자연 소멸하도록 함. `sadd`와 `expire`는 `executePipeline`으로 묶어 원자성 있게 처리.
-   더 이상 쓰이지 않는 `resetIpTable` 스케줄러와 `FEED_ALL_IP_KEY` 상수는 제거.

# 📋 작업 내용

-   `getSecondsUntilNextKstMidnight` 유틸 추가 (`kstDate.ts`)
-   `feed-viewed.listener.ts`: `feed:{feedId}:userId` set에 사용자 추가 시 파이프라인으로 TTL 설정
-   `feed.service.ts`: `feed:{feedId}:ip` set에 IP 추가 시 파이프라인으로 TTL 설정
-   `feed.scheduler.ts`: `resetIpTable` 크론 잡 제거
-   `redis.constant.ts`: 미사용 `FEED_ALL_IP_KEY` 제거
-   관련 유닛 테스트 추가/수정 (`feed.scheduler.unit.spec.ts`, `feed.service.unit.spec.ts`)

# 📷 스크린 샷(선택 사항)
<img width="550" height="297" alt="image" src="https://github.com/user-attachments/assets/2d0dad11-e8e0-42ae-b26f-88f689c5a4c8" />
