### PR TITLE
🐛 fix: AI 재요약 실패 시 DB summary NULL 초기화

### DIFF
--- a/feed-crawler/src/event_worker/workers/ai-summary-retry-event-worker.ts
+++ b/feed-crawler/src/event_worker/workers/ai-summary-retry-event-worker.ts
@@ -8,6 +8,8 @@ import { redisConstant } from '@common/redis/redis.constant';
 import { RMQ_QUEUES } from '@rabbitmq/rabbitmq.constant';
 import { RabbitMQService } from '@rabbitmq/rabbitmq.service';
 
+import { FeedRepository } from '@repository/feed.repository';
+
 import { FeedCrawler } from '../../feed-crawler';
 
 @injectable()
@@ -22,6 +24,8 @@ export class AiSummaryRetryEventWorker implements Lifecycle {
     private readonly redisConnection: RedisConnection,
     @inject(FeedCrawler)
     private readonly feedCrawler: FeedCrawler,
+    @inject(FeedRepository)
+    private readonly feedRepository: FeedRepository,
   ) {}
 
   async start(): Promise<void> {
@@ -60,7 +64,18 @@ export class AiSummaryRetryEventWorker implements Lifecycle {
     logger.error(
       `${this.nameTag} feedId ${feedId} AI 요약 재요청 실패: ${error.message}`,
     );
+    await this.resetSummary(feedId);
     await this.releaseRetryLock(feedId);
+  }
+
+  private async resetSummary(feedId: number): Promise<void> {
+    try {
+      await this.feedRepository.updateNullSummary(feedId);
+    } catch (error) {
+      logger.error(
+        `${this.nameTag} feedId ${feedId} summary 초기화 실패: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
   }
 
   private async releaseRetryLock(feedId: number): Promise<void> {

--- a/feed-crawler/test/unit/ai-summary-retry-event-worker.spec.ts
+++ b/feed-crawler/test/unit/ai-summary-retry-event-worker.spec.ts
@@ -9,6 +9,8 @@ import { AiSummaryRetryEventWorker } from '@event_worker/workers/ai-summary-retr
 import { RMQ_QUEUES } from '@rabbitmq/rabbitmq.constant';
 import { RabbitMQService } from '@rabbitmq/rabbitmq.service';
 
+import { FeedRepository } from '@repository/feed.repository';
+
 import { FeedCrawler } from '../../src/feed-crawler';
 
 describe('AiSummaryRetryEventWorker', () => {
@@ -16,10 +18,12 @@ describe('AiSummaryRetryEventWorker', () => {
   let mockRabbitMQService: jest.Mocked<RabbitMQService>;
   let mockRedisConnection: jest.Mocked<RedisConnection>;
   let mockFeedCrawler: jest.Mocked<FeedCrawler>;
+  let mockFeedRepository: jest.Mocked<FeedRepository>;
   let consumeMessageMock: jest.Mock;
   let closeConsumerMock: jest.Mock;
   let delMock: jest.Mock;
   let requeueMock: jest.Mock;
+  let updateNullSummaryMock: jest.Mock;
 
   const feedId = 7;
 
@@ -28,6 +32,7 @@ describe('AiSummaryRetryEventWorker', () => {
     closeConsumerMock = jest.fn();
     delMock = jest.fn();
     requeueMock = jest.fn();
+    updateNullSummaryMock = jest.fn().mockResolvedValue(undefined);
 
     mockRabbitMQService = {
       consumeMessage: consumeMessageMock,
@@ -42,10 +47,15 @@ describe('AiSummaryRetryEventWorker', () => {
       requeueFeedForAiSummary: requeueMock,
     } as any;
 
+    mockFeedRepository = {
+      updateNullSummary: updateNullSummaryMock,
+    } as any;
+
     worker = new AiSummaryRetryEventWorker(
       mockRabbitMQService,
       mockRedisConnection,
       mockFeedCrawler,
+      mockFeedRepository,
     );
   });
 
@@ -117,6 +127,36 @@ describe('AiSummaryRetryEventWorker', () => {
       await worker['handleFailure'](feedId, error);
 
       // Then
+      expect(delMock).toHaveBeenCalledWith(
+        `${redisConstant.FEED_AI_RETRY_LOCK}:${feedId}`,
+      );
+    });
+
+    it('실패하면 summary를 NULL로 초기화해야 한다', async () => {
+      // Given
+      const error = new Error('일시적 오류');
+      delMock.mockResolvedValue(undefined);
+
+      // When
+      await worker['handleFailure'](feedId, error);
+
+      // Then
+      expect(updateNullSummaryMock).toHaveBeenCalledWith(feedId);
+    });
+
+    it('summary 초기화가 실패해도 예외를 던지지 않고 로깅해야 한다', async () => {
+      // Given
+      const errorSpy = jest.spyOn(logger, 'error').mockImplementation();
+      updateNullSummaryMock.mockRejectedValue(new Error('db down'));
+      delMock.mockResolvedValue(undefined);
+
+      // When & Then
+      await expect(
+        worker['handleFailure'](feedId, new Error('일시적 오류')),
+      ).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('summary 초기화 실패'),
+      );
       expect(delMock).toHaveBeenCalledWith(
         `${redisConstant.FEED_AI_RETRY_LOCK}:${feedId}`,
       );


### PR DESCRIPTION
# 🔨 테스크

### Issue

-   close #966

### 재요약 신청 후 실패 시 요약중 상태가 안 풀리는 문제

-   관리자가 게시글 AI 재요약을 신청하면 `FeedService.requestAiSummary`가 DB summary를 "요약 진행중" 문구로 바꾼 뒤 RabbitMQ(`crawling.aiRetry.queue`)로 발행한다.
-   feed-crawler의 `AiSummaryRetryEventWorker`가 이 큐를 리스닝해 `FeedCrawler.requeueFeedForAiSummary`를 호출하는데, 원본 게시글을 못 찾거나(RSS 미노출/삭제) 네트워크 오류가 나서 실패해도 Redis 재시도 락만 해제할 뿐 DB summary는 그대로 "요약 진행중" 문구로 남아있었다.
-   그 결과 `GET /admins/feeds/no-summary`(summary IS NULL 기준 조회)에 다시 노출되지 않아, 관리자가 실패를 인지하지도 재요청하지도 못하는 상태로 방치됐다.
-   이 큐는 자체 재시도/DLQ 로직이 없어(메시지 처리 중 발생한 에러를 내부에서 모두 삼키고 항상 ack) 한 번 실패하면 그걸로 끝이기 때문에, 이번 수정에서는 실패 시 무조건 summary를 NULL로 되돌리는 방식으로 처리했다.

# 📋 작업 내용

-   `AiSummaryRetryEventWorker.handleFailure`에서 기존 `ClaudeEventWorker`가 사용하던 `FeedRepository.updateNullSummary`를 재사용해 실패 시 DB summary를 NULL로 초기화하도록 추가
-   summary 초기화 자체가 실패해도 예외를 던지지 않고 로깅만 하도록 처리(락 해제 로직과 동일한 방어 패턴)
-   관련 유닛 테스트 추가 (`ai-summary-retry-event-worker.spec.ts`)

# 📷 스크린 샷(선택 사항)
<img width="487" height="337" alt="image" src="https://github.com/user-attachments/assets/0914ad2d-8c45-4c84-a148-135268ea62c6" />
